### PR TITLE
test: customer・delivery-location application層テストをtesting-backend規約に準拠 (#85)

### DIFF
--- a/src/server/subdomains/customer/application/commands/__tests__/CreateCustomerCommand.test.ts
+++ b/src/server/subdomains/customer/application/commands/__tests__/CreateCustomerCommand.test.ts
@@ -1,0 +1,85 @@
+import prisma from "@server/prisma";
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { CustomerCodeDuplicationCheckDomainService } from "@subdomains/customer/domain/services/CustomerCodeDuplicationCheckDomainService";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CreateCustomerCommand } from "../CreateCustomerCommand";
+
+describe("CreateCustomerCommand", () => {
+  let command: CreateCustomerCommand;
+  let repository: PrismaCustomerRepository;
+  let codeDuplicationCheckService: CustomerCodeDuplicationCheckDomainService;
+
+  const TEST_CODES = ["CUST999911", "CUST999912"];
+
+  beforeEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: TEST_CODES } },
+    });
+
+    repository = new PrismaCustomerRepository();
+    codeDuplicationCheckService = new CustomerCodeDuplicationCheckDomainService(repository);
+
+    command = new CreateCustomerCommand(repository, codeDuplicationCheckService);
+  });
+
+  afterEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: TEST_CODES } },
+    });
+  });
+
+  it("得意先を新規登録できる（必須項目のみ）", async () => {
+    await command.execute({
+      code: TEST_CODES[0],
+      name: "テスト得意先A",
+    });
+
+    const saved = await repository.findByCode(new CompanyCode(TEST_CODES[0]));
+    expect(saved).not.toBeNull();
+    expect(saved?.name.value).toBe("テスト得意先A");
+    expect(saved?.code.value).toBe(TEST_CODES[0]);
+    expect(saved?.isActive).toBe(true);
+    expect(saved?.marginRate).toBeNull();
+  });
+
+  it("全オプション項目付きで新規登録できる", async () => {
+    await command.execute({
+      code: TEST_CODES[0],
+      name: "テスト得意先B",
+      postalCode: "100-0001",
+      prefecture: "東京都",
+      address: "千代田区1-1-1",
+      phoneNumber: "03-1234-5678",
+      faxNumber: "03-1234-5679",
+      contactPerson: "担当太郎",
+      marginRate: 15.5,
+    });
+
+    const saved = await repository.findByCode(new CompanyCode(TEST_CODES[0]));
+    expect(saved).not.toBeNull();
+    expect(saved?.name.value).toBe("テスト得意先B");
+    expect(saved?.postalCode?.value).toBe("1000001");
+    expect(saved?.prefecture?.value).toBe("東京都");
+    expect(saved?.address?.value).toBe("千代田区1-1-1");
+    expect(saved?.phoneNumber?.value).toBe("0312345678");
+    expect(saved?.faxNumber?.value).toBe("0312345679");
+    expect(saved?.contactPerson).toBe("担当太郎");
+    expect(saved?.marginRate?.value).toBe(15.5);
+  });
+
+  it("コードが重複している場合は ValidationError", async () => {
+    await command.execute({
+      code: TEST_CODES[0],
+      name: "重複元",
+    });
+
+    await expect(
+      command.execute({
+        code: TEST_CODES[0],
+        name: "重複先",
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+});

--- a/src/server/subdomains/customer/application/commands/__tests__/DeleteCustomerCommand.test.ts
+++ b/src/server/subdomains/customer/application/commands/__tests__/DeleteCustomerCommand.test.ts
@@ -1,0 +1,50 @@
+import prisma from "@server/prisma";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DeleteCustomerCommand } from "../DeleteCustomerCommand";
+
+describe("DeleteCustomerCommand", () => {
+  let command: DeleteCustomerCommand;
+  let repository: PrismaCustomerRepository;
+  let testCustomerId: string;
+
+  const TEST_CODES = ["CUST999914"];
+
+  beforeEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: TEST_CODES } },
+    });
+
+    repository = new PrismaCustomerRepository();
+    command = new DeleteCustomerCommand(repository);
+
+    // テスト用得意先を事前作成
+    const customer = Customer.create(
+      new CompanyCode(TEST_CODES[0]),
+      new CompanyName("削除テスト得意先")
+    );
+    const saved = await repository.save(customer);
+    testCustomerId = saved.id;
+  });
+
+  afterEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: TEST_CODES } },
+    });
+  });
+
+  it("得意先を削除できる", async () => {
+    await command.execute({ id: testCustomerId });
+
+    const deleted = await repository.findById(testCustomerId);
+    expect(deleted).toBeNull();
+  });
+
+  it("存在しないIDの場合は NotFoundEntityError", async () => {
+    await expect(command.execute({ id: "non-existent-id" })).rejects.toThrow(NotFoundEntityError);
+  });
+});

--- a/src/server/subdomains/customer/application/commands/__tests__/UpdateCustomerCommand.test.ts
+++ b/src/server/subdomains/customer/application/commands/__tests__/UpdateCustomerCommand.test.ts
@@ -1,0 +1,105 @@
+import prisma from "@server/prisma";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { UpdateCustomerCommand } from "../UpdateCustomerCommand";
+
+describe("UpdateCustomerCommand", () => {
+  let command: UpdateCustomerCommand;
+  let repository: PrismaCustomerRepository;
+  let testCustomerId: string;
+
+  const TEST_CODES = ["CUST999913"];
+
+  beforeEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: TEST_CODES } },
+    });
+
+    repository = new PrismaCustomerRepository();
+    command = new UpdateCustomerCommand(repository);
+
+    // テスト用得意先を事前作成
+    const customer = Customer.create(
+      new CompanyCode(TEST_CODES[0]),
+      new CompanyName("更新前得意先")
+    );
+    const saved = await repository.save(customer);
+    testCustomerId = saved.id;
+  });
+
+  afterEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: TEST_CODES } },
+    });
+  });
+
+  it("得意先情報を更新できる（名前変更）", async () => {
+    await command.execute({
+      id: testCustomerId,
+      name: "更新後得意先",
+    });
+
+    const updated = await repository.findById(testCustomerId);
+    expect(updated).not.toBeNull();
+    expect(updated?.name.value).toBe("更新後得意先");
+  });
+
+  it("住所・連絡先・マージン率を更新できる", async () => {
+    await command.execute({
+      id: testCustomerId,
+      name: "更新前得意先",
+      postalCode: "200-0002",
+      prefecture: "大阪府",
+      address: "大阪市2-2-2",
+      phoneNumber: "06-1234-5678",
+      faxNumber: "06-1234-5679",
+      contactPerson: "更新担当",
+      marginRate: 20,
+    });
+
+    const updated = await repository.findById(testCustomerId);
+    expect(updated).not.toBeNull();
+    expect(updated?.postalCode?.value).toBe("2000002");
+    expect(updated?.prefecture?.value).toBe("大阪府");
+    expect(updated?.address?.value).toBe("大阪市2-2-2");
+    expect(updated?.phoneNumber?.value).toBe("0612345678");
+    expect(updated?.faxNumber?.value).toBe("0612345679");
+    expect(updated?.contactPerson).toBe("更新担当");
+    expect(updated?.marginRate?.value).toBe(20);
+  });
+
+  it("isActive を変更できる", async () => {
+    // deactivate
+    await command.execute({
+      id: testCustomerId,
+      name: "更新前得意先",
+      isActive: false,
+    });
+
+    let updated = await repository.findById(testCustomerId);
+    expect(updated?.isActive).toBe(false);
+
+    // activate
+    await command.execute({
+      id: testCustomerId,
+      name: "更新前得意先",
+      isActive: true,
+    });
+
+    updated = await repository.findById(testCustomerId);
+    expect(updated?.isActive).toBe(true);
+  });
+
+  it("存在しないIDの場合は NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        id: "non-existent-id",
+        name: "存在しない",
+      })
+    ).rejects.toThrow(NotFoundEntityError);
+  });
+});

