### PR TITLE
feat: 部署新規作成ページ

### DIFF
--- a/src/app/(features)/departments/_lib/error-handler.ts
+++ b/src/app/(features)/departments/_lib/error-handler.ts
@@ -1,0 +1,30 @@
+import { NotFoundEntityError, NotFoundError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
+import type { ActionResult } from "@shared/types/ActionResult";
+
+/**
+ * Server Action内で発生したエラーを適切なActionResultに変換する
+ */
+export function handleCommandError(error: unknown): ActionResult {
+  console.error("Command failed:", error);
+
+  if (error instanceof ValidationError) {
+    return {
+      success: false,
+      error: `入力内容に誤りがあります: ${error.message}`,
+    };
+  }
+
+  if (error instanceof BusinessRuleViolationError) {
+    return { success: false, error: error.message };
+  }
+
+  if (error instanceof NotFoundEntityError || error instanceof NotFoundError) {
+    return { success: false, error: "指定されたリソースが見つかりません" };
+  }
+
+  return {
+    success: false,
+    error: "処理に失敗しました。しばらくしてから再度お試しください。",
+  };
+}

--- a/src/app/(features)/departments/_shared/schema.ts
+++ b/src/app/(features)/departments/_shared/schema.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+/**
+ * 部署フォームの基盤スキーマ
+ * 作成・編集で共通のフィールド（name, abbreviation, displayOrder, parentId）
+ */
+export const departmentBaseSchema = z.object({
+  name: z
+    .string({ error: "必須入力です" })
+    .trim()
+    .min(1, { error: "部署名を入力してください" })
+    .max(100, { error: "部署名は100文字以内で入力してください" }),
+  abbreviation: z
+    .string({ error: "必須入力です" })
+    .trim()
+    .min(1, { error: "略称を入力してください" })
+    .max(20, { error: "略称は20文字以内で入力してください" }),
+  displayOrder: z.coerce
+    .number({ error: "数値を入力してください" })
+    .int({ error: "整数を入力してください" })
+    .min(0, { error: "表示順は0以上で入力してください" }),
+  parentId: z
+    .string()
+    .optional()
+    .transform((val) => (val === "" ? undefined : val)),
+});
+
+/**
+ * 部署コードのスキーマ（作成時のみ使用）
+ */
+export const departmentCdSchema = z
+  .string({ error: "必須入力です" })
+  .trim()
+  .regex(/^DEPT\d{3}$/, {
+    error: "部署コードはDEPT + 3桁の数字で入力してください",
+  })
+  .refine(
+    (val) => parseInt(val.substring(4), 10) >= 1,
+    "部署コードは DEPT001 以上である必要があります"
+  );

--- a/src/app/(features)/departments/new/DepartmentCreateForm.tsx
+++ b/src/app/(features)/departments/new/DepartmentCreateForm.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { getFormProps, getInputProps } from "@conform-to/react";
+import { useServerForm } from "@/app/_hooks/useServerForm";
+import { createDepartment } from "./actions";
+import { createDepartmentSchema } from "./schema";
+
+type Props = {
+  /** 親部署選択フィールド（Server Component を slot として受け取る） */
+  parentDepartmentSelectSlot: React.ReactNode;
+};
+
+export function DepartmentCreateForm({ parentDepartmentSelectSlot }: Props) {
+  const { form, fields, isPending } = useServerForm({
+    action: createDepartment,
+    schema: createDepartmentSchema,
+  });
+
+  return (
+    <div className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+      {/* 全体エラーメッセージ表示 */}
+      {form.errors && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+          role="alert"
+        >
+          <p className="font-bold">エラー</p>
+          <p>{form.errors}</p>
+        </div>
+      )}
+
+      <form {...getFormProps(form)} noValidate className="space-y-4">
+        <div>
+          <label
+            htmlFor={fields.departmentCd.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            部署コード
+          </label>
+          <input
+            {...getInputProps(fields.departmentCd, { type: "text" })}
+            disabled={isPending}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+            placeholder="DEPT001"
+          />
+          {fields.departmentCd.errors ? (
+            <p className="text-red-500 text-xs mt-1" id={fields.departmentCd.errorId}>
+              {fields.departmentCd.errors[0]}
+            </p>
+          ) : (
+            <p className="text-gray-600 text-xs mt-1">形式: DEPT + 3桁の数字</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor={fields.name.id} className="block text-gray-700 text-sm font-bold mb-2">
+            部署名
+          </label>
+          <input
+            {...getInputProps(fields.name, { type: "text" })}
+            disabled={isPending}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+            placeholder="営業部"
+          />
+          {fields.name.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.name.errorId}>
+              {fields.name.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor={fields.abbreviation.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            略称
+          </label>
+          <input
+            {...getInputProps(fields.abbreviation, { type: "text" })}
+            disabled={isPending}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+            placeholder="営業"
+          />
+          {fields.abbreviation.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.abbreviation.errorId}>
+              {fields.abbreviation.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor={fields.displayOrder.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            表示順
+          </label>
+          <input
+            {...getInputProps(fields.displayOrder, { type: "number" })}
+            defaultValue={0}
+            disabled={isPending}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+          />
+          {fields.displayOrder.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.displayOrder.errorId}>
+              {fields.displayOrder.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="parentId" className="block text-gray-700 text-sm font-bold mb-2">
+            親部署
+          </label>
+          {parentDepartmentSelectSlot}
+          {fields.parentId.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.parentId.errorId}>
+              {fields.parentId.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div className="flex gap-4">
+          <button
+            type="submit"
+            disabled={isPending}
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            {isPending ? "登録中..." : "登録"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(features)/departments/new/actions.ts
+++ b/src/app/(features)/departments/new/actions.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { verifyAdmin } from "@/app/_lib/verifyAuthentication";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { REDIRECT_REASON } from "@shared/constants/redirect-reasons";
+import { createDepartmentCommandFactory } from "@subdomains/department/application/factories";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { handleCommandError } from "../_lib/error-handler";
+import { createDepartmentSchema } from "./schema";
+
+// ========================================
+// 部署作成
+// ========================================
+export async function createDepartment(prevState: unknown, formData: FormData) {
+  // 認証・認可チェック: 管理者のみ
+  await verifyAdmin();
+
+  // Conformを使用してFormDataをパース・バリデーション
+  const submission = parseWithZod(formData, {
+    schema: createDepartmentSchema,
+  });
+
+  // バリデーション失敗時はエラーを返却
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const { departmentCd, name, abbreviation, displayOrder, parentId } = submission.value;
+
+  try {
+    const command = createDepartmentCommandFactory();
+
+    await command.execute({
+      departmentCd,
+      name,
+      abbreviation,
+      displayOrder,
+      parentId,
+    });
+
+    revalidatePath("/departments");
+  } catch (error) {
+    const errorResult = handleCommandError(error);
+    const errorMessage = !errorResult.success && errorResult.error ? errorResult.error : undefined;
+    return submission.reply({
+      formErrors: errorMessage ? [errorMessage] : [],
+    });
+  }
+
+  redirect(`/departments?reason=${REDIRECT_REASON.DEPARTMENT_CREATED}`);
+}

--- a/src/app/(features)/departments/new/page.tsx
+++ b/src/app/(features)/departments/new/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { DepartmentSelectField } from "@/app/_components/form";
+import { DepartmentCreateForm } from "./DepartmentCreateForm";
+
+export default function DepartmentNewPage() {
+  return (
+    <div className="container mx-auto p-8">
+      <div className="mb-8">
+        <Link href="/departments" className="text-blue-600 hover:text-blue-800 hover:underline">
+          ← 部署一覧に戻る
+        </Link>
+      </div>
+
+      <h1 className="text-3xl font-bold mb-8">新規部署登録</h1>
+
+      <DepartmentCreateForm
+        parentDepartmentSelectSlot={
+          <DepartmentSelectField
+            name="parentId"
+            id="parentId"
+            required={false}
+            placeholder="親部署を選択してください"
+          />
+        }
+      />
+
+      <div className="mt-4">
+        <Link
+          href="/departments"
+          className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline inline-block"
+        >
+          キャンセル
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(features)/departments/new/schema.ts
+++ b/src/app/(features)/departments/new/schema.ts
@@ -1,0 +1,12 @@
+import type { z } from "zod";
+import { departmentBaseSchema, departmentCdSchema } from "../_shared/schema";
+
+/**
+ * 部署作成フォームのバリデーションスキーマ
+ * 基盤スキーマ + departmentCd
+ */
+export const createDepartmentSchema = departmentBaseSchema.extend({
+  departmentCd: departmentCdSchema,
+});
+
+export type CreateDepartmentInput = z.infer<typeof createDepartmentSchema>;

--- a/src/app/_components/form/SelectField.tsx
+++ b/src/app/_components/form/SelectField.tsx
@@ -48,7 +48,7 @@ export function SelectField({
   defaultValue = "",
   placeholder = "選択してください",
   disabled = false,
-  required = false,
+  required = true,
   className,
   ...rest
 }: SelectFieldProps) {
@@ -67,7 +67,7 @@ export function SelectField({
       className={cn(baseClassName, className)}
       {...rest}
     >
-      <option value="" disabled>
+      <option value="" disabled={required}>
         {placeholder}
       </option>
       {options.map((option) => (

--- a/src/app/_components/redirect-reason-toast.tsx
+++ b/src/app/_components/redirect-reason-toast.tsx
@@ -33,6 +33,18 @@ const FLASH_MESSAGES: Record<RedirectReason, FlashMessage> = {
     type: FLASH_MESSAGE_TYPE.SUCCESS,
     message: "従業員を削除しました。",
   },
+  [REDIRECT_REASON.DEPARTMENT_CREATED]: {
+    type: FLASH_MESSAGE_TYPE.SUCCESS,
+    message: "部署を登録しました。",
+  },
+  [REDIRECT_REASON.DEPARTMENT_UPDATED]: {
+    type: FLASH_MESSAGE_TYPE.SUCCESS,
+    message: "部署情報を更新しました。",
+  },
+  [REDIRECT_REASON.DEPARTMENT_DELETED]: {
+    type: FLASH_MESSAGE_TYPE.SUCCESS,
+    message: "部署を削除しました。",
+  },
 };
 
 function RedirectReasonToastInner() {

--- a/src/shared/constants/redirect-reasons.ts
+++ b/src/shared/constants/redirect-reasons.ts
@@ -8,6 +8,9 @@ export const REDIRECT_REASON = {
   EMPLOYEE_CREATED: "employee_created",
   EMPLOYEE_UPDATED: "employee_updated",
   EMPLOYEE_DELETED: "employee_deleted",
+  DEPARTMENT_CREATED: "department_created",
+  DEPARTMENT_UPDATED: "department_updated",
+  DEPARTMENT_DELETED: "department_deleted",
 } as const;
 
 export type RedirectReason = (typeof REDIRECT_REASON)[keyof typeof REDIRECT_REASON];


### PR DESCRIPTION
## Summary

部署の新規作成フォームとServer Actionを実装。従業員作成ページ (`employees/new/`) と同一パターンに従い、Zodバリデーション、Conform連携、DepartmentSelectFieldのslot注入による親部署選択を含む。

Closes #101

## Implementation Notes

計画通りに実装が完了しました。特筆すべき逸脱はありません。

実装のポイント:
- `SelectField` の `required` デフォルトを `true` に変更し、placeholder `<option>` の `disabled` を `required` に連動させた。これにより `required={false}` で親部署の「未選択」への戻しが可能に
- `displayOrder` は `z.coerce.number()` でHTMLフォームの文字列を数値に型変換
- `parentId` は空文字列を `undefined` に変換する `transform` を適用

## Test Plan

- [x] `pnpm build` が成功すること
- [x] `pnpm lint` がエラーなしで通ること
- [x] `pnpm test` が全件パスすること
- [ ] ブラウザで部署作成の動作確認（正常系・バリデーションエラー・重複CDエラー）
- [ ] 管理者のみ作成可能であることの確認

---

Generated with [Claude Code](https://claude.ai/code)