### PR TITLE
feat: useServerFormカスタムフック導入でReact 19フォームリセット問題を解決

### DIFF
--- a/learning/react19-form-reset-conform.md
+++ b/learning/react19-form-reset-conform.md
@@ -1,0 +1,115 @@
+# React 19の自動フォームリセット問題とconformでの解決策
+
+作成日: 2026-01-28
+
+## 概要
+
+React 19では、`<form action={serverAction}>` を使用した場合、Server Action完了後にフォームが自動的にリセットされる仕様が導入された。これがconformの状態管理と干渉し、バックエンドエラー時に入力値が失われる問題が発生する。
+
+## 問題の詳細
+
+### 症状
+
+- フロントエンドバリデーションエラー時：入力値が保持される ✅
+- バックエンドエラー時（ビジネスロジックエラー等）：入力値がリセットされる ❌
+
+### 原因
+
+React 19の自動リセットが発生する条件：
+
+1. `<form action={serverAction}>` のようにaction属性にServer Actionを渡している
+2. フォームのネイティブsubmitイベントが発火する
+3. Actionが完了する（成功・失敗問わず）
+
+フロントエンドバリデーションエラー時は、Reactの観点では「Action失敗」として扱われる可能性があり、リセットがトリガーされない。一方、バックエンドエラー時はバリデーション自体は成功しており、catchブロックで`submission.reply()`を返しても「Actionは完了した」と見なされ、自動リセットがトリガーされる。
+
+## 解決策
+
+conformの`onSubmit`で`event.preventDefault()`し、`startTransition`を使って手動でactionを呼び出す。
+
+```tsx
+import { startTransition } from "react";
+
+const [lastResult, formAction, isPending] = useActionState(
+  createEmployee,
+  undefined
+);
+
+const [form, fields] = useForm({
+  lastResult,
+  onSubmit(event, { formData }) {
+    event.preventDefault();
+    startTransition(async () => {
+      await formAction(formData);
+    });
+  },
+  onValidate({ formData }) {
+    return parseWithZod(formData, { schema: createEmployeeSchema });
+  },
+  shouldValidate: "onBlur",
+  shouldRevalidate: "onInput",
+});
+```
+
+### なぜこれで解決するのか
+
+#### `event.preventDefault()` の役割
+
+ブラウザのネイティブフォーム送信をキャンセルする。React 19の自動リセットは、`<form action={...}>` を通じたネイティブのフォーム送信フローに組み込まれているため、`preventDefault()`でこのフローを止めると自動リセット機構も発動しない。
+
+#### `startTransition` の役割
+
+1. **非同期処理の適切なスケジューリング**: Server Actionは非同期処理であり、`startTransition`はReactに「この更新は緊急ではない」と伝え、UIの応答性を保つ
+2. **isPendingの正常動作**: `useActionState`の`isPending`が正しく動作するために必要
+3. **Suspenseとの統合**: React 19のSuspense境界と適切に連携する
+
+## 処理フローの比較
+
+### 通常（自動リセットが発生）
+
+```
+ユーザーがsubmit
+  ↓
+ネイティブsubmitイベント発火
+  ↓
+React が action={formAction} を検出
+  ↓
+React が formAction を実行
+  ↓
+Action完了
+  ↓
+React が自動的にフォームをリセット ← 問題
+  ↓
+lastResult が反映されるが、フォームは既にリセット済み
+```
+
+### `preventDefault()` + `startTransition`
+
+```
+ユーザーがsubmit
+  ↓
+ネイティブsubmitイベント発火
+  ↓
+conform の onSubmit が呼ばれる
+  ↓
+event.preventDefault() でネイティブ送信をキャンセル
+  ↓
+startTransition 内で手動で formAction を呼び出す
+  ↓
+Action完了
+  ↓
+React の自動リセット機構は発動しない（ネイティブ送信ではないため）
+  ↓
+lastResult が反映され、conform がフォーム状態を制御
+```
+
+## 参考
+
+- [React 19 allow opting out of automatic form reset - GitHub Issue](https://github.com/facebook/react/issues/29034)
+- [Conform Discussion #606 - Form reset issue](https://github.com/edmundhung/conform/discussions/606)
+- [How to (not) reset a form after a Server Action in React](https://www.robinwieruch.de/react-server-action-reset-form/)
+
+### 関連ファイル
+
+- `src/app/(features)/employees/new/EmployeeCreateForm.tsx`
+- `src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.tsx`

--- a/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.test.tsx
+++ b/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi, type Mock } from "vitest";
 import { updateEmployee } from "./actions";
@@ -25,8 +25,23 @@ const mockEmployee = {
   name: "山田太郎",
   email: "yamada@example.com",
   employeeCd: "EMP000001",
+  departmentId: "dept-1",
   role: USER_ROLES.USER,
 };
+
+// 部署選択スロットのモック
+const mockDepartmentSelectSlot = (
+  <select
+    name="departmentId"
+    id="departmentId"
+    aria-label="所属部署"
+    defaultValue="dept-1"
+  >
+    <option value="">選択してください</option>
+    <option value="dept-1">営業部</option>
+    <option value="dept-2">開発部</option>
+  </select>
+);
 
 describe("EmployeeUpdateForm", () => {
   beforeEach(() => {
@@ -39,20 +54,33 @@ describe("EmployeeUpdateForm", () => {
 
   describe("レンダリングテスト", () => {
     test("全てのフォームフィールドが表示される", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       // 各フィールドのラベルが表示されていることを確認
       expect(screen.getByLabelText("名前")).toBeInTheDocument();
       expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
       expect(screen.getByLabelText("従業員コード")).toBeInTheDocument();
       expect(screen.getByLabelText("権限")).toBeInTheDocument();
+      expect(screen.getByLabelText("所属部署")).toBeInTheDocument();
 
       // 送信ボタンが表示されていることを確認
       expect(screen.getByRole("button", { name: "更新" })).toBeInTheDocument();
     });
 
     test("初期値が正しく設定される", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       expect(screen.getByLabelText("名前")).toHaveValue("山田太郎");
       expect(screen.getByLabelText("メールアドレス")).toHaveValue(
@@ -63,7 +91,13 @@ describe("EmployeeUpdateForm", () => {
     });
 
     test("従業員コードは読み取り専用で表示される", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       const employeeCdInput = screen.getByLabelText("従業員コード");
       expect(employeeCdInput).toBeDisabled();
@@ -71,7 +105,13 @@ describe("EmployeeUpdateForm", () => {
     });
 
     test("従業員コードの入力ヒントが表示される", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       expect(
         screen.getByText("形式: EMP + 6桁の数字（例: EMP000001）")
@@ -79,7 +119,13 @@ describe("EmployeeUpdateForm", () => {
     });
 
     test("権限のセレクトボックスにオプションが表示される", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       expect(
         screen.getByRole("option", { name: "一般ユーザー" })
@@ -92,19 +138,37 @@ describe("EmployeeUpdateForm", () => {
 
   describe("canUpdate=true の場合（編集モード）", () => {
     test("タイトルが「従業員変更」と表示される", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       expect(screen.getByText("従業員変更")).toBeInTheDocument();
     });
 
     test("更新ボタンが表示される", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       expect(screen.getByRole("button", { name: "更新" })).toBeInTheDocument();
     });
 
     test("入力フィールドが有効になっている", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       expect(screen.getByLabelText("名前")).not.toBeDisabled();
       expect(screen.getByLabelText("メールアドレス")).not.toBeDisabled();
@@ -114,13 +178,25 @@ describe("EmployeeUpdateForm", () => {
 
   describe("canUpdate=false の場合（詳細表示モード）", () => {
     test("タイトルが「従業員詳細」と表示される", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={false} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={false}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       expect(screen.getByText("従業員詳細")).toBeInTheDocument();
     });
 
     test("更新ボタンが表示されない", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={false} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={false}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       expect(
         screen.queryByRole("button", { name: "更新" })
@@ -128,7 +204,13 @@ describe("EmployeeUpdateForm", () => {
     });
 
     test("入力フィールドが無効になっている", () => {
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={false} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={false}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       expect(screen.getByLabelText("名前")).toBeDisabled();
       expect(screen.getByLabelText("メールアドレス")).toBeDisabled();
@@ -139,7 +221,13 @@ describe("EmployeeUpdateForm", () => {
   describe("入力テスト", () => {
     test("ユーザーがフォームの値を変更できる", async () => {
       const user = userEvent.setup();
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       // 名前を変更
       const nameInput = screen.getByLabelText("名前");
@@ -156,7 +244,13 @@ describe("EmployeeUpdateForm", () => {
 
     test("権限を変更できる", async () => {
       const user = userEvent.setup();
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       const roleSelect = screen.getByLabelText("権限");
 
@@ -171,19 +265,35 @@ describe("EmployeeUpdateForm", () => {
   describe("サブミットテスト", () => {
     test("フォームを送信するとupdateEmployeeが呼び出される", async () => {
       const user = userEvent.setup();
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       // フォームを送信
       const submitButton = screen.getByRole("button", { name: "更新" });
-      await user.click(submitButton);
+      await act(async () => {
+        await user.click(submitButton);
+      });
 
-      // updateEmployeeが呼び出されたことを確認
-      expect(mockUpdateEmployee).toHaveBeenCalled();
+      // updateEmployeeが呼び出されたことを確認（startTransitionによる非同期処理を待機）
+      await waitFor(() => {
+        expect(mockUpdateEmployee).toHaveBeenCalled();
+      });
     });
 
     test("送信されたFormDataに正しい値が含まれている", async () => {
       const user = userEvent.setup();
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       // 値を変更
       const nameInput = screen.getByLabelText("名前");
@@ -193,12 +303,17 @@ describe("EmployeeUpdateForm", () => {
       await user.selectOptions(screen.getByLabelText("権限"), USER_ROLES.ADMIN);
 
       // フォームを送信
-      await user.click(screen.getByRole("button", { name: "更新" }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: "更新" }));
+      });
+
+      // updateEmployeeが呼び出されたことを確認（startTransitionによる非同期処理を待機）
+      await waitFor(() => {
+        expect(mockUpdateEmployee).toHaveBeenCalled();
+      });
 
       // updateEmployeeの引数を検証
-      // TODO: これ何なのか理解する
       // bind(null, employeeCd)により、引数は (employeeCd, prevState, formData) の順
-      expect(mockUpdateEmployee).toHaveBeenCalled();
       const callArgs = mockUpdateEmployee.mock.calls[0];
 
       // 最初の引数はbindされたemployeeCd
@@ -226,10 +341,18 @@ describe("EmployeeUpdateForm", () => {
         initialValue: {},
       });
 
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       // フォームを送信
-      await user.click(screen.getByRole("button", { name: "更新" }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: "更新" }));
+      });
 
       // エラーメッセージが表示されることを確認
       expect(
@@ -254,12 +377,20 @@ describe("EmployeeUpdateForm", () => {
         },
       });
 
-      render(<EmployeeUpdateForm employee={mockEmployee} canUpdate={true} />);
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
 
       // フォームを送信
-      await user.click(screen.getByRole("button", { name: "更新" }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: "更新" }));
+      });
 
-      // createEmployeeが呼び出されたことを確認
+      // updateEmployeeが呼び出されたことを確認
       await waitFor(() => {
         expect(mockUpdateEmployee).toHaveBeenCalled();
       });

--- a/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.tsx
+++ b/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.tsx
@@ -1,15 +1,9 @@
 "use client";
 
-import {
-  getFormProps,
-  getInputProps,
-  getSelectProps,
-  useForm,
-} from "@conform-to/react";
-import { parseWithZod } from "@conform-to/zod/v4";
+import { getFormProps, getInputProps, getSelectProps } from "@conform-to/react";
+import { useServerForm } from "@/app/_hooks/useServerForm";
 import type { UserRole } from "@server/shared/auth/types";
 import { USER_ROLES } from "@server/shared/auth/types";
-import { useActionState } from "react";
 import { updateEmployee } from "./actions";
 import { updateEmployeeSchema } from "./schema";
 
@@ -40,24 +34,15 @@ export function EmployeeUpdateForm({
     employee.employeeCd
   );
 
-  const [lastResult, formAction, isPending] = useActionState(
-    updateEmployeeWithEmployeeCd,
-    undefined
-  );
-
-  const [form, fields] = useForm({
-    lastResult,
+  const { form, fields, isPending } = useServerForm({
+    action: updateEmployeeWithEmployeeCd,
+    schema: updateEmployeeSchema,
     defaultValue: {
       name: employee.name,
       email: employee.email,
       departmentId: employee.departmentId,
       role: employee.role ?? USER_ROLES.USER,
     },
-    onValidate({ formData }) {
-      return parseWithZod(formData, { schema: updateEmployeeSchema });
-    },
-    shouldValidate: "onBlur",
-    shouldRevalidate: "onInput",
   });
 
   return (
@@ -77,12 +62,7 @@ export function EmployeeUpdateForm({
         </div>
       )}
 
-      <form
-        {...getFormProps(form)}
-        action={formAction}
-        noValidate
-        className="space-y-4"
-      >
+      <form {...getFormProps(form)} noValidate className="space-y-4">
         <div>
           <label
             htmlFor={fields.name.id}

--- a/src/app/(features)/employees/new/EmployeeCreateForm.test.tsx
+++ b/src/app/(features)/employees/new/EmployeeCreateForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, test, vi, beforeEach, type Mock } from "vitest";
 import { createEmployee } from "./actions";
@@ -12,15 +12,32 @@ vi.mock("./actions", () => ({
 
 const mockCreateEmployee = createEmployee as Mock;
 
+// 部署選択スロットのモック
+const mockDepartmentSelectSlot = (
+  <select
+    name="departmentId"
+    id="departmentId"
+    aria-label="所属部署"
+    defaultValue="dept-1"
+  >
+    <option value="">選択してください</option>
+    <option value="dept-1">営業部</option>
+    <option value="dept-2">開発部</option>
+  </select>
+);
+
 describe("EmployeeCreateForm", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     // デフォルトのモック: 成功時はredirectするため undefined を返す
     mockCreateEmployee.mockResolvedValue(undefined);
   });
 
   describe("レンダリングテスト", () => {
     test("全てのフォームフィールドが表示される", () => {
-      render(<EmployeeCreateForm />);
+      render(
+        <EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />
+      );
 
       // 各フィールドのラベルが表示されていることを確認
       expect(screen.getByLabelText("名前")).toBeInTheDocument();
@@ -28,33 +45,46 @@ describe("EmployeeCreateForm", () => {
       expect(screen.getByLabelText("従業員コード")).toBeInTheDocument();
       expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
       expect(screen.getByLabelText("権限")).toBeInTheDocument();
+      expect(screen.getByLabelText("所属部署")).toBeInTheDocument();
 
       // 送信ボタンが表示されていることを確認
       expect(screen.getByRole("button", { name: "登録" })).toBeInTheDocument();
     });
 
     test("権限のセレクトボックスにオプションが表示される", () => {
-      render(<EmployeeCreateForm />);
+      render(
+        <EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />
+      );
 
       const roleSelect = screen.getByLabelText("権限");
       expect(roleSelect).toHaveValue(USER_ROLES.USER); // デフォルト値
 
       // オプションの存在を確認
-      expect(screen.getByRole("option", { name: "一般ユーザー" })).toBeInTheDocument();
-      expect(screen.getByRole("option", { name: "管理者" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: "一般ユーザー" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: "管理者" })
+      ).toBeInTheDocument();
     });
 
     test("従業員コードの入力ヒントが表示される", () => {
-      render(<EmployeeCreateForm />);
+      render(
+        <EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />
+      );
 
-      expect(screen.getByText("形式: EMP + 6桁の数字（例: EMP000001）")).toBeInTheDocument();
+      expect(
+        screen.getByText("形式: EMP + 6桁の数字（例: EMP000001）")
+      ).toBeInTheDocument();
     });
   });
 
   describe("入力テスト", () => {
     test("ユーザーがフォームに値を入力できる", async () => {
       const user = userEvent.setup();
-      render(<EmployeeCreateForm />);
+      render(
+        <EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />
+      );
 
       // 各フィールドに値を入力
       const nameInput = screen.getByLabelText("名前");
@@ -76,7 +106,9 @@ describe("EmployeeCreateForm", () => {
 
     test("権限を変更できる", async () => {
       const user = userEvent.setup();
-      render(<EmployeeCreateForm />);
+      render(
+        <EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />
+      );
 
       const roleSelect = screen.getByLabelText("権限");
 
@@ -91,38 +123,60 @@ describe("EmployeeCreateForm", () => {
   describe("サブミットテスト", () => {
     test("フォームを送信するとcreateEmployeeが呼び出される", async () => {
       const user = userEvent.setup();
-      render(<EmployeeCreateForm />);
+      render(
+        <EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />
+      );
 
       // 必須フィールドに値を入力
       await user.type(screen.getByLabelText("名前"), "山田太郎");
-      await user.type(screen.getByLabelText("メールアドレス"), "yamada@example.com");
+      await user.type(
+        screen.getByLabelText("メールアドレス"),
+        "yamada@example.com"
+      );
       await user.type(screen.getByLabelText("従業員コード"), "EMP000001");
       await user.type(screen.getByLabelText("パスワード"), "password123");
 
       // フォームを送信
       const submitButton = screen.getByRole("button", { name: "登録" });
-      await user.click(submitButton);
+      await act(async () => {
+        await user.click(submitButton);
+      });
 
-      // createEmployeeが呼び出されたことを確認
-      expect(mockCreateEmployee).toHaveBeenCalled();
+      // createEmployeeが呼び出されたことを確認（startTransitionによる非同期処理を待機）
+      await waitFor(() => {
+        expect(mockCreateEmployee).toHaveBeenCalled();
+      });
     });
 
     test("送信されたFormDataに正しい値が含まれている", async () => {
       const user = userEvent.setup();
-      render(<EmployeeCreateForm />);
+      render(
+        <EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />
+      );
 
       // 必須フィールドに値を入力
       await user.type(screen.getByLabelText("名前"), "山田太郎");
-      await user.type(screen.getByLabelText("メールアドレス"), "yamada@example.com");
+      await user.type(
+        screen.getByLabelText("メールアドレス"),
+        "yamada@example.com"
+      );
       await user.type(screen.getByLabelText("従業員コード"), "EMP000001");
       await user.type(screen.getByLabelText("パスワード"), "password123");
-      await user.selectOptions(screen.getByLabelText("権限"), USER_ROLES.ADMIN);
+      await user.selectOptions(
+        screen.getByLabelText("権限"),
+        USER_ROLES.ADMIN
+      );
 
       // フォームを送信
-      await user.click(screen.getByRole("button", { name: "登録" }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: "登録" }));
+      });
 
-      // createEmployeeの引数を検証
-      expect(mockCreateEmployee).toHaveBeenCalled();
+      // createEmployeeが呼び出されたことを確認（startTransitionによる非同期処理を待機）
+      await waitFor(() => {
+        expect(mockCreateEmployee).toHaveBeenCalled();
+      });
+
       const callArgs = mockCreateEmployee.mock.calls[0];
       const formData = callArgs[1] as FormData;
 
@@ -148,19 +202,28 @@ describe("EmployeeCreateForm", () => {
         initialValue: {},
       });
 
-      render(<EmployeeCreateForm />);
+      render(
+        <EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />
+      );
 
       // 必須フィールドに値を入力
       await user.type(screen.getByLabelText("名前"), "山田太郎");
-      await user.type(screen.getByLabelText("メールアドレス"), "yamada@example.com");
+      await user.type(
+        screen.getByLabelText("メールアドレス"),
+        "yamada@example.com"
+      );
       await user.type(screen.getByLabelText("従業員コード"), "EMP000001");
       await user.type(screen.getByLabelText("パスワード"), "password123");
 
       // フォームを送信
-      await user.click(screen.getByRole("button", { name: "登録" }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: "登録" }));
+      });
 
       // エラーメッセージが表示されることを確認
-      expect(await screen.findByText("サーバーエラーが発生しました")).toBeInTheDocument();
+      expect(
+        await screen.findByText("サーバーエラーが発生しました")
+      ).toBeInTheDocument();
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
 
@@ -184,17 +247,24 @@ describe("EmployeeCreateForm", () => {
         },
       });
 
-      render(<EmployeeCreateForm />);
+      render(
+        <EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />
+      );
 
       // HTML5バリデーションを通過する有効な値を入力
       // （サーバーサイドでエラーを返すシナリオ）
       await user.type(screen.getByLabelText("名前"), "山田太郎");
-      await user.type(screen.getByLabelText("メールアドレス"), "yamada@example.com");
+      await user.type(
+        screen.getByLabelText("メールアドレス"),
+        "yamada@example.com"
+      );
       await user.type(screen.getByLabelText("従業員コード"), "EMP000001");
       await user.type(screen.getByLabelText("パスワード"), "password123");
 
       // フォームを送信
-      await user.click(screen.getByRole("button", { name: "登録" }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: "登録" }));
+      });
 
       // createEmployeeが呼び出されたことを確認
       await waitFor(() => {
@@ -202,9 +272,15 @@ describe("EmployeeCreateForm", () => {
       });
 
       // 各フィールドのエラーメッセージが表示されることを確認
-      expect(await screen.findByText("名前は2文字以上で入力してください")).toBeInTheDocument();
-      expect(screen.getByText("このメールアドレスは既に使用されています")).toBeInTheDocument();
-      expect(screen.getByText("この従業員コードは既に使用されています")).toBeInTheDocument();
+      expect(
+        await screen.findByText("名前は2文字以上で入力してください")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("このメールアドレスは既に使用されています")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("この従業員コードは既に使用されています")
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/app/(features)/employees/new/EmployeeCreateForm.tsx
+++ b/src/app/(features)/employees/new/EmployeeCreateForm.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import {
-  useForm,
-  getFormProps,
-  getInputProps,
-  getSelectProps,
-} from "@conform-to/react";
-import { parseWithZod } from "@conform-to/zod/v4";
-import { useActionState } from "react";
+import { getFormProps, getInputProps, getSelectProps } from "@conform-to/react";
+import { useServerForm } from "@/app/_hooks/useServerForm";
 import { createEmployee } from "./actions";
 import { createEmployeeSchema } from "./schema";
 
@@ -17,18 +11,9 @@ type Props = {
 };
 
 export function EmployeeCreateForm({ departmentSelectSlot }: Props) {
-  const [lastResult, formAction, isPending] = useActionState(
-    createEmployee,
-    undefined
-  );
-
-  const [form, fields] = useForm({
-    lastResult,
-    onValidate({ formData }) {
-      return parseWithZod(formData, { schema: createEmployeeSchema });
-    },
-    shouldValidate: "onBlur",
-    shouldRevalidate: "onInput",
+  const { form, fields, isPending } = useServerForm({
+    action: createEmployee,
+    schema: createEmployeeSchema,
   });
 
   return (
@@ -44,12 +29,7 @@ export function EmployeeCreateForm({ departmentSelectSlot }: Props) {
         </div>
       )}
 
-      <form
-        {...getFormProps(form)}
-        action={formAction}
-        noValidate
-        className="space-y-4"
-      >
+      <form {...getFormProps(form)} noValidate className="space-y-4">
         <div>
           <label
             htmlFor={fields.name.id}

--- a/src/app/_hooks/useServerForm.ts
+++ b/src/app/_hooks/useServerForm.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useForm, type DefaultValue } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { startTransition, useActionState } from "react";
+import type { z } from "zod";
+
+/**
+ * useServerForm のオプション
+ *
+ * @template TSchema - Zodスキーマの型
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type UseServerFormOptions<TSchema extends z.ZodObject<any>> = {
+  /** Server Action */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  action: (prevState: any, formData: FormData) => Promise<any>;
+  /** Zodスキーマ */
+  schema: TSchema;
+  /** フォームのデフォルト値（編集フォーム用） */
+  defaultValue?: DefaultValue<z.infer<TSchema>>;
+  /** バリデーションタイミング */
+  shouldValidate?: "onSubmit" | "onBlur" | "onInput";
+  /** 再バリデーションタイミング */
+  shouldRevalidate?: "onSubmit" | "onBlur" | "onInput";
+};
+
+/**
+ * Server Action対応のフォームフック
+ *
+ * React 19の自動フォームリセット問題を回避するため、
+ * event.preventDefault() + startTransition を使用してフォーム送信を制御する。
+ *
+ * @see learning/react19-form-reset-conform.md
+ *
+ * @example
+ * ```tsx
+ * const { form, fields, isPending } = useServerForm({
+ *   action: createEmployee,
+ *   schema: createEmployeeSchema,
+ *   shouldValidate: "onBlur",
+ *   shouldRevalidate: "onInput",
+ * });
+ * ```
+ */
+export function useServerForm<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TSchema extends z.ZodObject<any>,
+>({
+  action,
+  schema,
+  defaultValue,
+  shouldValidate = "onBlur",
+  shouldRevalidate = "onInput",
+}: UseServerFormOptions<TSchema>) {
+  const [lastResult, formAction, isPending] = useActionState(action, undefined);
+
+  const [form, fields] = useForm<z.infer<TSchema>>({
+    lastResult,
+    defaultValue,
+    onSubmit(event, { formData }) {
+      // React 19の自動フォームリセットを回避
+      // ネイティブのフォーム送信をキャンセルし、手動でactionを呼び出す
+      event.preventDefault();
+      startTransition(() => {
+        formAction(formData);
+      });
+    },
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema });
+    },
+    shouldValidate,
+    shouldRevalidate,
+  });
+
+  return { form, fields, isPending };
+}


### PR DESCRIPTION
## Summary

- React 19の自動フォームリセット問題を回避する`useServerForm`カスタムフックを作成
- `event.preventDefault()` + `startTransition`を内部で使用し、React 19の自動リセットを回避
- EmployeeCreateForm / EmployeeUpdateFormをカスタムフックに移行
- 関連テストファイルを修正

## 変更内容

| ファイル | 変更内容 |
|----------|----------|
| `src/app/_hooks/useServerForm.ts` | 新規作成：カスタムフック |
| `src/app/(features)/employees/new/EmployeeCreateForm.tsx` | useServerFormに移行 |
| `src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.tsx` | useServerFormに移行 |
| `learning/react19-form-reset-conform.md` | 学習ドキュメント |

## 背景

React 19では、`<form action={serverAction}>`を使用した場合、Server Action完了後にフォームが自動的にリセットされる仕様が導入された。これがconformの状態管理と干渉し、バックエンドエラー時に入力値が失われる問題が発生していた。

## Test plan

- [x] `pnpm build` 成功
- [x] `pnpm lint` 成功（警告のみ）
- [x] EmployeeCreateForm/EmployeeUpdateFormのテスト全件パス

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)