--- a/src/server/subdomains/customer/application/commands/__tests__/UpdateCustomerCommand.test.ts
+++ b/src/server/subdomains/customer/application/commands/__tests__/UpdateCustomerCommand.test.ts
@@ -94,6 +94,44 @@ describe("UpdateCustomerCommand", () => {
     expect(updated?.isActive).toBe(true);
   });
 
+  it("nullを渡すとオプション項目をクリアできる", async () => {
+    // まず値を設定
+    await command.execute({
+      id: testCustomerId,
+      name: "更新前得意先",
+      postalCode: "200-0002",
+      prefecture: "大阪府",
+      address: "大阪市2-2-2",
+      phoneNumber: "06-1234-5678",
+      faxNumber: "06-1234-5679",
+      contactPerson: "更新担当",
+      marginRate: 20,
+    });
+
+    // nullで全クリア
+    await command.execute({
+      id: testCustomerId,
+      name: "更新前得意先",
+      postalCode: null,
+      prefecture: null,
+      address: null,
+      phoneNumber: null,
+      faxNumber: null,
+      contactPerson: null,
+      marginRate: null,
+    });
+
+    const updated = await repository.findById(testCustomerId);
+    expect(updated).not.toBeNull();
+    expect(updated?.postalCode).toBeNull();
+    expect(updated?.prefecture).toBeNull();
+    expect(updated?.address).toBeNull();
+    expect(updated?.phoneNumber).toBeNull();
+    expect(updated?.faxNumber).toBeNull();
+    expect(updated?.contactPerson).toBeNull();
+    expect(updated?.marginRate).toBeNull();
+  });
+
   it("存在しないIDの場合は NotFoundEntityError", async () => {
     await expect(
       command.execute({

--- a/src/server/subdomains/customer/application/queries/__tests__/GetAllCustomersQuery.test.ts
+++ b/src/server/subdomains/customer/application/queries/__tests__/GetAllCustomersQuery.test.ts
@@ -1,0 +1,92 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { CompanyType } from "@generated/prisma/client";
+import { PrismaCustomerQueryService } from "@subdomains/customer/infrastructure/queries/PrismaCustomerQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetAllCustomersQuery } from "../GetAllCustomersQuery";
+
+describe("GetAllCustomersQuery", () => {
+  let query: GetAllCustomersQuery;
+  const testCompanyIds: string[] = [];
+
+  const TEST_CODES = ["CUST999921", "CUST999922"];
+
+  async function createTestCustomer(data: { code: string; name: string; marginRate?: number }) {
+    const companyId = createId();
+    const customerId = createId();
+
+    await prisma.company.create({
+      data: {
+        id: companyId,
+        code: data.code,
+        name: data.name,
+        type: CompanyType.CUSTOMER,
+        isActive: true,
+      },
+    });
+
+    await prisma.customer.create({
+      data: {
+        id: customerId,
+        companyId,
+        marginRate: data.marginRate ?? null,
+      },
+    });
+
+    testCompanyIds.push(companyId);
+    return { companyId, customerId };
+  }
+
+  beforeEach(async () => {
+    testCompanyIds.length = 0;
+
+    await prisma.company.deleteMany({
+      where: { code: { in: TEST_CODES } },
+    });
+
+    query = new GetAllCustomersQuery(new PrismaCustomerQueryService());
+  });
+
+  afterEach(async () => {
+    if (testCompanyIds.length > 0) {
+      await prisma.company.deleteMany({
+        where: { id: { in: testCompanyIds } },
+      });
+    }
+  });
+
+  it("全得意先を取得できる", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "全取得得意先1" });
+    await createTestCustomer({ code: TEST_CODES[1], name: "全取得得意先2" });
+
+    const result = await query.execute();
+
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    const codes = result.map((r) => r.code);
+    expect(codes).toContain(TEST_CODES[0]);
+    expect(codes).toContain(TEST_CODES[1]);
+  });
+
+  it("limit/offset付きで取得できる", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "全取得得意先3" });
+    await createTestCustomer({ code: TEST_CODES[1], name: "全取得得意先4" });
+
+    const result = await query.execute({ limit: 1 });
+
+    expect(result.length).toBe(1);
+  });
+
+  it("ソート順を指定して取得できる", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "全取得得意先5" });
+    await createTestCustomer({ code: TEST_CODES[1], name: "全取得得意先6" });
+
+    // 直近作成のレコードのみ取得して並び順を検証
+    const result = await query.execute({
+      limit: 2,
+      orderBy: { field: "createdAt", direction: "desc" },
+    });
+
+    expect(result.length).toBe(2);
+    expect(result[0].createdAt.getTime()).toBeGreaterThanOrEqual(result[1].createdAt.getTime());
+  });
+});

