### PR TITLE
feat: 取引先マスタ（得意先・納品先）のDDD実装

### DIFF
--- a/prisma/migrations/20260217074132_add_company_issue_73/migration.sql
+++ b/prisma/migrations/20260217074132_add_company_issue_73/migration.sql
@@ -1,0 +1,74 @@
+-- CreateEnum
+CREATE TYPE "CompanyType" AS ENUM ('CUSTOMER', 'DELIVERY_LOCATION');
+
+-- CreateTable
+CREATE TABLE "companies" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" "CompanyType" NOT NULL,
+    "postal_code" TEXT,
+    "prefecture" TEXT,
+    "address" TEXT,
+    "phone_number" TEXT,
+    "fax_number" TEXT,
+    "contact_person" TEXT,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "companies_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "customers" (
+    "id" TEXT NOT NULL,
+    "company_id" TEXT NOT NULL,
+    "margin_rate" DECIMAL(5,2),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "customers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "delivery_locations" (
+    "id" TEXT NOT NULL,
+    "company_id" TEXT NOT NULL,
+    "customer_id" TEXT NOT NULL,
+    "delivery_notes" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "delivery_locations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "companies_code_key" ON "companies"("code");
+
+-- CreateIndex
+CREATE INDEX "companies_code_idx" ON "companies"("code");
+
+-- CreateIndex
+CREATE INDEX "companies_type_idx" ON "companies"("type");
+
+-- CreateIndex
+CREATE INDEX "companies_is_active_idx" ON "companies"("is_active");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "customers_company_id_key" ON "customers"("company_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "delivery_locations_company_id_key" ON "delivery_locations"("company_id");
+
+-- CreateIndex
+CREATE INDEX "delivery_locations_customer_id_idx" ON "delivery_locations"("customer_id");
+
+-- AddForeignKey
+ALTER TABLE "customers" ADD CONSTRAINT "customers_company_id_fkey" FOREIGN KEY ("company_id") REFERENCES "companies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "delivery_locations" ADD CONSTRAINT "delivery_locations_company_id_fkey" FOREIGN KEY ("company_id") REFERENCES "companies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "delivery_locations" ADD CONSTRAINT "delivery_locations_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -145,3 +145,83 @@ model Verification {
   @@index([identifier])
   @@map("verification")
 }
+
+// ========================================
+// 取引先関連
+// ========================================
+
+enum CompanyType {
+  CUSTOMER // 得意先
+  DELIVERY_LOCATION // 納品先
+}
+
+model Company {
+  id   String      @id // ドメイン層でCUID生成
+  code String      @unique // 手入力（例: C001, D001）
+  name String
+  type CompanyType
+
+  // 住所情報
+  postalCode String? @map("postal_code") // 郵便番号
+  prefecture String? // 都道府県
+  address    String? // 住所（市区町村以降）
+
+  // 連絡先
+  phoneNumber   String? @map("phone_number")
+  faxNumber     String? @map("fax_number")
+  contactPerson String? @map("contact_person") // 担当者名
+
+  // 有効フラグ
+  isActive Boolean @default(true) @map("is_active")
+
+  // 関連
+  customer         Customer?
+  deliveryLocation DeliveryLocation?
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@index([code])
+  @@index([type])
+  @@index([isActive])
+  @@map("companies")
+}
+
+model Customer {
+  id        String  @id // ドメイン層でCUID生成
+  companyId String  @unique @map("company_id")
+  company   Company @relation(fields: [companyId], references: [id], onDelete: Cascade)
+
+  // 得意先固有の属性
+  marginRate Decimal? @map("margin_rate") @db.Decimal(5, 2) // 標準マージン率
+
+  // 配下の納品先
+  deliveryLocations DeliveryLocation[]
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("customers")
+}
+
+model DeliveryLocation {
+  id        String  @id // ドメイン層でCUID生成
+  companyId String  @unique @map("company_id")
+  company   Company @relation(fields: [companyId], references: [id], onDelete: Cascade)
+
+  // 親得意先への参照
+  customerId String   @map("customer_id")
+  customer   Customer @relation(fields: [customerId], references: [id])
+
+  // 納品先固有の属性
+  deliveryNotes String? @map("delivery_notes") @db.Text // 配送時の注意事項
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@index([customerId])
+  @@map("delivery_locations")
+}

--- a/src/server/shared/domain/values/Address.ts
+++ b/src/server/shared/domain/values/Address.ts
@@ -1,0 +1,14 @@
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * 住所値オブジェクト（市区町村以降）
+ */
+export class Address extends StringValueObject<"Address"> {
+  protected static readonly LABEL = "住所";
+  protected static readonly MIN_LENGTH = 1;
+  protected static readonly MAX_LENGTH = 200;
+
+  constructor(value: string) {
+    super(value.trim());
+  }
+}

--- a/src/server/shared/domain/values/CompanyCode.ts
+++ b/src/server/shared/domain/values/CompanyCode.ts
@@ -1,0 +1,21 @@
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * 取引先コード値オブジェクト
+ *
+ * 手入力のコード。英数字・ハイフン・アンダースコアを許可。
+ * 大文字に正規化される。
+ */
+export class CompanyCode extends StringValueObject<"CompanyCode"> {
+  protected static readonly LABEL = "取引先コード";
+  protected static readonly REGEX = /^[A-Z0-9\-_]+$/;
+  protected static readonly MIN_LENGTH = 1;
+  protected static readonly MAX_LENGTH = 20;
+  protected static readonly ERROR_MESSAGE_EMPTY = "取引先コードは必須です";
+  protected static readonly ERROR_MESSAGE_INVALID_FORMAT =
+    "取引先コードは英数字・ハイフン・アンダースコアのみ使用できます";
+
+  constructor(value: string) {
+    super(value.toUpperCase().trim());
+  }
+}

--- a/src/server/shared/domain/values/CompanyName.ts
+++ b/src/server/shared/domain/values/CompanyName.ts
@@ -1,0 +1,14 @@
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * 会社名値オブジェクト
+ */
+export class CompanyName extends StringValueObject<"CompanyName"> {
+  protected static readonly LABEL = "会社名";
+  protected static readonly MIN_LENGTH = 1;
+  protected static readonly MAX_LENGTH = 100;
+
+  constructor(value: string) {
+    super(value.trim());
+  }
+}

--- a/src/server/shared/domain/values/FaxNumber.ts
+++ b/src/server/shared/domain/values/FaxNumber.ts
@@ -1,0 +1,19 @@
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * FAX番号値オブジェクト
+ *
+ * 電話番号と同じ形式。ハイフンあり/なしどちらも受け入れ、内部はハイフンなしで保持。
+ */
+export class FaxNumber extends StringValueObject<"FaxNumber"> {
+  protected static readonly LABEL = "FAX番号";
+  protected static readonly REGEX = /^[0-9]{10,11}$/;
+  protected static readonly MIN_LENGTH = 10;
+  protected static readonly MAX_LENGTH = 11;
+  protected static readonly ERROR_MESSAGE_INVALID_FORMAT =
+    "FAX番号は10〜11桁の数字で入力してください";
+
+  constructor(value: string) {
+    super(value.replace(/-/g, "").trim());
+  }
+}

--- a/src/server/shared/domain/values/PhoneNumber.ts
+++ b/src/server/shared/domain/values/PhoneNumber.ts
@@ -1,0 +1,19 @@
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * 電話番号値オブジェクト
+ *
+ * 日本国内の電話番号形式。ハイフンあり/なしどちらも受け入れ、内部はハイフンなしで保持。
+ */
+export class PhoneNumber extends StringValueObject<"PhoneNumber"> {
+  protected static readonly LABEL = "電話番号";
+  protected static readonly REGEX = /^[0-9]{10,11}$/;
+  protected static readonly MIN_LENGTH = 10;
+  protected static readonly MAX_LENGTH = 11;
+  protected static readonly ERROR_MESSAGE_INVALID_FORMAT =
+    "電話番号は10〜11桁の数字で入力してください";
+
+  constructor(value: string) {
+    super(value.replace(/-/g, "").trim());
+  }
+}

--- a/src/server/shared/domain/values/PostalCode.ts
+++ b/src/server/shared/domain/values/PostalCode.ts
@@ -1,0 +1,24 @@
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * 郵便番号値オブジェクト
+ *
+ * 7桁の数字。ハイフンあり/なしどちらも受け入れ、内部はハイフンなしで保持。
+ */
+export class PostalCode extends StringValueObject<"PostalCode"> {
+  protected static readonly LABEL = "郵便番号";
+  protected static readonly REGEX = /^[0-9]{7}$/;
+  protected static readonly MIN_LENGTH = 7;
+  protected static readonly MAX_LENGTH = 7;
+  protected static readonly ERROR_MESSAGE_INVALID_FORMAT =
+    "郵便番号は7桁の数字で入力してください（例: 1234567）";
+
+  constructor(value: string) {
+    super(value.replace(/-/g, "").trim());
+  }
+
+  /** ハイフン付きフォーマット（例: 123-4567） */
+  get formatted(): string {
+    return `${this._value.slice(0, 3)}-${this._value.slice(3)}`;
+  }
+}

--- a/src/server/shared/domain/values/Prefecture.ts
+++ b/src/server/shared/domain/values/Prefecture.ts
@@ -1,0 +1,75 @@
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+const PREFECTURES = [
+  "北海道",
+  "青森県",
+  "岩手県",
+  "宮城県",
+  "秋田県",
+  "山形県",
+  "福島県",
+  "茨城県",
+  "栃木県",
+  "群馬県",
+  "埼玉県",
+  "千葉県",
+  "東京都",
+  "神奈川県",
+  "新潟県",
+  "富山県",
+  "石川県",
+  "福井県",
+  "山梨県",
+  "長野県",
+  "岐阜県",
+  "静岡県",
+  "愛知県",
+  "三重県",
+  "滋賀県",
+  "京都府",
+  "大阪府",
+  "兵庫県",
+  "奈良県",
+  "和歌山県",
+  "鳥取県",
+  "島根県",
+  "岡山県",
+  "広島県",
+  "山口県",
+  "徳島県",
+  "香川県",
+  "愛媛県",
+  "高知県",
+  "福岡県",
+  "佐賀県",
+  "長崎県",
+  "熊本県",
+  "大分県",
+  "宮崎県",
+  "鹿児島県",
+  "沖縄県",
+] as const;
+
+export type PrefectureName = (typeof PREFECTURES)[number];
+
+/**
+ * 都道府県値オブジェクト
+ */
+export class Prefecture extends StringValueObject<"Prefecture"> {
+  protected static readonly LABEL = "都道府県";
+  protected static readonly MIN_LENGTH = 1;
+  protected static readonly MAX_LENGTH = 4;
+
+  constructor(value: string) {
+    super(value.trim());
+  }
+
+  protected validate(value: string): void {
+    super.validate(value);
+
+    if (!PREFECTURES.includes(value as PrefectureName)) {
+      throw new ValidationError("有効な都道府県名を入力してください");
+    }
+  }
+}

--- a/src/server/shared/domain/values/__tests__/Address.test.ts
+++ b/src/server/shared/domain/values/__tests__/Address.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { Address } from "../Address";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("Address", () => {
+  describe("正常系", () => {
+    it("住所を受け入れる", () => {
+      const address = new Address("渋谷区神宮前1-2-3");
+      expect(address.value).toBe("渋谷区神宮前1-2-3");
+    });
+
+    it("前後の空白はトリムされる", () => {
+      const address = new Address("  渋谷区1-2-3  ");
+      expect(address.value).toBe("渋谷区1-2-3");
+    });
+
+    it("200文字の住所を受け入れる", () => {
+      const address = new Address("あ".repeat(200));
+      expect(address.value).toBe("あ".repeat(200));
+    });
+  });
+
+  describe("異常系", () => {
+    it("空文字を拒否する", () => {
+      expect(() => new Address("")).toThrow(ValidationError);
+    });
+
+    it("201文字以上を拒否する", () => {
+      expect(() => new Address("あ".repeat(201))).toThrow(ValidationError);
+    });
+  });
+});

