### PR TITLE
feat: 部署一覧ページ（検索・ページネーション付き）

### DIFF
--- a/src/app/(features)/departments/_components/DepartmentSearchForm.tsx
+++ b/src/app/(features)/departments/_components/DepartmentSearchForm.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
+
+type Props = {
+  defaultValues: {
+    name: string;
+    abbreviation: string;
+    departmentCd: string;
+    isActive: string;
+  };
+};
+
+export function DepartmentSearchForm({ defaultValues }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const [name, setName] = useState(defaultValues.name);
+  const [abbreviation, setAbbreviation] = useState(defaultValues.abbreviation);
+  const [departmentCd, setDepartmentCd] = useState(defaultValues.departmentCd);
+  const [isActive, setIsActive] = useState(defaultValues.isActive);
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const params = new URLSearchParams();
+
+    if (name.trim()) params.set("name", name.trim());
+    if (abbreviation.trim()) params.set("abbreviation", abbreviation.trim());
+    if (departmentCd.trim()) params.set("departmentCd", departmentCd.trim());
+    if (isActive) params.set("isActive", isActive);
+
+    const queryString = params.toString();
+    router.push(queryString ? `${pathname}?${queryString}` : pathname);
+  };
+
+  const handleClear = () => {
+    setName("");
+    setAbbreviation("");
+    setDepartmentCd("");
+    setIsActive("");
+    router.push(pathname);
+  };
+
+  return (
+    <div className="bg-white shadow-md rounded px-8 pt-2 pb-4 mb-4">
+      <h2 className="text-xl font-semibold mb-4 text-gray-500">検索条件</h2>
+      <form onSubmit={handleSearch}>
+        <div className="flex flex-wrap items-end gap-4">
+          <div className="flex-1 min-w-[150px]">
+            <label htmlFor="search-name" className="block text-gray-700 text-sm font-bold mb-2">
+              部署名
+            </label>
+            <input
+              id="search-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="部分一致"
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            />
+          </div>
+          <div className="flex-1 min-w-[150px]">
+            <label
+              htmlFor="search-abbreviation"
+              className="block text-gray-700 text-sm font-bold mb-2"
+            >
+              略称
+            </label>
+            <input
+              id="search-abbreviation"
+              type="text"
+              value={abbreviation}
+              onChange={(e) => setAbbreviation(e.target.value)}
+              placeholder="部分一致"
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            />
+          </div>
+          <div className="flex-1 min-w-[150px]">
+            <label
+              htmlFor="search-departmentCd"
+              className="block text-gray-700 text-sm font-bold mb-2"
+            >
+              部署コード
+            </label>
+            <input
+              id="search-departmentCd"
+              type="text"
+              value={departmentCd}
+              onChange={(e) => setDepartmentCd(e.target.value)}
+              placeholder="完全一致"
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            />
+          </div>
+          <div className="w-[140px]">
+            <label htmlFor="search-isActive" className="block text-gray-700 text-sm font-bold mb-2">
+              状態
+            </label>
+            <select
+              id="search-isActive"
+              value={isActive}
+              onChange={(e) => setIsActive(e.target.value)}
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            >
+              <option value="">すべて</option>
+              <option value="true">有効</option>
+              <option value="false">無効</option>
+            </select>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleClear}
+              className="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            >
+              クリア
+            </button>
+            <button
+              type="submit"
+              className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            >
+              検索
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(features)/departments/layout.tsx
+++ b/src/app/(features)/departments/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "部署管理 - ESM",
+};
+
+export default function DepartmentLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/src/app/(features)/departments/page.tsx
+++ b/src/app/(features)/departments/page.tsx
@@ -1,0 +1,179 @@
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { isAdmin } from "@server/shared/auth";
+import {
+  getAllDepartmentsQueryFactory,
+  searchDepartmentsQueryFactory,
+} from "@subdomains/department/application/factories/departmentQueryFactory";
+import type { DepartmentSearchCriteria } from "@subdomains/department/application/queries/dto/DepartmentSearchCriteria";
+import Link from "next/link";
+import { DepartmentSearchForm } from "./_components/DepartmentSearchForm";
+import { Pagination } from "@/app/_components/shared/Pagination";
+import { Badge } from "@/app/_components/shadcnui/badge";
+
+// ページネーション設定
+const PAGE_SIZE = 100;
+const MAX_PAGES = 10;
+
+type SearchParams = { [key: string]: string | string[] | undefined };
+
+// ヘルパー関数: 文字列値を安全に取得
+function getStringParam(params: SearchParams, key: string): string | undefined {
+  const value = params[key];
+  if (typeof value === "string" && value.trim() !== "") {
+    return value.trim();
+  }
+  return undefined;
+}
+
+// ヘルパー関数: ページ番号を安全に取得
+function getPageParam(params: SearchParams): number {
+  const value = params["page"];
+  if (typeof value === "string") {
+    const page = parseInt(value, 10);
+    if (!isNaN(page) && page >= 1 && page <= MAX_PAGES) {
+      return page;
+    }
+  }
+  return 1;
+}
+
+// ヘルパー関数: isActive値を検証
+function validateIsActive(value: string | undefined): boolean | undefined {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
+export default async function DepartmentPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const session = await verifySession();
+  const params = await searchParams;
+
+  // 検索条件の構築
+  const criteria: DepartmentSearchCriteria = {
+    name: getStringParam(params, "name"),
+    abbreviation: getStringParam(params, "abbreviation"),
+    departmentCd: getStringParam(params, "departmentCd"),
+    isActive: validateIsActive(getStringParam(params, "isActive")),
+  };
+
+  // ページ番号の取得
+  const currentPage = getPageParam(params);
+
+  // 検索実行（ページネーション付き）
+  const searchQuery = searchDepartmentsQueryFactory();
+  const result = await searchQuery.executeWithPagination({
+    criteria,
+    pagination: {
+      page: currentPage,
+      pageSize: PAGE_SIZE,
+    },
+    orderBy: { field: "displayOrder", direction: "asc" },
+  });
+
+  // 親部署名解決: 全部署取得してMap構築
+  const getAllQuery = getAllDepartmentsQueryFactory();
+  const allDepartments = await getAllQuery.execute({});
+  const parentNameMap = new Map(allDepartments.map((dept) => [dept.id, dept.name]));
+
+  // Client Componentに渡すdefaultValues
+  const defaultSearchValues = {
+    name: getStringParam(params, "name") ?? "",
+    abbreviation: getStringParam(params, "abbreviation") ?? "",
+    departmentCd: getStringParam(params, "departmentCd") ?? "",
+    isActive: getStringParam(params, "isActive") ?? "",
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex justify-between items-center mb-2 px-4 pt-4">
+        <h1 className="text-3xl font-bold">部署管理</h1>
+        {isAdmin(session) && (
+          <Link
+            href="/departments/new"
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          >
+            新規登録
+          </Link>
+        )}
+      </div>
+
+      {/* 検索フォーム */}
+      <div className="px-4">
+        <DepartmentSearchForm defaultValues={defaultSearchValues} />
+      </div>
+
+      {/* 一覧表示 */}
+      <div className="flex-1 flex flex-col min-h-0 bg-white shadow-md rounded mx-4 mb-4 text-gray-500">
+        <div className="px-8 pt-6 pb-2">
+          <h2 className="text-xl font-semibold">部署一覧</h2>
+        </div>
+
+        {/* テーブルコンテナ - 縦スクロール可能 */}
+        <div className="flex-1 overflow-hidden px-8">
+          <div className="h-full overflow-y-auto">
+            <table className="min-w-full table-auto">
+              <thead className="bg-gray-200 sticky top-0 z-10">
+                <tr>
+                  <th className="px-4 py-2 text-left">部署コード</th>
+                  <th className="px-4 py-2 text-left">部署名</th>
+                  <th className="px-4 py-2 text-left">略称</th>
+                  <th className="px-4 py-2 text-left">親部署名</th>
+                  <th className="px-4 py-2 text-left">表示順</th>
+                  <th className="px-4 py-2 text-left">状態</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.items.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-4 text-center text-gray-500">
+                      部署が登録されていません
+                    </td>
+                  </tr>
+                ) : (
+                  result.items.map((dept) => (
+                    <tr key={dept.id} className="border-b hover:bg-gray-50">
+                      <td className="px-4 py-2">
+                        <Link
+                          href={`/departments/${dept.departmentCd}`}
+                          className="text-blue-600 hover:text-blue-800 hover:underline"
+                        >
+                          {dept.departmentCd}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2">{dept.name}</td>
+                      <td className="px-4 py-2">{dept.abbreviation}</td>
+                      <td className="px-4 py-2">
+                        {dept.parentId ? (parentNameMap.get(dept.parentId) ?? "-") : "-"}
+                      </td>
+                      <td className="px-4 py-2">{dept.displayOrder}</td>
+                      <td className="px-4 py-2">
+                        <Badge variant={dept.isActive ? "default" : "secondary"}>
+                          {dept.isActive ? "有効" : "無効"}
+                        </Badge>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* ページネーション */}
+        <div className="shrink-0">
+          <Pagination
+            currentPage={result.currentPage}
+            totalPages={result.totalPages}
+            totalCount={result.totalCount}
+            pageSize={result.pageSize}
+            maxPages={MAX_PAGES}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

部署(Department)の一覧ページを新規作成。従業員一覧ページのパターンに準拠し、検索フォーム（部署名・略称・部署コード・状態）とページネーション機能を実装。
親部署名は全部署取得による Map 解決で表示し、管理者のみ「新規登録」ボタンを表示する。

Closes #100

## Implementation Notes

計画通りに実装が完了しました。特筆すべき逸脱はありません。

### 作成ファイル
- `departments/layout.tsx` - メタデータのみのパススルーレイアウト
- `departments/_components/DepartmentSearchForm.tsx` - 4項目検索フォーム（Client Component）
- `departments/page.tsx` - 一覧ページ本体（Server Component）

## Test Plan

- [x] `pnpm build` が成功すること
- [x] `pnpm lint` がエラーなしで通ること
- [x] `pnpm test` が全件パスすること（408 tests passed）
- [ ] ブラウザで `/departments` にアクセスし一覧表示を確認
- [ ] 検索フォームで各フィールドの検索動作を確認
- [ ] ページネーションの動作確認
- [ ] 管理者/一般ユーザーでの「新規登録」ボタン表示制御確認

---

Generated with [Claude Code](https://claude.ai/code)