--- a/src/server/subdomains/customer/application/queries/__tests__/GetCustomerByIdQuery.test.ts
+++ b/src/server/subdomains/customer/application/queries/__tests__/GetCustomerByIdQuery.test.ts
@@ -1,0 +1,77 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { CompanyType } from "@generated/prisma/client";
+import { PrismaCustomerQueryService } from "@subdomains/customer/infrastructure/queries/PrismaCustomerQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetCustomerByIdQuery } from "../GetCustomerByIdQuery";
+
+describe("GetCustomerByIdQuery", () => {
+  let query: GetCustomerByIdQuery;
+  const testCompanyIds: string[] = [];
+
+  const TEST_CODES = ["CUST999923"];
+
+  async function createTestCustomer(data: { code: string; name: string; marginRate?: number }) {
+    const companyId = createId();
+    const customerId = createId();
+
+    await prisma.company.create({
+      data: {
+        id: companyId,
+        code: data.code,
+        name: data.name,
+        type: CompanyType.CUSTOMER,
+        isActive: true,
+      },
+    });
+
+    await prisma.customer.create({
+      data: {
+        id: customerId,
+        companyId,
+        marginRate: data.marginRate ?? null,
+      },
+    });
+
+    testCompanyIds.push(companyId);
+    return { companyId, customerId };
+  }
+
+  beforeEach(async () => {
+    testCompanyIds.length = 0;
+
+    await prisma.company.deleteMany({
+      where: { code: { in: TEST_CODES } },
+    });
+
+    query = new GetCustomerByIdQuery(new PrismaCustomerQueryService());
+  });
+
+  afterEach(async () => {
+    if (testCompanyIds.length > 0) {
+      await prisma.company.deleteMany({
+        where: { id: { in: testCompanyIds } },
+      });
+    }
+  });
+
+  it("IDで得意先を取得できる", async () => {
+    const { customerId } = await createTestCustomer({
+      code: TEST_CODES[0],
+      name: "ID取得テスト得意先",
+    });
+
+    const result = await query.execute({ id: customerId });
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(customerId);
+    expect(result?.code).toBe(TEST_CODES[0]);
+    expect(result?.name).toBe("ID取得テスト得意先");
+  });
+
+  it("存在しないIDの場合は null を返す", async () => {
+    const result = await query.execute({ id: "non-existent-id" });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/server/subdomains/customer/application/queries/__tests__/SearchCustomersQuery.test.ts
+++ b/src/server/subdomains/customer/application/queries/__tests__/SearchCustomersQuery.test.ts
@@ -137,29 +137,29 @@ describe("SearchCustomersQuery", () => {
 
   it("createdAfterで指定日時以降の得意先を取得できる", async () => {
     const before = new Date();
-    await createTestCustomer({ code: TEST_CODES[0], name: "日付検索得意先A" });
+    await createTestCustomer({ code: TEST_CODES[0], name: "SQ日付検索得意先A" });
 
-    const result = await query.execute({ createdAfter: before });
+    const result = await query.execute({ name: "SQ日付検索得意先", createdAfter: before });
 
     const codes = result.map((r) => r.code);
     expect(codes).toContain(TEST_CODES[0]);
   });
 
   it("createdAfterで指定日時以降に該当しない場合はヒットしない", async () => {
-    await createTestCustomer({ code: TEST_CODES[0], name: "日付検索得意先B" });
+    await createTestCustomer({ code: TEST_CODES[0], name: "SQ日付検索得意先B" });
     const future = new Date(Date.now() + 60_000);
 
-    const result = await query.execute({ createdAfter: future });
+    const result = await query.execute({ name: "SQ日付検索得意先", createdAfter: future });
 
     const codes = result.map((r) => r.code);
     expect(codes).not.toContain(TEST_CODES[0]);
   });
 
   it("createdBeforeで指定日時以前の得意先を取得できる", async () => {
-    await createTestCustomer({ code: TEST_CODES[0], name: "日付検索得意先C" });
+    await createTestCustomer({ code: TEST_CODES[0], name: "SQ日付検索得意先C" });
     const after = new Date(Date.now() + 60_000);
 
-    const result = await query.execute({ createdBefore: after });
+    const result = await query.execute({ name: "SQ日付検索得意先", createdBefore: after });
 
     const codes = result.map((r) => r.code);
     expect(codes).toContain(TEST_CODES[0]);
@@ -169,9 +169,9 @@ describe("SearchCustomersQuery", () => {
     const past = new Date();
     // 少し待ってからレコード作成（pastより後に作成される）
     await new Promise((resolve) => setTimeout(resolve, 50));
-    await createTestCustomer({ code: TEST_CODES[0], name: "日付検索得意先D" });
+    await createTestCustomer({ code: TEST_CODES[0], name: "SQ日付検索得意先D" });
 
-    const result = await query.execute({ createdBefore: past });
+    const result = await query.execute({ name: "SQ日付検索得意先", createdBefore: past });
 
     const codes = result.map((r) => r.code);
     expect(codes).not.toContain(TEST_CODES[0]);

--- a/src/server/subdomains/customer/application/queries/__tests__/SearchCustomersQuery.test.ts
+++ b/src/server/subdomains/customer/application/queries/__tests__/SearchCustomersQuery.test.ts
@@ -1,0 +1,85 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { CompanyType } from "@generated/prisma/client";
+import { PrismaCustomerQueryService } from "@subdomains/customer/infrastructure/queries/PrismaCustomerQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SearchCustomersQuery } from "../SearchCustomersQuery";
+
+describe("SearchCustomersQuery", () => {
+  let query: SearchCustomersQuery;
+  const testCompanyIds: string[] = [];
+
+  const TEST_CODES = ["CUST999924", "CUST999925", "CUST999926"];
+
+  async function createTestCustomer(data: { code: string; name: string; marginRate?: number }) {
+    const companyId = createId();
+    const customerId = createId();
+
+    await prisma.company.create({
+      data: {
+        id: companyId,
+        code: data.code,
+        name: data.name,
+        type: CompanyType.CUSTOMER,
+        isActive: true,
+      },
+    });
+
+    await prisma.customer.create({
+      data: {
+        id: customerId,
+        companyId,
+        marginRate: data.marginRate ?? null,
+      },
+    });
+
+    testCompanyIds.push(companyId);
+    return { companyId, customerId };
+  }
+
+  beforeEach(async () => {
+    testCompanyIds.length = 0;
+
+    await prisma.company.deleteMany({
+      where: { code: { in: TEST_CODES } },
+    });
+
+    query = new SearchCustomersQuery(new PrismaCustomerQueryService());
+  });
+
+  afterEach(async () => {
+    if (testCompanyIds.length > 0) {
+      await prisma.company.deleteMany({
+        where: { id: { in: testCompanyIds } },
+      });
+    }
+  });
+
+  it("名前で検索できる（部分一致）", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "SQ検索得意先A" });
+    await createTestCustomer({ code: TEST_CODES[1], name: "SQ検索得意先B" });
+
+    const result = await query.execute({ name: "SQ検索得意先" });
+
+    expect(result.length).toBe(2);
+    const names = result.map((r) => r.name);
+    expect(names).toContain("SQ検索得意先A");
+    expect(names).toContain("SQ検索得意先B");
+  });
+
+  it("コードで検索できる（完全一致）", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "コード検索A" });
+    await createTestCustomer({ code: TEST_CODES[1], name: "コード検索B" });
+
+    const result = await query.execute({ code: TEST_CODES[0] });
+
+    expect(result.length).toBe(1);
+    expect(result[0].code).toBe(TEST_CODES[0]);
+  });
+
+  it("条件に一致する得意先がない場合は空配列を返す", async () => {
+    const result = await query.execute({ name: "存在しないSQ得意先名" });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/server/subdomains/customer/application/queries/__tests__/SearchCustomersQuery.test.ts
+++ b/src/server/subdomains/customer/application/queries/__tests__/SearchCustomersQuery.test.ts
@@ -11,7 +11,12 @@ describe("SearchCustomersQuery", () => {
 
   const TEST_CODES = ["CUST999924", "CUST999925", "CUST999926"];
 
-  async function createTestCustomer(data: { code: string; name: string; marginRate?: number }) {
+  async function createTestCustomer(data: {
+    code: string;
+    name: string;
+    marginRate?: number;
+    isActive?: boolean;
+  }) {
     const companyId = createId();
     const customerId = createId();
 
@@ -21,7 +26,7 @@ describe("SearchCustomersQuery", () => {
         code: data.code,
         name: data.name,
         type: CompanyType.CUSTOMER,
-        isActive: true,
+        isActive: data.isActive ?? true,
       },
     });
 
@@ -67,6 +72,14 @@ describe("SearchCustomersQuery", () => {
     expect(names).toContain("SQ検索得意先B");
   });
 
+  it("名前で検索してヒットしない場合は空配列を返す", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "SQ検索得意先A" });
+
+    const result = await query.execute({ name: "該当なしSQ名前" });
+
+    expect(result).toEqual([]);
+  });
+
   it("コードで検索できる（完全一致）", async () => {
     await createTestCustomer({ code: TEST_CODES[0], name: "コード検索A" });
     await createTestCustomer({ code: TEST_CODES[1], name: "コード検索B" });
@@ -77,9 +90,90 @@ describe("SearchCustomersQuery", () => {
     expect(result[0].code).toBe(TEST_CODES[0]);
   });
 
-  it("条件に一致する得意先がない場合は空配列を返す", async () => {
-    const result = await query.execute({ name: "存在しないSQ得意先名" });
+  it("コードで検索してヒットしない場合は空配列を返す", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "コード検索A" });
+
+    const result = await query.execute({ code: "NONEXIST999" });
 
     expect(result).toEqual([]);
+  });
+
+  it("コードの部分一致ではヒットしない", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "部分一致テスト" });
+
+    const result = await query.execute({ code: TEST_CODES[0].slice(0, 6) });
+
+    expect(result).toEqual([]);
+  });
+
+  it("isActiveで検索できる", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "SQアクティブ得意先", isActive: true });
+    await createTestCustomer({ code: TEST_CODES[1], name: "SQアクティブ得意先", isActive: false });
+
+    const activeResult = await query.execute({ name: "SQアクティブ得意先", isActive: true });
+    expect(activeResult.length).toBe(1);
+    expect(activeResult[0].code).toBe(TEST_CODES[0]);
+
+    const inactiveResult = await query.execute({ name: "SQアクティブ得意先", isActive: false });
+    expect(inactiveResult.length).toBe(1);
+    expect(inactiveResult[0].code).toBe(TEST_CODES[1]);
+  });
+
+  it("複数条件を組み合わせて検索できる", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "複合検索得意先A", isActive: true });
+    await createTestCustomer({ code: TEST_CODES[1], name: "複合検索得意先B", isActive: false });
+    await createTestCustomer({ code: TEST_CODES[2], name: "別名得意先C", isActive: true });
+
+    const result = await query.execute({
+      name: "複合検索",
+      code: TEST_CODES[0],
+      isActive: true,
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].code).toBe(TEST_CODES[0]);
+    expect(result[0].name).toBe("複合検索得意先A");
+  });
+
+  it("createdAfterで指定日時以降の得意先を取得できる", async () => {
+    const before = new Date();
+    await createTestCustomer({ code: TEST_CODES[0], name: "日付検索得意先A" });
+
+    const result = await query.execute({ createdAfter: before });
+
+    const codes = result.map((r) => r.code);
+    expect(codes).toContain(TEST_CODES[0]);
+  });
+
+  it("createdAfterで指定日時以降に該当しない場合はヒットしない", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "日付検索得意先B" });
+    const future = new Date(Date.now() + 60_000);
+
+    const result = await query.execute({ createdAfter: future });
+
+    const codes = result.map((r) => r.code);
+    expect(codes).not.toContain(TEST_CODES[0]);
+  });
+
+  it("createdBeforeで指定日時以前の得意先を取得できる", async () => {
+    await createTestCustomer({ code: TEST_CODES[0], name: "日付検索得意先C" });
+    const after = new Date(Date.now() + 60_000);
+
+    const result = await query.execute({ createdBefore: after });
+
+    const codes = result.map((r) => r.code);
+    expect(codes).toContain(TEST_CODES[0]);
+  });
+
+  it("createdBeforeで指定日時以前に該当しない場合はヒットしない", async () => {
+    const past = new Date();
+    // 少し待ってからレコード作成（pastより後に作成される）
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await createTestCustomer({ code: TEST_CODES[0], name: "日付検索得意先D" });
+
+    const result = await query.execute({ createdBefore: past });
+
+    const codes = result.map((r) => r.code);
+    expect(codes).not.toContain(TEST_CODES[0]);
   });
 });

