### PR TITLE
ci: worktree判定でprepare-commit-msg hookをスキップする

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,1 +1,4 @@
+if [ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]; then
+  exit 0
+fi
 exec < /dev/tty && git cz --hook || true


### PR DESCRIPTION
## Summary
- `prepare-commit-msg` hookがttyのないCLI環境（Claude Code等）で失敗する問題を修正
- worktree内かどうかを`git rev-parse --git-dir`と`--git-common-dir`の比較で判定し、worktree内ではcommitizenをスキップする
- 手動コミット時は従来通り`git cz --hook`が動作する

## Test plan
- [x] worktree環境で`--git-dir`と`--git-common-dir`が異なることを確認
- [x] 全テスト通過（42ファイル、321テスト）
- [x] worktree環境でコミットが正常に作成されることを確認

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)