### PR TITLE
feat: searchDepartmentsQuery にページネーション機能を追加

### DIFF
--- a/src/server/subdomains/department/application/queries/SearchDepartmentsQuery.ts
+++ b/src/server/subdomains/department/application/queries/SearchDepartmentsQuery.ts
@@ -1,3 +1,5 @@
+import { PaginatedResult, PaginationOptions } from "@server/shared/queries/PaginatedResult";
+
 import { DepartmentDTO } from "./dto/DepartmentDTO";
 import { DepartmentSearchCriteria, DepartmentListOptions } from "./dto/DepartmentSearchCriteria";
 import { DepartmentQueryService } from "./DepartmentQueryService";
@@ -5,6 +7,12 @@ import { DepartmentQueryService } from "./DepartmentQueryService";
 export type SearchDepartmentsInput = {
   criteria: DepartmentSearchCriteria;
   options?: DepartmentListOptions;
+};
+
+export type SearchDepartmentsPaginatedInput = {
+  criteria: DepartmentSearchCriteria;
+  pagination: PaginationOptions;
+  orderBy?: DepartmentListOptions["orderBy"];
 };
 
 /**
@@ -15,5 +23,52 @@ export class SearchDepartmentsQuery {
 
   async execute(input: SearchDepartmentsInput): Promise<DepartmentDTO[]> {
     return await this.departmentQueryService.search(input.criteria, input.options);
+  }
+
+  /**
+   * ページネーション付きで検索を実行
+   */
+  async executeWithPagination(
+    input: SearchDepartmentsPaginatedInput
+  ): Promise<PaginatedResult<DepartmentDTO>> {
+    const { criteria, pagination, orderBy } = input;
+    const { page, pageSize } = pagination;
+
+    // 総件数を取得
+    const totalCount = await this.departmentQueryService.count(criteria);
+
+    // 総ページ数を計算
+    const totalPages = Math.ceil(totalCount / pageSize);
+
+    // 現在のページが範囲外の場合は空配列を返す
+    if (page < 1 || (totalPages > 0 && page > totalPages)) {
+      return {
+        items: [],
+        totalCount,
+        totalPages,
+        currentPage: page,
+        pageSize,
+        hasNextPage: false,
+        hasPreviousPage: page > 1,
+      };
+    }
+
+    // データを取得
+    const offset = (page - 1) * pageSize;
+    const items = await this.departmentQueryService.search(criteria, {
+      limit: pageSize,
+      offset,
+      orderBy,
+    });
+
+    return {
+      items,
+      totalCount,
+      totalPages,
+      currentPage: page,
+      pageSize,
+      hasNextPage: page < totalPages,
+      hasPreviousPage: page > 1,
+    };
   }
 }

--- a/src/server/subdomains/department/application/queries/__tests__/SearchDepartmentsQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/SearchDepartmentsQuery.test.ts
@@ -196,4 +196,76 @@ describe("SearchDepartmentsQuery", () => {
 
     expect(result).toEqual([]);
   });
+
+  describe("executeWithPagination", () => {
+    beforeEach(async () => {
+      await createTestDepartment({
+        departmentCd: TEST_CODES[0],
+        name: "SQページ部署A",
+        abbreviation: "SQページA",
+      });
+      await createTestDepartment({
+        departmentCd: TEST_CODES[1],
+        name: "SQページ部署B",
+        abbreviation: "SQページB",
+      });
+      await createTestDepartment({
+        departmentCd: TEST_CODES[2],
+        name: "SQページ部署C",
+        abbreviation: "SQページC",
+      });
+    });
+
+    it("正常にページネーション結果を返す", async () => {
+      const result = await query.executeWithPagination({
+        criteria: { name: "SQページ部署" },
+        pagination: { page: 1, pageSize: 2 },
+        orderBy: { field: "departmentCd", direction: "asc" },
+      });
+
+      expect(result.items.length).toBe(2);
+      expect(result.totalCount).toBe(3);
+      expect(result.totalPages).toBe(2);
+      expect(result.currentPage).toBe(1);
+      expect(result.pageSize).toBe(2);
+      expect(result.hasNextPage).toBe(true);
+      expect(result.hasPreviousPage).toBe(false);
+    });
+
+    it("2ページ目を取得できる", async () => {
+      const result = await query.executeWithPagination({
+        criteria: { name: "SQページ部署" },
+        pagination: { page: 2, pageSize: 2 },
+        orderBy: { field: "departmentCd", direction: "asc" },
+      });
+
+      expect(result.items.length).toBe(1);
+      expect(result.hasNextPage).toBe(false);
+      expect(result.hasPreviousPage).toBe(true);
+    });
+
+    it("ページ範囲外の場合は空配列を返す", async () => {
+      const result = await query.executeWithPagination({
+        criteria: { name: "SQページ部署" },
+        pagination: { page: 99, pageSize: 2 },
+      });
+
+      expect(result.items).toEqual([]);
+      expect(result.totalCount).toBe(3);
+      expect(result.hasNextPage).toBe(false);
+    });
+
+    it("0件の場合のページネーション", async () => {
+      const result = await query.executeWithPagination({
+        criteria: { name: "存在しないSQページ部署名" },
+        pagination: { page: 1, pageSize: 10 },
+      });
+
+      expect(result.items).toEqual([]);
+      expect(result.totalCount).toBe(0);
+      expect(result.totalPages).toBe(0);
+      expect(result.hasNextPage).toBe(false);
+      expect(result.hasPreviousPage).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- SearchDepartmentsQuery に `executeWithPagination` メソッドを追加（SearchCustomersQuery と同パターン）
- ページネーション付き検索テスト4件を追加（正常系、2ページ目、範囲外、0件）

Closes #95

## Test plan
- [x] `pnpm test` 全404テスト通過
- [x] SearchDepartmentsQuery の新規4テストケースが通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)