--- a/src/server/subdomains/delivery-location/application/commands/__tests__/CreateDeliveryLocationCommand.test.ts
+++ b/src/server/subdomains/delivery-location/application/commands/__tests__/CreateDeliveryLocationCommand.test.ts
@@ -1,0 +1,144 @@
+import prisma from "@server/prisma";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocationCodeDuplicationCheckDomainService } from "@subdomains/delivery-location/domain/services/DeliveryLocationCodeDuplicationCheckDomainService";
+import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CreateDeliveryLocationCommand } from "../CreateDeliveryLocationCommand";
+
+describe("CreateDeliveryLocationCommand", () => {
+  let command: CreateDeliveryLocationCommand;
+  let dlRepository: PrismaDeliveryLocationRepository;
+  let customerRepository: PrismaCustomerRepository;
+  let codeDuplicationCheckService: DeliveryLocationCodeDuplicationCheckDomainService;
+  let testCustomerId: string;
+
+  const DL_TEST_CODES = ["DL999911", "DL999912"];
+  const CUSTOMER_TEST_CODE = "CUST999931";
+
+  beforeEach(async () => {
+    // DL の Company → Customer の Company の順で削除
+    await prisma.company.deleteMany({
+      where: { code: { in: DL_TEST_CODES } },
+    });
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+
+    customerRepository = new PrismaCustomerRepository();
+    dlRepository = new PrismaDeliveryLocationRepository();
+    codeDuplicationCheckService = new DeliveryLocationCodeDuplicationCheckDomainService(
+      dlRepository
+    );
+
+    command = new CreateDeliveryLocationCommand(
+      dlRepository,
+      customerRepository,
+      codeDuplicationCheckService
+    );
+
+    // テスト用得意先を事前作成
+    const customer = Customer.create(
+      new CompanyCode(CUSTOMER_TEST_CODE),
+      new CompanyName("納品先テスト用得意先")
+    );
+    const saved = await customerRepository.save(customer);
+    testCustomerId = saved.id;
+  });
+
+  afterEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: DL_TEST_CODES } },
+    });
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+  });
+
+  it("納品先を新規登録できる（必須項目のみ）", async () => {
+    await command.execute({
+      code: DL_TEST_CODES[0],
+      name: "テスト納品先A",
+      customerId: testCustomerId,
+    });
+
+    const saved = await dlRepository.findByCode(new CompanyCode(DL_TEST_CODES[0]));
+    expect(saved).not.toBeNull();
+    expect(saved?.name.value).toBe("テスト納品先A");
+    expect(saved?.code.value).toBe(DL_TEST_CODES[0]);
+    expect(saved?.customerId).toBe(testCustomerId);
+    expect(saved?.isActive).toBe(true);
+    expect(saved?.deliveryNotes).toBeNull();
+  });
+
+  it("全オプション項目付きで新規登録できる", async () => {
+    await command.execute({
+      code: DL_TEST_CODES[0],
+      name: "テスト納品先B",
+      customerId: testCustomerId,
+      postalCode: "100-0001",
+      prefecture: "東京都",
+      address: "千代田区1-1-1",
+      phoneNumber: "03-1234-5678",
+      faxNumber: "03-1234-5679",
+      contactPerson: "配送担当",
+      deliveryNotes: "裏口から搬入してください",
+    });
+
+    const saved = await dlRepository.findByCode(new CompanyCode(DL_TEST_CODES[0]));
+    expect(saved).not.toBeNull();
+    expect(saved?.name.value).toBe("テスト納品先B");
+    expect(saved?.postalCode?.value).toBe("1000001");
+    expect(saved?.prefecture?.value).toBe("東京都");
+    expect(saved?.address?.value).toBe("千代田区1-1-1");
+    expect(saved?.phoneNumber?.value).toBe("0312345678");
+    expect(saved?.faxNumber?.value).toBe("0312345679");
+    expect(saved?.contactPerson).toBe("配送担当");
+    expect(saved?.deliveryNotes?.value).toBe("裏口から搬入してください");
+  });
+
+  it("コードが重複している場合は ValidationError", async () => {
+    await command.execute({
+      code: DL_TEST_CODES[0],
+      name: "重複元納品先",
+      customerId: testCustomerId,
+    });
+
+    await expect(
+      command.execute({
+        code: DL_TEST_CODES[0],
+        name: "重複先納品先",
+        customerId: testCustomerId,
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("親得意先が存在しない場合は NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        code: DL_TEST_CODES[0],
+        name: "親なし納品先",
+        customerId: "non-existent-customer-id",
+      })
+    ).rejects.toThrow(NotFoundEntityError);
+  });
+
+  it("親得意先が無効化されている場合は ValidationError", async () => {
+    // 得意先を無効化
+    const customer = await customerRepository.findById(testCustomerId);
+    customer!.deactivate();
+    await customerRepository.save(customer!);
+
+    await expect(
+      command.execute({
+        code: DL_TEST_CODES[0],
+        name: "無効得意先の納品先",
+        customerId: testCustomerId,
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+});

--- a/src/server/subdomains/delivery-location/application/commands/__tests__/DeleteDeliveryLocationCommand.test.ts
+++ b/src/server/subdomains/delivery-location/application/commands/__tests__/DeleteDeliveryLocationCommand.test.ts
@@ -1,0 +1,71 @@
+import prisma from "@server/prisma";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DeleteDeliveryLocationCommand } from "../DeleteDeliveryLocationCommand";
+
+describe("DeleteDeliveryLocationCommand", () => {
+  let command: DeleteDeliveryLocationCommand;
+  let dlRepository: PrismaDeliveryLocationRepository;
+  let customerRepository: PrismaCustomerRepository;
+  let testCustomerId: string;
+  let testDeliveryLocationId: string;
+
+  const DL_TEST_CODES = ["DL999914"];
+  const CUSTOMER_TEST_CODE = "CUST999933";
+
+  beforeEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: DL_TEST_CODES } },
+    });
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+
+    customerRepository = new PrismaCustomerRepository();
+    dlRepository = new PrismaDeliveryLocationRepository();
+    command = new DeleteDeliveryLocationCommand(dlRepository);
+
+    // テスト用得意先を事前作成
+    const customer = Customer.create(
+      new CompanyCode(CUSTOMER_TEST_CODE),
+      new CompanyName("削除テスト用得意先")
+    );
+    const savedCustomer = await customerRepository.save(customer);
+    testCustomerId = savedCustomer.id;
+
+    // テスト用納品先を事前作成
+    const dl = DeliveryLocation.create(
+      new CompanyCode(DL_TEST_CODES[0]),
+      new CompanyName("削除テスト納品先"),
+      testCustomerId
+    );
+    const savedDl = await dlRepository.save(dl);
+    testDeliveryLocationId = savedDl.id;
+  });
+
+  afterEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: DL_TEST_CODES } },
+    });
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+  });
+
+  it("納品先を削除できる", async () => {
+    await command.execute({ id: testDeliveryLocationId });
+
+    const deleted = await dlRepository.findById(testDeliveryLocationId);
+    expect(deleted).toBeNull();
+  });
+
+  it("存在しないIDの場合は NotFoundEntityError", async () => {
+    await expect(command.execute({ id: "non-existent-id" })).rejects.toThrow(NotFoundEntityError);
+  });
+});

