### PR TITLE
refactor: Iプレフィックスinterfaceのリファクタリング

### DIFF
--- a/src/server/shared/auth/AuthService.ts
+++ b/src/server/shared/auth/AuthService.ts
@@ -5,7 +5,7 @@ import type { AuthSession, SignInInput, SignInResult, SignOutResult } from "./ty
  *
  * 認証機能の抽象化を提供し、実装の詳細（Better Auth等）を隠蔽する
  */
-export interface IAuthService {
+export interface AuthService {
   /**
    * 現在のセッションを取得する
    * Server Component / Server Action から呼び出す

--- a/src/server/shared/auth/UserManagementService.ts
+++ b/src/server/shared/auth/UserManagementService.ts
@@ -55,7 +55,7 @@ export type UpdateAuthUserRoleResult = { success: true } | { success: false; err
 // インターフェース
 // ========================================
 
-export interface IUserManagementService {
+export interface UserManagementService {
   /**
    * 認証ユーザー（User/Account）を作成する
    *

--- a/src/server/shared/auth/better-auth/BetterAuthService.ts
+++ b/src/server/shared/auth/better-auth/BetterAuthService.ts
@@ -1,12 +1,12 @@
 import { headers } from "next/headers";
-import type { IAuthService } from "../IAuthService";
+import type { AuthService } from "../AuthService";
 import type { AuthSession, AuthUser, SignInInput, SignInResult, SignOutResult } from "../types";
 import { auth } from "./auth";
 
 /**
- * Better Auth による IAuthService の実装
+ * Better Auth による AuthService の実装
  */
-export class BetterAuthService implements IAuthService {
+export class BetterAuthService implements AuthService {
   async getCurrentSession(): Promise<AuthSession | null> {
     const session = await auth.api.getSession({
       headers: await headers(),

--- a/src/server/shared/auth/better-auth/BetterAuthUserManagementService.ts
+++ b/src/server/shared/auth/better-auth/BetterAuthUserManagementService.ts
@@ -3,21 +3,21 @@ import { headers } from "next/headers";
 import type {
   CreateAuthUserInput,
   CreateAuthUserResult,
-  IUserManagementService,
+  UserManagementService,
   RemoveAuthUserResult,
   UpdateAuthUserEmailResult,
   UpdateAuthUserRoleResult,
-} from "../IUserManagementService";
+} from "../UserManagementService";
 import type { UserRole } from "../types";
 import { auth } from "./auth";
 
 /**
- * Better Auth による IUserManagementService の実装
+ * Better Auth による UserManagementService の実装
  *
  * Better Auth Admin API を使用して認証ユーザーの作成・更新・削除を行う。
  * Employee（ドメインエンティティ）と認証ユーザーの同期に使用する。
  */
-export class BetterAuthUserManagementService implements IUserManagementService {
+export class BetterAuthUserManagementService implements UserManagementService {
   /**
    * 認証ユーザー（User/Account）を作成する
    *

--- a/src/server/shared/auth/fake/FakeUserManagementService.ts
+++ b/src/server/shared/auth/fake/FakeUserManagementService.ts
@@ -2,11 +2,11 @@ import { randomUUID } from "crypto";
 import type {
   CreateAuthUserInput,
   CreateAuthUserResult,
-  IUserManagementService,
+  UserManagementService,
   RemoveAuthUserResult,
   UpdateAuthUserEmailResult,
   UpdateAuthUserRoleResult,
-} from "../IUserManagementService";
+} from "../UserManagementService";
 import type { AuthUser, UserRole } from "../types";
 
 /**
@@ -14,7 +14,7 @@ import type { AuthUser, UserRole } from "../types";
  *
  * インメモリでユーザー管理を行い、テスト用のフラグで失敗をシミュレートできる。
  */
-export class FakeUserManagementService implements IUserManagementService {
+export class FakeUserManagementService implements UserManagementService {
   private users = new Map<string, AuthUser>();
   private usersByEmployeeId = new Map<string, AuthUser>();
   private shouldFailOnCreate = false;

--- a/src/server/shared/auth/index.ts
+++ b/src/server/shared/auth/index.ts
@@ -5,14 +5,14 @@
  * 実装の詳細（Better Auth）は隠蔽される。
  */
 
-export type { IAuthService } from "./IAuthService";
-export type { IUserManagementService } from "./IUserManagementService";
+export type { AuthService } from "./AuthService";
+export type { UserManagementService } from "./UserManagementService";
 export type {
   CreateAuthUserInput,
   CreateAuthUserResult,
   RemoveAuthUserResult,
   UpdateAuthUserEmailResult,
-} from "./IUserManagementService";
+} from "./UserManagementService";
 export type { AuthSession, AuthUser, SignInInput, SignInResult, SignOutResult } from "./types";
 
 // 認可チェックヘルパー関数

--- a/src/server/subdomains/department/application/commands/CreateDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/CreateDepartmentCommand.ts
@@ -1,5 +1,5 @@
 import { Department } from "@subdomains/department/domain/entities/Department";
-import { IDepartmentRepository } from "@subdomains/department/domain/repositories/IDepartmentRepository";
+import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
 import { DepartmentCdDuplicationCheckDomainService } from "@subdomains/department/domain/services/DepartmentCdDuplicationCheckDomainService";
 import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
 import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
@@ -19,7 +19,7 @@ export type CreateDepartmentInput = {
  */
 export class CreateDepartmentCommand {
   public constructor(
-    private readonly departmentRepository: IDepartmentRepository,
+    private readonly departmentRepository: DepartmentRepository,
     private readonly departmentCdDuplicationCheckDomainService: DepartmentCdDuplicationCheckDomainService
   ) {}
 

--- a/src/server/subdomains/department/application/commands/DeleteDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/DeleteDepartmentCommand.ts
@@ -1,5 +1,5 @@
 import { Department } from "@subdomains/department/domain/entities/Department";
-import { IDepartmentRepository } from "@subdomains/department/domain/repositories/IDepartmentRepository";
+import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
 import { ValidationError } from "@server/shared/errors/DomainError";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 
@@ -14,7 +14,7 @@ export type DeleteDepartmentInput = {
  * 論理削除（無効化）を行う場合は UpdateDepartmentCommand の isActive を使用すること。
  */
 export class DeleteDepartmentCommand {
-  public constructor(private readonly departmentRepository: IDepartmentRepository) {}
+  public constructor(private readonly departmentRepository: DepartmentRepository) {}
 
   async execute(input: DeleteDepartmentInput): Promise<void> {
     const department = await this.departmentRepository.findById(input.id);

--- a/src/server/subdomains/department/application/commands/UpdateDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/UpdateDepartmentCommand.ts
@@ -1,5 +1,5 @@
 import { Department } from "@subdomains/department/domain/entities/Department";
-import { IDepartmentRepository } from "@subdomains/department/domain/repositories/IDepartmentRepository";
+import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
 import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
 import { Abbreviation } from "@subdomains/department/domain/values/Abbreviation";
 import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
@@ -18,7 +18,7 @@ export type UpdateDepartmentInput = {
  * 部署更新コマンド
  */
 export class UpdateDepartmentCommand {
-  public constructor(private readonly departmentRepository: IDepartmentRepository) {}
+  public constructor(private readonly departmentRepository: DepartmentRepository) {}
 
   async execute(input: UpdateDepartmentInput): Promise<Department> {
     const department = await this.departmentRepository.findById(input.id);

--- a/src/server/subdomains/department/application/commands/__tests__/CreateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/CreateDepartmentCommand.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CreateDepartmentCommand } from "../CreateDepartmentCommand";
-import { IDepartmentRepository } from "@subdomains/department/domain/repositories/IDepartmentRepository";
+import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
 import { DepartmentCdDuplicationCheckDomainService } from "@subdomains/department/domain/services/DepartmentCdDuplicationCheckDomainService";
 import { Department } from "@subdomains/department/domain/entities/Department";
 import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
@@ -10,7 +10,7 @@ import { ValidationError } from "@server/shared/errors/DomainError";
 
 describe("CreateDepartmentCommand", () => {
   let command: CreateDepartmentCommand;
-  let mockRepository: IDepartmentRepository;
+  let mockRepository: DepartmentRepository;
   let mockDuplicationCheckService: DepartmentCdDuplicationCheckDomainService;
 
   beforeEach(() => {

--- a/src/server/subdomains/department/application/commands/__tests__/DeleteDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/DeleteDepartmentCommand.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DeleteDepartmentCommand } from "../DeleteDepartmentCommand";
-import { IDepartmentRepository } from "@subdomains/department/domain/repositories/IDepartmentRepository";
+import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
 import { Department } from "@subdomains/department/domain/entities/Department";
 import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
 import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
@@ -10,7 +10,7 @@ import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 
 describe("DeleteDepartmentCommand", () => {
   let command: DeleteDepartmentCommand;
-  let mockRepository: IDepartmentRepository;
+  let mockRepository: DepartmentRepository;
 
   const createTestDepartment = (id: string = "dept-1") => {
     return Department.reconstruct(

--- a/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { UpdateDepartmentCommand } from "../UpdateDepartmentCommand";
-import { IDepartmentRepository } from "@subdomains/department/domain/repositories/IDepartmentRepository";
+import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
 import { Department } from "@subdomains/department/domain/entities/Department";
 import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
 import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
@@ -10,7 +10,7 @@ import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 
 describe("UpdateDepartmentCommand", () => {
   let command: UpdateDepartmentCommand;
-  let mockRepository: IDepartmentRepository;
+  let mockRepository: DepartmentRepository;
 
   const createTestDepartment = (id: string = "dept-1") => {
     return Department.reconstruct(

--- a/src/server/subdomains/department/application/queries/DepartmentQueryService.ts
+++ b/src/server/subdomains/department/application/queries/DepartmentQueryService.ts
@@ -11,7 +11,7 @@ import { DepartmentSearchCriteria, DepartmentListOptions } from "./dto/Departmen
  * - リポジトリ：Entity の永続化・取得（完全な Entity の再構築）
  * - QueryService：検索・一覧取得（軽量な DTO で返却）
  */
-export interface IDepartmentQueryService {
+export interface DepartmentQueryService {
   /**
    * IDで部署を取得
    * @param id 部署ID

--- a/src/server/subdomains/department/application/queries/GetActiveDepartmentsQuery.ts
+++ b/src/server/subdomains/department/application/queries/GetActiveDepartmentsQuery.ts
@@ -1,6 +1,6 @@
 import { DepartmentDTO } from "./dto/DepartmentDTO";
 import { DepartmentListOptions } from "./dto/DepartmentSearchCriteria";
-import { IDepartmentQueryService } from "./IDepartmentQueryService";
+import { DepartmentQueryService } from "./DepartmentQueryService";
 
 export type GetActiveDepartmentsInput = {
   options?: DepartmentListOptions;
@@ -10,7 +10,7 @@ export type GetActiveDepartmentsInput = {
  * 有効な部署のみ取得クエリ
  */
 export class GetActiveDepartmentsQuery {
-  public constructor(private readonly departmentQueryService: IDepartmentQueryService) {}
+  public constructor(private readonly departmentQueryService: DepartmentQueryService) {}
 
   async execute(input: GetActiveDepartmentsInput): Promise<DepartmentDTO[]> {
     return await this.departmentQueryService.findActive(input.options);

--- a/src/server/subdomains/department/application/queries/GetAllDepartmentsQuery.ts
+++ b/src/server/subdomains/department/application/queries/GetAllDepartmentsQuery.ts
@@ -1,6 +1,6 @@
 import { DepartmentDTO } from "./dto/DepartmentDTO";
 import { DepartmentListOptions } from "./dto/DepartmentSearchCriteria";
-import { IDepartmentQueryService } from "./IDepartmentQueryService";
+import { DepartmentQueryService } from "./DepartmentQueryService";
 
 export type GetAllDepartmentsInput = {
   options?: DepartmentListOptions;
@@ -10,7 +10,7 @@ export type GetAllDepartmentsInput = {
  * 全部署取得クエリ
  */
 export class GetAllDepartmentsQuery {
-  public constructor(private readonly departmentQueryService: IDepartmentQueryService) {}
+  public constructor(private readonly departmentQueryService: DepartmentQueryService) {}
 
   async execute(input: GetAllDepartmentsInput): Promise<DepartmentDTO[]> {
     return await this.departmentQueryService.findAll(input.options);

--- a/src/server/subdomains/department/application/queries/GetDepartmentByIdQuery.ts
+++ b/src/server/subdomains/department/application/queries/GetDepartmentByIdQuery.ts
@@ -1,5 +1,5 @@
 import { DepartmentDTO } from "./dto/DepartmentDTO";
-import { IDepartmentQueryService } from "./IDepartmentQueryService";
+import { DepartmentQueryService } from "./DepartmentQueryService";
 
 export type GetDepartmentByIdInput = {
   id: string;
@@ -9,7 +9,7 @@ export type GetDepartmentByIdInput = {
  * ID指定部署取得クエリ
  */
 export class GetDepartmentByIdQuery {
-  public constructor(private readonly departmentQueryService: IDepartmentQueryService) {}
+  public constructor(private readonly departmentQueryService: DepartmentQueryService) {}
 
   async execute(input: GetDepartmentByIdInput): Promise<DepartmentDTO | null> {
     return await this.departmentQueryService.findById(input.id);

--- a/src/server/subdomains/department/application/queries/GetDepartmentTreeQuery.ts
+++ b/src/server/subdomains/department/application/queries/GetDepartmentTreeQuery.ts
@@ -1,5 +1,5 @@
 import { DepartmentTreeDTO } from "./dto/DepartmentDTO";
-import { IDepartmentQueryService } from "./IDepartmentQueryService";
+import { DepartmentQueryService } from "./DepartmentQueryService";
 
 export type GetDepartmentTreeInput = {
   rootId?: string | null;
@@ -9,7 +9,7 @@ export type GetDepartmentTreeInput = {
  * 部署ツリー取得クエリ
  */
 export class GetDepartmentTreeQuery {
-  public constructor(private readonly departmentQueryService: IDepartmentQueryService) {}
+  public constructor(private readonly departmentQueryService: DepartmentQueryService) {}
 
   async execute(input: GetDepartmentTreeInput): Promise<DepartmentTreeDTO[]> {
     return await this.departmentQueryService.getTree(input.rootId);

--- a/src/server/subdomains/department/application/queries/SearchDepartmentsQuery.ts
+++ b/src/server/subdomains/department/application/queries/SearchDepartmentsQuery.ts
@@ -1,6 +1,6 @@
 import { DepartmentDTO } from "./dto/DepartmentDTO";
 import { DepartmentSearchCriteria, DepartmentListOptions } from "./dto/DepartmentSearchCriteria";
-import { IDepartmentQueryService } from "./IDepartmentQueryService";
+import { DepartmentQueryService } from "./DepartmentQueryService";
 
 export type SearchDepartmentsInput = {
   criteria: DepartmentSearchCriteria;
@@ -11,7 +11,7 @@ export type SearchDepartmentsInput = {
  * 部署検索クエリ
  */
 export class SearchDepartmentsQuery {
-  public constructor(private readonly departmentQueryService: IDepartmentQueryService) {}
+  public constructor(private readonly departmentQueryService: DepartmentQueryService) {}
 
   async execute(input: SearchDepartmentsInput): Promise<DepartmentDTO[]> {
     return await this.departmentQueryService.search(input.criteria, input.options);

--- a/src/server/subdomains/department/domain/repositories/DepartmentRepository.ts
+++ b/src/server/subdomains/department/domain/repositories/DepartmentRepository.ts
@@ -5,9 +5,9 @@ import { DepartmentCd } from "../values/DepartmentCd";
  * 部署リポジトリインターフェース
  *
  * Repository は Entity の永続化・取得（完全な Entity の再構築）を担当する。
- * 検索・一覧取得など読み取り専用の操作は IDepartmentQueryService を使用すること。
+ * 検索・一覧取得など読み取り専用の操作は DepartmentQueryService を使用すること。
  */
-export interface IDepartmentRepository {
+export interface DepartmentRepository {
   /**
    * 部署を保存（新規作成・更新）
    */
@@ -20,7 +20,7 @@ export interface IDepartmentRepository {
 
   /**
    * IDで部署を取得（Entity の完全な再構築が必要な場合に使用）
-   * 単なる表示目的の場合は IDepartmentQueryService を使用すること
+   * 単なる表示目的の場合は DepartmentQueryService を使用すること
    */
   findById(id: string): Promise<Department | null>;
 

--- a/src/server/subdomains/department/domain/services/DepartmentCdDuplicationCheckDomainService.ts
+++ b/src/server/subdomains/department/domain/services/DepartmentCdDuplicationCheckDomainService.ts
@@ -1,4 +1,4 @@
-import { IDepartmentRepository } from "@subdomains/department/domain/repositories/IDepartmentRepository";
+import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
 import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
 
 /**
@@ -7,7 +7,7 @@ import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd"
  * 部署コードが既に使用されているかどうかを確認する。
  */
 export class DepartmentCdDuplicationCheckDomainService {
-  constructor(private departmentRepository: IDepartmentRepository) {}
+  constructor(private departmentRepository: DepartmentRepository) {}
 
   /**
    * 部署コードが重複しているかチェック

--- a/src/server/subdomains/department/domain/services/__tests__/DepartmentCdDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/department/domain/services/__tests__/DepartmentCdDuplicationCheckDomainService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DepartmentCdDuplicationCheckDomainService } from "../DepartmentCdDuplicationCheckDomainService";
-import { IDepartmentRepository } from "../../repositories/IDepartmentRepository";
+import { DepartmentRepository } from "../../repositories/DepartmentRepository";
 import { DepartmentCd } from "../../values/DepartmentCd";
 import { Department } from "../../entities/Department";
 import { DepartmentName } from "../../values/DepartmentName";
@@ -8,7 +8,7 @@ import { Abbreviation } from "../../values/Abbreviation";
 
 describe("DepartmentCdDuplicationCheckDomainService", () => {
   let service: DepartmentCdDuplicationCheckDomainService;
-  let mockRepository: IDepartmentRepository;
+  let mockRepository: DepartmentRepository;
 
   beforeEach(() => {
     mockRepository = {

--- a/src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts
+++ b/src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts
@@ -1,10 +1,10 @@
 import { Department } from "@subdomains/department/domain/entities/Department";
-import { IDepartmentRepository } from "@subdomains/department/domain/repositories/IDepartmentRepository";
+import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
 import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
 import { DepartmentMapper } from "@subdomains/department/infrastructure/mappers/DepartmentMapper";
 import prisma from "@server/prisma";
 
-export class PrismaDepartmentRepository implements IDepartmentRepository {
+export class PrismaDepartmentRepository implements DepartmentRepository {
   /**
    * 部署を保存（新規作成・更新の両方に対応）
    *

--- a/src/server/subdomains/department/infrastructure/queries/PrismaDepartmentQueryService.ts
+++ b/src/server/subdomains/department/infrastructure/queries/PrismaDepartmentQueryService.ts
@@ -6,7 +6,7 @@ import {
   DepartmentSearchCriteria,
   DepartmentListOptions,
 } from "@subdomains/department/application/queries/dto/DepartmentSearchCriteria";
-import { IDepartmentQueryService } from "@subdomains/department/application/queries/IDepartmentQueryService";
+import { DepartmentQueryService } from "@subdomains/department/application/queries/DepartmentQueryService";
 import prisma from "@server/prisma";
 import { Prisma } from "@generated/prisma/client";
 
@@ -15,7 +15,7 @@ import { Prisma } from "@generated/prisma/client";
  *
  * データベースから直接DTOを取得し、軽量で高速な読み取りを実現
  */
-export class PrismaDepartmentQueryService implements IDepartmentQueryService {
+export class PrismaDepartmentQueryService implements DepartmentQueryService {
   async findById(id: string): Promise<DepartmentDTO | null> {
     const department = await prisma.department.findUnique({
       where: { id },

--- a/src/server/subdomains/employee/application/commands/CreateEmployeeCommand.ts
+++ b/src/server/subdomains/employee/application/commands/CreateEmployeeCommand.ts
@@ -1,9 +1,9 @@
-import type { IUserManagementService } from "@server/shared/auth/IUserManagementService";
+import type { UserManagementService } from "@server/shared/auth/UserManagementService";
 import type { UserRole } from "@server/shared/auth/types";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { ValidationError } from "@server/shared/errors/DomainError";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
-import { IEmployeeRepository } from "@subdomains/employee/domain/repositories/IEmployeeRepository";
+import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
 import { EmployeeCdDuplicationCheckDomainService } from "@subdomains/employee/domain/services/EmployeeCdDuplicationCheckDomainService";
 import { MailAddressDuplicationCheckDomainService } from "@subdomains/employee/domain/services/MailAddressDuplicationCheckDomainService";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
@@ -29,10 +29,10 @@ export type CreateEmployeeInput = {
  */
 export class CreateEmployeeCommand {
   public constructor(
-    private readonly employeeRepository: IEmployeeRepository,
+    private readonly employeeRepository: EmployeeRepository,
     private readonly employeeCdDuplicationCheckDomainService: EmployeeCdDuplicationCheckDomainService,
     private readonly mailAddressDuplicationCheckDomainService: MailAddressDuplicationCheckDomainService,
-    private readonly userManagementService: IUserManagementService
+    private readonly userManagementService: UserManagementService
   ) {}
 
   async execute(input: CreateEmployeeInput): Promise<void> {

--- a/src/server/subdomains/employee/application/commands/DeleteEmployeeCommand.ts
+++ b/src/server/subdomains/employee/application/commands/DeleteEmployeeCommand.ts
@@ -1,7 +1,7 @@
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
-import { IEmployeeRepository } from "@subdomains/employee/domain/repositories/IEmployeeRepository";
-import type { IUserManagementService } from "@server/shared/auth/IUserManagementService";
+import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
+import type { UserManagementService } from "@server/shared/auth/UserManagementService";
 
 export type DeleteEmployeeInput = {
   id: string;
@@ -15,8 +15,8 @@ export type DeleteEmployeeInput = {
  */
 export class DeleteEmployeeCommand {
   public constructor(
-    private readonly employeeRepository: IEmployeeRepository,
-    private readonly userManagementService: IUserManagementService
+    private readonly employeeRepository: EmployeeRepository,
+    private readonly userManagementService: UserManagementService
   ) {}
 
   async execute(input: DeleteEmployeeInput): Promise<void> {

--- a/src/server/subdomains/employee/application/commands/UpdateEmployeeCommand.ts
+++ b/src/server/subdomains/employee/application/commands/UpdateEmployeeCommand.ts
@@ -1,10 +1,10 @@
-import type { IUserManagementService } from "@server/shared/auth/IUserManagementService";
+import type { UserManagementService } from "@server/shared/auth/UserManagementService";
 import type { UserRole } from "@server/shared/auth/types";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { ValidationError } from "@server/shared/errors/DomainError";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
-import { IEmployeeRepository } from "@subdomains/employee/domain/repositories/IEmployeeRepository";
+import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
 import { MailAddressDuplicationCheckDomainService } from "@subdomains/employee/domain/services/MailAddressDuplicationCheckDomainService";
 import { EmployeeName } from "@subdomains/employee/domain/values/EmployeeName";
 
@@ -26,9 +26,9 @@ export type UpdateEmployeeInput = {
  */
 export class UpdateEmployeeCommand {
   public constructor(
-    private readonly employeeRepository: IEmployeeRepository,
+    private readonly employeeRepository: EmployeeRepository,
     private readonly mailAddressDuplicationCheckDomainService: MailAddressDuplicationCheckDomainService,
-    private readonly userManagementService: IUserManagementService
+    private readonly userManagementService: UserManagementService
   ) {}
 
   async execute(input: UpdateEmployeeInput): Promise<void> {

--- a/src/server/subdomains/employee/application/queries/CountEmployeesQuery.ts
+++ b/src/server/subdomains/employee/application/queries/CountEmployeesQuery.ts
@@ -1,4 +1,4 @@
-import { IEmployeeQueryService } from "@subdomains/employee/application/queries/IEmployeeQueryService";
+import { EmployeeQueryService } from "@subdomains/employee/application/queries/EmployeeQueryService";
 import { EmployeeSearchCriteria } from "@subdomains/employee/application/queries/dto/EmployeeSearchCriteria";
 
 export type CountEmployeesInput = {
@@ -9,7 +9,7 @@ export type CountEmployeesInput = {
  * 検索条件に一致する従業員数をカウントするクエリ
  */
 export class CountEmployeesQuery {
-  public constructor(private readonly employeeQueryService: IEmployeeQueryService) {}
+  public constructor(private readonly employeeQueryService: EmployeeQueryService) {}
 
   async execute(input: CountEmployeesInput): Promise<number> {
     return await this.employeeQueryService.count(input.criteria);

--- a/src/server/subdomains/employee/application/queries/EmployeeQueryService.ts
+++ b/src/server/subdomains/employee/application/queries/EmployeeQueryService.ts
@@ -11,7 +11,7 @@ import { EmployeeSearchCriteria, ListOptions } from "./dto/EmployeeSearchCriteri
  * - リポジトリ：Entity の永続化・取得（完全な Entity の再構築）
  * - QueryService：検索・一覧取得（軽量な DTO で返却）
  */
-export interface IEmployeeQueryService {
+export interface EmployeeQueryService {
   /**
    * IDで従業員を取得
    * @param id 従業員ID

--- a/src/server/subdomains/employee/application/queries/GetAllEmployeesQuery.ts
+++ b/src/server/subdomains/employee/application/queries/GetAllEmployeesQuery.ts
@@ -1,4 +1,4 @@
-import { IEmployeeQueryService } from "@subdomains/employee/application/queries/IEmployeeQueryService";
+import { EmployeeQueryService } from "@subdomains/employee/application/queries/EmployeeQueryService";
 import { EmployeeDTO } from "@subdomains/employee/application/queries/dto/EmployeeDTO";
 import { ListOptions } from "@subdomains/employee/application/queries/dto/EmployeeSearchCriteria";
 
@@ -10,7 +10,7 @@ export type GetAllEmployeesInput = {
  * 全従業員を取得するクエリ
  */
 export class GetAllEmployeesQuery {
-  public constructor(private readonly employeeQueryService: IEmployeeQueryService) {}
+  public constructor(private readonly employeeQueryService: EmployeeQueryService) {}
 
   async execute(input: GetAllEmployeesInput): Promise<EmployeeDTO[]> {
     return await this.employeeQueryService.findAll(input.options);

--- a/src/server/subdomains/employee/application/queries/GetEmployeeByEmailQuery.ts
+++ b/src/server/subdomains/employee/application/queries/GetEmployeeByEmailQuery.ts
@@ -1,4 +1,4 @@
-import { IEmployeeQueryService } from "@subdomains/employee/application/queries/IEmployeeQueryService";
+import { EmployeeQueryService } from "@subdomains/employee/application/queries/EmployeeQueryService";
 import { EmployeeDTO } from "@subdomains/employee/application/queries/dto/EmployeeDTO";
 
 export type GetEmployeeByEmailInput = {
@@ -9,7 +9,7 @@ export type GetEmployeeByEmailInput = {
  * メールアドレスで従業員を取得するクエリ
  */
 export class GetEmployeeByEmailQuery {
-  public constructor(private readonly employeeQueryService: IEmployeeQueryService) {}
+  public constructor(private readonly employeeQueryService: EmployeeQueryService) {}
 
   async execute(input: GetEmployeeByEmailInput): Promise<EmployeeDTO | null> {
     return await this.employeeQueryService.findByEmail(input.email);

--- a/src/server/subdomains/employee/application/queries/GetEmployeeByEmployeeCdQuery.ts
+++ b/src/server/subdomains/employee/application/queries/GetEmployeeByEmployeeCdQuery.ts
@@ -1,4 +1,4 @@
-import { IEmployeeQueryService } from "@subdomains/employee/application/queries/IEmployeeQueryService";
+import { EmployeeQueryService } from "@subdomains/employee/application/queries/EmployeeQueryService";
 import { EmployeeDTO } from "@subdomains/employee/application/queries/dto/EmployeeDTO";
 
 export type GetEmployeeByEmployeeCdInput = {
@@ -9,7 +9,7 @@ export type GetEmployeeByEmployeeCdInput = {
  * 従業員CDで従業員を取得するクエリ
  */
 export class GetEmployeeByEmployeeCdQuery {
-  public constructor(private readonly employeeQueryService: IEmployeeQueryService) {}
+  public constructor(private readonly employeeQueryService: EmployeeQueryService) {}
 
   async execute(input: GetEmployeeByEmployeeCdInput): Promise<EmployeeDTO | null> {
     return await this.employeeQueryService.findByEmployeeCd(input.employeeCd);

--- a/src/server/subdomains/employee/application/queries/GetEmployeeByIdQuery.ts
+++ b/src/server/subdomains/employee/application/queries/GetEmployeeByIdQuery.ts
@@ -1,4 +1,4 @@
-import { IEmployeeQueryService } from "@subdomains/employee/application/queries/IEmployeeQueryService";
+import { EmployeeQueryService } from "@subdomains/employee/application/queries/EmployeeQueryService";
 import { EmployeeDTO } from "@subdomains/employee/application/queries/dto/EmployeeDTO";
 
 export type GetEmployeeByIdInput = {
@@ -9,7 +9,7 @@ export type GetEmployeeByIdInput = {
  * IDで従業員を取得するクエリ
  */
 export class GetEmployeeByIdQuery {
-  public constructor(private readonly employeeQueryService: IEmployeeQueryService) {}
+  public constructor(private readonly employeeQueryService: EmployeeQueryService) {}
 
   async execute(input: GetEmployeeByIdInput): Promise<EmployeeDTO | null> {
     return await this.employeeQueryService.findById(input.id);

--- a/src/server/subdomains/employee/application/queries/SearchEmployeesQuery.ts
+++ b/src/server/subdomains/employee/application/queries/SearchEmployeesQuery.ts
@@ -1,4 +1,4 @@
-import { IEmployeeQueryService } from "@subdomains/employee/application/queries/IEmployeeQueryService";
+import { EmployeeQueryService } from "@subdomains/employee/application/queries/EmployeeQueryService";
 import { EmployeeDTO } from "@subdomains/employee/application/queries/dto/EmployeeDTO";
 import {
   EmployeeSearchCriteria,
@@ -24,7 +24,7 @@ export type SearchEmployeesPaginatedInput = {
  * 検索条件に基づいて従業員を検索するクエリ
  */
 export class SearchEmployeesQuery {
-  public constructor(private readonly employeeQueryService: IEmployeeQueryService) {}
+  public constructor(private readonly employeeQueryService: EmployeeQueryService) {}
 
   async execute(input: SearchEmployeesInput): Promise<EmployeeDTO[]> {
     return await this.employeeQueryService.search(input.criteria, input.options);

--- a/src/server/subdomains/employee/application/queries/__tests__/CountEmployeesQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/CountEmployeesQuery.test.ts
@@ -1,12 +1,12 @@
 import { EmployeeSearchCriteria } from "../dto/EmployeeSearchCriteria";
-import { IEmployeeQueryService } from "../IEmployeeQueryService";
+import { EmployeeQueryService } from "../EmployeeQueryService";
 import { CountEmployeesQuery } from "../CountEmployeesQuery";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { USER_ROLES } from "@server/shared/auth/types";
 
 describe("CountEmployeesQuery", () => {
   let query: CountEmployeesQuery;
-  let mockQueryService: IEmployeeQueryService;
+  let mockQueryService: EmployeeQueryService;
 
   beforeEach(() => {
     mockQueryService = {

--- a/src/server/subdomains/employee/application/queries/__tests__/GetAllEmployeesQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetAllEmployeesQuery.test.ts
@@ -1,13 +1,13 @@
 import { EmployeeDTO } from "../dto/EmployeeDTO";
 import { ListOptions } from "../dto/EmployeeSearchCriteria";
-import { IEmployeeQueryService } from "../IEmployeeQueryService";
+import { EmployeeQueryService } from "../EmployeeQueryService";
 import { GetAllEmployeesQuery } from "../GetAllEmployeesQuery";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { USER_ROLES } from "@server/shared/auth/types";
 
 describe("GetAllEmployeesQuery", () => {
   let query: GetAllEmployeesQuery;
-  let mockQueryService: IEmployeeQueryService;
+  let mockQueryService: EmployeeQueryService;
 
   const mockEmployeeDTO: EmployeeDTO = {
     id: "test-id-001",

--- a/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmailQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmailQuery.test.ts
@@ -1,12 +1,12 @@
 import { EmployeeDTO } from "../dto/EmployeeDTO";
-import { IEmployeeQueryService } from "../IEmployeeQueryService";
+import { EmployeeQueryService } from "../EmployeeQueryService";
 import { GetEmployeeByEmailQuery } from "../GetEmployeeByEmailQuery";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { USER_ROLES } from "@server/shared/auth/types";
 
 describe("GetEmployeeByEmailQuery", () => {
   let query: GetEmployeeByEmailQuery;
-  let mockQueryService: IEmployeeQueryService;
+  let mockQueryService: EmployeeQueryService;
 
   const mockEmployeeDTO: EmployeeDTO = {
     id: "test-id-001",

--- a/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmployeeCdQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmployeeCdQuery.test.ts
@@ -1,12 +1,12 @@
 import { EmployeeDTO } from "../dto/EmployeeDTO";
-import { IEmployeeQueryService } from "../IEmployeeQueryService";
+import { EmployeeQueryService } from "../EmployeeQueryService";
 import { GetEmployeeByEmployeeCdQuery } from "../GetEmployeeByEmployeeCdQuery";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { USER_ROLES } from "@server/shared/auth/types";
 
 describe("GetEmployeeByEmployeeCdQuery", () => {
   let query: GetEmployeeByEmployeeCdQuery;
-  let mockQueryService: IEmployeeQueryService;
+  let mockQueryService: EmployeeQueryService;
 
   const mockEmployeeDTO: EmployeeDTO = {
     id: "test-id-001",

--- a/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByIdQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByIdQuery.test.ts
@@ -1,12 +1,12 @@
 import { EmployeeDTO } from "../dto/EmployeeDTO";
-import { IEmployeeQueryService } from "../IEmployeeQueryService";
+import { EmployeeQueryService } from "../EmployeeQueryService";
 import { GetEmployeeByIdQuery } from "../GetEmployeeByIdQuery";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { USER_ROLES } from "@server/shared/auth/types";
 
 describe("GetEmployeeByIdQuery", () => {
   let query: GetEmployeeByIdQuery;
-  let mockQueryService: IEmployeeQueryService;
+  let mockQueryService: EmployeeQueryService;
 
   const mockEmployeeDTO: EmployeeDTO = {
     id: "test-id-001",

--- a/src/server/subdomains/employee/application/queries/__tests__/SearchEmployeesQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/SearchEmployeesQuery.test.ts
@@ -1,13 +1,13 @@
 import { EmployeeDTO } from "../dto/EmployeeDTO";
 import { EmployeeSearchCriteria, ListOptions } from "../dto/EmployeeSearchCriteria";
-import { IEmployeeQueryService } from "../IEmployeeQueryService";
+import { EmployeeQueryService } from "../EmployeeQueryService";
 import { SearchEmployeesQuery } from "../SearchEmployeesQuery";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { USER_ROLES } from "@server/shared/auth/types";
 
 describe("SearchEmployeesQuery", () => {
   let query: SearchEmployeesQuery;
-  let mockQueryService: IEmployeeQueryService;
+  let mockQueryService: EmployeeQueryService;
 
   const mockEmployeeDTO: EmployeeDTO = {
     id: "test-id-001",

--- a/src/server/subdomains/employee/domain/repositories/EmployeeRepository.ts
+++ b/src/server/subdomains/employee/domain/repositories/EmployeeRepository.ts
@@ -8,9 +8,9 @@ import { MailAddress } from "@server/shared/domain/values/MailAddress";
  * 永続化層の抽象化を提供
  * リポジトリは Entity の永続化と、ID による取得のみを責務とする
  *
- * 検索・一覧取得については IEmployeeQueryService を使用すること
+ * 検索・一覧取得については EmployeeQueryService を使用すること
  */
-export interface IEmployeeRepository {
+export interface EmployeeRepository {
   /**
    * 従業員を保存（新規作成・更新）
    */
@@ -23,7 +23,7 @@ export interface IEmployeeRepository {
 
   /**
    * IDで従業員を取得（Entity の完全な再構築が必要な場合に使用）
-   * 単なる表示目的の場合は IEmployeeQueryService を使用すること
+   * 単なる表示目的の場合は EmployeeQueryService を使用すること
    */
   findById(id: string): Promise<Employee | null>;
 

--- a/src/server/subdomains/employee/domain/services/EmployeeCdDuplicationCheckDomainService.ts
+++ b/src/server/subdomains/employee/domain/services/EmployeeCdDuplicationCheckDomainService.ts
@@ -1,8 +1,8 @@
-import { IEmployeeRepository } from "@subdomains/employee/domain/repositories/IEmployeeRepository";
+import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
 
 export class EmployeeCdDuplicationCheckDomainService {
-  constructor(private employeeRepository: IEmployeeRepository) {}
+  constructor(private employeeRepository: EmployeeRepository) {}
 
   async execute(employeeCd: EmployeeCd): Promise<boolean> {
     const duplicatedEmployee = await this.employeeRepository.findByEmployeeCd(employeeCd);

--- a/src/server/subdomains/employee/domain/services/MailAddressDuplicationCheckDomainService.ts
+++ b/src/server/subdomains/employee/domain/services/MailAddressDuplicationCheckDomainService.ts
@@ -1,8 +1,8 @@
-import { IEmployeeRepository } from "@subdomains/employee/domain/repositories/IEmployeeRepository";
+import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 
 export class MailAddressDuplicationCheckDomainService {
-  constructor(private employeeRepository: IEmployeeRepository) {}
+  constructor(private employeeRepository: EmployeeRepository) {}
 
   async execute(mailAddress: MailAddress): Promise<boolean> {
     const duplicatedEmployee = await this.employeeRepository.findByEmail(mailAddress);

--- a/src/server/subdomains/employee/infrastructure/in-memory/InMemoryEmployeeRepository.ts
+++ b/src/server/subdomains/employee/infrastructure/in-memory/InMemoryEmployeeRepository.ts
@@ -1,10 +1,10 @@
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
-import { IEmployeeRepository } from "@subdomains/employee/domain/repositories/IEmployeeRepository";
+import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { randomUUID } from "crypto";
 
-export class InMemoryEmployeeRepository implements IEmployeeRepository {
+export class InMemoryEmployeeRepository implements EmployeeRepository {
   public DB: {
     [id: string]: Employee;
   } = {};

--- a/src/server/subdomains/employee/infrastructure/in-memory/__tests__/InMemoryEmployeeRepository.test.ts
+++ b/src/server/subdomains/employee/infrastructure/in-memory/__tests__/InMemoryEmployeeRepository.test.ts
@@ -151,6 +151,6 @@ describe("InMemoryEmployeeRepository", () => {
     });
   });
 
-  // findAll は IEmployeeRepository から削除されました
-  // 一覧取得には IEmployeeQueryService を使用してください
+  // findAll は EmployeeRepository から削除されました
+  // 一覧取得には EmployeeQueryService を使用してください
 });

--- a/src/server/subdomains/employee/infrastructure/prisma/PrismaEmployeeRepository.ts
+++ b/src/server/subdomains/employee/infrastructure/prisma/PrismaEmployeeRepository.ts
@@ -1,11 +1,11 @@
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
-import { IEmployeeRepository } from "@subdomains/employee/domain/repositories/IEmployeeRepository";
+import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { EmployeeMapper } from "@subdomains/employee/infrastructure/mappers/EmployeeMapper";
 import prisma from "@server/prisma";
 
-export class PrismaEmployeeRepository implements IEmployeeRepository {
+export class PrismaEmployeeRepository implements EmployeeRepository {
   // ClientManagerをDIする
   // constructor(private prisma: PrismaClientManager) {}
 

--- a/src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts
+++ b/src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts
@@ -207,6 +207,6 @@ describe("PrismaEmployeeRepository", () => {
     });
   });
 
-  // findAll は IEmployeeRepository から削除されました
-  // 一覧取得には IEmployeeQueryService を使用してください
+  // findAll は EmployeeRepository から削除されました
+  // 一覧取得には EmployeeQueryService を使用してください
 });

--- a/src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts
+++ b/src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts
@@ -3,7 +3,7 @@ import {
   EmployeeSearchCriteria,
   ListOptions,
 } from "@subdomains/employee/application/queries/dto/EmployeeSearchCriteria";
-import { IEmployeeQueryService } from "@subdomains/employee/application/queries/IEmployeeQueryService";
+import { EmployeeQueryService } from "@subdomains/employee/application/queries/EmployeeQueryService";
 import prisma from "@server/prisma";
 import { Prisma } from "@generated/prisma/client";
 import type { UserRole } from "@server/shared/auth/types";
@@ -14,7 +14,7 @@ import type { UserRole } from "@server/shared/auth/types";
  * データベースから直接DTOを取得し、軽量で高速な読み取りを実現
  * Note: roleはUser.roleから取得する
  */
-export class PrismaEmployeeQueryService implements IEmployeeQueryService {
+export class PrismaEmployeeQueryService implements EmployeeQueryService {
   async findById(id: string): Promise<EmployeeDTO | null> {
     const employee = await prisma.employee.findUnique({
       where: { id },


### PR DESCRIPTION
## Summary
- Issue #67 の関連タスクとして、インターフェースの I プレフィックスを削除
- 以下のインターフェースをリファクタリング:
  - IAuthService → AuthService
  - IUserManagementService → UserManagementService
  - IDepartmentQueryService → DepartmentQueryService
  - IDepartmentRepository → DepartmentRepository
  - IEmployeeQueryService → EmployeeQueryService
  - IEmployeeRepository → EmployeeRepository
- TypeScript/ESLint の命名規則に準拠

## Test plan
- [x] pnpm lint 通過
- [x] pnpm test 通過（258 tests）
- [x] TypeScript 型チェック（既存の SVG インポートエラー以外は問題なし）

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)