### PR TITLE
feat: searchDeliveryLocationsQuery にページネーション機能を追加

### DIFF
--- a/src/server/subdomains/delivery-location/application/queries/SearchDeliveryLocationsQuery.ts
+++ b/src/server/subdomains/delivery-location/application/queries/SearchDeliveryLocationsQuery.ts
@@ -1,9 +1,17 @@
+import { PaginatedResult, PaginationOptions } from "@server/shared/queries/PaginatedResult";
+
 import { DeliveryLocationQueryService } from "./DeliveryLocationQueryService";
 import { DeliveryLocationDTO } from "./dto/DeliveryLocationDTO";
 import {
   DeliveryLocationSearchCriteria,
   DeliveryLocationListOptions,
 } from "./dto/DeliveryLocationSearchCriteria";
+
+export type SearchDeliveryLocationsPaginatedInput = {
+  criteria: DeliveryLocationSearchCriteria;
+  pagination: PaginationOptions;
+  orderBy?: DeliveryLocationListOptions["orderBy"];
+};
 
 export class SearchDeliveryLocationsQuery {
   constructor(private readonly deliveryLocationQueryService: DeliveryLocationQueryService) {}
@@ -13,5 +21,52 @@ export class SearchDeliveryLocationsQuery {
     options?: DeliveryLocationListOptions
   ): Promise<DeliveryLocationDTO[]> {
     return await this.deliveryLocationQueryService.search(criteria, options);
+  }
+
+  /**
+   * ページネーション付きで検索を実行
+   */
+  async executeWithPagination(
+    input: SearchDeliveryLocationsPaginatedInput
+  ): Promise<PaginatedResult<DeliveryLocationDTO>> {
+    const { criteria, pagination, orderBy } = input;
+    const { page, pageSize } = pagination;
+
+    // 総件数を取得
+    const totalCount = await this.deliveryLocationQueryService.count(criteria);
+
+    // 総ページ数を計算
+    const totalPages = Math.ceil(totalCount / pageSize);
+
+    // 現在のページが範囲外の場合は空配列を返す
+    if (page < 1 || (totalPages > 0 && page > totalPages)) {
+      return {
+        items: [],
+        totalCount,
+        totalPages,
+        currentPage: page,
+        pageSize,
+        hasNextPage: false,
+        hasPreviousPage: page > 1,
+      };
+    }
+
+    // データを取得
+    const offset = (page - 1) * pageSize;
+    const items = await this.deliveryLocationQueryService.search(criteria, {
+      limit: pageSize,
+      offset,
+      orderBy,
+    });
+
+    return {
+      items,
+      totalCount,
+      totalPages,
+      currentPage: page,
+      pageSize,
+      hasNextPage: page < totalPages,
+      hasPreviousPage: page > 1,
+    };
   }
 }

--- a/src/server/subdomains/delivery-location/application/queries/__tests__/SearchDeliveryLocationsQuery.test.ts
+++ b/src/server/subdomains/delivery-location/application/queries/__tests__/SearchDeliveryLocationsQuery.test.ts
@@ -207,4 +207,64 @@ describe("SearchDeliveryLocationsQuery", () => {
     expect(result[0].code).toBe(DL_TEST_CODES[0]);
     expect(result[0].name).toBe("複合検索納品先A");
   });
+
+  describe("executeWithPagination", () => {
+    beforeEach(async () => {
+      await createTestDeliveryLocation({ code: DL_TEST_CODES[0], name: "SQページ納品先A" });
+      await createTestDeliveryLocation({ code: DL_TEST_CODES[1], name: "SQページ納品先B" });
+      await createTestDeliveryLocation({ code: DL_TEST_CODES[2], name: "SQページ納品先C" });
+    });
+
+    it("正常にページネーション結果を返す", async () => {
+      const result = await query.executeWithPagination({
+        criteria: { name: "SQページ納品先" },
+        pagination: { page: 1, pageSize: 2 },
+        orderBy: { field: "code", direction: "asc" },
+      });
+
+      expect(result.items.length).toBe(2);
+      expect(result.totalCount).toBe(3);
+      expect(result.totalPages).toBe(2);
+      expect(result.currentPage).toBe(1);
+      expect(result.pageSize).toBe(2);
+      expect(result.hasNextPage).toBe(true);
+      expect(result.hasPreviousPage).toBe(false);
+    });
+
+    it("2ページ目を取得できる", async () => {
+      const result = await query.executeWithPagination({
+        criteria: { name: "SQページ納品先" },
+        pagination: { page: 2, pageSize: 2 },
+        orderBy: { field: "code", direction: "asc" },
+      });
+
+      expect(result.items.length).toBe(1);
+      expect(result.hasNextPage).toBe(false);
+      expect(result.hasPreviousPage).toBe(true);
+    });
+
+    it("ページ範囲外の場合は空配列を返す", async () => {
+      const result = await query.executeWithPagination({
+        criteria: { name: "SQページ納品先" },
+        pagination: { page: 99, pageSize: 2 },
+      });
+
+      expect(result.items).toEqual([]);
+      expect(result.totalCount).toBe(3);
+      expect(result.hasNextPage).toBe(false);
+    });
+
+    it("0件の場合のページネーション", async () => {
+      const result = await query.executeWithPagination({
+        criteria: { name: "存在しないSQページ名前" },
+        pagination: { page: 1, pageSize: 10 },
+      });
+
+      expect(result.items).toEqual([]);
+      expect(result.totalCount).toBe(0);
+      expect(result.totalPages).toBe(0);
+      expect(result.hasNextPage).toBe(false);
+      expect(result.hasPreviousPage).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- `SearchDeliveryLocationsQuery` に `executeWithPagination` メソッドを追加
- `SearchDeliveryLocationsPaginatedInput` 型を定義（`PaginatedResult<T>` / `PaginationOptions` を利用）
- ページネーション付き検索のテスト4件を追加（正常系、2ページ目、範囲外、0件）

Closes #94

## Test plan
- [x] `pnpm test` で全404テスト通過を確認
- [x] 新規追加の4テストケースが正常にパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)