--- a/src/server/subdomains/delivery-location/application/commands/__tests__/UpdateDeliveryLocationCommand.test.ts
+++ b/src/server/subdomains/delivery-location/application/commands/__tests__/UpdateDeliveryLocationCommand.test.ts
@@ -1,0 +1,126 @@
+import prisma from "@server/prisma";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { UpdateDeliveryLocationCommand } from "../UpdateDeliveryLocationCommand";
+
+describe("UpdateDeliveryLocationCommand", () => {
+  let command: UpdateDeliveryLocationCommand;
+  let dlRepository: PrismaDeliveryLocationRepository;
+  let customerRepository: PrismaCustomerRepository;
+  let testCustomerId: string;
+  let testDeliveryLocationId: string;
+
+  const DL_TEST_CODES = ["DL999913"];
+  const CUSTOMER_TEST_CODE = "CUST999932";
+
+  beforeEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: DL_TEST_CODES } },
+    });
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+
+    customerRepository = new PrismaCustomerRepository();
+    dlRepository = new PrismaDeliveryLocationRepository();
+    command = new UpdateDeliveryLocationCommand(dlRepository);
+
+    // テスト用得意先を事前作成
+    const customer = Customer.create(
+      new CompanyCode(CUSTOMER_TEST_CODE),
+      new CompanyName("更新テスト用得意先")
+    );
+    const savedCustomer = await customerRepository.save(customer);
+    testCustomerId = savedCustomer.id;
+
+    // テスト用納品先を事前作成
+    const dl = DeliveryLocation.create(
+      new CompanyCode(DL_TEST_CODES[0]),
+      new CompanyName("更新前納品先"),
+      testCustomerId
+    );
+    const savedDl = await dlRepository.save(dl);
+    testDeliveryLocationId = savedDl.id;
+  });
+
+  afterEach(async () => {
+    await prisma.company.deleteMany({
+      where: { code: { in: DL_TEST_CODES } },
+    });
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+  });
+
+  it("納品先情報を更新できる（名前変更）", async () => {
+    await command.execute({
+      id: testDeliveryLocationId,
+      name: "更新後納品先",
+    });
+
+    const updated = await dlRepository.findById(testDeliveryLocationId);
+    expect(updated).not.toBeNull();
+    expect(updated?.name.value).toBe("更新後納品先");
+  });
+
+  it("住所・連絡先・配送メモを更新できる", async () => {
+    await command.execute({
+      id: testDeliveryLocationId,
+      name: "更新前納品先",
+      postalCode: "300-0003",
+      prefecture: "愛知県",
+      address: "名古屋市3-3-3",
+      phoneNumber: "052-1234-5678",
+      faxNumber: "052-1234-5679",
+      contactPerson: "配送更新担当",
+      deliveryNotes: "午前中のみ受付可能",
+    });
+
+    const updated = await dlRepository.findById(testDeliveryLocationId);
+    expect(updated).not.toBeNull();
+    expect(updated?.postalCode?.value).toBe("3000003");
+    expect(updated?.prefecture?.value).toBe("愛知県");
+    expect(updated?.address?.value).toBe("名古屋市3-3-3");
+    expect(updated?.phoneNumber?.value).toBe("05212345678");
+    expect(updated?.faxNumber?.value).toBe("05212345679");
+    expect(updated?.contactPerson).toBe("配送更新担当");
+    expect(updated?.deliveryNotes?.value).toBe("午前中のみ受付可能");
+  });
+
+  it("isActive を変更できる", async () => {
+    // deactivate
+    await command.execute({
+      id: testDeliveryLocationId,
+      name: "更新前納品先",
+      isActive: false,
+    });
+
+    let updated = await dlRepository.findById(testDeliveryLocationId);
+    expect(updated?.isActive).toBe(false);
+
+    // activate
+    await command.execute({
+      id: testDeliveryLocationId,
+      name: "更新前納品先",
+      isActive: true,
+    });
+
+    updated = await dlRepository.findById(testDeliveryLocationId);
+    expect(updated?.isActive).toBe(true);
+  });
+
+  it("存在しないIDの場合は NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        id: "non-existent-id",
+        name: "存在しない",
+      })
+    ).rejects.toThrow(NotFoundEntityError);
+  });
+});

