### PR TITLE
feat: 部署詳細・編集・削除ページ

### DIFF
--- a/src/app/(features)/departments/[departmentCd]/DepartmentDeleteForm.tsx
+++ b/src/app/(features)/departments/[departmentCd]/DepartmentDeleteForm.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useActionState } from "react";
+import { deleteDepartment } from "./actions";
+
+type Props = {
+  departmentId: string;
+};
+
+export function DepartmentDeleteForm({ departmentId }: Props) {
+  const [deleteState, formAction, isPending] = useActionState(deleteDepartment, {
+    success: true,
+  });
+
+  return (
+    <div className="mt-4">
+      {/* エラーメッセージ表示 */}
+      {!deleteState.success && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+          role="alert"
+        >
+          <p className="font-bold">エラー</p>
+          <p>{deleteState.error}</p>
+        </div>
+      )}
+
+      <form noValidate action={formAction}>
+        {/* hidden inputでIDを渡す */}
+        <input type="hidden" name="id" value={departmentId} />
+
+        <button
+          type="submit"
+          disabled={isPending}
+          className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+        >
+          {isPending ? "削除中..." : "削除"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(features)/departments/[departmentCd]/DepartmentUpdateForm.tsx
+++ b/src/app/(features)/departments/[departmentCd]/DepartmentUpdateForm.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { getFormProps, getInputProps } from "@conform-to/react";
+import { useServerForm } from "@/app/_hooks/useServerForm";
+import { updateDepartment } from "./actions";
+import { updateDepartmentSchema } from "./schema";
+
+type Department = {
+  id: string;
+  departmentCd: string;
+  name: string;
+  abbreviation: string;
+  displayOrder: number;
+  isActive: boolean;
+  parentId: string | null;
+};
+
+type Props = {
+  department: Department;
+  canUpdate: boolean;
+  /** 親部署選択フィールド（Server Component を slot として受け取る） */
+  parentDepartmentSelectSlot: React.ReactNode;
+};
+
+export function DepartmentUpdateForm({ department, canUpdate, parentDepartmentSelectSlot }: Props) {
+  const updateDepartmentWithCd = updateDepartment.bind(null, department.departmentCd);
+
+  const { form, fields, isPending } = useServerForm({
+    action: updateDepartmentWithCd,
+    schema: updateDepartmentSchema,
+    defaultValue: {
+      name: department.name,
+      abbreviation: department.abbreviation,
+      displayOrder: department.displayOrder,
+      parentId: department.parentId ?? "",
+      isActive: department.isActive,
+    },
+  });
+
+  return (
+    <div className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+      <h2 className="text-xl font-semibold mb-4 text-gray-500">
+        {canUpdate ? "部署変更" : "部署詳細"}
+      </h2>
+
+      {/* 全体エラーメッセージ表示 */}
+      {form.errors && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+          role="alert"
+        >
+          <p className="font-bold">エラー</p>
+          <p>{form.errors}</p>
+        </div>
+      )}
+
+      <form {...getFormProps(form)} noValidate className="space-y-4">
+        <div>
+          <label
+            htmlFor="departmentCd-display"
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            部署コード
+          </label>
+          <input
+            type="text"
+            id="departmentCd-display"
+            value={department.departmentCd}
+            disabled
+            readOnly
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline bg-gray-100"
+          />
+          <p className="text-gray-600 text-xs mt-1">形式: DEPT + 3桁の数字（例: DEPT001）</p>
+        </div>
+
+        <div>
+          <label htmlFor={fields.name.id} className="block text-gray-700 text-sm font-bold mb-2">
+            部署名
+          </label>
+          <input
+            {...getInputProps(fields.name, { type: "text" })}
+            disabled={isPending || !canUpdate}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+          />
+          {fields.name.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.name.errorId}>
+              {fields.name.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor={fields.abbreviation.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            略称
+          </label>
+          <input
+            {...getInputProps(fields.abbreviation, { type: "text" })}
+            disabled={isPending || !canUpdate}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+          />
+          {fields.abbreviation.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.abbreviation.errorId}>
+              {fields.abbreviation.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor={fields.displayOrder.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            表示順
+          </label>
+          <input
+            {...getInputProps(fields.displayOrder, { type: "number" })}
+            disabled={isPending || !canUpdate}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+          />
+          {fields.displayOrder.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.displayOrder.errorId}>
+              {fields.displayOrder.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="parentId" className="block text-gray-700 text-sm font-bold mb-2">
+            親部署
+          </label>
+          {parentDepartmentSelectSlot}
+          {fields.parentId.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.parentId.errorId}>
+              {fields.parentId.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center">
+          <input
+            {...getInputProps(fields.isActive, { type: "checkbox" })}
+            disabled={isPending || !canUpdate}
+            className="mr-2 leading-tight"
+          />
+          <label htmlFor={fields.isActive.id} className="text-gray-700 text-sm font-bold">
+            有効
+          </label>
+        </div>
+
+        {canUpdate && (
+          <div className="flex gap-4">
+            <button
+              type="submit"
+              disabled={isPending}
+              className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {isPending ? "更新中..." : "更新"}
+            </button>
+          </div>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/src/app/(features)/departments/[departmentCd]/actions.ts
+++ b/src/app/(features)/departments/[departmentCd]/actions.ts
@@ -1,0 +1,109 @@
+"use server";
+
+import { verifyAdmin } from "@/app/_lib/verifyAuthentication";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { REDIRECT_REASON } from "@shared/constants/redirect-reasons";
+import type { ActionResult } from "@shared/types/ActionResult";
+import { deleteDepartmentCommandFactory } from "@subdomains/department/application/factories/deleteDepartmentCommandFactory";
+import { updateDepartmentCommandFactory } from "@subdomains/department/application/factories/updateDepartmentCommandFactory";
+import { PrismaDepartmentQueryService } from "@subdomains/department/infrastructure/queries/PrismaDepartmentQueryService";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { handleCommandError } from "../_lib/error-handler";
+import { updateDepartmentSchema } from "./schema";
+
+// ========================================
+// 部署更新
+// ========================================
+
+/**
+ * 部署更新Server Action
+ * @param departmentCd - URLパラメータから取得した部署コード（bind()で渡す）
+ * @param prevState - 前回の状態（Conform用）
+ * @param formData - フォームデータ
+ */
+export async function updateDepartment(
+  departmentCd: string,
+  prevState: unknown,
+  formData: FormData
+) {
+  // 認証・認可チェック: 管理者のみ
+  await verifyAdmin();
+
+  // Conformを使用してFormDataをパース・バリデーション
+  const submission = parseWithZod(formData, {
+    schema: updateDepartmentSchema,
+  });
+
+  // バリデーション失敗時はエラーを返却
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const { name, abbreviation, displayOrder, parentId, isActive } = submission.value;
+
+  // departmentCdからidを取得
+  const queryService = new PrismaDepartmentQueryService();
+  const department = await queryService.findByDepartmentCd(departmentCd);
+  if (!department) {
+    return submission.reply({
+      formErrors: ["部署が見つかりません"],
+    });
+  }
+
+  const { id } = department;
+
+  try {
+    const command = updateDepartmentCommandFactory();
+
+    await command.execute({
+      id,
+      name,
+      abbreviation,
+      displayOrder,
+      parentId: parentId ?? null,
+      isActive,
+    });
+
+    revalidatePath("/departments");
+    revalidatePath(`/departments/${departmentCd}`);
+  } catch (error) {
+    // ドメイン層エラーをConform形式に変換
+    const errorResult = handleCommandError(error);
+    const errorMessage = !errorResult.success && errorResult.error ? errorResult.error : undefined;
+    return submission.reply({
+      formErrors: errorMessage ? [errorMessage] : [],
+    });
+  }
+
+  // 成功時は同じページにリダイレクト（フォーム状態をリセット）
+  redirect(`/departments/${departmentCd}?reason=${REDIRECT_REASON.DEPARTMENT_UPDATED}`);
+}
+
+// ========================================
+// 部署削除
+// ========================================
+export async function deleteDepartment(
+  _prevState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  // 認証・認可チェック: 管理者のみ
+  await verifyAdmin();
+
+  const id = formData.get("id") as string;
+
+  try {
+    const command = deleteDepartmentCommandFactory();
+
+    await command.execute({
+      id,
+    });
+
+    revalidatePath("/departments");
+  } catch (error) {
+    return handleCommandError(error);
+  }
+
+  // 成功時は一覧ページにリダイレクト
+  redirect(`/departments?reason=${REDIRECT_REASON.DEPARTMENT_DELETED}`);
+}

--- a/src/app/(features)/departments/[departmentCd]/page.tsx
+++ b/src/app/(features)/departments/[departmentCd]/page.tsx
@@ -1,0 +1,48 @@
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { DepartmentSelectField } from "@/app/_components/form";
+import { isAdmin } from "@server/shared/auth";
+import { PrismaDepartmentQueryService } from "@subdomains/department/infrastructure/queries/PrismaDepartmentQueryService";
+import { notFound } from "next/navigation";
+import { DepartmentDeleteForm } from "./DepartmentDeleteForm";
+import { DepartmentUpdateForm } from "./DepartmentUpdateForm";
+
+export default async function Page({ params }: { params: Promise<{ departmentCd: string }> }) {
+  const { departmentCd } = await params;
+
+  const session = await verifySession();
+
+  // データ取得
+  const queryService = new PrismaDepartmentQueryService();
+  const department = await queryService.findByDepartmentCd(departmentCd);
+  if (!department) {
+    notFound();
+  }
+
+  // 権限判定
+  const canUpdate = isAdmin(session);
+  const canDelete = isAdmin(session);
+
+  return (
+    <div className="container mx-auto p-8">
+      <h1 className="text-3xl font-bold mb-8">部署管理</h1>
+
+      {/* 更新フォーム（Client Component） */}
+      <DepartmentUpdateForm
+        department={department}
+        canUpdate={canUpdate}
+        parentDepartmentSelectSlot={
+          <DepartmentSelectField
+            name="parentId"
+            id="parentId"
+            defaultValue={department.parentId ?? undefined}
+            disabled={!canUpdate}
+            excludeIds={[department.id]}
+          />
+        }
+      />
+
+      {/* 削除フォーム（Client Component） */}
+      {canDelete && <DepartmentDeleteForm departmentId={department.id} />}
+    </div>
+  );
+}

--- a/src/app/(features)/departments/[departmentCd]/schema.ts
+++ b/src/app/(features)/departments/[departmentCd]/schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { departmentBaseSchema } from "../_shared/schema";
+
+/**
+ * 部署更新フォームのバリデーションスキーマ
+ * 基盤スキーマ + isActive（departmentCdはURLパラメータから取得）
+ */
+export const updateDepartmentSchema = departmentBaseSchema.extend({
+  isActive: z.coerce.boolean(),
+});
+
+export type UpdateDepartmentInput = z.infer<typeof updateDepartmentSchema>;

--- a/src/app/_components/form/DepartmentSelectField.tsx
+++ b/src/app/_components/form/DepartmentSelectField.tsx
@@ -1,7 +1,10 @@
 import { PrismaDepartmentQueryService } from "@subdomains/department/infrastructure/queries/PrismaDepartmentQueryService";
 import { SelectField, type SelectFieldProps } from "./SelectField";
 
-type DepartmentSelectFieldProps = Omit<SelectFieldProps, "options">;
+type DepartmentSelectFieldProps = Omit<SelectFieldProps, "options"> & {
+  /** 除外する部署IDの配列（自己参照防止用） */
+  excludeIds?: string[];
+};
 
 /**
  * 部署選択用セレクトボックスコンポーネント（Server Component）
@@ -9,16 +12,18 @@ type DepartmentSelectFieldProps = Omit<SelectFieldProps, "options">;
  * DBから有効な部署を取得し、表示順でソートして表示する。
  * Container/Presentation パターンの Container 部分。
  */
-export async function DepartmentSelectField(props: DepartmentSelectFieldProps) {
+export async function DepartmentSelectField({ excludeIds, ...props }: DepartmentSelectFieldProps) {
   const queryService = new PrismaDepartmentQueryService();
   const departments = await queryService.findActive({
     orderBy: { field: "displayOrder", direction: "asc" },
   });
 
-  const options = departments.map((dept) => ({
-    label: dept.name,
-    value: dept.id,
-  }));
+  const options = departments
+    .filter((dept) => !excludeIds?.includes(dept.id))
+    .map((dept) => ({
+      label: dept.name,
+      value: dept.id,
+    }));
 
   return (
     <SelectField

--- a/src/server/subdomains/department/application/commands/DeleteDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/DeleteDepartmentCommand.ts
@@ -1,6 +1,6 @@
 import { Department } from "@subdomains/department/domain/entities/Department";
 import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
-import { ValidationError } from "@server/shared/errors/DomainError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 
 export type DeleteDepartmentInput = {
@@ -25,7 +25,7 @@ export class DeleteDepartmentCommand {
     // 子部署がある場合は削除できない
     const children = await this.departmentRepository.findChildren(input.id);
     if (children.length > 0) {
-      throw new ValidationError(
+      throw new BusinessRuleViolationError(
         "子部署が存在するため、この部署を削除できません。先に子部署を削除してください。"
       );
     }

--- a/src/server/subdomains/department/application/commands/__tests__/DeleteDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/DeleteDepartmentCommand.test.ts
@@ -1,7 +1,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import prisma from "@server/prisma";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
-import { ValidationError } from "@server/shared/errors/DomainError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
 import { PrismaDepartmentRepository } from "@subdomains/department/infrastructure/prisma/PrismaDepartmentRepository";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DeleteDepartmentCommand } from "../DeleteDepartmentCommand";
@@ -81,6 +81,6 @@ describe("DeleteDepartmentCommand", () => {
       },
     });
 
-    await expect(command.execute({ id: parentId })).rejects.toThrow(ValidationError);
+    await expect(command.execute({ id: parentId })).rejects.toThrow(BusinessRuleViolationError);
   });
 });


### PR DESCRIPTION
## Summary

部署の詳細表示・更新・削除ページを実装。従業員ページ (`employees/[employeeCd]/`) のパターンを踏襲し、Server/Client Component のスロット注入パターンで構成。また、`DeleteDepartmentCommand` のエラー型を `ValidationError` → `BusinessRuleViolationError` に修正し、`UpdateDepartmentCommand` と統一した。

Closes #102

## Implementation Notes

計画通りに実装が完了しました。特筆すべき逸脱はありません。

追加で発見・修正した点:
- `DeleteDepartmentCommand` の子部署存在チェックが `ValidationError` を使用していたが、エンティティ間の関係に依存するビジネスルールであるため `BusinessRuleViolationError` に修正（`UpdateDepartmentCommand` の同等チェックと統一）

## Test Plan

- [x] `pnpm build` が成功すること
- [x] `pnpm test` が全テスト通過すること（408 tests passed）
- [x] `pnpm lint` がエラーなしで通ること
- [ ] ブラウザ確認: `/departments/{departmentCd}` で詳細表示
- [ ] ブラウザ確認: 管理者で編集・削除可能、一般ユーザーで閲覧のみ
- [ ] ブラウザ確認: 親部署セレクトに自分自身が表示されないこと
- [ ] ブラウザ確認: 無効化時に有効な子部署があればエラー表示
- [ ] ブラウザ確認: 削除時に子部署があればエラー表示
- [ ] ブラウザ確認: 更新/削除成功後のリダイレクト＋トースト表示

---

Generated with [Claude Code](https://claude.ai/code)