--- a/src/server/shared/domain/values/__tests__/CompanyCode.test.ts
+++ b/src/server/shared/domain/values/__tests__/CompanyCode.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { CompanyCode } from "../CompanyCode";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("CompanyCode", () => {
+  describe("正常系", () => {
+    it("英数字のコードを受け入れる", () => {
+      const code = new CompanyCode("CUST001");
+      expect(code.value).toBe("CUST001");
+    });
+
+    it("ハイフンを含むコードを受け入れる", () => {
+      const code = new CompanyCode("ABC-123");
+      expect(code.value).toBe("ABC-123");
+    });
+
+    it("アンダースコアを含むコードを受け入れる", () => {
+      const code = new CompanyCode("ABC_123");
+      expect(code.value).toBe("ABC_123");
+    });
+
+    it("小文字は大文字に正規化される", () => {
+      const code = new CompanyCode("cust001");
+      expect(code.value).toBe("CUST001");
+    });
+
+    it("前後の空白はトリムされる", () => {
+      const code = new CompanyCode("  CUST001  ");
+      expect(code.value).toBe("CUST001");
+    });
+
+    it("1文字のコードを受け入れる", () => {
+      const code = new CompanyCode("A");
+      expect(code.value).toBe("A");
+    });
+
+    it("20文字のコードを受け入れる", () => {
+      const code = new CompanyCode("A".repeat(20));
+      expect(code.value).toBe("A".repeat(20));
+    });
+  });
+
+  describe("異常系", () => {
+    it("空文字を拒否する", () => {
+      expect(() => new CompanyCode("")).toThrow(ValidationError);
+    });
+
+    it("21文字以上を拒否する", () => {
+      expect(() => new CompanyCode("A".repeat(21))).toThrow(ValidationError);
+    });
+
+    it("日本語を拒否する", () => {
+      expect(() => new CompanyCode("得意先001")).toThrow(ValidationError);
+    });
+
+    it("スペースを含むコードを拒否する", () => {
+      expect(() => new CompanyCode("CUST 001")).toThrow(ValidationError);
+    });
+
+    it("特殊文字を拒否する", () => {
+      expect(() => new CompanyCode("CUST@001")).toThrow(ValidationError);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値は等しい", () => {
+      const a = new CompanyCode("CUST001");
+      const b = new CompanyCode("CUST001");
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("異なる値は等しくない", () => {
+      const a = new CompanyCode("CUST001");
+      const b = new CompanyCode("CUST002");
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+});

--- a/src/server/shared/domain/values/__tests__/CompanyName.test.ts
+++ b/src/server/shared/domain/values/__tests__/CompanyName.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { CompanyName } from "../CompanyName";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("CompanyName", () => {
+  describe("正常系", () => {
+    it("会社名を受け入れる", () => {
+      const name = new CompanyName("株式会社テスト");
+      expect(name.value).toBe("株式会社テスト");
+    });
+
+    it("前後の空白はトリムされる", () => {
+      const name = new CompanyName("  株式会社テスト  ");
+      expect(name.value).toBe("株式会社テスト");
+    });
+
+    it("100文字の名前を受け入れる", () => {
+      const name = new CompanyName("あ".repeat(100));
+      expect(name.value).toBe("あ".repeat(100));
+    });
+  });
+
+  describe("異常系", () => {
+    it("空文字を拒否する", () => {
+      expect(() => new CompanyName("")).toThrow(ValidationError);
+    });
+
+    it("101文字以上を拒否する", () => {
+      expect(() => new CompanyName("あ".repeat(101))).toThrow(ValidationError);
+    });
+  });
+});

--- a/src/server/shared/domain/values/__tests__/FaxNumber.test.ts
+++ b/src/server/shared/domain/values/__tests__/FaxNumber.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { FaxNumber } from "../FaxNumber";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("FaxNumber", () => {
+  describe("正常系", () => {
+    it("10桁のFAX番号を受け入れる", () => {
+      const fax = new FaxNumber("0312345678");
+      expect(fax.value).toBe("0312345678");
+    });
+
+    it("ハイフン付きを受け入れてハイフンなしに正規化する", () => {
+      const fax = new FaxNumber("03-1234-5678");
+      expect(fax.value).toBe("0312345678");
+    });
+  });
+
+  describe("異常系", () => {
+    it("9桁を拒否する", () => {
+      expect(() => new FaxNumber("031234567")).toThrow(ValidationError);
+    });
+
+    it("空文字を拒否する", () => {
+      expect(() => new FaxNumber("")).toThrow(ValidationError);
+    });
+  });
+});

--- a/src/server/shared/domain/values/__tests__/PhoneNumber.test.ts
+++ b/src/server/shared/domain/values/__tests__/PhoneNumber.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { PhoneNumber } from "../PhoneNumber";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("PhoneNumber", () => {
+  describe("正常系", () => {
+    it("10桁の電話番号を受け入れる", () => {
+      const phone = new PhoneNumber("0312345678");
+      expect(phone.value).toBe("0312345678");
+    });
+
+    it("11桁の電話番号を受け入れる", () => {
+      const phone = new PhoneNumber("09012345678");
+      expect(phone.value).toBe("09012345678");
+    });
+
+    it("ハイフン付きを受け入れてハイフンなしに正規化する", () => {
+      const phone = new PhoneNumber("03-1234-5678");
+      expect(phone.value).toBe("0312345678");
+    });
+  });
+
+  describe("異常系", () => {
+    it("9桁を拒否する", () => {
+      expect(() => new PhoneNumber("031234567")).toThrow(ValidationError);
+    });
+
+    it("12桁を拒否する", () => {
+      expect(() => new PhoneNumber("031234567890")).toThrow(ValidationError);
+    });
+
+    it("英字を含む場合を拒否する", () => {
+      expect(() => new PhoneNumber("03-ABCD-5678")).toThrow(ValidationError);
+    });
+
+    it("空文字を拒否する", () => {
+      expect(() => new PhoneNumber("")).toThrow(ValidationError);
+    });
+  });
+});

--- a/src/server/shared/domain/values/__tests__/PostalCode.test.ts
+++ b/src/server/shared/domain/values/__tests__/PostalCode.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { PostalCode } from "../PostalCode";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("PostalCode", () => {
+  describe("正常系", () => {
+    it("7桁の数字を受け入れる", () => {
+      const code = new PostalCode("1234567");
+      expect(code.value).toBe("1234567");
+    });
+
+    it("ハイフン付きを受け入れてハイフンなしに正規化する", () => {
+      const code = new PostalCode("123-4567");
+      expect(code.value).toBe("1234567");
+    });
+
+    it("formattedでハイフン付きを返す", () => {
+      const code = new PostalCode("1234567");
+      expect(code.formatted).toBe("123-4567");
+    });
+  });
+
+  describe("異常系", () => {
+    it("6桁を拒否する", () => {
+      expect(() => new PostalCode("123456")).toThrow(ValidationError);
+    });
+
+    it("8桁を拒否する", () => {
+      expect(() => new PostalCode("12345678")).toThrow(ValidationError);
+    });
+
+    it("英字を含む場合を拒否する", () => {
+      expect(() => new PostalCode("123456A")).toThrow(ValidationError);
+    });
+
+    it("空文字を拒否する", () => {
+      expect(() => new PostalCode("")).toThrow(ValidationError);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ郵便番号は等しい", () => {
+      const a = new PostalCode("1234567");
+      const b = new PostalCode("123-4567");
+      expect(a.equals(b)).toBe(true);
+    });
+  });
+});

--- a/src/server/shared/domain/values/__tests__/Prefecture.test.ts
+++ b/src/server/shared/domain/values/__tests__/Prefecture.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { Prefecture } from "../Prefecture";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("Prefecture", () => {
+  describe("正常系", () => {
+    it("東京都を受け入れる", () => {
+      const pref = new Prefecture("東京都");
+      expect(pref.value).toBe("東京都");
+    });
+
+    it("北海道を受け入れる", () => {
+      const pref = new Prefecture("北海道");
+      expect(pref.value).toBe("北海道");
+    });
+
+    it("大阪府を受け入れる", () => {
+      const pref = new Prefecture("大阪府");
+      expect(pref.value).toBe("大阪府");
+    });
+
+    it("沖縄県を受け入れる", () => {
+      const pref = new Prefecture("沖縄県");
+      expect(pref.value).toBe("沖縄県");
+    });
+  });
+
+  describe("異常系", () => {
+    it("存在しない都道府県を拒否する", () => {
+      expect(() => new Prefecture("テスト県")).toThrow(ValidationError);
+    });
+
+    it("空文字を拒否する", () => {
+      expect(() => new Prefecture("")).toThrow(ValidationError);
+    });
+
+    it("都道府県の部分一致を拒否する", () => {
+      expect(() => new Prefecture("東京")).toThrow(ValidationError);
+    });
+  });
+});

--- a/src/server/subdomains/customer/application/commands/CreateCustomerCommand.ts
+++ b/src/server/subdomains/customer/application/commands/CreateCustomerCommand.ts
@@ -1,0 +1,55 @@
+import { Address } from "@server/shared/domain/values/Address";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
+import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
+import { PostalCode } from "@server/shared/domain/values/PostalCode";
+import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+import { CustomerCodeDuplicationCheckDomainService } from "@subdomains/customer/domain/services/CustomerCodeDuplicationCheckDomainService";
+import { MarginRate } from "@subdomains/customer/domain/values/MarginRate";
+
+export type CreateCustomerInput = {
+  code: string;
+  name: string;
+  postalCode?: string;
+  prefecture?: string;
+  address?: string;
+  phoneNumber?: string;
+  faxNumber?: string;
+  contactPerson?: string;
+  marginRate?: number;
+};
+
+/**
+ * 得意先新規登録コマンド
+ */
+export class CreateCustomerCommand {
+  constructor(
+    private readonly customerRepository: CustomerRepository,
+    private readonly customerCodeDuplicationCheckDomainService: CustomerCodeDuplicationCheckDomainService
+  ) {}
+
+  async execute(input: CreateCustomerInput): Promise<void> {
+    const code = new CompanyCode(input.code);
+
+    const isDuplicated = await this.customerCodeDuplicationCheckDomainService.execute(code);
+    if (isDuplicated) {
+      throw new ValidationError(`既に存在する取引先コードです: コード=${code.value}`);
+    }
+
+    const customer = Customer.create(code, new CompanyName(input.name), {
+      postalCode: input.postalCode ? new PostalCode(input.postalCode) : undefined,
+      prefecture: input.prefecture ? new Prefecture(input.prefecture) : undefined,
+      address: input.address ? new Address(input.address) : undefined,
+      phoneNumber: input.phoneNumber ? new PhoneNumber(input.phoneNumber) : undefined,
+      faxNumber: input.faxNumber ? new FaxNumber(input.faxNumber) : undefined,
+      contactPerson: input.contactPerson,
+      marginRate: input.marginRate !== undefined ? new MarginRate(input.marginRate) : undefined,
+    });
+
+    await this.customerRepository.save(customer);
+  }
+}

--- a/src/server/subdomains/customer/application/commands/DeleteCustomerCommand.ts
+++ b/src/server/subdomains/customer/application/commands/DeleteCustomerCommand.ts
@@ -1,0 +1,23 @@
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+
+export type DeleteCustomerInput = {
+  id: string;
+};
+
+/**
+ * 得意先削除コマンド
+ */
+export class DeleteCustomerCommand {
+  constructor(private readonly customerRepository: CustomerRepository) {}
+
+  async execute(input: DeleteCustomerInput): Promise<void> {
+    const customer = await this.customerRepository.findById(input.id);
+    if (!customer) {
+      throw new NotFoundEntityError(Customer, { id: input.id });
+    }
+
+    await this.customerRepository.delete(input.id);
+  }
+}

--- a/src/server/subdomains/customer/application/commands/UpdateCustomerCommand.ts
+++ b/src/server/subdomains/customer/application/commands/UpdateCustomerCommand.ts
@@ -1,0 +1,69 @@
+import { Address } from "@server/shared/domain/values/Address";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
+import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
+import { PostalCode } from "@server/shared/domain/values/PostalCode";
+import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+import { MarginRate } from "@subdomains/customer/domain/values/MarginRate";
+
+export type UpdateCustomerInput = {
+  id: string;
+  name: string;
+  postalCode?: string | null;
+  prefecture?: string | null;
+  address?: string | null;
+  phoneNumber?: string | null;
+  faxNumber?: string | null;
+  contactPerson?: string | null;
+  marginRate?: number | null;
+  isActive?: boolean;
+};
+
+/**
+ * 得意先情報変更コマンド
+ *
+ * コード（code）は変更不可。
+ */
+export class UpdateCustomerCommand {
+  constructor(private readonly customerRepository: CustomerRepository) {}
+
+  async execute(input: UpdateCustomerInput): Promise<void> {
+    const customer = await this.customerRepository.findById(input.id);
+    if (!customer) {
+      throw new NotFoundEntityError(Customer, { id: input.id });
+    }
+
+    customer.changeName(new CompanyName(input.name));
+
+    customer.changeAddress(
+      input.postalCode ? new PostalCode(input.postalCode) : null,
+      input.prefecture ? new Prefecture(input.prefecture) : null,
+      input.address ? new Address(input.address) : null
+    );
+
+    customer.changeContactInfo(
+      input.phoneNumber ? new PhoneNumber(input.phoneNumber) : null,
+      input.faxNumber ? new FaxNumber(input.faxNumber) : null,
+      input.contactPerson ?? null
+    );
+
+    customer.changeMarginRate(
+      input.marginRate !== undefined && input.marginRate !== null
+        ? new MarginRate(input.marginRate)
+        : null
+    );
+
+    if (input.isActive !== undefined) {
+      if (input.isActive) {
+        customer.activate();
+      } else {
+        customer.deactivate();
+      }
+    }
+
+    await this.customerRepository.save(customer);
+  }
+}

--- a/src/server/subdomains/customer/application/factories/createCustomerCommandFactory.ts
+++ b/src/server/subdomains/customer/application/factories/createCustomerCommandFactory.ts
@@ -1,0 +1,12 @@
+import { CreateCustomerCommand } from "../commands/CreateCustomerCommand";
+import { CustomerCodeDuplicationCheckDomainService } from "../../domain/services/CustomerCodeDuplicationCheckDomainService";
+import { PrismaCustomerRepository } from "../../infrastructure/prisma/PrismaCustomerRepository";
+
+export function createCustomerCommandFactory(): CreateCustomerCommand {
+  const repository = new PrismaCustomerRepository();
+
+  return new CreateCustomerCommand(
+    repository,
+    new CustomerCodeDuplicationCheckDomainService(repository)
+  );
+}

--- a/src/server/subdomains/customer/application/factories/customerQueryFactory.ts
+++ b/src/server/subdomains/customer/application/factories/customerQueryFactory.ts
@@ -1,0 +1,16 @@
+import { GetCustomerByIdQuery } from "../queries/GetCustomerByIdQuery";
+import { GetAllCustomersQuery } from "../queries/GetAllCustomersQuery";
+import { SearchCustomersQuery } from "../queries/SearchCustomersQuery";
+import { PrismaCustomerQueryService } from "../../infrastructure/queries/PrismaCustomerQueryService";
+
+export function getCustomerByIdQueryFactory(): GetCustomerByIdQuery {
+  return new GetCustomerByIdQuery(new PrismaCustomerQueryService());
+}
+
+export function getAllCustomersQueryFactory(): GetAllCustomersQuery {
+  return new GetAllCustomersQuery(new PrismaCustomerQueryService());
+}
+
+export function searchCustomersQueryFactory(): SearchCustomersQuery {
+  return new SearchCustomersQuery(new PrismaCustomerQueryService());
+}

--- a/src/server/subdomains/customer/application/factories/deleteCustomerCommandFactory.ts
+++ b/src/server/subdomains/customer/application/factories/deleteCustomerCommandFactory.ts
@@ -1,0 +1,7 @@
+import { DeleteCustomerCommand } from "../commands/DeleteCustomerCommand";
+import { PrismaCustomerRepository } from "../../infrastructure/prisma/PrismaCustomerRepository";
+
+export function deleteCustomerCommandFactory(): DeleteCustomerCommand {
+  const repository = new PrismaCustomerRepository();
+  return new DeleteCustomerCommand(repository);
+}

--- a/src/server/subdomains/customer/application/factories/index.ts
+++ b/src/server/subdomains/customer/application/factories/index.ts
@@ -1,0 +1,8 @@
+export { createCustomerCommandFactory } from "./createCustomerCommandFactory";
+export { updateCustomerCommandFactory } from "./updateCustomerCommandFactory";
+export { deleteCustomerCommandFactory } from "./deleteCustomerCommandFactory";
+export {
+  getCustomerByIdQueryFactory,
+  getAllCustomersQueryFactory,
+  searchCustomersQueryFactory,
+} from "./customerQueryFactory";

--- a/src/server/subdomains/customer/application/factories/updateCustomerCommandFactory.ts
+++ b/src/server/subdomains/customer/application/factories/updateCustomerCommandFactory.ts
@@ -1,0 +1,7 @@
+import { UpdateCustomerCommand } from "../commands/UpdateCustomerCommand";
+import { PrismaCustomerRepository } from "../../infrastructure/prisma/PrismaCustomerRepository";
+
+export function updateCustomerCommandFactory(): UpdateCustomerCommand {
+  const repository = new PrismaCustomerRepository();
+  return new UpdateCustomerCommand(repository);
+}

--- a/src/server/subdomains/customer/application/queries/CustomerQueryService.ts
+++ b/src/server/subdomains/customer/application/queries/CustomerQueryService.ts
@@ -1,0 +1,13 @@
+import { CustomerDTO } from "./dto/CustomerDTO";
+import { CustomerSearchCriteria, CustomerListOptions } from "./dto/CustomerSearchCriteria";
+
+/**
+ * 得意先クエリサービスインターフェース
+ */
+export interface CustomerQueryService {
+  findById(id: string): Promise<CustomerDTO | null>;
+  findByCode(code: string): Promise<CustomerDTO | null>;
+  search(criteria: CustomerSearchCriteria, options?: CustomerListOptions): Promise<CustomerDTO[]>;
+  findAll(options?: CustomerListOptions): Promise<CustomerDTO[]>;
+  count(criteria: CustomerSearchCriteria): Promise<number>;
+}

--- a/src/server/subdomains/customer/application/queries/GetAllCustomersQuery.ts
+++ b/src/server/subdomains/customer/application/queries/GetAllCustomersQuery.ts
@@ -1,0 +1,11 @@
+import { CustomerQueryService } from "./CustomerQueryService";
+import { CustomerDTO } from "./dto/CustomerDTO";
+import { CustomerListOptions } from "./dto/CustomerSearchCriteria";
+
+export class GetAllCustomersQuery {
+  constructor(private readonly customerQueryService: CustomerQueryService) {}
+
+  async execute(options?: CustomerListOptions): Promise<CustomerDTO[]> {
+    return await this.customerQueryService.findAll(options);
+  }
+}

--- a/src/server/subdomains/customer/application/queries/GetCustomerByIdQuery.ts
+++ b/src/server/subdomains/customer/application/queries/GetCustomerByIdQuery.ts
@@ -1,0 +1,14 @@
+import { CustomerQueryService } from "./CustomerQueryService";
+import { CustomerDTO } from "./dto/CustomerDTO";
+
+export type GetCustomerByIdInput = {
+  id: string;
+};
+
+export class GetCustomerByIdQuery {
+  constructor(private readonly customerQueryService: CustomerQueryService) {}
+
+  async execute(input: GetCustomerByIdInput): Promise<CustomerDTO | null> {
+    return await this.customerQueryService.findById(input.id);
+  }
+}

--- a/src/server/subdomains/customer/application/queries/SearchCustomersQuery.ts
+++ b/src/server/subdomains/customer/application/queries/SearchCustomersQuery.ts
@@ -1,0 +1,14 @@
+import { CustomerQueryService } from "./CustomerQueryService";
+import { CustomerDTO } from "./dto/CustomerDTO";
+import { CustomerSearchCriteria, CustomerListOptions } from "./dto/CustomerSearchCriteria";
+
+export class SearchCustomersQuery {
+  constructor(private readonly customerQueryService: CustomerQueryService) {}
+
+  async execute(
+    criteria: CustomerSearchCriteria,
+    options?: CustomerListOptions
+  ): Promise<CustomerDTO[]> {
+    return await this.customerQueryService.search(criteria, options);
+  }
+}

--- a/src/server/subdomains/customer/application/queries/dto/CustomerDTO.ts
+++ b/src/server/subdomains/customer/application/queries/dto/CustomerDTO.ts
@@ -1,0 +1,18 @@
+/**
+ * 得意先データ転送オブジェクト
+ */
+export type CustomerDTO = {
+  id: string;
+  code: string;
+  name: string;
+  postalCode: string | null;
+  prefecture: string | null;
+  address: string | null;
+  phoneNumber: string | null;
+  faxNumber: string | null;
+  contactPerson: string | null;
+  isActive: boolean;
+  marginRate: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/server/subdomains/customer/application/queries/dto/CustomerSearchCriteria.ts
+++ b/src/server/subdomains/customer/application/queries/dto/CustomerSearchCriteria.ts
@@ -1,0 +1,27 @@
+/**
+ * 得意先検索条件
+ */
+export type CustomerSearchCriteria = {
+  /** 名前での部分一致検索 */
+  name?: string;
+  /** コードでの完全一致検索 */
+  code?: string;
+  /** 有効/無効フィルタ */
+  isActive?: boolean;
+  /** この日時以降に作成された得意先 */
+  createdAfter?: Date;
+  /** この日時以前に作成された得意先 */
+  createdBefore?: Date;
+};
+
+/**
+ * リスト取得のオプション
+ */
+export type CustomerListOptions = {
+  limit?: number;
+  offset?: number;
+  orderBy?: {
+    field: "name" | "code" | "createdAt" | "updatedAt";
+    direction: "asc" | "desc";
+  };
+};

--- a/src/server/subdomains/customer/domain/entities/Customer.ts
+++ b/src/server/subdomains/customer/domain/entities/Customer.ts
@@ -1,0 +1,213 @@
+import { createId } from "@paralleldrive/cuid2";
+import { Address } from "@server/shared/domain/values/Address";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
+import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
+import { PostalCode } from "@server/shared/domain/values/PostalCode";
+import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { MarginRate } from "@subdomains/customer/domain/values/MarginRate";
+
+export type CustomerCreateOptions = {
+  postalCode?: PostalCode;
+  prefecture?: Prefecture;
+  address?: Address;
+  phoneNumber?: PhoneNumber;
+  faxNumber?: FaxNumber;
+  contactPerson?: string;
+  marginRate?: MarginRate;
+};
+
+/**
+ * 得意先エンティティ
+ *
+ * Company（取引先基底）の情報を埋め込んだ集約ルート。
+ * 得意先固有の属性として標準マージン率を持つ。
+ */
+export class Customer {
+  static readonly ENTITY_NAME = "得意先";
+
+  private constructor(
+    private readonly _id: string,
+    private readonly _companyId: string,
+    private readonly _code: CompanyCode,
+    private _name: CompanyName,
+    private _postalCode: PostalCode | null,
+    private _prefecture: Prefecture | null,
+    private _address: Address | null,
+    private _phoneNumber: PhoneNumber | null,
+    private _faxNumber: FaxNumber | null,
+    private _contactPerson: string | null,
+    private _isActive: boolean,
+    private _marginRate: MarginRate | null,
+    private readonly _createdAt: Date,
+    private _updatedAt: Date
+  ) {}
+
+  /**
+   * 新規得意先を作成
+   */
+  static create(code: CompanyCode, name: CompanyName, options?: CustomerCreateOptions): Customer {
+    const now = new Date();
+
+    return new Customer(
+      createId(),
+      createId(),
+      code,
+      name,
+      options?.postalCode ?? null,
+      options?.prefecture ?? null,
+      options?.address ?? null,
+      options?.phoneNumber ?? null,
+      options?.faxNumber ?? null,
+      options?.contactPerson ?? null,
+      true,
+      options?.marginRate ?? null,
+      now,
+      now
+    );
+  }
+
+  /**
+   * DBから得意先を再構築
+   */
+  static reconstruct(
+    id: string,
+    companyId: string,
+    code: CompanyCode,
+    name: CompanyName,
+    postalCode: PostalCode | null,
+    prefecture: Prefecture | null,
+    address: Address | null,
+    phoneNumber: PhoneNumber | null,
+    faxNumber: FaxNumber | null,
+    contactPerson: string | null,
+    isActive: boolean,
+    marginRate: MarginRate | null,
+    createdAt: Date,
+    updatedAt: Date
+  ): Customer {
+    return new Customer(
+      id,
+      companyId,
+      code,
+      name,
+      postalCode,
+      prefecture,
+      address,
+      phoneNumber,
+      faxNumber,
+      contactPerson,
+      isActive,
+      marginRate,
+      createdAt,
+      updatedAt
+    );
+  }
+
+  // ========================================
+  // ビジネスロジック
+  // ========================================
+
+  changeName(newName: CompanyName): void {
+    this._name = newName;
+    this._updatedAt = new Date();
+  }
+
+  changeAddress(
+    postalCode: PostalCode | null,
+    prefecture: Prefecture | null,
+    address: Address | null
+  ): void {
+    this._postalCode = postalCode;
+    this._prefecture = prefecture;
+    this._address = address;
+    this._updatedAt = new Date();
+  }
+
+  changeContactInfo(
+    phoneNumber: PhoneNumber | null,
+    faxNumber: FaxNumber | null,
+    contactPerson: string | null
+  ): void {
+    this._phoneNumber = phoneNumber;
+    this._faxNumber = faxNumber;
+    this._contactPerson = contactPerson;
+    this._updatedAt = new Date();
+  }
+
+  changeMarginRate(newRate: MarginRate | null): void {
+    this._marginRate = newRate;
+    this._updatedAt = new Date();
+  }
+
+  activate(): void {
+    this._isActive = true;
+    this._updatedAt = new Date();
+  }
+
+  deactivate(): void {
+    this._isActive = false;
+    this._updatedAt = new Date();
+  }
+
+  // ========================================
+  // ゲッター
+  // ========================================
+
+  get id(): string {
+    return this._id;
+  }
+
+  get companyId(): string {
+    return this._companyId;
+  }
+
+  get code(): CompanyCode {
+    return this._code;
+  }
+
+  get name(): CompanyName {
+    return this._name;
+  }
+
+  get postalCode(): PostalCode | null {
+    return this._postalCode;
+  }
+
+  get prefecture(): Prefecture | null {
+    return this._prefecture;
+  }
+
+  get address(): Address | null {
+    return this._address;
+  }
+
+  get phoneNumber(): PhoneNumber | null {
+    return this._phoneNumber;
+  }
+
+  get faxNumber(): FaxNumber | null {
+    return this._faxNumber;
+  }
+
+  get contactPerson(): string | null {
+    return this._contactPerson;
+  }
+
+  get isActive(): boolean {
+    return this._isActive;
+  }
+
+  get marginRate(): MarginRate | null {
+    return this._marginRate;
+  }
+
+  get createdAt(): Date {
+    return this._createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+}

--- a/src/server/subdomains/customer/domain/entities/__tests__/Customer.test.ts
+++ b/src/server/subdomains/customer/domain/entities/__tests__/Customer.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { Customer } from "../Customer";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { MarginRate } from "@subdomains/customer/domain/values/MarginRate";
+import { PostalCode } from "@server/shared/domain/values/PostalCode";
+import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { Address } from "@server/shared/domain/values/Address";
+import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
+import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
+
+describe("Customer Entity", () => {
+  const createTestCustomer = () =>
+    Customer.create(new CompanyCode("CUST001"), new CompanyName("株式会社テスト"), {
+      marginRate: new MarginRate(10),
+    });
+
+  describe("create", () => {
+    it("必須項目のみで得意先を作成できる", () => {
+      const customer = Customer.create(
+        new CompanyCode("CUST001"),
+        new CompanyName("株式会社テスト")
+      );
+
+      expect(customer.id).toBeTruthy();
+      expect(customer.companyId).toBeTruthy();
+      expect(customer.id).not.toBe(customer.companyId);
+      expect(customer.code.value).toBe("CUST001");
+      expect(customer.name.value).toBe("株式会社テスト");
+      expect(customer.isActive).toBe(true);
+      expect(customer.marginRate).toBeNull();
+      expect(customer.postalCode).toBeNull();
+    });
+
+    it("全オプションを指定して得意先を作成できる", () => {
+      const customer = Customer.create(new CompanyCode("CUST002"), new CompanyName("テスト商事"), {
+        postalCode: new PostalCode("1234567"),
+        prefecture: new Prefecture("東京都"),
+        address: new Address("渋谷区1-2-3"),
+        phoneNumber: new PhoneNumber("0312345678"),
+        faxNumber: new FaxNumber("0312345679"),
+        contactPerson: "田中太郎",
+        marginRate: new MarginRate(15.5),
+      });
+
+      expect(customer.postalCode?.value).toBe("1234567");
+      expect(customer.prefecture?.value).toBe("東京都");
+      expect(customer.address?.value).toBe("渋谷区1-2-3");
+      expect(customer.phoneNumber?.value).toBe("0312345678");
+      expect(customer.faxNumber?.value).toBe("0312345679");
+      expect(customer.contactPerson).toBe("田中太郎");
+      expect(customer.marginRate?.value).toBe(15.5);
+    });
+  });
+
+  describe("reconstruct", () => {
+    it("DBからの再構築が正しく動作する", () => {
+      const now = new Date();
+      const customer = Customer.reconstruct(
+        "test-id",
+        "test-company-id",
+        new CompanyCode("CUST001"),
+        new CompanyName("株式会社テスト"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        true,
+        new MarginRate(10),
+        now,
+        now
+      );
+
+      expect(customer.id).toBe("test-id");
+      expect(customer.companyId).toBe("test-company-id");
+      expect(customer.createdAt).toBe(now);
+    });
+  });
+
+  describe("changeName", () => {
+    it("名前を変更できる", () => {
+      const customer = createTestCustomer();
+
+      customer.changeName(new CompanyName("新しい会社名"));
+
+      expect(customer.name.value).toBe("新しい会社名");
+    });
+  });
+
+  describe("changeAddress", () => {
+    it("住所を変更できる", () => {
+      const customer = createTestCustomer();
+
+      customer.changeAddress(
+        new PostalCode("9876543"),
+        new Prefecture("大阪府"),
+        new Address("中央区4-5-6")
+      );
+
+      expect(customer.postalCode?.value).toBe("9876543");
+      expect(customer.prefecture?.value).toBe("大阪府");
+      expect(customer.address?.value).toBe("中央区4-5-6");
+    });
+
+    it("住所をnullにクリアできる", () => {
+      const customer = Customer.create(new CompanyCode("CUST001"), new CompanyName("テスト"), {
+        postalCode: new PostalCode("1234567"),
+      });
+
+      customer.changeAddress(null, null, null);
+
+      expect(customer.postalCode).toBeNull();
+      expect(customer.prefecture).toBeNull();
+      expect(customer.address).toBeNull();
+    });
+  });
+
+  describe("changeContactInfo", () => {
+    it("連絡先を変更できる", () => {
+      const customer = createTestCustomer();
+
+      customer.changeContactInfo(
+        new PhoneNumber("0612345678"),
+        new FaxNumber("0612345679"),
+        "佐藤花子"
+      );
+
+      expect(customer.phoneNumber?.value).toBe("0612345678");
+      expect(customer.faxNumber?.value).toBe("0612345679");
+      expect(customer.contactPerson).toBe("佐藤花子");
+    });
+  });
+
+  describe("changeMarginRate", () => {
+    it("マージン率を変更できる", () => {
+      const customer = createTestCustomer();
+
+      customer.changeMarginRate(new MarginRate(20));
+
+      expect(customer.marginRate?.value).toBe(20);
+    });
+
+    it("マージン率をnullにクリアできる", () => {
+      const customer = createTestCustomer();
+
+      customer.changeMarginRate(null);
+
+      expect(customer.marginRate).toBeNull();
+    });
+  });
+
+  describe("activate / deactivate", () => {
+    it("無効化できる", () => {
+      const customer = createTestCustomer();
+
+      customer.deactivate();
+
+      expect(customer.isActive).toBe(false);
+    });
+
+    it("有効化できる", () => {
+      const customer = createTestCustomer();
+      customer.deactivate();
+
+      customer.activate();
+
+      expect(customer.isActive).toBe(true);
+    });
+  });
+});

--- a/src/server/subdomains/customer/domain/repositories/CustomerRepository.ts
+++ b/src/server/subdomains/customer/domain/repositories/CustomerRepository.ts
@@ -1,0 +1,29 @@
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+
+/**
+ * 得意先リポジトリインターフェース
+ *
+ * 検索・一覧取得については CustomerQueryService を使用すること
+ */
+export interface CustomerRepository {
+  /**
+   * 得意先を保存（新規作成・更新）
+   */
+  save(customer: Customer): Promise<Customer>;
+
+  /**
+   * 得意先を削除
+   */
+  delete(id: string): Promise<void>;
+
+  /**
+   * IDで得意先を取得
+   */
+  findById(id: string): Promise<Customer | null>;
+
+  /**
+   * 取引先コードで得意先を取得（重複チェック等で使用）
+   */
+  findByCode(code: CompanyCode): Promise<Customer | null>;
+}

--- a/src/server/subdomains/customer/domain/services/CustomerCodeDuplicationCheckDomainService.ts
+++ b/src/server/subdomains/customer/domain/services/CustomerCodeDuplicationCheckDomainService.ts
@@ -1,0 +1,11 @@
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+
+export class CustomerCodeDuplicationCheckDomainService {
+  constructor(private customerRepository: CustomerRepository) {}
+
+  async execute(code: CompanyCode): Promise<boolean> {
+    const existing = await this.customerRepository.findByCode(code);
+    return !!existing;
+  }
+}

--- a/src/server/subdomains/customer/domain/services/__tests__/CustomerCodeDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/customer/domain/services/__tests__/CustomerCodeDuplicationCheckDomainService.test.ts
@@ -1,0 +1,41 @@
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { InMemoryCustomerRepository } from "@subdomains/customer/infrastructure/in-memory/InMemoryCustomerRepository";
+import { beforeEach, describe, expect, test } from "vitest";
+import { CustomerCodeDuplicationCheckDomainService } from "../CustomerCodeDuplicationCheckDomainService";
+
+describe("CustomerCodeDuplicationCheckDomainService", () => {
+  let service: CustomerCodeDuplicationCheckDomainService;
+  let repository: InMemoryCustomerRepository;
+
+  beforeEach(() => {
+    repository = new InMemoryCustomerRepository();
+    service = new CustomerCodeDuplicationCheckDomainService(repository);
+  });
+
+  test("重複がない場合、falseを返す", async () => {
+    const code = new CompanyCode("CUST001");
+    const isDuplicated = await service.execute(code);
+    expect(isDuplicated).toBe(false);
+  });
+
+  test("重複がある場合、trueを返す", async () => {
+    const code = new CompanyCode("CUST001");
+    const customer = Customer.create(code, new CompanyName("テスト株式会社"));
+    await repository.save(customer);
+
+    const isDuplicated = await service.execute(code);
+    expect(isDuplicated).toBe(true);
+  });
+
+  test("異なるコードで重複がない場合、falseを返す", async () => {
+    const existingCode = new CompanyCode("CUST001");
+    const customer = Customer.create(existingCode, new CompanyName("テスト株式会社"));
+    await repository.save(customer);
+
+    const newCode = new CompanyCode("CUST002");
+    const isDuplicated = await service.execute(newCode);
+    expect(isDuplicated).toBe(false);
+  });
+});

--- a/src/server/subdomains/customer/domain/values/MarginRate.ts
+++ b/src/server/subdomains/customer/domain/values/MarginRate.ts
@@ -1,0 +1,31 @@
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { ValueObject } from "@server/shared/ValueObject";
+
+/**
+ * マージン率値オブジェクト
+ *
+ * 0.00〜100.00%の範囲で指定。
+ */
+export class MarginRate extends ValueObject<number, "MarginRate"> {
+  private static readonly MIN = 0;
+  private static readonly MAX = 100;
+
+  constructor(value: number) {
+    super(value);
+  }
+
+  get value(): number {
+    return this._value;
+  }
+
+  protected validate(value: number): void {
+    if (!Number.isFinite(value)) {
+      throw new ValidationError("マージン率は有効な数値で指定してください");
+    }
+    if (value < MarginRate.MIN || value > MarginRate.MAX) {
+      throw new ValidationError(
+        `マージン率は${MarginRate.MIN}〜${MarginRate.MAX}%の範囲で指定してください`
+      );
+    }
+  }
+}

--- a/src/server/subdomains/customer/domain/values/__tests__/MarginRate.test.ts
+++ b/src/server/subdomains/customer/domain/values/__tests__/MarginRate.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { MarginRate } from "../MarginRate";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("MarginRate", () => {
+  describe("正常系", () => {
+    it("0%を受け入れる", () => {
+      const rate = new MarginRate(0);
+      expect(rate.value).toBe(0);
+    });
+
+    it("100%を受け入れる", () => {
+      const rate = new MarginRate(100);
+      expect(rate.value).toBe(100);
+    });
+
+    it("小数を受け入れる", () => {
+      const rate = new MarginRate(10.5);
+      expect(rate.value).toBe(10.5);
+    });
+  });
+
+  describe("異常系", () => {
+    it("負の値を拒否する", () => {
+      expect(() => new MarginRate(-1)).toThrow(ValidationError);
+    });
+
+    it("100超の値を拒否する", () => {
+      expect(() => new MarginRate(100.01)).toThrow(ValidationError);
+    });
+
+    it("NaNを拒否する", () => {
+      expect(() => new MarginRate(NaN)).toThrow(ValidationError);
+    });
+
+    it("Infinityを拒否する", () => {
+      expect(() => new MarginRate(Infinity)).toThrow(ValidationError);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値は等しい", () => {
+      const a = new MarginRate(10);
+      const b = new MarginRate(10);
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("異なる値は等しくない", () => {
+      const a = new MarginRate(10);
+      const b = new MarginRate(20);
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+});

--- a/src/server/subdomains/customer/infrastructure/in-memory/InMemoryCustomerRepository.ts
+++ b/src/server/subdomains/customer/infrastructure/in-memory/InMemoryCustomerRepository.ts
@@ -1,0 +1,25 @@
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+
+export class InMemoryCustomerRepository implements CustomerRepository {
+  public DB: { [id: string]: Customer } = {};
+
+  async save(customer: Customer): Promise<Customer> {
+    this.DB[customer.id] = customer;
+    return customer;
+  }
+
+  async delete(id: string): Promise<void> {
+    delete this.DB[id];
+  }
+
+  async findById(id: string): Promise<Customer | null> {
+    return this.DB[id] || null;
+  }
+
+  async findByCode(code: CompanyCode): Promise<Customer | null> {
+    const customer = Object.values(this.DB).find((c) => c.code.equals(code));
+    return customer || null;
+  }
+}

--- a/src/server/subdomains/customer/infrastructure/mappers/CustomerMapper.ts
+++ b/src/server/subdomains/customer/infrastructure/mappers/CustomerMapper.ts
@@ -1,0 +1,84 @@
+import { Address } from "@server/shared/domain/values/Address";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
+import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
+import { PostalCode } from "@server/shared/domain/values/PostalCode";
+import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { MarginRate } from "@subdomains/customer/domain/values/MarginRate";
+import type { Company, Customer as PrismaCustomer } from "@generated/prisma/client";
+import { CompanyType, Prisma } from "@generated/prisma/client";
+
+type PrismaCustomerWithCompany = PrismaCustomer & {
+  company: Company;
+};
+
+/**
+ * CustomerMapper
+ *
+ * Company + Customer の複合データとドメインエンティティを相互変換する
+ */
+export class CustomerMapper {
+  static toDomain(data: PrismaCustomerWithCompany): Customer {
+    return Customer.reconstruct(
+      data.id,
+      data.companyId,
+      new CompanyCode(data.company.code),
+      new CompanyName(data.company.name),
+      data.company.postalCode ? new PostalCode(data.company.postalCode) : null,
+      data.company.prefecture ? new Prefecture(data.company.prefecture) : null,
+      data.company.address ? new Address(data.company.address) : null,
+      data.company.phoneNumber ? new PhoneNumber(data.company.phoneNumber) : null,
+      data.company.faxNumber ? new FaxNumber(data.company.faxNumber) : null,
+      data.company.contactPerson,
+      data.company.isActive,
+      data.marginRate !== null ? new MarginRate(Number(data.marginRate)) : null,
+      data.createdAt,
+      data.updatedAt
+    );
+  }
+
+  static toPrismaCreate(customer: Customer) {
+    return {
+      id: customer.id,
+      marginRate:
+        customer.marginRate !== null ? new Prisma.Decimal(customer.marginRate.value) : null,
+      company: {
+        create: {
+          id: customer.companyId,
+          code: customer.code.value,
+          name: customer.name.value,
+          type: CompanyType.CUSTOMER,
+          postalCode: customer.postalCode?.value ?? null,
+          prefecture: customer.prefecture?.value ?? null,
+          address: customer.address?.value ?? null,
+          phoneNumber: customer.phoneNumber?.value ?? null,
+          faxNumber: customer.faxNumber?.value ?? null,
+          contactPerson: customer.contactPerson,
+          isActive: customer.isActive,
+        },
+      },
+    };
+  }
+
+  static toPrismaUpdate(customer: Customer) {
+    return {
+      marginRate:
+        customer.marginRate !== null ? new Prisma.Decimal(customer.marginRate.value) : null,
+      updatedAt: customer.updatedAt,
+      company: {
+        update: {
+          name: customer.name.value,
+          postalCode: customer.postalCode?.value ?? null,
+          prefecture: customer.prefecture?.value ?? null,
+          address: customer.address?.value ?? null,
+          phoneNumber: customer.phoneNumber?.value ?? null,
+          faxNumber: customer.faxNumber?.value ?? null,
+          contactPerson: customer.contactPerson,
+          isActive: customer.isActive,
+        },
+      },
+    };
+  }
+}

--- a/src/server/subdomains/customer/infrastructure/prisma/PrismaCustomerRepository.ts
+++ b/src/server/subdomains/customer/infrastructure/prisma/PrismaCustomerRepository.ts
@@ -1,0 +1,70 @@
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyType } from "@generated/prisma/client";
+import prisma from "@server/prisma";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+import { CustomerMapper } from "@subdomains/customer/infrastructure/mappers/CustomerMapper";
+
+const INCLUDE_COMPANY = { company: true } as const;
+
+export class PrismaCustomerRepository implements CustomerRepository {
+  async save(customer: Customer): Promise<Customer> {
+    const existing = await prisma.customer.findUnique({
+      where: { id: customer.id },
+    });
+
+    let prismaCustomer;
+
+    if (existing) {
+      prismaCustomer = await prisma.customer.update({
+        where: { id: customer.id },
+        data: CustomerMapper.toPrismaUpdate(customer),
+        include: INCLUDE_COMPANY,
+      });
+    } else {
+      prismaCustomer = await prisma.customer.create({
+        data: CustomerMapper.toPrismaCreate(customer),
+        include: INCLUDE_COMPANY,
+      });
+    }
+
+    return CustomerMapper.toDomain(prismaCustomer);
+  }
+
+  async delete(id: string): Promise<void> {
+    const customer = await prisma.customer.findUnique({
+      where: { id },
+      select: { companyId: true },
+    });
+
+    if (customer) {
+      // Company をカスケード削除（Company削除でCustomerも削除される）
+      await prisma.company.delete({
+        where: { id: customer.companyId },
+      });
+    }
+  }
+
+  async findById(id: string): Promise<Customer | null> {
+    const prismaCustomer = await prisma.customer.findUnique({
+      where: { id },
+      include: INCLUDE_COMPANY,
+    });
+
+    return prismaCustomer ? CustomerMapper.toDomain(prismaCustomer) : null;
+  }
+
+  async findByCode(code: CompanyCode): Promise<Customer | null> {
+    const prismaCustomer = await prisma.customer.findFirst({
+      where: {
+        company: {
+          code: code.value,
+          type: CompanyType.CUSTOMER,
+        },
+      },
+      include: INCLUDE_COMPANY,
+    });
+
+    return prismaCustomer ? CustomerMapper.toDomain(prismaCustomer) : null;
+  }
+}

--- a/src/server/subdomains/customer/infrastructure/queries/PrismaCustomerQueryService.ts
+++ b/src/server/subdomains/customer/infrastructure/queries/PrismaCustomerQueryService.ts
@@ -1,0 +1,168 @@
+import { CustomerDTO } from "@subdomains/customer/application/queries/dto/CustomerDTO";
+import {
+  CustomerSearchCriteria,
+  CustomerListOptions,
+} from "@subdomains/customer/application/queries/dto/CustomerSearchCriteria";
+import { CustomerQueryService } from "@subdomains/customer/application/queries/CustomerQueryService";
+import prisma from "@server/prisma";
+import { CompanyType, Prisma } from "@generated/prisma/client";
+
+export class PrismaCustomerQueryService implements CustomerQueryService {
+  async findById(id: string): Promise<CustomerDTO | null> {
+    const customer = await prisma.customer.findUnique({
+      where: { id },
+      select: this.getSelectFields(),
+    });
+
+    return customer ? this.toDTO(customer) : null;
+  }
+
+  async findByCode(code: string): Promise<CustomerDTO | null> {
+    const customer = await prisma.customer.findFirst({
+      where: {
+        company: { code, type: CompanyType.CUSTOMER },
+      },
+      select: this.getSelectFields(),
+    });
+
+    return customer ? this.toDTO(customer) : null;
+  }
+
+  async search(
+    criteria: CustomerSearchCriteria,
+    options?: CustomerListOptions
+  ): Promise<CustomerDTO[]> {
+    const where = this.buildWhereClause(criteria);
+    const orderBy = this.buildOrderBy(options);
+
+    const customers = await prisma.customer.findMany({
+      where,
+      select: this.getSelectFields(),
+      orderBy,
+      take: options?.limit,
+      skip: options?.offset,
+    });
+
+    return customers.map((c) => this.toDTO(c));
+  }
+
+  async findAll(options?: CustomerListOptions): Promise<CustomerDTO[]> {
+    const orderBy = this.buildOrderBy(options);
+
+    const customers = await prisma.customer.findMany({
+      select: this.getSelectFields(),
+      orderBy,
+      take: options?.limit,
+      skip: options?.offset,
+    });
+
+    return customers.map((c) => this.toDTO(c));
+  }
+
+  async count(criteria: CustomerSearchCriteria): Promise<number> {
+    const where = this.buildWhereClause(criteria);
+    return await prisma.customer.count({ where });
+  }
+
+  private buildWhereClause(criteria: CustomerSearchCriteria): Prisma.CustomerWhereInput {
+    const where: Prisma.CustomerWhereInput = {};
+    const companyWhere: Prisma.CompanyWhereInput = { type: CompanyType.CUSTOMER };
+
+    if (criteria.name) {
+      companyWhere.name = { contains: criteria.name, mode: "insensitive" };
+    }
+
+    if (criteria.code) {
+      companyWhere.code = criteria.code;
+    }
+
+    if (criteria.isActive !== undefined) {
+      companyWhere.isActive = criteria.isActive;
+    }
+
+    if (criteria.createdAfter || criteria.createdBefore) {
+      where.createdAt = {};
+      if (criteria.createdAfter) {
+        where.createdAt.gte = criteria.createdAfter;
+      }
+      if (criteria.createdBefore) {
+        where.createdAt.lte = criteria.createdBefore;
+      }
+    }
+
+    where.company = companyWhere;
+    return where;
+  }
+
+  private buildOrderBy(
+    options?: CustomerListOptions
+  ): Prisma.CustomerOrderByWithRelationInput | undefined {
+    if (!options?.orderBy) {
+      return undefined;
+    }
+
+    const { field, direction } = options.orderBy;
+
+    if (field === "name" || field === "code") {
+      return { company: { [field]: direction } };
+    }
+
+    return { [field]: direction };
+  }
+
+  private getSelectFields() {
+    return {
+      id: true,
+      marginRate: true,
+      createdAt: true,
+      updatedAt: true,
+      company: {
+        select: {
+          code: true,
+          name: true,
+          postalCode: true,
+          prefecture: true,
+          address: true,
+          phoneNumber: true,
+          faxNumber: true,
+          contactPerson: true,
+          isActive: true,
+        },
+      },
+    } as const;
+  }
+
+  private toDTO(customer: {
+    id: string;
+    marginRate: Prisma.Decimal | null;
+    createdAt: Date;
+    updatedAt: Date;
+    company: {
+      code: string;
+      name: string;
+      postalCode: string | null;
+      prefecture: string | null;
+      address: string | null;
+      phoneNumber: string | null;
+      faxNumber: string | null;
+      contactPerson: string | null;
+      isActive: boolean;
+    };
+  }): CustomerDTO {
+    return {
+      id: customer.id,
+      code: customer.company.code,
+      name: customer.company.name,
+      postalCode: customer.company.postalCode,
+      prefecture: customer.company.prefecture,
+      address: customer.company.address,
+      phoneNumber: customer.company.phoneNumber,
+      faxNumber: customer.company.faxNumber,
+      contactPerson: customer.company.contactPerson,
+      isActive: customer.company.isActive,
+      marginRate: customer.marginRate !== null ? Number(customer.marginRate) : null,
+      createdAt: customer.createdAt,
+      updatedAt: customer.updatedAt,
+    };
+  }
+}

--- a/src/server/subdomains/delivery-location/application/commands/CreateDeliveryLocationCommand.ts
+++ b/src/server/subdomains/delivery-location/application/commands/CreateDeliveryLocationCommand.ts
@@ -1,0 +1,75 @@
+import { Address } from "@server/shared/domain/values/Address";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
+import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
+import { PostalCode } from "@server/shared/domain/values/PostalCode";
+import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
+import { DeliveryLocationCodeDuplicationCheckDomainService } from "@subdomains/delivery-location/domain/services/DeliveryLocationCodeDuplicationCheckDomainService";
+import { DeliveryNotes } from "@subdomains/delivery-location/domain/values/DeliveryNotes";
+
+export type CreateDeliveryLocationInput = {
+  code: string;
+  name: string;
+  customerId: string;
+  postalCode?: string;
+  prefecture?: string;
+  address?: string;
+  phoneNumber?: string;
+  faxNumber?: string;
+  contactPerson?: string;
+  deliveryNotes?: string;
+};
+
+/**
+ * 納品先新規登録コマンド
+ */
+export class CreateDeliveryLocationCommand {
+  constructor(
+    private readonly deliveryLocationRepository: DeliveryLocationRepository,
+    private readonly customerRepository: CustomerRepository,
+    private readonly deliveryLocationCodeDuplicationCheckDomainService: DeliveryLocationCodeDuplicationCheckDomainService
+  ) {}
+
+  async execute(input: CreateDeliveryLocationInput): Promise<void> {
+    // 親得意先の存在チェック
+    const customer = await this.customerRepository.findById(input.customerId);
+    if (!customer) {
+      throw new NotFoundEntityError(Customer, { id: input.customerId });
+    }
+
+    if (!customer.isActive) {
+      throw new ValidationError("無効化された得意先には納品先を追加できません");
+    }
+
+    const code = new CompanyCode(input.code);
+
+    const isDuplicated = await this.deliveryLocationCodeDuplicationCheckDomainService.execute(code);
+    if (isDuplicated) {
+      throw new ValidationError(`既に存在する取引先コードです: コード=${code.value}`);
+    }
+
+    const deliveryLocation = DeliveryLocation.create(
+      code,
+      new CompanyName(input.name),
+      input.customerId,
+      {
+        postalCode: input.postalCode ? new PostalCode(input.postalCode) : undefined,
+        prefecture: input.prefecture ? new Prefecture(input.prefecture) : undefined,
+        address: input.address ? new Address(input.address) : undefined,
+        phoneNumber: input.phoneNumber ? new PhoneNumber(input.phoneNumber) : undefined,
+        faxNumber: input.faxNumber ? new FaxNumber(input.faxNumber) : undefined,
+        contactPerson: input.contactPerson,
+        deliveryNotes: input.deliveryNotes ? new DeliveryNotes(input.deliveryNotes) : undefined,
+      }
+    );
+
+    await this.deliveryLocationRepository.save(deliveryLocation);
+  }
+}

--- a/src/server/subdomains/delivery-location/application/commands/DeleteDeliveryLocationCommand.ts
+++ b/src/server/subdomains/delivery-location/application/commands/DeleteDeliveryLocationCommand.ts
@@ -1,0 +1,23 @@
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
+
+export type DeleteDeliveryLocationInput = {
+  id: string;
+};
+
+/**
+ * 納品先削除コマンド
+ */
+export class DeleteDeliveryLocationCommand {
+  constructor(private readonly deliveryLocationRepository: DeliveryLocationRepository) {}
+
+  async execute(input: DeleteDeliveryLocationInput): Promise<void> {
+    const deliveryLocation = await this.deliveryLocationRepository.findById(input.id);
+    if (!deliveryLocation) {
+      throw new NotFoundEntityError(DeliveryLocation, { id: input.id });
+    }
+
+    await this.deliveryLocationRepository.delete(input.id);
+  }
+}

--- a/src/server/subdomains/delivery-location/application/commands/UpdateDeliveryLocationCommand.ts
+++ b/src/server/subdomains/delivery-location/application/commands/UpdateDeliveryLocationCommand.ts
@@ -1,0 +1,67 @@
+import { Address } from "@server/shared/domain/values/Address";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
+import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
+import { PostalCode } from "@server/shared/domain/values/PostalCode";
+import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
+import { DeliveryNotes } from "@subdomains/delivery-location/domain/values/DeliveryNotes";
+
+export type UpdateDeliveryLocationInput = {
+  id: string;
+  name: string;
+  postalCode?: string | null;
+  prefecture?: string | null;
+  address?: string | null;
+  phoneNumber?: string | null;
+  faxNumber?: string | null;
+  contactPerson?: string | null;
+  deliveryNotes?: string | null;
+  isActive?: boolean;
+};
+
+/**
+ * 納品先情報変更コマンド
+ *
+ * コード（code）と親得意先（customerId）は変更不可。
+ */
+export class UpdateDeliveryLocationCommand {
+  constructor(private readonly deliveryLocationRepository: DeliveryLocationRepository) {}
+
+  async execute(input: UpdateDeliveryLocationInput): Promise<void> {
+    const deliveryLocation = await this.deliveryLocationRepository.findById(input.id);
+    if (!deliveryLocation) {
+      throw new NotFoundEntityError(DeliveryLocation, { id: input.id });
+    }
+
+    deliveryLocation.changeName(new CompanyName(input.name));
+
+    deliveryLocation.changeAddress(
+      input.postalCode ? new PostalCode(input.postalCode) : null,
+      input.prefecture ? new Prefecture(input.prefecture) : null,
+      input.address ? new Address(input.address) : null
+    );
+
+    deliveryLocation.changeContactInfo(
+      input.phoneNumber ? new PhoneNumber(input.phoneNumber) : null,
+      input.faxNumber ? new FaxNumber(input.faxNumber) : null,
+      input.contactPerson ?? null
+    );
+
+    deliveryLocation.changeDeliveryNotes(
+      input.deliveryNotes ? new DeliveryNotes(input.deliveryNotes) : null
+    );
+
+    if (input.isActive !== undefined) {
+      if (input.isActive) {
+        deliveryLocation.activate();
+      } else {
+        deliveryLocation.deactivate();
+      }
+    }
+
+    await this.deliveryLocationRepository.save(deliveryLocation);
+  }
+}

--- a/src/server/subdomains/delivery-location/application/factories/createDeliveryLocationCommandFactory.ts
+++ b/src/server/subdomains/delivery-location/application/factories/createDeliveryLocationCommandFactory.ts
@@ -1,0 +1,15 @@
+import { CreateDeliveryLocationCommand } from "../commands/CreateDeliveryLocationCommand";
+import { DeliveryLocationCodeDuplicationCheckDomainService } from "../../domain/services/DeliveryLocationCodeDuplicationCheckDomainService";
+import { PrismaDeliveryLocationRepository } from "../../infrastructure/prisma/PrismaDeliveryLocationRepository";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+
+export function createDeliveryLocationCommandFactory(): CreateDeliveryLocationCommand {
+  const deliveryLocationRepository = new PrismaDeliveryLocationRepository();
+  const customerRepository = new PrismaCustomerRepository();
+
+  return new CreateDeliveryLocationCommand(
+    deliveryLocationRepository,
+    customerRepository,
+    new DeliveryLocationCodeDuplicationCheckDomainService(deliveryLocationRepository)
+  );
+}

--- a/src/server/subdomains/delivery-location/application/factories/deleteDeliveryLocationCommandFactory.ts
+++ b/src/server/subdomains/delivery-location/application/factories/deleteDeliveryLocationCommandFactory.ts
@@ -1,0 +1,6 @@
+import { DeleteDeliveryLocationCommand } from "../commands/DeleteDeliveryLocationCommand";
+import { PrismaDeliveryLocationRepository } from "../../infrastructure/prisma/PrismaDeliveryLocationRepository";
+
+export function deleteDeliveryLocationCommandFactory(): DeleteDeliveryLocationCommand {
+  return new DeleteDeliveryLocationCommand(new PrismaDeliveryLocationRepository());
+}

--- a/src/server/subdomains/delivery-location/application/factories/deliveryLocationQueryFactory.ts
+++ b/src/server/subdomains/delivery-location/application/factories/deliveryLocationQueryFactory.ts
@@ -1,0 +1,16 @@
+import { GetDeliveryLocationByIdQuery } from "../queries/GetDeliveryLocationByIdQuery";
+import { GetDeliveryLocationsByCustomerIdQuery } from "../queries/GetDeliveryLocationsByCustomerIdQuery";
+import { SearchDeliveryLocationsQuery } from "../queries/SearchDeliveryLocationsQuery";
+import { PrismaDeliveryLocationQueryService } from "../../infrastructure/queries/PrismaDeliveryLocationQueryService";
+
+export function getDeliveryLocationByIdQueryFactory(): GetDeliveryLocationByIdQuery {
+  return new GetDeliveryLocationByIdQuery(new PrismaDeliveryLocationQueryService());
+}
+
+export function getDeliveryLocationsByCustomerIdQueryFactory(): GetDeliveryLocationsByCustomerIdQuery {
+  return new GetDeliveryLocationsByCustomerIdQuery(new PrismaDeliveryLocationQueryService());
+}
+
+export function searchDeliveryLocationsQueryFactory(): SearchDeliveryLocationsQuery {
+  return new SearchDeliveryLocationsQuery(new PrismaDeliveryLocationQueryService());
+}

--- a/src/server/subdomains/delivery-location/application/factories/index.ts
+++ b/src/server/subdomains/delivery-location/application/factories/index.ts
@@ -1,0 +1,8 @@
+export { createDeliveryLocationCommandFactory } from "./createDeliveryLocationCommandFactory";
+export { updateDeliveryLocationCommandFactory } from "./updateDeliveryLocationCommandFactory";
+export { deleteDeliveryLocationCommandFactory } from "./deleteDeliveryLocationCommandFactory";
+export {
+  getDeliveryLocationByIdQueryFactory,
+  getDeliveryLocationsByCustomerIdQueryFactory,
+  searchDeliveryLocationsQueryFactory,
+} from "./deliveryLocationQueryFactory";

--- a/src/server/subdomains/delivery-location/application/factories/updateDeliveryLocationCommandFactory.ts
+++ b/src/server/subdomains/delivery-location/application/factories/updateDeliveryLocationCommandFactory.ts
@@ -1,0 +1,6 @@
+import { UpdateDeliveryLocationCommand } from "../commands/UpdateDeliveryLocationCommand";
+import { PrismaDeliveryLocationRepository } from "../../infrastructure/prisma/PrismaDeliveryLocationRepository";
+
+export function updateDeliveryLocationCommandFactory(): UpdateDeliveryLocationCommand {
+  return new UpdateDeliveryLocationCommand(new PrismaDeliveryLocationRepository());
+}

--- a/src/server/subdomains/delivery-location/application/queries/DeliveryLocationQueryService.ts
+++ b/src/server/subdomains/delivery-location/application/queries/DeliveryLocationQueryService.ts
@@ -1,0 +1,23 @@
+import { DeliveryLocationDTO } from "./dto/DeliveryLocationDTO";
+import {
+  DeliveryLocationSearchCriteria,
+  DeliveryLocationListOptions,
+} from "./dto/DeliveryLocationSearchCriteria";
+
+/**
+ * 納品先クエリサービスインターフェース
+ */
+export interface DeliveryLocationQueryService {
+  findById(id: string): Promise<DeliveryLocationDTO | null>;
+  findByCode(code: string): Promise<DeliveryLocationDTO | null>;
+  findByCustomerId(
+    customerId: string,
+    options?: DeliveryLocationListOptions
+  ): Promise<DeliveryLocationDTO[]>;
+  search(
+    criteria: DeliveryLocationSearchCriteria,
+    options?: DeliveryLocationListOptions
+  ): Promise<DeliveryLocationDTO[]>;
+  findAll(options?: DeliveryLocationListOptions): Promise<DeliveryLocationDTO[]>;
+  count(criteria: DeliveryLocationSearchCriteria): Promise<number>;
+}

--- a/src/server/subdomains/delivery-location/application/queries/GetDeliveryLocationByIdQuery.ts
+++ b/src/server/subdomains/delivery-location/application/queries/GetDeliveryLocationByIdQuery.ts
@@ -1,0 +1,14 @@
+import { DeliveryLocationQueryService } from "./DeliveryLocationQueryService";
+import { DeliveryLocationDTO } from "./dto/DeliveryLocationDTO";
+
+export type GetDeliveryLocationByIdInput = {
+  id: string;
+};
+
+export class GetDeliveryLocationByIdQuery {
+  constructor(private readonly deliveryLocationQueryService: DeliveryLocationQueryService) {}
+
+  async execute(input: GetDeliveryLocationByIdInput): Promise<DeliveryLocationDTO | null> {
+    return await this.deliveryLocationQueryService.findById(input.id);
+  }
+}

--- a/src/server/subdomains/delivery-location/application/queries/GetDeliveryLocationsByCustomerIdQuery.ts
+++ b/src/server/subdomains/delivery-location/application/queries/GetDeliveryLocationsByCustomerIdQuery.ts
@@ -1,0 +1,18 @@
+import { DeliveryLocationQueryService } from "./DeliveryLocationQueryService";
+import { DeliveryLocationDTO } from "./dto/DeliveryLocationDTO";
+import { DeliveryLocationListOptions } from "./dto/DeliveryLocationSearchCriteria";
+
+export type GetDeliveryLocationsByCustomerIdInput = {
+  customerId: string;
+};
+
+export class GetDeliveryLocationsByCustomerIdQuery {
+  constructor(private readonly deliveryLocationQueryService: DeliveryLocationQueryService) {}
+
+  async execute(
+    input: GetDeliveryLocationsByCustomerIdInput,
+    options?: DeliveryLocationListOptions
+  ): Promise<DeliveryLocationDTO[]> {
+    return await this.deliveryLocationQueryService.findByCustomerId(input.customerId, options);
+  }
+}

--- a/src/server/subdomains/delivery-location/application/queries/SearchDeliveryLocationsQuery.ts
+++ b/src/server/subdomains/delivery-location/application/queries/SearchDeliveryLocationsQuery.ts
@@ -1,0 +1,17 @@
+import { DeliveryLocationQueryService } from "./DeliveryLocationQueryService";
+import { DeliveryLocationDTO } from "./dto/DeliveryLocationDTO";
+import {
+  DeliveryLocationSearchCriteria,
+  DeliveryLocationListOptions,
+} from "./dto/DeliveryLocationSearchCriteria";
+
+export class SearchDeliveryLocationsQuery {
+  constructor(private readonly deliveryLocationQueryService: DeliveryLocationQueryService) {}
+
+  async execute(
+    criteria: DeliveryLocationSearchCriteria,
+    options?: DeliveryLocationListOptions
+  ): Promise<DeliveryLocationDTO[]> {
+    return await this.deliveryLocationQueryService.search(criteria, options);
+  }
+}

--- a/src/server/subdomains/delivery-location/application/queries/dto/DeliveryLocationDTO.ts
+++ b/src/server/subdomains/delivery-location/application/queries/dto/DeliveryLocationDTO.ts
@@ -1,0 +1,19 @@
+/**
+ * 納品先データ転送オブジェクト
+ */
+export type DeliveryLocationDTO = {
+  id: string;
+  code: string;
+  name: string;
+  postalCode: string | null;
+  prefecture: string | null;
+  address: string | null;
+  phoneNumber: string | null;
+  faxNumber: string | null;
+  contactPerson: string | null;
+  isActive: boolean;
+  customerId: string;
+  deliveryNotes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/server/subdomains/delivery-location/application/queries/dto/DeliveryLocationSearchCriteria.ts
+++ b/src/server/subdomains/delivery-location/application/queries/dto/DeliveryLocationSearchCriteria.ts
@@ -1,0 +1,25 @@
+/**
+ * 納品先検索条件
+ */
+export type DeliveryLocationSearchCriteria = {
+  /** 名前での部分一致検索 */
+  name?: string;
+  /** コードでの完全一致検索 */
+  code?: string;
+  /** 得意先IDでのフィルタ */
+  customerId?: string;
+  /** 有効/無効フィルタ */
+  isActive?: boolean;
+};
+
+/**
+ * リスト取得のオプション
+ */
+export type DeliveryLocationListOptions = {
+  limit?: number;
+  offset?: number;
+  orderBy?: {
+    field: "name" | "code" | "createdAt" | "updatedAt";
+    direction: "asc" | "desc";
+  };
+};

--- a/src/server/subdomains/delivery-location/domain/entities/DeliveryLocation.ts
+++ b/src/server/subdomains/delivery-location/domain/entities/DeliveryLocation.ts
@@ -1,0 +1,231 @@
+import { createId } from "@paralleldrive/cuid2";
+import { Address } from "@server/shared/domain/values/Address";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
+import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
+import { PostalCode } from "@server/shared/domain/values/PostalCode";
+import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { DeliveryNotes } from "@subdomains/delivery-location/domain/values/DeliveryNotes";
+
+export type DeliveryLocationCreateOptions = {
+  postalCode?: PostalCode;
+  prefecture?: Prefecture;
+  address?: Address;
+  phoneNumber?: PhoneNumber;
+  faxNumber?: FaxNumber;
+  contactPerson?: string;
+  deliveryNotes?: DeliveryNotes;
+};
+
+/**
+ * 納品先エンティティ
+ *
+ * Company（取引先基底）の情報を埋め込んだ集約ルート。
+ * 必ず1つの得意先（Customer）に紐づく。
+ */
+export class DeliveryLocation {
+  static readonly ENTITY_NAME = "納品先";
+
+  private constructor(
+    private readonly _id: string,
+    private readonly _companyId: string,
+    private readonly _code: CompanyCode,
+    private _name: CompanyName,
+    private _postalCode: PostalCode | null,
+    private _prefecture: Prefecture | null,
+    private _address: Address | null,
+    private _phoneNumber: PhoneNumber | null,
+    private _faxNumber: FaxNumber | null,
+    private _contactPerson: string | null,
+    private _isActive: boolean,
+    private readonly _customerId: string,
+    private _deliveryNotes: DeliveryNotes | null,
+    private readonly _createdAt: Date,
+    private _updatedAt: Date
+  ) {}
+
+  /**
+   * 新規納品先を作成
+   *
+   * @param code 取引先コード
+   * @param name 名称
+   * @param customerId 親得意先ID（不変）
+   * @param options オプション属性
+   */
+  static create(
+    code: CompanyCode,
+    name: CompanyName,
+    customerId: string,
+    options?: DeliveryLocationCreateOptions
+  ): DeliveryLocation {
+    const now = new Date();
+
+    return new DeliveryLocation(
+      createId(),
+      createId(),
+      code,
+      name,
+      options?.postalCode ?? null,
+      options?.prefecture ?? null,
+      options?.address ?? null,
+      options?.phoneNumber ?? null,
+      options?.faxNumber ?? null,
+      options?.contactPerson ?? null,
+      true,
+      customerId,
+      options?.deliveryNotes ?? null,
+      now,
+      now
+    );
+  }
+
+  /**
+   * DBから納品先を再構築
+   */
+  static reconstruct(
+    id: string,
+    companyId: string,
+    code: CompanyCode,
+    name: CompanyName,
+    postalCode: PostalCode | null,
+    prefecture: Prefecture | null,
+    address: Address | null,
+    phoneNumber: PhoneNumber | null,
+    faxNumber: FaxNumber | null,
+    contactPerson: string | null,
+    isActive: boolean,
+    customerId: string,
+    deliveryNotes: DeliveryNotes | null,
+    createdAt: Date,
+    updatedAt: Date
+  ): DeliveryLocation {
+    return new DeliveryLocation(
+      id,
+      companyId,
+      code,
+      name,
+      postalCode,
+      prefecture,
+      address,
+      phoneNumber,
+      faxNumber,
+      contactPerson,
+      isActive,
+      customerId,
+      deliveryNotes,
+      createdAt,
+      updatedAt
+    );
+  }
+
+  // ========================================
+  // ビジネスロジック
+  // ========================================
+
+  changeName(newName: CompanyName): void {
+    this._name = newName;
+    this._updatedAt = new Date();
+  }
+
+  changeAddress(
+    postalCode: PostalCode | null,
+    prefecture: Prefecture | null,
+    address: Address | null
+  ): void {
+    this._postalCode = postalCode;
+    this._prefecture = prefecture;
+    this._address = address;
+    this._updatedAt = new Date();
+  }
+
+  changeContactInfo(
+    phoneNumber: PhoneNumber | null,
+    faxNumber: FaxNumber | null,
+    contactPerson: string | null
+  ): void {
+    this._phoneNumber = phoneNumber;
+    this._faxNumber = faxNumber;
+    this._contactPerson = contactPerson;
+    this._updatedAt = new Date();
+  }
+
+  changeDeliveryNotes(newNotes: DeliveryNotes | null): void {
+    this._deliveryNotes = newNotes;
+    this._updatedAt = new Date();
+  }
+
+  activate(): void {
+    this._isActive = true;
+    this._updatedAt = new Date();
+  }
+
+  deactivate(): void {
+    this._isActive = false;
+    this._updatedAt = new Date();
+  }
+
+  // ========================================
+  // ゲッター
+  // ========================================
+
+  get id(): string {
+    return this._id;
+  }
+
+  get companyId(): string {
+    return this._companyId;
+  }
+
+  get code(): CompanyCode {
+    return this._code;
+  }
+
+  get name(): CompanyName {
+    return this._name;
+  }
+
+  get postalCode(): PostalCode | null {
+    return this._postalCode;
+  }
+
+  get prefecture(): Prefecture | null {
+    return this._prefecture;
+  }
+
+  get address(): Address | null {
+    return this._address;
+  }
+
+  get phoneNumber(): PhoneNumber | null {
+    return this._phoneNumber;
+  }
+
+  get faxNumber(): FaxNumber | null {
+    return this._faxNumber;
+  }
+
+  get contactPerson(): string | null {
+    return this._contactPerson;
+  }
+
+  get isActive(): boolean {
+    return this._isActive;
+  }
+
+  get customerId(): string {
+    return this._customerId;
+  }
+
+  get deliveryNotes(): DeliveryNotes | null {
+    return this._deliveryNotes;
+  }
+
+  get createdAt(): Date {
+    return this._createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+}

--- a/src/server/subdomains/delivery-location/domain/entities/__tests__/DeliveryLocation.test.ts
+++ b/src/server/subdomains/delivery-location/domain/entities/__tests__/DeliveryLocation.test.ts
@@ -1,0 +1,148 @@
+import { Address } from "@server/shared/domain/values/Address";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
+import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
+import { PostalCode } from "@server/shared/domain/values/PostalCode";
+import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { DeliveryNotes } from "@subdomains/delivery-location/domain/values/DeliveryNotes";
+import { describe, expect, it } from "vitest";
+import { DeliveryLocation } from "../DeliveryLocation";
+
+describe("DeliveryLocation Entity", () => {
+  const CUSTOMER_ID = "test-customer-id";
+
+  const createTestDeliveryLocation = () =>
+    DeliveryLocation.create(new CompanyCode("DL001"), new CompanyName("テスト納品先"), CUSTOMER_ID);
+
+  describe("create", () => {
+    it("必須項目のみで納品先を作成できる", () => {
+      const dl = createTestDeliveryLocation();
+
+      expect(dl.id).toBeTruthy();
+      expect(dl.companyId).toBeTruthy();
+      expect(dl.id).not.toBe(dl.companyId);
+      expect(dl.code.value).toBe("DL001");
+      expect(dl.name.value).toBe("テスト納品先");
+      expect(dl.customerId).toBe(CUSTOMER_ID);
+      expect(dl.isActive).toBe(true);
+      expect(dl.deliveryNotes).toBeNull();
+    });
+
+    it("全オプションを指定して納品先を作成できる", () => {
+      const dl = DeliveryLocation.create(
+        new CompanyCode("DL002"),
+        new CompanyName("テスト倉庫"),
+        CUSTOMER_ID,
+        {
+          postalCode: new PostalCode("1234567"),
+          prefecture: new Prefecture("東京都"),
+          address: new Address("渋谷区1-2-3"),
+          phoneNumber: new PhoneNumber("0312345678"),
+          faxNumber: new FaxNumber("0312345679"),
+          contactPerson: "田中太郎",
+          deliveryNotes: new DeliveryNotes("午前中配送希望"),
+        }
+      );
+
+      expect(dl.postalCode?.value).toBe("1234567");
+      expect(dl.prefecture?.value).toBe("東京都");
+      expect(dl.deliveryNotes?.value).toBe("午前中配送希望");
+    });
+  });
+
+  describe("reconstruct", () => {
+    it("DBからの再構築が正しく動作する", () => {
+      const now = new Date();
+      const dl = DeliveryLocation.reconstruct(
+        "test-id",
+        "test-company-id",
+        new CompanyCode("DL001"),
+        new CompanyName("テスト納品先"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        true,
+        CUSTOMER_ID,
+        null,
+        now,
+        now
+      );
+
+      expect(dl.id).toBe("test-id");
+      expect(dl.companyId).toBe("test-company-id");
+      expect(dl.customerId).toBe(CUSTOMER_ID);
+    });
+  });
+
+  describe("changeName", () => {
+    it("名前を変更できる", () => {
+      const dl = createTestDeliveryLocation();
+
+      dl.changeName(new CompanyName("新しい納品先名"));
+
+      expect(dl.name.value).toBe("新しい納品先名");
+    });
+  });
+
+  describe("changeAddress", () => {
+    it("住所を変更できる", () => {
+      const dl = createTestDeliveryLocation();
+
+      dl.changeAddress(
+        new PostalCode("9876543"),
+        new Prefecture("大阪府"),
+        new Address("中央区4-5-6")
+      );
+
+      expect(dl.postalCode?.value).toBe("9876543");
+      expect(dl.prefecture?.value).toBe("大阪府");
+      expect(dl.address?.value).toBe("中央区4-5-6");
+    });
+  });
+
+  describe("changeDeliveryNotes", () => {
+    it("配送備考を変更できる", () => {
+      const dl = createTestDeliveryLocation();
+
+      dl.changeDeliveryNotes(new DeliveryNotes("土日不可"));
+
+      expect(dl.deliveryNotes?.value).toBe("土日不可");
+    });
+
+    it("配送備考をnullにクリアできる", () => {
+      const dl = DeliveryLocation.create(
+        new CompanyCode("DL001"),
+        new CompanyName("テスト"),
+        CUSTOMER_ID,
+        { deliveryNotes: new DeliveryNotes("メモ") }
+      );
+
+      dl.changeDeliveryNotes(null);
+
+      expect(dl.deliveryNotes).toBeNull();
+    });
+  });
+
+  describe("activate / deactivate", () => {
+    it("無効化できる", () => {
+      const dl = createTestDeliveryLocation();
+
+      dl.deactivate();
+
+      expect(dl.isActive).toBe(false);
+    });
+
+    it("有効化できる", () => {
+      const dl = createTestDeliveryLocation();
+      dl.deactivate();
+
+      dl.activate();
+
+      expect(dl.isActive).toBe(true);
+    });
+  });
+});

--- a/src/server/subdomains/delivery-location/domain/repositories/DeliveryLocationRepository.ts
+++ b/src/server/subdomains/delivery-location/domain/repositories/DeliveryLocationRepository.ts
@@ -1,0 +1,29 @@
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+
+/**
+ * 納品先リポジトリインターフェース
+ *
+ * 検索・一覧取得については DeliveryLocationQueryService を使用すること
+ */
+export interface DeliveryLocationRepository {
+  /**
+   * 納品先を保存（新規作成・更新）
+   */
+  save(deliveryLocation: DeliveryLocation): Promise<DeliveryLocation>;
+
+  /**
+   * 納品先を削除
+   */
+  delete(id: string): Promise<void>;
+
+  /**
+   * IDで納品先を取得
+   */
+  findById(id: string): Promise<DeliveryLocation | null>;
+
+  /**
+   * 取引先コードで納品先を取得（重複チェック等で使用）
+   */
+  findByCode(code: CompanyCode): Promise<DeliveryLocation | null>;
+}

--- a/src/server/subdomains/delivery-location/domain/services/DeliveryLocationCodeDuplicationCheckDomainService.ts
+++ b/src/server/subdomains/delivery-location/domain/services/DeliveryLocationCodeDuplicationCheckDomainService.ts
@@ -1,0 +1,11 @@
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
+
+export class DeliveryLocationCodeDuplicationCheckDomainService {
+  constructor(private deliveryLocationRepository: DeliveryLocationRepository) {}
+
+  async execute(code: CompanyCode): Promise<boolean> {
+    const existing = await this.deliveryLocationRepository.findByCode(code);
+    return !!existing;
+  }
+}

--- a/src/server/subdomains/delivery-location/domain/services/__tests__/DeliveryLocationCodeDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/delivery-location/domain/services/__tests__/DeliveryLocationCodeDuplicationCheckDomainService.test.ts
@@ -1,0 +1,41 @@
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { InMemoryDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/in-memory/InMemoryDeliveryLocationRepository";
+import { beforeEach, describe, expect, test } from "vitest";
+import { DeliveryLocationCodeDuplicationCheckDomainService } from "../DeliveryLocationCodeDuplicationCheckDomainService";
+
+describe("DeliveryLocationCodeDuplicationCheckDomainService", () => {
+  let service: DeliveryLocationCodeDuplicationCheckDomainService;
+  let repository: InMemoryDeliveryLocationRepository;
+
+  beforeEach(() => {
+    repository = new InMemoryDeliveryLocationRepository();
+    service = new DeliveryLocationCodeDuplicationCheckDomainService(repository);
+  });
+
+  test("重複がない場合、falseを返す", async () => {
+    const code = new CompanyCode("DL001");
+    const isDuplicated = await service.execute(code);
+    expect(isDuplicated).toBe(false);
+  });
+
+  test("重複がある場合、trueを返す", async () => {
+    const code = new CompanyCode("DL001");
+    const dl = DeliveryLocation.create(code, new CompanyName("テスト倉庫"), "customer-id");
+    await repository.save(dl);
+
+    const isDuplicated = await service.execute(code);
+    expect(isDuplicated).toBe(true);
+  });
+
+  test("異なるコードで重複がない場合、falseを返す", async () => {
+    const existingCode = new CompanyCode("DL001");
+    const dl = DeliveryLocation.create(existingCode, new CompanyName("テスト倉庫"), "customer-id");
+    await repository.save(dl);
+
+    const newCode = new CompanyCode("DL002");
+    const isDuplicated = await service.execute(newCode);
+    expect(isDuplicated).toBe(false);
+  });
+});

--- a/src/server/subdomains/delivery-location/domain/values/DeliveryNotes.ts
+++ b/src/server/subdomains/delivery-location/domain/values/DeliveryNotes.ts
@@ -1,0 +1,14 @@
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * 配送備考値オブジェクト
+ */
+export class DeliveryNotes extends StringValueObject<"DeliveryNotes"> {
+  protected static readonly LABEL = "配送備考";
+  protected static readonly MIN_LENGTH = 1;
+  protected static readonly MAX_LENGTH = 500;
+
+  constructor(value: string) {
+    super(value.trim());
+  }
+}

--- a/src/server/subdomains/delivery-location/domain/values/__tests__/DeliveryNotes.test.ts
+++ b/src/server/subdomains/delivery-location/domain/values/__tests__/DeliveryNotes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { DeliveryNotes } from "../DeliveryNotes";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("DeliveryNotes", () => {
+  describe("正常系", () => {
+    it("備考を受け入れる", () => {
+      const notes = new DeliveryNotes("午前中配送希望");
+      expect(notes.value).toBe("午前中配送希望");
+    });
+
+    it("前後の空白はトリムされる", () => {
+      const notes = new DeliveryNotes("  午前中配送  ");
+      expect(notes.value).toBe("午前中配送");
+    });
+
+    it("500文字の備考を受け入れる", () => {
+      const notes = new DeliveryNotes("あ".repeat(500));
+      expect(notes.value).toBe("あ".repeat(500));
+    });
+  });
+
+  describe("異常系", () => {
+    it("空文字を拒否する", () => {
+      expect(() => new DeliveryNotes("")).toThrow(ValidationError);
+    });
+
+    it("501文字以上を拒否する", () => {
+      expect(() => new DeliveryNotes("あ".repeat(501))).toThrow(ValidationError);
+    });
+  });
+});

--- a/src/server/subdomains/delivery-location/infrastructure/in-memory/InMemoryDeliveryLocationRepository.ts
+++ b/src/server/subdomains/delivery-location/infrastructure/in-memory/InMemoryDeliveryLocationRepository.ts
@@ -1,0 +1,25 @@
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
+
+export class InMemoryDeliveryLocationRepository implements DeliveryLocationRepository {
+  public DB: { [id: string]: DeliveryLocation } = {};
+
+  async save(deliveryLocation: DeliveryLocation): Promise<DeliveryLocation> {
+    this.DB[deliveryLocation.id] = deliveryLocation;
+    return deliveryLocation;
+  }
+
+  async delete(id: string): Promise<void> {
+    delete this.DB[id];
+  }
+
+  async findById(id: string): Promise<DeliveryLocation | null> {
+    return this.DB[id] || null;
+  }
+
+  async findByCode(code: CompanyCode): Promise<DeliveryLocation | null> {
+    const dl = Object.values(this.DB).find((d) => d.code.equals(code));
+    return dl || null;
+  }
+}

--- a/src/server/subdomains/delivery-location/infrastructure/mappers/DeliveryLocationMapper.ts
+++ b/src/server/subdomains/delivery-location/infrastructure/mappers/DeliveryLocationMapper.ts
@@ -1,0 +1,86 @@
+import { Address } from "@server/shared/domain/values/Address";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
+import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
+import { PostalCode } from "@server/shared/domain/values/PostalCode";
+import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryNotes } from "@subdomains/delivery-location/domain/values/DeliveryNotes";
+import type { Company, DeliveryLocation as PrismaDeliveryLocation } from "@generated/prisma/client";
+import { CompanyType } from "@generated/prisma/client";
+
+type PrismaDeliveryLocationWithCompany = PrismaDeliveryLocation & {
+  company: Company;
+};
+
+/**
+ * DeliveryLocationMapper
+ *
+ * Company + DeliveryLocation の複合データとドメインエンティティを相互変換する
+ */
+export class DeliveryLocationMapper {
+  static toDomain(data: PrismaDeliveryLocationWithCompany): DeliveryLocation {
+    return DeliveryLocation.reconstruct(
+      data.id,
+      data.companyId,
+      new CompanyCode(data.company.code),
+      new CompanyName(data.company.name),
+      data.company.postalCode ? new PostalCode(data.company.postalCode) : null,
+      data.company.prefecture ? new Prefecture(data.company.prefecture) : null,
+      data.company.address ? new Address(data.company.address) : null,
+      data.company.phoneNumber ? new PhoneNumber(data.company.phoneNumber) : null,
+      data.company.faxNumber ? new FaxNumber(data.company.faxNumber) : null,
+      data.company.contactPerson,
+      data.company.isActive,
+      data.customerId,
+      data.deliveryNotes ? new DeliveryNotes(data.deliveryNotes) : null,
+      data.createdAt,
+      data.updatedAt
+    );
+  }
+
+  static toPrismaCreate(deliveryLocation: DeliveryLocation) {
+    return {
+      id: deliveryLocation.id,
+      customer: {
+        connect: { id: deliveryLocation.customerId },
+      },
+      deliveryNotes: deliveryLocation.deliveryNotes?.value ?? null,
+      company: {
+        create: {
+          id: deliveryLocation.companyId,
+          code: deliveryLocation.code.value,
+          name: deliveryLocation.name.value,
+          type: CompanyType.DELIVERY_LOCATION,
+          postalCode: deliveryLocation.postalCode?.value ?? null,
+          prefecture: deliveryLocation.prefecture?.value ?? null,
+          address: deliveryLocation.address?.value ?? null,
+          phoneNumber: deliveryLocation.phoneNumber?.value ?? null,
+          faxNumber: deliveryLocation.faxNumber?.value ?? null,
+          contactPerson: deliveryLocation.contactPerson,
+          isActive: deliveryLocation.isActive,
+        },
+      },
+    };
+  }
+
+  static toPrismaUpdate(deliveryLocation: DeliveryLocation) {
+    return {
+      deliveryNotes: deliveryLocation.deliveryNotes?.value ?? null,
+      updatedAt: deliveryLocation.updatedAt,
+      company: {
+        update: {
+          name: deliveryLocation.name.value,
+          postalCode: deliveryLocation.postalCode?.value ?? null,
+          prefecture: deliveryLocation.prefecture?.value ?? null,
+          address: deliveryLocation.address?.value ?? null,
+          phoneNumber: deliveryLocation.phoneNumber?.value ?? null,
+          faxNumber: deliveryLocation.faxNumber?.value ?? null,
+          contactPerson: deliveryLocation.contactPerson,
+          isActive: deliveryLocation.isActive,
+        },
+      },
+    };
+  }
+}

--- a/src/server/subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository.ts
+++ b/src/server/subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository.ts
@@ -1,0 +1,69 @@
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyType } from "@generated/prisma/client";
+import prisma from "@server/prisma";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
+import { DeliveryLocationMapper } from "@subdomains/delivery-location/infrastructure/mappers/DeliveryLocationMapper";
+
+const INCLUDE_COMPANY = { company: true } as const;
+
+export class PrismaDeliveryLocationRepository implements DeliveryLocationRepository {
+  async save(deliveryLocation: DeliveryLocation): Promise<DeliveryLocation> {
+    const existing = await prisma.deliveryLocation.findUnique({
+      where: { id: deliveryLocation.id },
+    });
+
+    let prismaDeliveryLocation;
+
+    if (existing) {
+      prismaDeliveryLocation = await prisma.deliveryLocation.update({
+        where: { id: deliveryLocation.id },
+        data: DeliveryLocationMapper.toPrismaUpdate(deliveryLocation),
+        include: INCLUDE_COMPANY,
+      });
+    } else {
+      prismaDeliveryLocation = await prisma.deliveryLocation.create({
+        data: DeliveryLocationMapper.toPrismaCreate(deliveryLocation),
+        include: INCLUDE_COMPANY,
+      });
+    }
+
+    return DeliveryLocationMapper.toDomain(prismaDeliveryLocation);
+  }
+
+  async delete(id: string): Promise<void> {
+    const deliveryLocation = await prisma.deliveryLocation.findUnique({
+      where: { id },
+      select: { companyId: true },
+    });
+
+    if (deliveryLocation) {
+      await prisma.company.delete({
+        where: { id: deliveryLocation.companyId },
+      });
+    }
+  }
+
+  async findById(id: string): Promise<DeliveryLocation | null> {
+    const prismaDeliveryLocation = await prisma.deliveryLocation.findUnique({
+      where: { id },
+      include: INCLUDE_COMPANY,
+    });
+
+    return prismaDeliveryLocation ? DeliveryLocationMapper.toDomain(prismaDeliveryLocation) : null;
+  }
+
+  async findByCode(code: CompanyCode): Promise<DeliveryLocation | null> {
+    const prismaDeliveryLocation = await prisma.deliveryLocation.findFirst({
+      where: {
+        company: {
+          code: code.value,
+          type: CompanyType.DELIVERY_LOCATION,
+        },
+      },
+      include: INCLUDE_COMPANY,
+    });
+
+    return prismaDeliveryLocation ? DeliveryLocationMapper.toDomain(prismaDeliveryLocation) : null;
+  }
+}

--- a/src/server/subdomains/delivery-location/infrastructure/queries/PrismaDeliveryLocationQueryService.ts
+++ b/src/server/subdomains/delivery-location/infrastructure/queries/PrismaDeliveryLocationQueryService.ts
@@ -1,0 +1,184 @@
+import { DeliveryLocationDTO } from "@subdomains/delivery-location/application/queries/dto/DeliveryLocationDTO";
+import {
+  DeliveryLocationSearchCriteria,
+  DeliveryLocationListOptions,
+} from "@subdomains/delivery-location/application/queries/dto/DeliveryLocationSearchCriteria";
+import { DeliveryLocationQueryService } from "@subdomains/delivery-location/application/queries/DeliveryLocationQueryService";
+import prisma from "@server/prisma";
+import { CompanyType, Prisma } from "@generated/prisma/client";
+
+export class PrismaDeliveryLocationQueryService implements DeliveryLocationQueryService {
+  async findById(id: string): Promise<DeliveryLocationDTO | null> {
+    const dl = await prisma.deliveryLocation.findUnique({
+      where: { id },
+      select: this.getSelectFields(),
+    });
+
+    return dl ? this.toDTO(dl) : null;
+  }
+
+  async findByCode(code: string): Promise<DeliveryLocationDTO | null> {
+    const dl = await prisma.deliveryLocation.findFirst({
+      where: {
+        company: { code, type: CompanyType.DELIVERY_LOCATION },
+      },
+      select: this.getSelectFields(),
+    });
+
+    return dl ? this.toDTO(dl) : null;
+  }
+
+  async findByCustomerId(
+    customerId: string,
+    options?: DeliveryLocationListOptions
+  ): Promise<DeliveryLocationDTO[]> {
+    const orderBy = this.buildOrderBy(options);
+
+    const dls = await prisma.deliveryLocation.findMany({
+      where: { customerId },
+      select: this.getSelectFields(),
+      orderBy,
+      take: options?.limit,
+      skip: options?.offset,
+    });
+
+    return dls.map((dl) => this.toDTO(dl));
+  }
+
+  async search(
+    criteria: DeliveryLocationSearchCriteria,
+    options?: DeliveryLocationListOptions
+  ): Promise<DeliveryLocationDTO[]> {
+    const where = this.buildWhereClause(criteria);
+    const orderBy = this.buildOrderBy(options);
+
+    const dls = await prisma.deliveryLocation.findMany({
+      where,
+      select: this.getSelectFields(),
+      orderBy,
+      take: options?.limit,
+      skip: options?.offset,
+    });
+
+    return dls.map((dl) => this.toDTO(dl));
+  }
+
+  async findAll(options?: DeliveryLocationListOptions): Promise<DeliveryLocationDTO[]> {
+    const orderBy = this.buildOrderBy(options);
+
+    const dls = await prisma.deliveryLocation.findMany({
+      select: this.getSelectFields(),
+      orderBy,
+      take: options?.limit,
+      skip: options?.offset,
+    });
+
+    return dls.map((dl) => this.toDTO(dl));
+  }
+
+  async count(criteria: DeliveryLocationSearchCriteria): Promise<number> {
+    const where = this.buildWhereClause(criteria);
+    return await prisma.deliveryLocation.count({ where });
+  }
+
+  private buildWhereClause(
+    criteria: DeliveryLocationSearchCriteria
+  ): Prisma.DeliveryLocationWhereInput {
+    const where: Prisma.DeliveryLocationWhereInput = {};
+    const companyWhere: Prisma.CompanyWhereInput = { type: CompanyType.DELIVERY_LOCATION };
+
+    if (criteria.name) {
+      companyWhere.name = { contains: criteria.name, mode: "insensitive" };
+    }
+
+    if (criteria.code) {
+      companyWhere.code = criteria.code;
+    }
+
+    if (criteria.isActive !== undefined) {
+      companyWhere.isActive = criteria.isActive;
+    }
+
+    if (criteria.customerId) {
+      where.customerId = criteria.customerId;
+    }
+
+    where.company = companyWhere;
+    return where;
+  }
+
+  private buildOrderBy(
+    options?: DeliveryLocationListOptions
+  ): Prisma.DeliveryLocationOrderByWithRelationInput | undefined {
+    if (!options?.orderBy) {
+      return undefined;
+    }
+
+    const { field, direction } = options.orderBy;
+
+    if (field === "name" || field === "code") {
+      return { company: { [field]: direction } };
+    }
+
+    return { [field]: direction };
+  }
+
+  private getSelectFields() {
+    return {
+      id: true,
+      customerId: true,
+      deliveryNotes: true,
+      createdAt: true,
+      updatedAt: true,
+      company: {
+        select: {
+          code: true,
+          name: true,
+          postalCode: true,
+          prefecture: true,
+          address: true,
+          phoneNumber: true,
+          faxNumber: true,
+          contactPerson: true,
+          isActive: true,
+        },
+      },
+    } as const;
+  }
+
+  private toDTO(dl: {
+    id: string;
+    customerId: string;
+    deliveryNotes: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    company: {
+      code: string;
+      name: string;
+      postalCode: string | null;
+      prefecture: string | null;
+      address: string | null;
+      phoneNumber: string | null;
+      faxNumber: string | null;
+      contactPerson: string | null;
+      isActive: boolean;
+    };
+  }): DeliveryLocationDTO {
+    return {
+      id: dl.id,
+      code: dl.company.code,
+      name: dl.company.name,
+      postalCode: dl.company.postalCode,
+      prefecture: dl.company.prefecture,
+      address: dl.company.address,
+      phoneNumber: dl.company.phoneNumber,
+      faxNumber: dl.company.faxNumber,
+      contactPerson: dl.company.contactPerson,
+      isActive: dl.company.isActive,
+      customerId: dl.customerId,
+      deliveryNotes: dl.deliveryNotes,
+      createdAt: dl.createdAt,
+      updatedAt: dl.updatedAt,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Closes #73

取引先マスタ（得意先・納品先）をDDDアーキテクチャで実装しました。

- **Company基底テーブル**: `CompanyType`（CUSTOMER / DELIVERY_LOCATION）で区別するSTI的アプローチ
- **Customerサブドメイン**: 得意先のドメインエンティティ、値オブジェクト、リポジトリ、コマンド/クエリ、インフラ層を実装
- **DeliveryLocationサブドメイン**: 納品先のドメインエンティティ、値オブジェクト、リポジトリ、コマンド/クエリ、インフラ層を実装
- **共有値オブジェクト**: CompanyCode, CompanyName, PostalCode, PhoneNumber, FaxNumber, Prefecture, Address を `src/server/shared/domain/values/` に作成
- **テスト**: エンティティ、値オブジェクト、ドメインサービスのユニットテスト（全348テスト合格）

### 主な構成

```
src/server/shared/domain/values/     - 共有値オブジェクト（7種）
src/server/subdomains/customer/      - 得意先サブドメイン（domain/application/infrastructure）
src/server/subdomains/delivery-location/ - 納品先サブドメイン（domain/application/infrastructure）
prisma/schema.prisma                 - Company, Customer, DeliveryLocation モデル追加
```

## Test plan

- [x] 全348テスト合格（`pnpm test`）
- [x] ESLint通過（`pnpm lint`）
- [x] TypeScript型チェック通過
- [x] Prismaマイグレーション実行済み
- [ ] 手動テスト: 得意先CRUD操作の確認
- [ ] 手動テスト: 納品先CRUD操作の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)