--- a/src/server/subdomains/delivery-location/application/commands/__tests__/UpdateDeliveryLocationCommand.test.ts
+++ b/src/server/subdomains/delivery-location/application/commands/__tests__/UpdateDeliveryLocationCommand.test.ts
@@ -115,6 +115,44 @@ describe("UpdateDeliveryLocationCommand", () => {
     expect(updated?.isActive).toBe(true);
   });
 
+  it("nullを渡すとオプション項目をクリアできる", async () => {
+    // まず値を設定
+    await command.execute({
+      id: testDeliveryLocationId,
+      name: "更新前納品先",
+      postalCode: "300-0003",
+      prefecture: "愛知県",
+      address: "名古屋市3-3-3",
+      phoneNumber: "052-1234-5678",
+      faxNumber: "052-1234-5679",
+      contactPerson: "配送更新担当",
+      deliveryNotes: "午前中のみ受付可能",
+    });
+
+    // nullで全クリア
+    await command.execute({
+      id: testDeliveryLocationId,
+      name: "更新前納品先",
+      postalCode: null,
+      prefecture: null,
+      address: null,
+      phoneNumber: null,
+      faxNumber: null,
+      contactPerson: null,
+      deliveryNotes: null,
+    });
+
+    const updated = await dlRepository.findById(testDeliveryLocationId);
+    expect(updated).not.toBeNull();
+    expect(updated?.postalCode).toBeNull();
+    expect(updated?.prefecture).toBeNull();
+    expect(updated?.address).toBeNull();
+    expect(updated?.phoneNumber).toBeNull();
+    expect(updated?.faxNumber).toBeNull();
+    expect(updated?.contactPerson).toBeNull();
+    expect(updated?.deliveryNotes).toBeNull();
+  });
+
   it("存在しないIDの場合は NotFoundEntityError", async () => {
     await expect(
       command.execute({

--- a/src/server/subdomains/delivery-location/application/queries/__tests__/GetDeliveryLocationByIdQuery.test.ts
+++ b/src/server/subdomains/delivery-location/application/queries/__tests__/GetDeliveryLocationByIdQuery.test.ts
@@ -1,0 +1,113 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { CompanyType } from "@generated/prisma/client";
+import { PrismaDeliveryLocationQueryService } from "@subdomains/delivery-location/infrastructure/queries/PrismaDeliveryLocationQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetDeliveryLocationByIdQuery } from "../GetDeliveryLocationByIdQuery";
+
+describe("GetDeliveryLocationByIdQuery", () => {
+  let query: GetDeliveryLocationByIdQuery;
+  const testCompanyIds: string[] = [];
+  let testCustomerId: string;
+  let customerCompanyId: string;
+
+  const DL_TEST_CODES = ["DL999921"];
+  const CUSTOMER_TEST_CODE = "CUST999941";
+
+  async function createTestDeliveryLocation(data: {
+    code: string;
+    name: string;
+    deliveryNotes?: string;
+  }) {
+    const companyId = createId();
+    const dlId = createId();
+
+    await prisma.company.create({
+      data: {
+        id: companyId,
+        code: data.code,
+        name: data.name,
+        type: CompanyType.DELIVERY_LOCATION,
+        isActive: true,
+      },
+    });
+
+    await prisma.deliveryLocation.create({
+      data: {
+        id: dlId,
+        companyId,
+        customerId: testCustomerId,
+        deliveryNotes: data.deliveryNotes ?? null,
+      },
+    });
+
+    testCompanyIds.push(companyId);
+    return { companyId, dlId };
+  }
+
+  beforeEach(async () => {
+    testCompanyIds.length = 0;
+
+    await prisma.company.deleteMany({
+      where: { code: { in: DL_TEST_CODES } },
+    });
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+
+    // テスト用得意先をDB直接投入
+    customerCompanyId = createId();
+    testCustomerId = createId();
+
+    await prisma.company.create({
+      data: {
+        id: customerCompanyId,
+        code: CUSTOMER_TEST_CODE,
+        name: "DLクエリテスト用得意先",
+        type: CompanyType.CUSTOMER,
+        isActive: true,
+      },
+    });
+
+    await prisma.customer.create({
+      data: {
+        id: testCustomerId,
+        companyId: customerCompanyId,
+      },
+    });
+
+    query = new GetDeliveryLocationByIdQuery(new PrismaDeliveryLocationQueryService());
+  });
+
+  afterEach(async () => {
+    if (testCompanyIds.length > 0) {
+      await prisma.company.deleteMany({
+        where: { id: { in: testCompanyIds } },
+      });
+    }
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+  });
+
+  it("IDで納品先を取得できる", async () => {
+    const { dlId } = await createTestDeliveryLocation({
+      code: DL_TEST_CODES[0],
+      name: "ID取得テスト納品先",
+    });
+
+    const result = await query.execute({ id: dlId });
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(dlId);
+    expect(result?.code).toBe(DL_TEST_CODES[0]);
+    expect(result?.name).toBe("ID取得テスト納品先");
+    expect(result?.customerId).toBe(testCustomerId);
+  });
+
+  it("存在しないIDの場合は null を返す", async () => {
+    const result = await query.execute({ id: "non-existent-id" });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/server/subdomains/delivery-location/application/queries/__tests__/GetDeliveryLocationsByCustomerIdQuery.test.ts
+++ b/src/server/subdomains/delivery-location/application/queries/__tests__/GetDeliveryLocationsByCustomerIdQuery.test.ts
@@ -1,0 +1,122 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { CompanyType } from "@generated/prisma/client";
+import { PrismaDeliveryLocationQueryService } from "@subdomains/delivery-location/infrastructure/queries/PrismaDeliveryLocationQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetDeliveryLocationsByCustomerIdQuery } from "../GetDeliveryLocationsByCustomerIdQuery";
+
+describe("GetDeliveryLocationsByCustomerIdQuery", () => {
+  let query: GetDeliveryLocationsByCustomerIdQuery;
+  const testCompanyIds: string[] = [];
+  let testCustomerId: string;
+  let customerCompanyId: string;
+
+  const DL_TEST_CODES = ["DL999922", "DL999923"];
+  const CUSTOMER_TEST_CODE = "CUST999942";
+
+  async function createTestDeliveryLocation(data: {
+    code: string;
+    name: string;
+    deliveryNotes?: string;
+  }) {
+    const companyId = createId();
+    const dlId = createId();
+
+    await prisma.company.create({
+      data: {
+        id: companyId,
+        code: data.code,
+        name: data.name,
+        type: CompanyType.DELIVERY_LOCATION,
+        isActive: true,
+      },
+    });
+
+    await prisma.deliveryLocation.create({
+      data: {
+        id: dlId,
+        companyId,
+        customerId: testCustomerId,
+        deliveryNotes: data.deliveryNotes ?? null,
+      },
+    });
+
+    testCompanyIds.push(companyId);
+    return { companyId, dlId };
+  }
+
+  beforeEach(async () => {
+    testCompanyIds.length = 0;
+
+    await prisma.company.deleteMany({
+      where: { code: { in: DL_TEST_CODES } },
+    });
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+
+    // テスト用得意先をDB直接投入
+    customerCompanyId = createId();
+    testCustomerId = createId();
+
+    await prisma.company.create({
+      data: {
+        id: customerCompanyId,
+        code: CUSTOMER_TEST_CODE,
+        name: "DL一覧クエリテスト用得意先",
+        type: CompanyType.CUSTOMER,
+        isActive: true,
+      },
+    });
+
+    await prisma.customer.create({
+      data: {
+        id: testCustomerId,
+        companyId: customerCompanyId,
+      },
+    });
+
+    query = new GetDeliveryLocationsByCustomerIdQuery(new PrismaDeliveryLocationQueryService());
+  });
+
+  afterEach(async () => {
+    if (testCompanyIds.length > 0) {
+      await prisma.company.deleteMany({
+        where: { id: { in: testCompanyIds } },
+      });
+    }
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+  });
+
+  it("得意先IDで納品先一覧を取得できる", async () => {
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "一覧納品先A" });
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[1], name: "一覧納品先B" });
+
+    const result = await query.execute({ customerId: testCustomerId });
+
+    expect(result.length).toBe(2);
+    const codes = result.map((r) => r.code);
+    expect(codes).toContain(DL_TEST_CODES[0]);
+    expect(codes).toContain(DL_TEST_CODES[1]);
+    for (const dl of result) {
+      expect(dl.customerId).toBe(testCustomerId);
+    }
+  });
+
+  it("該当なしの場合は空配列を返す", async () => {
+    const result = await query.execute({ customerId: "non-existent-customer-id" });
+
+    expect(result).toEqual([]);
+  });
+
+  it("limit/offset付きで取得できる", async () => {
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "ページ納品先A" });
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[1], name: "ページ納品先B" });
+
+    const result = await query.execute({ customerId: testCustomerId }, { limit: 1 });
+
+    expect(result.length).toBe(1);
+  });
+});

--- a/src/server/subdomains/delivery-location/application/queries/__tests__/SearchDeliveryLocationsQuery.test.ts
+++ b/src/server/subdomains/delivery-location/application/queries/__tests__/SearchDeliveryLocationsQuery.test.ts
@@ -18,6 +18,8 @@ describe("SearchDeliveryLocationsQuery", () => {
     code: string;
     name: string;
     deliveryNotes?: string;
+    isActive?: boolean;
+    customerId?: string;
   }) {
     const companyId = createId();
     const dlId = createId();
@@ -28,7 +30,7 @@ describe("SearchDeliveryLocationsQuery", () => {
         code: data.code,
         name: data.name,
         type: CompanyType.DELIVERY_LOCATION,
-        isActive: true,
+        isActive: data.isActive ?? true,
       },
     });
 
@@ -36,7 +38,7 @@ describe("SearchDeliveryLocationsQuery", () => {
       data: {
         id: dlId,
         companyId,
-        customerId: testCustomerId,
+        customerId: data.customerId ?? testCustomerId,
         deliveryNotes: data.deliveryNotes ?? null,
       },
     });
@@ -102,6 +104,14 @@ describe("SearchDeliveryLocationsQuery", () => {
     expect(names).toContain("SQ検索納品先B");
   });
 
+  it("名前で検索してヒットしない場合は空配列を返す", async () => {
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "SQ検索納品先A" });
+
+    const result = await query.execute({ name: "該当なしSQ名前" });
+
+    expect(result).toEqual([]);
+  });
+
   it("コードで検索できる（完全一致）", async () => {
     await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "コード検索DL-A" });
     await createTestDeliveryLocation({ code: DL_TEST_CODES[1], name: "コード検索DL-B" });
