### PR TITLE
test: department application層テストをtesting-backend規約に準拠させる

### DIFF
--- a/src/server/subdomains/department/application/commands/__tests__/CreateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/CreateDepartmentCommand.test.ts
@@ -1,140 +1,129 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { CreateDepartmentCommand } from "../CreateDepartmentCommand";
-import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
-import { DepartmentCdDuplicationCheckDomainService } from "@subdomains/department/domain/services/DepartmentCdDuplicationCheckDomainService";
-import { Department } from "@subdomains/department/domain/entities/Department";
-import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
-import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
-import { Abbreviation } from "@subdomains/department/domain/values/Abbreviation";
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
 import { ValidationError } from "@server/shared/errors/DomainError";
+import { DepartmentCdDuplicationCheckDomainService } from "@subdomains/department/domain/services/DepartmentCdDuplicationCheckDomainService";
+import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
+import { PrismaDepartmentRepository } from "@subdomains/department/infrastructure/prisma/PrismaDepartmentRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CreateDepartmentCommand } from "../CreateDepartmentCommand";
 
 describe("CreateDepartmentCommand", () => {
   let command: CreateDepartmentCommand;
-  let mockRepository: DepartmentRepository;
-  let mockDuplicationCheckService: DepartmentCdDuplicationCheckDomainService;
+  let repository: PrismaDepartmentRepository;
 
-  beforeEach(() => {
-    mockRepository = {
-      save: vi.fn().mockImplementation((dept) => Promise.resolve(dept)),
-      delete: vi.fn(),
-      findById: vi.fn(),
-      findByDepartmentCd: vi.fn(),
-      findChildren: vi.fn(),
-      findRootDepartments: vi.fn(),
-    };
+  const TEST_CODES = ["DEPT991", "DEPT992"];
 
-    mockDuplicationCheckService = {
-      execute: vi.fn(),
-    } as unknown as DepartmentCdDuplicationCheckDomainService;
+  async function cleanup() {
+    await prisma.department.deleteMany({
+      where: { parentId: { not: null }, departmentCd: { in: TEST_CODES } },
+    });
+    await prisma.department.deleteMany({
+      where: { departmentCd: { in: TEST_CODES } },
+    });
+  }
 
-    command = new CreateDepartmentCommand(mockRepository, mockDuplicationCheckService);
+  beforeEach(async () => {
+    await cleanup();
+
+    repository = new PrismaDepartmentRepository();
+    const duplicationCheckService = new DepartmentCdDuplicationCheckDomainService(repository);
+    command = new CreateDepartmentCommand(repository, duplicationCheckService);
+  });
+
+  afterEach(async () => {
+    await cleanup();
   });
 
   it("部署を新規登録できる", async () => {
-    vi.mocked(mockDuplicationCheckService.execute).mockResolvedValue(false);
-
-    const result = await command.execute({
-      departmentCd: "DEPT001",
-      name: "営業部",
-      abbreviation: "営業",
+    await command.execute({
+      departmentCd: TEST_CODES[0],
+      name: "テスト営業部",
+      abbreviation: "テスト営業",
     });
 
-    expect(result).toBeInstanceOf(Department);
-    expect(result.departmentCd.value).toBe("DEPT001");
-    expect(result.name.value).toBe("営業部");
-    expect(result.abbreviation.value).toBe("営業");
-    expect(result.displayOrder).toBe(0);
-    expect(result.parentId).toBeNull();
-    expect(mockRepository.save).toHaveBeenCalledTimes(1);
+    const saved = await repository.findByDepartmentCd(new DepartmentCd(TEST_CODES[0]));
+    expect(saved).not.toBeNull();
+    expect(saved?.departmentCd.value).toBe(TEST_CODES[0]);
+    expect(saved?.name.value).toBe("テスト営業部");
+    expect(saved?.abbreviation.value).toBe("テスト営業");
+    expect(saved?.displayOrder).toBe(0);
+    expect(saved?.parentId).toBeNull();
   });
 
   it("表示順と親部署を指定して登録できる", async () => {
-    vi.mocked(mockDuplicationCheckService.execute).mockResolvedValue(false);
-    const parentDepartment = Department.create(
-      new DepartmentCd("DEPT001"),
-      new DepartmentName("本社"),
-      new Abbreviation("本社")
-    );
-    vi.mocked(mockRepository.findById).mockResolvedValue(parentDepartment);
-
-    const result = await command.execute({
-      departmentCd: "DEPT002",
-      name: "営業部",
-      abbreviation: "営業",
-      displayOrder: 10,
-      parentId: parentDepartment.id,
+    const parentId = createId();
+    await prisma.department.create({
+      data: {
+        id: parentId,
+        departmentCd: TEST_CODES[0],
+        name: "親部署",
+        abbreviation: "親",
+        displayOrder: 1,
+        isActive: true,
+      },
     });
 
-    expect(result.displayOrder).toBe(10);
-    expect(result.parentId).toBe(parentDepartment.id);
+    await command.execute({
+      departmentCd: TEST_CODES[1],
+      name: "子部署",
+      abbreviation: "子",
+      displayOrder: 10,
+      parentId,
+    });
+
+    const saved = await repository.findByDepartmentCd(new DepartmentCd(TEST_CODES[1]));
+    expect(saved).not.toBeNull();
+    expect(saved?.displayOrder).toBe(10);
+    expect(saved?.parentId).toBe(parentId);
   });
 
   it("既に存在する部署コードの場合はエラー", async () => {
-    vi.mocked(mockDuplicationCheckService.execute).mockResolvedValue(true);
+    await command.execute({
+      departmentCd: TEST_CODES[0],
+      name: "最初の部署",
+      abbreviation: "最初",
+    });
 
     await expect(
       command.execute({
-        departmentCd: "DEPT001",
-        name: "営業部",
-        abbreviation: "営業",
+        departmentCd: TEST_CODES[0],
+        name: "重複部署",
+        abbreviation: "重複",
       })
     ).rejects.toThrow(ValidationError);
-
-    expect(mockRepository.save).not.toHaveBeenCalled();
   });
 
   it("存在しない親部署を指定するとエラー", async () => {
-    vi.mocked(mockDuplicationCheckService.execute).mockResolvedValue(false);
-    vi.mocked(mockRepository.findById).mockResolvedValue(null);
-
     await expect(
       command.execute({
-        departmentCd: "DEPT001",
+        departmentCd: TEST_CODES[0],
         name: "営業部",
         abbreviation: "営業",
         parentId: "non-existent-id",
       })
     ).rejects.toThrow(ValidationError);
-    await expect(
-      command.execute({
-        departmentCd: "DEPT001",
-        name: "営業部",
-        abbreviation: "営業",
-        parentId: "non-existent-id",
-      })
-    ).rejects.toThrow("親部署が存在しません");
   });
 
   it("無効な部署を親部署に指定するとエラー", async () => {
-    vi.mocked(mockDuplicationCheckService.execute).mockResolvedValue(false);
-    const inactiveParent = Department.reconstruct(
-      "parent-id",
-      new DepartmentCd("DEPT001"),
-      new DepartmentName("旧部署"),
-      new Abbreviation("旧"),
-      0,
-      false, // 無効
-      null,
-      new Date(),
-      new Date()
-    );
-    vi.mocked(mockRepository.findById).mockResolvedValue(inactiveParent);
+    const inactiveParentId = createId();
+    await prisma.department.create({
+      data: {
+        id: inactiveParentId,
+        departmentCd: TEST_CODES[0],
+        name: "無効部署",
+        abbreviation: "無効",
+        displayOrder: 1,
+        isActive: false,
+      },
+    });
 
     await expect(
       command.execute({
-        departmentCd: "DEPT002",
-        name: "営業部",
-        abbreviation: "営業",
-        parentId: "parent-id",
+        departmentCd: TEST_CODES[1],
+        name: "子部署",
+        abbreviation: "子",
+        parentId: inactiveParentId,
       })
     ).rejects.toThrow(ValidationError);
-    await expect(
-      command.execute({
-        departmentCd: "DEPT002",
-        name: "営業部",
-        abbreviation: "営業",
-        parentId: "parent-id",
-      })
-    ).rejects.toThrow("無効な部署を親部署に設定することはできません");
   });
 });

--- a/src/server/subdomains/department/application/commands/__tests__/DeleteDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/DeleteDepartmentCommand.test.ts
@@ -1,71 +1,86 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { DeleteDepartmentCommand } from "../DeleteDepartmentCommand";
-import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
-import { Department } from "@subdomains/department/domain/entities/Department";
-import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
-import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
-import { Abbreviation } from "@subdomains/department/domain/values/Abbreviation";
-import { ValidationError } from "@server/shared/errors/DomainError";
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { PrismaDepartmentRepository } from "@subdomains/department/infrastructure/prisma/PrismaDepartmentRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DeleteDepartmentCommand } from "../DeleteDepartmentCommand";
 
 describe("DeleteDepartmentCommand", () => {
   let command: DeleteDepartmentCommand;
-  let mockRepository: DepartmentRepository;
+  let repository: PrismaDepartmentRepository;
 
-  const createTestDepartment = (id: string = "dept-1") => {
-    return Department.reconstruct(
-      id,
-      new DepartmentCd("DEPT001"),
-      new DepartmentName("営業部"),
-      new Abbreviation("営業"),
-      0,
-      true,
-      null,
-      new Date(),
-      new Date()
-    );
-  };
+  const TEST_CODES = ["DEPT996", "DEPT997"];
 
-  beforeEach(() => {
-    mockRepository = {
-      save: vi.fn(),
-      delete: vi.fn(),
-      findById: vi.fn(),
-      findByDepartmentCd: vi.fn(),
-      findChildren: vi.fn().mockResolvedValue([]),
-      findRootDepartments: vi.fn(),
-    };
+  async function cleanup() {
+    await prisma.department.deleteMany({
+      where: { parentId: { not: null }, departmentCd: { in: TEST_CODES } },
+    });
+    await prisma.department.deleteMany({
+      where: { departmentCd: { in: TEST_CODES } },
+    });
+  }
 
-    command = new DeleteDepartmentCommand(mockRepository);
+  beforeEach(async () => {
+    await cleanup();
+
+    repository = new PrismaDepartmentRepository();
+    command = new DeleteDepartmentCommand(repository);
+  });
+
+  afterEach(async () => {
+    await cleanup();
   });
 
   it("部署を削除できる", async () => {
-    const department = createTestDepartment();
-    vi.mocked(mockRepository.findById).mockResolvedValue(department);
-    vi.mocked(mockRepository.findChildren).mockResolvedValue([]);
+    const deptId = createId();
+    await prisma.department.create({
+      data: {
+        id: deptId,
+        departmentCd: TEST_CODES[0],
+        name: "削除テスト部署",
+        abbreviation: "削除テスト",
+        displayOrder: 1,
+        isActive: true,
+      },
+    });
 
-    await command.execute({ id: "dept-1" });
+    await command.execute({ id: deptId });
 
-    expect(mockRepository.delete).toHaveBeenCalledWith("dept-1");
+    const deleted = await prisma.department.findUnique({ where: { id: deptId } });
+    expect(deleted).toBeNull();
   });
 
   it("存在しない部署を削除しようとするとエラー", async () => {
-    vi.mocked(mockRepository.findById).mockResolvedValue(null);
-
-    await expect(command.execute({ id: "non-existent" })).rejects.toThrow(NotFoundEntityError);
-
-    expect(mockRepository.delete).not.toHaveBeenCalled();
+    await expect(command.execute({ id: "non-existent-id" })).rejects.toThrow(NotFoundEntityError);
   });
 
   it("子部署がある場合は削除できない", async () => {
-    const department = createTestDepartment();
-    const childDepartment = createTestDepartment("child-1");
-    vi.mocked(mockRepository.findById).mockResolvedValue(department);
-    vi.mocked(mockRepository.findChildren).mockResolvedValue([childDepartment]);
+    const parentId = createId();
+    const childId = createId();
 
-    await expect(command.execute({ id: "dept-1" })).rejects.toThrow(ValidationError);
-    await expect(command.execute({ id: "dept-1" })).rejects.toThrow("子部署が存在するため");
+    await prisma.department.create({
+      data: {
+        id: parentId,
+        departmentCd: TEST_CODES[0],
+        name: "親部署",
+        abbreviation: "親",
+        displayOrder: 1,
+        isActive: true,
+      },
+    });
+    await prisma.department.create({
+      data: {
+        id: childId,
+        departmentCd: TEST_CODES[1],
+        name: "子部署",
+        abbreviation: "子",
+        displayOrder: 1,
+        isActive: true,
+        parentId,
+      },
+    });
 
-    expect(mockRepository.delete).not.toHaveBeenCalled();
+    await expect(command.execute({ id: parentId })).rejects.toThrow(ValidationError);
   });
 });

--- a/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
@@ -81,6 +81,21 @@ describe("UpdateDepartmentCommand", () => {
     ).rejects.toThrow(NotFoundEntityError);
   });
 
+  it("部署を有効化できる", async () => {
+    // まず無効化
+    await prisma.department.update({
+      where: { id: baseDeptId },
+      data: { isActive: false },
+    });
+
+    const result = await command.execute({
+      id: baseDeptId,
+      isActive: true,
+    });
+
+    expect(result.isActive).toBe(true);
+  });
+
   it("部署を無効化できる", async () => {
     const result = await command.execute({
       id: baseDeptId,
@@ -131,6 +146,45 @@ describe("UpdateDepartmentCommand", () => {
     });
 
     expect(result.parentId).toBe(newParentId);
+  });
+
+  it("自分自身を親部署に設定するとエラー", async () => {
+    await expect(
+      command.execute({
+        id: baseDeptId,
+        parentId: baseDeptId,
+      })
+    ).rejects.toThrow(BusinessRuleViolationError);
+  });
+
+  it("存在しない部署を親部署に設定するとエラー", async () => {
+    await expect(
+      command.execute({
+        id: baseDeptId,
+        parentId: "non-existent-parent-id",
+      })
+    ).rejects.toThrow(BusinessRuleViolationError);
+  });
+
+  it("無効な部署を親部署に設定するとエラー", async () => {
+    const inactiveParentId = createId();
+    await prisma.department.create({
+      data: {
+        id: inactiveParentId,
+        departmentCd: TEST_CODES[1],
+        name: "無効親部署",
+        abbreviation: "無効親",
+        displayOrder: 1,
+        isActive: false,
+      },
+    });
+
+    await expect(
+      command.execute({
+        id: baseDeptId,
+        parentId: inactiveParentId,
+      })
+    ).rejects.toThrow(BusinessRuleViolationError);
   });
 
   it("循環参照になる親部署を設定するとエラー", async () => {

--- a/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
@@ -1,63 +1,62 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { UpdateDepartmentCommand } from "../UpdateDepartmentCommand";
-import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
-import { Department } from "@subdomains/department/domain/entities/Department";
-import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
-import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
-import { Abbreviation } from "@subdomains/department/domain/values/Abbreviation";
-import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { PrismaDepartmentRepository } from "@subdomains/department/infrastructure/prisma/PrismaDepartmentRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { UpdateDepartmentCommand } from "../UpdateDepartmentCommand";
 
 describe("UpdateDepartmentCommand", () => {
   let command: UpdateDepartmentCommand;
-  let mockRepository: DepartmentRepository;
+  let repository: PrismaDepartmentRepository;
 
-  const createTestDepartment = (id: string = "dept-1") => {
-    return Department.reconstruct(
-      id,
-      new DepartmentCd("DEPT001"),
-      new DepartmentName("営業部"),
-      new Abbreviation("営業"),
-      0,
-      true,
-      null,
-      new Date(),
-      new Date()
-    );
-  };
+  const TEST_CODES = ["DEPT993", "DEPT994", "DEPT995"];
+  let baseDeptId: string;
 
-  beforeEach(() => {
-    mockRepository = {
-      save: vi.fn().mockImplementation((dept) => Promise.resolve(dept)),
-      delete: vi.fn(),
-      findById: vi.fn(),
-      findByDepartmentCd: vi.fn(),
-      findChildren: vi.fn().mockResolvedValue([]),
-      findRootDepartments: vi.fn(),
-    };
+  async function cleanup() {
+    await prisma.department.deleteMany({
+      where: { parentId: { not: null }, departmentCd: { in: TEST_CODES } },
+    });
+    await prisma.department.deleteMany({
+      where: { departmentCd: { in: TEST_CODES } },
+    });
+  }
 
-    command = new UpdateDepartmentCommand(mockRepository);
+  beforeEach(async () => {
+    await cleanup();
+
+    repository = new PrismaDepartmentRepository();
+    command = new UpdateDepartmentCommand(repository);
+
+    baseDeptId = createId();
+    await prisma.department.create({
+      data: {
+        id: baseDeptId,
+        departmentCd: TEST_CODES[0],
+        name: "営業部",
+        abbreviation: "営業",
+        displayOrder: 0,
+        isActive: true,
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await cleanup();
   });
 
   it("部署名を更新できる", async () => {
-    const department = createTestDepartment();
-    vi.mocked(mockRepository.findById).mockResolvedValue(department);
-
     const result = await command.execute({
-      id: "dept-1",
+      id: baseDeptId,
       name: "新営業部",
     });
 
     expect(result.name.value).toBe("新営業部");
-    expect(mockRepository.save).toHaveBeenCalledTimes(1);
   });
 
   it("略称を更新できる", async () => {
-    const department = createTestDepartment();
-    vi.mocked(mockRepository.findById).mockResolvedValue(department);
-
     const result = await command.execute({
-      id: "dept-1",
+      id: baseDeptId,
       abbreviation: "新営業",
     });
 
@@ -65,11 +64,8 @@ describe("UpdateDepartmentCommand", () => {
   });
 
   it("表示順を更新できる", async () => {
-    const department = createTestDepartment();
-    vi.mocked(mockRepository.findById).mockResolvedValue(department);
-
     const result = await command.execute({
-      id: "dept-1",
+      id: baseDeptId,
       displayOrder: 10,
     });
 
@@ -77,23 +73,17 @@ describe("UpdateDepartmentCommand", () => {
   });
 
   it("存在しない部署を更新しようとするとエラー", async () => {
-    vi.mocked(mockRepository.findById).mockResolvedValue(null);
-
     await expect(
       command.execute({
-        id: "non-existent",
+        id: "non-existent-id",
         name: "新営業部",
       })
     ).rejects.toThrow(NotFoundEntityError);
   });
 
   it("部署を無効化できる", async () => {
-    const department = createTestDepartment();
-    vi.mocked(mockRepository.findById).mockResolvedValue(department);
-    vi.mocked(mockRepository.findChildren).mockResolvedValue([]);
-
     const result = await command.execute({
-      id: "dept-1",
+      id: baseDeptId,
       isActive: false,
     });
 
@@ -101,92 +91,81 @@ describe("UpdateDepartmentCommand", () => {
   });
 
   it("有効な子部署がある場合は無効化できない", async () => {
-    const department = createTestDepartment();
-    const childDepartment = createTestDepartment("child-1");
-    vi.mocked(mockRepository.findById).mockResolvedValue(department);
-    vi.mocked(mockRepository.findChildren).mockResolvedValue([childDepartment]);
+    const childId = createId();
+    await prisma.department.create({
+      data: {
+        id: childId,
+        departmentCd: TEST_CODES[1],
+        name: "子部署",
+        abbreviation: "子",
+        displayOrder: 1,
+        isActive: true,
+        parentId: baseDeptId,
+      },
+    });
 
     await expect(
       command.execute({
-        id: "dept-1",
+        id: baseDeptId,
         isActive: false,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
-    await expect(
-      command.execute({
-        id: "dept-1",
-        isActive: false,
-      })
-    ).rejects.toThrow("有効な子部署が存在するため");
   });
 
   it("親部署を変更できる", async () => {
-    const department = createTestDepartment();
-    const newParent = Department.reconstruct(
-      "parent-id",
-      new DepartmentCd("DEPT002"),
-      new DepartmentName("本社"),
-      new Abbreviation("本社"),
-      0,
-      true,
-      null,
-      new Date(),
-      new Date()
-    );
-
-    vi.mocked(mockRepository.findById)
-      .mockResolvedValueOnce(department)
-      .mockResolvedValueOnce(newParent);
-
-    const result = await command.execute({
-      id: "dept-1",
-      parentId: "parent-id",
+    const newParentId = createId();
+    await prisma.department.create({
+      data: {
+        id: newParentId,
+        departmentCd: TEST_CODES[1],
+        name: "新親部署",
+        abbreviation: "新親",
+        displayOrder: 1,
+        isActive: true,
+      },
     });
 
-    expect(result.parentId).toBe("parent-id");
+    const result = await command.execute({
+      id: baseDeptId,
+      parentId: newParentId,
+    });
+
+    expect(result.parentId).toBe(newParentId);
   });
 
   it("循環参照になる親部署を設定するとエラー", async () => {
-    // dept-1 が親で、dept-2 がその子の場合
-    // dept-1 の親を dept-2 に変更しようとすると循環参照
-    const department = createTestDepartment("dept-1");
-    const childAsNewParent = Department.reconstruct(
-      "dept-2",
-      new DepartmentCd("DEPT002"),
-      new DepartmentName("子部署"),
-      new Abbreviation("子"),
-      0,
-      true,
-      "dept-1", // dept-1 が親
-      new Date(),
-      new Date()
-    );
+    // A → B → C の3階層を作成し、AのparentをCに変更 → 循環参照
+    const deptBId = createId();
+    const deptCId = createId();
 
-    vi.mocked(mockRepository.findById).mockImplementation((id: string) => {
-      if (id === "dept-1") return Promise.resolve(department);
-      if (id === "dept-2") return Promise.resolve(childAsNewParent);
-      return Promise.resolve(null);
+    await prisma.department.create({
+      data: {
+        id: deptBId,
+        departmentCd: TEST_CODES[1],
+        name: "部署B",
+        abbreviation: "B",
+        displayOrder: 1,
+        isActive: true,
+        parentId: baseDeptId,
+      },
+    });
+    await prisma.department.create({
+      data: {
+        id: deptCId,
+        departmentCd: TEST_CODES[2],
+        name: "部署C",
+        abbreviation: "C",
+        displayOrder: 2,
+        isActive: true,
+        parentId: deptBId,
+      },
     });
 
     await expect(
       command.execute({
-        id: "dept-1",
-        parentId: "dept-2",
+        id: baseDeptId,
+        parentId: deptCId,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
-
-    // reset mock for second assertion
-    vi.mocked(mockRepository.findById).mockImplementation((id: string) => {
-      if (id === "dept-1") return Promise.resolve(department);
-      if (id === "dept-2") return Promise.resolve(childAsNewParent);
-      return Promise.resolve(null);
-    });
-
-    await expect(
-      command.execute({
-        id: "dept-1",
-        parentId: "dept-2",
-      })
-    ).rejects.toThrow("循環参照が発生するため");
   });
 });

--- a/src/server/subdomains/department/application/queries/__tests__/GetActiveDepartmentsQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/GetActiveDepartmentsQuery.test.ts
@@ -1,0 +1,86 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { PrismaDepartmentQueryService } from "@subdomains/department/infrastructure/queries/PrismaDepartmentQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetActiveDepartmentsQuery } from "../GetActiveDepartmentsQuery";
+
+describe("GetActiveDepartmentsQuery", () => {
+  let query: GetActiveDepartmentsQuery;
+  const testDepartmentIds: string[] = [];
+
+  const TEST_CODES = ["DEPT977", "DEPT978"];
+
+  async function createTestDepartment(data: {
+    departmentCd: string;
+    name: string;
+    abbreviation: string;
+    displayOrder?: number;
+    isActive?: boolean;
+    parentId?: string | null;
+  }): Promise<string> {
+    const id = createId();
+    await prisma.department.create({ data: { id, ...data } });
+    testDepartmentIds.push(id);
+    return id;
+  }
+
+  async function cleanup() {
+    await prisma.department.deleteMany({
+      where: { parentId: { not: null }, departmentCd: { in: TEST_CODES } },
+    });
+    await prisma.department.deleteMany({
+      where: { departmentCd: { in: TEST_CODES } },
+    });
+  }
+
+  beforeEach(async () => {
+    testDepartmentIds.length = 0;
+    await cleanup();
+
+    query = new GetActiveDepartmentsQuery(new PrismaDepartmentQueryService());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("有効な部署のみ取得できる", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "有効部署",
+      abbreviation: "有効",
+      isActive: true,
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "無効部署",
+      abbreviation: "無効",
+      isActive: false,
+    });
+
+    const result = await query.execute({});
+
+    const departmentCds = result.map((r) => r.departmentCd);
+    expect(departmentCds).toContain(TEST_CODES[0]);
+    expect(departmentCds).not.toContain(TEST_CODES[1]);
+  });
+
+  it("オプション付きで取得できる", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "有効部署1",
+      abbreviation: "有効1",
+      isActive: true,
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "有効部署2",
+      abbreviation: "有効2",
+      isActive: true,
+    });
+
+    const result = await query.execute({ options: { limit: 1 } });
+
+    expect(result.length).toBe(1);
+  });
+});

--- a/src/server/subdomains/department/application/queries/__tests__/GetAllDepartmentsQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/GetAllDepartmentsQuery.test.ts
@@ -1,0 +1,105 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { PrismaDepartmentQueryService } from "@subdomains/department/infrastructure/queries/PrismaDepartmentQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetAllDepartmentsQuery } from "../GetAllDepartmentsQuery";
+
+describe("GetAllDepartmentsQuery", () => {
+  let query: GetAllDepartmentsQuery;
+  const testDepartmentIds: string[] = [];
+
+  const TEST_CODES = ["DEPT971", "DEPT972"];
+
+  async function createTestDepartment(data: {
+    departmentCd: string;
+    name: string;
+    abbreviation: string;
+    displayOrder?: number;
+    isActive?: boolean;
+    parentId?: string | null;
+  }): Promise<string> {
+    const id = createId();
+    await prisma.department.create({ data: { id, ...data } });
+    testDepartmentIds.push(id);
+    return id;
+  }
+
+  async function cleanup() {
+    await prisma.department.deleteMany({
+      where: { parentId: { not: null }, departmentCd: { in: TEST_CODES } },
+    });
+    await prisma.department.deleteMany({
+      where: { departmentCd: { in: TEST_CODES } },
+    });
+  }
+
+  beforeEach(async () => {
+    testDepartmentIds.length = 0;
+    await cleanup();
+
+    query = new GetAllDepartmentsQuery(new PrismaDepartmentQueryService());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("全部署を取得できる", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "全取得テスト部署1",
+      abbreviation: "全取得1",
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "全取得テスト部署2",
+      abbreviation: "全取得2",
+    });
+
+    const result = await query.execute({});
+
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    const departmentCds = result.map((r) => r.departmentCd);
+    expect(departmentCds).toContain(TEST_CODES[0]);
+    expect(departmentCds).toContain(TEST_CODES[1]);
+  });
+
+  it("limitを指定して取得できる", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "全取得テスト部署1",
+      abbreviation: "全取得1",
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "全取得テスト部署2",
+      abbreviation: "全取得2",
+    });
+
+    const result = await query.execute({ options: { limit: 1 } });
+
+    expect(result.length).toBe(1);
+  });
+
+  it("ソート順を指定して取得できる", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "全取得テスト部署1",
+      abbreviation: "全取得1",
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "全取得テスト部署2",
+      abbreviation: "全取得2",
+    });
+
+    const result = await query.execute({
+      options: { orderBy: { field: "departmentCd", direction: "asc" } },
+    });
+
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    for (let i = 0; i < result.length - 1; i++) {
+      expect(result[i].departmentCd <= result[i + 1].departmentCd).toBe(true);
+    }
+  });
+});

--- a/src/server/subdomains/department/application/queries/__tests__/GetDepartmentByIdQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/GetDepartmentByIdQuery.test.ts
@@ -1,0 +1,71 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { PrismaDepartmentQueryService } from "@subdomains/department/infrastructure/queries/PrismaDepartmentQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetDepartmentByIdQuery } from "../GetDepartmentByIdQuery";
+
+describe("GetDepartmentByIdQuery", () => {
+  let query: GetDepartmentByIdQuery;
+  const testDepartmentIds: string[] = [];
+
+  const TEST_CODES = ["DEPT973"];
+
+  async function createTestDepartment(data: {
+    departmentCd: string;
+    name: string;
+    abbreviation: string;
+    displayOrder?: number;
+    isActive?: boolean;
+    parentId?: string | null;
+  }): Promise<string> {
+    const id = createId();
+    await prisma.department.create({ data: { id, ...data } });
+    testDepartmentIds.push(id);
+    return id;
+  }
+
+  async function cleanup() {
+    await prisma.department.deleteMany({
+      where: { parentId: { not: null }, departmentCd: { in: TEST_CODES } },
+    });
+    await prisma.department.deleteMany({
+      where: { departmentCd: { in: TEST_CODES } },
+    });
+  }
+
+  beforeEach(async () => {
+    testDepartmentIds.length = 0;
+    await cleanup();
+
+    query = new GetDepartmentByIdQuery(new PrismaDepartmentQueryService());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("IDで部署を取得できる", async () => {
+    const deptId = await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "取得テスト部署",
+      abbreviation: "取得テスト",
+      displayOrder: 5,
+    });
+
+    const result = await query.execute({ id: deptId });
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(deptId);
+    expect(result?.departmentCd).toBe(TEST_CODES[0]);
+    expect(result?.name).toBe("取得テスト部署");
+    expect(result?.abbreviation).toBe("取得テスト");
+    expect(result?.displayOrder).toBe(5);
+    expect(result?.isActive).toBe(true);
+    expect(result?.parentId).toBeNull();
+  });
+
+  it("存在しないIDの場合nullを返す", async () => {
+    const result = await query.execute({ id: "non-existent-id" });
+    expect(result).toBeNull();
+  });
+});

--- a/src/server/subdomains/department/application/queries/__tests__/GetDepartmentTreeQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/GetDepartmentTreeQuery.test.ts
@@ -1,0 +1,136 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { PrismaDepartmentQueryService } from "@subdomains/department/infrastructure/queries/PrismaDepartmentQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetDepartmentTreeQuery } from "../GetDepartmentTreeQuery";
+
+describe("GetDepartmentTreeQuery", () => {
+  let query: GetDepartmentTreeQuery;
+  const testDepartmentIds: string[] = [];
+
+  const TEST_CODES = ["DEPT974", "DEPT975", "DEPT976"];
+
+  async function createTestDepartment(data: {
+    departmentCd: string;
+    name: string;
+    abbreviation: string;
+    displayOrder?: number;
+    isActive?: boolean;
+    parentId?: string | null;
+  }): Promise<string> {
+    const id = createId();
+    await prisma.department.create({ data: { id, ...data } });
+    testDepartmentIds.push(id);
+    return id;
+  }
+
+  async function cleanup() {
+    await prisma.department.deleteMany({
+      where: { parentId: { not: null }, departmentCd: { in: TEST_CODES } },
+    });
+    await prisma.department.deleteMany({
+      where: { departmentCd: { in: TEST_CODES } },
+    });
+  }
+
+  beforeEach(async () => {
+    testDepartmentIds.length = 0;
+    await cleanup();
+
+    query = new GetDepartmentTreeQuery(new PrismaDepartmentQueryService());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("部署ツリーを取得できる", async () => {
+    const rootId = await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "ルート部署",
+      abbreviation: "ルート",
+      displayOrder: 1,
+      isActive: true,
+    });
+    const childId = await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "子部署",
+      abbreviation: "子",
+      displayOrder: 1,
+      isActive: true,
+      parentId: rootId,
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[2],
+      name: "孫部署",
+      abbreviation: "孫",
+      displayOrder: 1,
+      isActive: true,
+      parentId: childId,
+    });
+
+    const result = await query.execute({});
+
+    const rootNode = result.find((r) => r.departmentCd === TEST_CODES[0]);
+    expect(rootNode).not.toBeUndefined();
+    expect(rootNode?.children.length).toBeGreaterThanOrEqual(1);
+
+    const childNode = rootNode?.children.find((c) => c.departmentCd === TEST_CODES[1]);
+    expect(childNode).not.toBeUndefined();
+    expect(childNode?.children.length).toBeGreaterThanOrEqual(1);
+
+    const grandchildNode = childNode?.children.find((c) => c.departmentCd === TEST_CODES[2]);
+    expect(grandchildNode).not.toBeUndefined();
+  });
+
+  it("指定したルートIDからツリーを取得できる", async () => {
+    const rootId = await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "ルート部署",
+      abbreviation: "ルート",
+      displayOrder: 1,
+      isActive: true,
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "子部署",
+      abbreviation: "子",
+      displayOrder: 1,
+      isActive: true,
+      parentId: rootId,
+    });
+
+    const result = await query.execute({ rootId });
+
+    // getTree(rootId)はrootIdの子を返す
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    const childNode = result.find((r) => r.departmentCd === TEST_CODES[1]);
+    expect(childNode).not.toBeUndefined();
+  });
+
+  it("無効な部署はツリーに含まれない", async () => {
+    const rootId = await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "有効ルート部署",
+      abbreviation: "有効ルート",
+      displayOrder: 1,
+      isActive: true,
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "無効子部署",
+      abbreviation: "無効子",
+      displayOrder: 1,
+      isActive: false,
+      parentId: rootId,
+    });
+
+    const result = await query.execute({});
+
+    const rootNode = result.find((r) => r.departmentCd === TEST_CODES[0]);
+    expect(rootNode).not.toBeUndefined();
+
+    const inactiveChild = rootNode?.children.find((c) => c.departmentCd === TEST_CODES[1]);
+    expect(inactiveChild).toBeUndefined();
+  });
+});

--- a/src/server/subdomains/department/application/queries/__tests__/SearchDepartmentsQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/SearchDepartmentsQuery.test.ts
@@ -65,6 +65,21 @@ describe("SearchDepartmentsQuery", () => {
     expect(departmentCds).not.toContain(TEST_CODES[1]);
   });
 
+  it("部署名が一致しない場合は検索結果に含まれない", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "SQ第一営業部",
+      abbreviation: "SQ一営",
+    });
+
+    const result = await query.execute({
+      criteria: { name: "総務" },
+    });
+
+    const departmentCds = result.map((r) => r.departmentCd);
+    expect(departmentCds).not.toContain(TEST_CODES[0]);
+  });
+
   it("略称で部分一致検索できる", async () => {
     await createTestDepartment({
       departmentCd: TEST_CODES[0],
@@ -86,6 +101,21 @@ describe("SearchDepartmentsQuery", () => {
     expect(departmentCds).not.toContain(TEST_CODES[1]);
   });
 
+  it("略称が一致しない場合は検索結果に含まれない", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "SQ略称検索部署A",
+      abbreviation: "SQ略称ターゲット",
+    });
+
+    const result = await query.execute({
+      criteria: { abbreviation: "該当なし" },
+    });
+
+    const departmentCds = result.map((r) => r.departmentCd);
+    expect(departmentCds).not.toContain(TEST_CODES[0]);
+  });
+
   it("部署コードで検索できる", async () => {
     await createTestDepartment({
       departmentCd: TEST_CODES[0],
@@ -99,6 +129,21 @@ describe("SearchDepartmentsQuery", () => {
 
     expect(result.length).toBe(1);
     expect(result[0].departmentCd).toBe(TEST_CODES[0]);
+  });
+
+  it("部署コードは完全一致検索のため部分一致ではヒットしない", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "検索コード部署",
+      abbreviation: "検索CD",
+    });
+
+    const result = await query.execute({
+      criteria: { departmentCd: "DEPT97" },
+    });
+
+    const departmentCds = result.map((r) => r.departmentCd);
+    expect(departmentCds).not.toContain(TEST_CODES[0]);
   });
 
   it("有効フラグで検索できる", async () => {

--- a/src/server/subdomains/department/application/queries/__tests__/SearchDepartmentsQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/SearchDepartmentsQuery.test.ts
@@ -44,27 +44,28 @@ describe("SearchDepartmentsQuery", () => {
     await cleanup();
   });
 
-  it("部署名で検索できる", async () => {
+  it("部署名で部分一致検索できる", async () => {
     await createTestDepartment({
       departmentCd: TEST_CODES[0],
-      name: "SQ検索営業部",
-      abbreviation: "SQ営業",
+      name: "SQ第一営業部",
+      abbreviation: "SQ一営",
     });
     await createTestDepartment({
       departmentCd: TEST_CODES[1],
-      name: "SQ検索開発部",
+      name: "SQ開発部",
       abbreviation: "SQ開発",
     });
 
     const result = await query.execute({
-      criteria: { name: "SQ検索営業" },
+      criteria: { name: "営業" },
     });
 
-    expect(result.length).toBe(1);
-    expect(result[0].name).toBe("SQ検索営業部");
+    const departmentCds = result.map((r) => r.departmentCd);
+    expect(departmentCds).toContain(TEST_CODES[0]);
+    expect(departmentCds).not.toContain(TEST_CODES[1]);
   });
 
-  it("略称で検索できる", async () => {
+  it("略称で部分一致検索できる", async () => {
     await createTestDepartment({
       departmentCd: TEST_CODES[0],
       name: "SQ略称検索部署A",
@@ -77,12 +78,12 @@ describe("SearchDepartmentsQuery", () => {
     });
 
     const result = await query.execute({
-      criteria: { abbreviation: "SQ略称ターゲット" },
+      criteria: { abbreviation: "ターゲット" },
     });
 
-    expect(result.length).toBe(1);
-    expect(result[0].abbreviation).toBe("SQ略称ターゲット");
-    expect(result[0].departmentCd).toBe(TEST_CODES[0]);
+    const departmentCds = result.map((r) => r.departmentCd);
+    expect(departmentCds).toContain(TEST_CODES[0]);
+    expect(departmentCds).not.toContain(TEST_CODES[1]);
   });
 
   it("部署コードで検索できる", async () => {

--- a/src/server/subdomains/department/application/queries/__tests__/SearchDepartmentsQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/SearchDepartmentsQuery.test.ts
@@ -1,0 +1,153 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { PrismaDepartmentQueryService } from "@subdomains/department/infrastructure/queries/PrismaDepartmentQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SearchDepartmentsQuery } from "../SearchDepartmentsQuery";
+
+describe("SearchDepartmentsQuery", () => {
+  let query: SearchDepartmentsQuery;
+  const testDepartmentIds: string[] = [];
+
+  const TEST_CODES = ["DEPT979", "DEPT980", "DEPT981", "DEPT982"];
+
+  async function createTestDepartment(data: {
+    departmentCd: string;
+    name: string;
+    abbreviation: string;
+    displayOrder?: number;
+    isActive?: boolean;
+    parentId?: string | null;
+  }): Promise<string> {
+    const id = createId();
+    await prisma.department.create({ data: { id, ...data } });
+    testDepartmentIds.push(id);
+    return id;
+  }
+
+  async function cleanup() {
+    await prisma.department.deleteMany({
+      where: { parentId: { not: null }, departmentCd: { in: TEST_CODES } },
+    });
+    await prisma.department.deleteMany({
+      where: { departmentCd: { in: TEST_CODES } },
+    });
+  }
+
+  beforeEach(async () => {
+    testDepartmentIds.length = 0;
+    await cleanup();
+
+    query = new SearchDepartmentsQuery(new PrismaDepartmentQueryService());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("部署名で検索できる", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "SQ検索営業部",
+      abbreviation: "SQ営業",
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "SQ検索開発部",
+      abbreviation: "SQ開発",
+    });
+
+    const result = await query.execute({
+      criteria: { name: "SQ検索営業" },
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].name).toBe("SQ検索営業部");
+  });
+
+  it("略称で検索できる", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "SQ略称検索部署A",
+      abbreviation: "SQ略称ターゲット",
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "SQ略称検索部署B",
+      abbreviation: "SQ略称その他",
+    });
+
+    const result = await query.execute({
+      criteria: { abbreviation: "SQ略称ターゲット" },
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].abbreviation).toBe("SQ略称ターゲット");
+    expect(result[0].departmentCd).toBe(TEST_CODES[0]);
+  });
+
+  it("部署コードで検索できる", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "検索コード部署",
+      abbreviation: "検索CD",
+    });
+
+    const result = await query.execute({
+      criteria: { departmentCd: TEST_CODES[0] },
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].departmentCd).toBe(TEST_CODES[0]);
+  });
+
+  it("有効フラグで検索できる", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "SQ有効部署",
+      abbreviation: "SQ有効",
+      isActive: true,
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "SQ無効部署",
+      abbreviation: "SQ無効",
+      isActive: false,
+    });
+
+    const result = await query.execute({
+      criteria: { isActive: true, name: "SQ" },
+    });
+
+    const departmentCds = result.map((r) => r.departmentCd);
+    expect(departmentCds).toContain(TEST_CODES[0]);
+    expect(departmentCds).not.toContain(TEST_CODES[1]);
+  });
+
+  it("検索条件とオプションを組み合わせて検索できる", async () => {
+    await createTestDepartment({
+      departmentCd: TEST_CODES[0],
+      name: "SQオプ検索部署A",
+      abbreviation: "SQオプA",
+    });
+    await createTestDepartment({
+      departmentCd: TEST_CODES[1],
+      name: "SQオプ検索部署B",
+      abbreviation: "SQオプB",
+    });
+
+    const result = await query.execute({
+      criteria: { name: "SQオプ検索" },
+      options: { limit: 1, orderBy: { field: "departmentCd", direction: "asc" } },
+    });
+
+    expect(result.length).toBe(1);
+  });
+
+  it("条件に一致する部署がない場合は空配列を返す", async () => {
+    const result = await query.execute({
+      criteria: { name: "存在しないSQ部署名" },
+    });
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Command テスト3本を `vi.fn()` モックから実DB統合テストに書き換え
- エラーアサーションを型のみチェックに統一（メッセージ文字列チェック削除）
- Query テスト5本を新規作成（GetAllDepartments, GetDepartmentById, GetDepartmentTree, GetActiveDepartments, SearchDepartments）
- 自己参照FK対応の2段階クリーンアップを実装
- SearchDepartmentsQueryに部分一致検索・不一致ケースのテストを追加
- UpdateDepartmentCommandの不足分岐（有効化、自己参照、存在しない親、無効な親）のテストを追加

### 変更ファイル (8本)
| 操作 | ファイル | テスト数 |
|------|----------|---------|
| 書き換え | `CreateDepartmentCommand.test.ts` | 5 |
| 書き換え | `DeleteDepartmentCommand.test.ts` | 3 |
| 書き換え | `UpdateDepartmentCommand.test.ts` | 12 |
| 新規 | `GetAllDepartmentsQuery.test.ts` | 3 |
| 新規 | `GetDepartmentByIdQuery.test.ts` | 2 |
| 新規 | `GetDepartmentTreeQuery.test.ts` | 3 |
| 新規 | `GetActiveDepartmentsQuery.test.ts` | 2 |
| 新規 | `SearchDepartmentsQuery.test.ts` | 9 |

合計: **39テスト** (全344テストパス)

Closes #86

## Test plan
- [x] `pnpm test` で全347テストがパスすること
- [x] department application層の8ファイル39テストがすべてパスすること
- [x] `vi.fn()` が department application テストから完全に除去されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)