### PR TITLE
feat: ダッシュボードに部署管理への遷移リンクを追加

### DIFF
--- a/src/app/(features)/dashboard/page.tsx
+++ b/src/app/(features)/dashboard/page.tsx
@@ -7,6 +7,11 @@ const navigationItems = [
     title: "従業員管理",
     description: "従業員の一覧表示、登録、編集、削除を行います。",
   },
+  {
+    href: "/departments",
+    title: "部署管理",
+    description: "部署の一覧表示、登録、編集、削除を行います。",
+  },
 ] as const;
 
 export default async function DashboardPage() {


### PR DESCRIPTION
## Summary

ダッシュボードの `navigationItems` 配列に部署管理カードを追加し、`/departments` への遷移リンクを設置した。

Closes #117

## Implementation Notes

計画通りに実装が完了しました。特筆すべき逸脱はありません。

- 変更は `src/app/(features)/dashboard/page.tsx` の1ファイル・1箇所のみ
- 既存の `navigationItems` 配列に新しいオブジェクトを追加

## Test Plan

- [x] `pnpm build` でビルドエラーがないこと
- [x] 全408テストがパス
- [ ] ダッシュボードに「部署管理」カードが表示されること
- [ ] クリックで `/departments` に遷移すること
- [ ] 「従業員管理」カードに影響がないこと

---

Generated with [Claude Code](https://claude.ai/code)