@@ -112,9 +122,89 @@ describe("SearchDeliveryLocationsQuery", () => {
     expect(result[0].code).toBe(DL_TEST_CODES[0]);
   });
 
-  it("条件に一致する納品先がない場合は空配列を返す", async () => {
-    const result = await query.execute({ name: "存在しないSQ納品先名" });
+  it("コードで検索してヒットしない場合は空配列を返す", async () => {
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "コード検索DL-A" });
+
+    const result = await query.execute({ code: "NONEXIST999" });
 
     expect(result).toEqual([]);
+  });
+
+  it("コードの部分一致ではヒットしない", async () => {
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "部分一致テスト" });
+
+    const result = await query.execute({ code: DL_TEST_CODES[0].slice(0, 4) });
+
+    expect(result).toEqual([]);
+  });
+
+  it("customerIdで検索できる", async () => {
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "得意先ID検索A" });
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[1], name: "得意先ID検索B" });
+
+    const result = await query.execute({ customerId: testCustomerId });
+
+    expect(result.length).toBe(2);
+    for (const dl of result) {
+      expect(dl.customerId).toBe(testCustomerId);
+    }
+  });
+
+  it("customerIdで検索してヒットしない場合は空配列を返す", async () => {
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "得意先ID検索C" });
+
+    const result = await query.execute({ customerId: "non-existent-customer-id" });
+
+    expect(result).toEqual([]);
+  });
+
+  it("isActiveで検索できる", async () => {
+    await createTestDeliveryLocation({
+      code: DL_TEST_CODES[0],
+      name: "SQアクティブ納品先",
+      isActive: true,
+    });
+    await createTestDeliveryLocation({
+      code: DL_TEST_CODES[1],
+      name: "SQアクティブ納品先",
+      isActive: false,
+    });
+
+    const activeResult = await query.execute({ name: "SQアクティブ納品先", isActive: true });
+    expect(activeResult.length).toBe(1);
+    expect(activeResult[0].code).toBe(DL_TEST_CODES[0]);
+
+    const inactiveResult = await query.execute({ name: "SQアクティブ納品先", isActive: false });
+    expect(inactiveResult.length).toBe(1);
+    expect(inactiveResult[0].code).toBe(DL_TEST_CODES[1]);
+  });
+
+  it("複数条件を組み合わせて検索できる", async () => {
+    await createTestDeliveryLocation({
+      code: DL_TEST_CODES[0],
+      name: "複合検索納品先A",
+      isActive: true,
+    });
+    await createTestDeliveryLocation({
+      code: DL_TEST_CODES[1],
+      name: "複合検索納品先B",
+      isActive: false,
+    });
+    await createTestDeliveryLocation({
+      code: DL_TEST_CODES[2],
+      name: "別名納品先C",
+      isActive: true,
+    });
+
+    const result = await query.execute({
+      name: "複合検索",
+      code: DL_TEST_CODES[0],
+      customerId: testCustomerId,
+      isActive: true,
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].code).toBe(DL_TEST_CODES[0]);
+    expect(result[0].name).toBe("複合検索納品先A");
   });
 });

--- a/src/server/subdomains/delivery-location/application/queries/__tests__/SearchDeliveryLocationsQuery.test.ts
+++ b/src/server/subdomains/delivery-location/application/queries/__tests__/SearchDeliveryLocationsQuery.test.ts
@@ -1,0 +1,120 @@
+import { createId } from "@paralleldrive/cuid2";
+import prisma from "@server/prisma";
+import { CompanyType } from "@generated/prisma/client";
+import { PrismaDeliveryLocationQueryService } from "@subdomains/delivery-location/infrastructure/queries/PrismaDeliveryLocationQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SearchDeliveryLocationsQuery } from "../SearchDeliveryLocationsQuery";
+
+describe("SearchDeliveryLocationsQuery", () => {
+  let query: SearchDeliveryLocationsQuery;
+  const testCompanyIds: string[] = [];
+  let testCustomerId: string;
+  let customerCompanyId: string;
+
+  const DL_TEST_CODES = ["DL999924", "DL999925", "DL999926"];
+  const CUSTOMER_TEST_CODE = "CUST999943";
+
+  async function createTestDeliveryLocation(data: {
+    code: string;
+    name: string;
+    deliveryNotes?: string;
+  }) {
+    const companyId = createId();
+    const dlId = createId();
+
+    await prisma.company.create({
+      data: {
+        id: companyId,
+        code: data.code,
+        name: data.name,
+        type: CompanyType.DELIVERY_LOCATION,
+        isActive: true,
+      },
+    });
+
+    await prisma.deliveryLocation.create({
+      data: {
+        id: dlId,
+        companyId,
+        customerId: testCustomerId,
+        deliveryNotes: data.deliveryNotes ?? null,
+      },
+    });
+
+    testCompanyIds.push(companyId);
+    return { companyId, dlId };
+  }
+
+  beforeEach(async () => {
+    testCompanyIds.length = 0;
+
+    await prisma.company.deleteMany({
+      where: { code: { in: DL_TEST_CODES } },
+    });
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+
+    // テスト用得意先をDB直接投入
+    customerCompanyId = createId();
+    testCustomerId = createId();
+
+    await prisma.company.create({
+      data: {
+        id: customerCompanyId,
+        code: CUSTOMER_TEST_CODE,
+        name: "DL検索クエリテスト用得意先",
+        type: CompanyType.CUSTOMER,
+        isActive: true,
+      },
+    });
+
+    await prisma.customer.create({
+      data: {
+        id: testCustomerId,
+        companyId: customerCompanyId,
+      },
+    });
+
+    query = new SearchDeliveryLocationsQuery(new PrismaDeliveryLocationQueryService());
+  });
+
+  afterEach(async () => {
+    if (testCompanyIds.length > 0) {
+      await prisma.company.deleteMany({
+        where: { id: { in: testCompanyIds } },
+      });
+    }
+    await prisma.company.deleteMany({
+      where: { code: CUSTOMER_TEST_CODE },
+    });
+  });
+
+  it("名前で検索できる（部分一致）", async () => {
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "SQ検索納品先A" });
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[1], name: "SQ検索納品先B" });
+
+    const result = await query.execute({ name: "SQ検索納品先" });
+
+    expect(result.length).toBe(2);
+    const names = result.map((r) => r.name);
+    expect(names).toContain("SQ検索納品先A");
+    expect(names).toContain("SQ検索納品先B");
+  });
+
+  it("コードで検索できる（完全一致）", async () => {
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "コード検索DL-A" });
+    await createTestDeliveryLocation({ code: DL_TEST_CODES[1], name: "コード検索DL-B" });
+
+    const result = await query.execute({ code: DL_TEST_CODES[0] });
+
+    expect(result.length).toBe(1);
+    expect(result[0].code).toBe(DL_TEST_CODES[0]);
+  });
+
+  it("条件に一致する納品先がない場合は空配列を返す", async () => {
+    const result = await query.execute({ name: "存在しないSQ納品先名" });
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- customer・delivery-location サブドメインの application 層テスト12本を新規作成し、testing-backend 規約に準拠させた
- SearchCustomersQuery / SearchDeliveryLocationsQuery のテストケースを全検索条件のヒット/ミスケースに拡充
- UpdateCustomerCommand / UpdateDeliveryLocationCommand に null クリアパスのテストを追加
- 並列テスト実行時のレースコンディション回避のため、広範スキャンを避ける name フィルタを併用

### 作成したテストファイル（12本）

**Customer Commands (3本)**
- `CreateCustomerCommand.test.ts` — 必須項目のみ / 全オプション / コード重複
- `UpdateCustomerCommand.test.ts` — 名前変更 / 住所・連絡先・マージン率 / null クリア / isActive / NotFound
- `DeleteCustomerCommand.test.ts` — 削除成功 / NotFound

**Customer Queries (3本)**
- `GetAllCustomersQuery.test.ts` — 全件取得 / limit・offset / ソート
- `GetCustomerByIdQuery.test.ts` — ID取得 / null返却
- `SearchCustomersQuery.test.ts` — 名前(部分一致) / コード(完全一致) / コード部分一致拒否 / isActive / createdAfter / createdBefore / 複合条件 / 各条件ミスケース (11テスト)

**DeliveryLocation Commands (3本)**
- `CreateDeliveryLocationCommand.test.ts` — 必須項目のみ / 全オプション / コード重複 / 親なし / 親無効
- `UpdateDeliveryLocationCommand.test.ts` — 名前変更 / 住所・連絡先・配送メモ / null クリア / isActive / NotFound
- `DeleteDeliveryLocationCommand.test.ts` — 削除成功 / NotFound

**DeliveryLocation Queries (3本)**
- `GetDeliveryLocationByIdQuery.test.ts` — ID取得 / null返却
- `GetDeliveryLocationsByCustomerIdQuery.test.ts` — 得意先ID一覧 / 該当なし / limit・offset
- `SearchDeliveryLocationsQuery.test.ts` — 名前(部分一致) / コード(完全一致) / コード部分一致拒否 / customerId / isActive / 複合条件 / 各条件ミスケース (9テスト)

## Test plan

- [x] `pnpm test` — 54ファイル 373テスト全パス
- [x] 複数回実行でレースコンディションが発生しないことを確認

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)