### PR TITLE
refactor: Department エンティティから displayOrder カラムを完全に削除する (#120)

### DIFF
--- a/learning/ddd-field-removal-strategy.md
+++ b/learning/ddd-field-removal-strategy.md
@@ -1,0 +1,169 @@
+# DDD アーキテクチャにおけるフィールド削除の順序戦略
+
+作成日: 2026-03-18
+
+## 概要
+
+DDD レイヤードアーキテクチャでフィールドを全レイヤーから削除する際、**どの順序で削除するか**によってコンパイル安全性・コミット粒度・履歴の読みやすさが変わる。`Department.displayOrder` 削除（約40ファイル影響）の設計議論を通じて、3つの戦略を比較検討した。
+
+## 背景：DDD の依存方向
+
+```
+Presentation → Application → Domain ← Infrastructure
+                                ↑
+                          (中心・参照先)
+```
+
+Domain 層は**参照される側**（callee）であり、Application・Infrastructure は**参照する側**（caller）である。
+
+具体例（`displayOrder` の場合）:
+
+```
+CreateDepartmentCommand  →  Department.create(..., displayOrder)   // Application → Domain
+UpdateDepartmentCommand  →  department.changeDisplayOrder(...)     // Application → Domain
+DepartmentMapper         →  Department.reconstruct(..., displayOrder) // Infrastructure → Domain
+DepartmentMapper         →  department.displayOrder（getter）        // Infrastructure → Domain
+PrismaDepartmentQueryService → displayOrder を select/toDTO        // Infrastructure 内部
+DepartmentCreateForm     →  Server Action → Command               // Presentation → Application
+```
+
+## 戦略1: Inside-out（Domain から外側へ）
+
+### 順序
+
+```
+Domain → Application → Infrastructure → Presentation → DB
+```
+
+### 考え方
+
+DDD の「中心はドメイン」という思想に沿い、まず Domain 層で「displayOrder は存在しない」という新しい真実を定義し、外側に波及させる。
+
+### 問題点
+
+Domain 層は**参照される側**なので、先に削除すると参照元でエラーが発生する：
+
+```typescript
+// Step 1 で Department.create() から displayOrder 引数を削除した直後:
+
+// CreateDepartmentCommand.ts — まだ修正していない
+Department.create(departmentCd, name, abbreviation, parentId, input.displayOrder ?? 0)
+//                                                            ^^^^^^^^^^^^^^^^^^^^^^^^
+// Error: Expected 4 arguments, but got 5.
+
+// DepartmentMapper.ts — まだ修正していない
+department.displayOrder
+//         ^^^^^^^^^^^^
+// Error: Property 'displayOrder' does not exist on type 'Department'.
+```
+
+### 評価
+
+| 項目 | 評価 |
+|------|------|
+| コミット粒度 | 1レイヤー = 1コミットで整理が美しい |
+| コンパイル安全性 | 中間コミットで `tsc` エラー |
+| pre-commit hook 互換性 | `tsc --noEmit` がある場合コミット不可 |
+| コミット履歴の読みやすさ | レイヤーごとに追いやすい |
+
+## 戦略2: Outside-in（Presentation から内側へ）
+
+### 順序
+
+```
+Presentation → Application → Infrastructure → Domain → DB
+```
+
+### 考え方
+
+参照元（caller）から先に削除すれば、参照先（callee）はまだ存在するのでエラーにならない。
+
+### 問題点
+
+一見良さそうだが、**隣接レイヤー間の型制約**で崩れるケースがある：
+
+```typescript
+// Step 2 で DepartmentDTO から displayOrder を削除した直後:
+
+// PrismaDepartmentQueryService.ts — まだ修正していない
+return {
+  id: department.id,
+  displayOrder: department.displayOrder,  // ← DTOに存在しないフィールドを返している
+  //            ^^^^^^^^^^^^^^^^^^^^^^^^
+  // Error: Object literal may only specify known properties
+};
+```
+
+DTO は Application 層、QueryService は Infrastructure 層。Outside-in の順番だと Application を先に直すが、Infrastructure がまだ古い DTO 型にマッピングしようとしてエラーになる。
+
+### 評価
+
+| 項目 | 評価 |
+|------|------|
+| コミット粒度 | 1レイヤー = 1コミットだが、一部中間エラー |
+| コンパイル安全性 | Inside-out よりマシだが完全ではない |
+| pre-commit hook 互換性 | 一部ステップでブロックされる可能性 |
+
+## 戦略3: 依存チェーン単位（推奨）
+
+### 順序
+
+**型の依存関係で繋がっているもの同士を1つのコミットにまとめる。**
+
+```
+Step 1: Domain Entity + 直接の caller（Commands, Mapper）
+        → create()/reconstruct() のシグネチャ変更と、それを呼ぶコードを同時修正
+        → ✅ コンパイル通る
+
+Step 2: DTO + QueryService（DTO型定義とそのマッピング元を同時に修正）
+        → ✅ コンパイル通る
+
+Step 3: Presentation 層（UI フォーム、Actions、カラム定義）
+        → ✅ コンパイル通る
+
+Step 4: Prisma スキーマ + マイグレーション + Seed
+        → ✅ コンパイル通る
+
+Step 5: 他サブドメインのテスト fixture
+        → ✅ コンパイル通る
+```
+
+### なぜこれが機能するか
+
+「型のつながり」を断面にしているため、各コミットの時点で：
+- 削除されたシグネチャを呼ぶコードは同時に修正済み
+- 変更された型を使うコードは同時に修正済み
+
+### 評価
+
+| 項目 | 評価 |
+|------|------|
+| コミット粒度 | 1コミットが複数レイヤーにまたがる |
+| コンパイル安全性 | 各コミットで `tsc` が通る |
+| pre-commit hook 互換性 | `tsc --noEmit` / `pnpm test` ともに通る |
+| コミット履歴の読みやすさ | レイヤー単位ではないが、変更の因果関係は追いやすい |
+
+## 3戦略の比較まとめ
+
+| 戦略 | コンパイル安全性 | コミット粒度 | 履歴の読みやすさ | pre-commit 互換 |
+|------|:---:|:---:|:---:|:---:|
+| Inside-out | NG | レイヤー単位で美しい | レイヤーで追える | NG |
+| Outside-in | 一部 NG | レイヤー単位 | レイヤーで追える | 一部 NG |
+| 依存チェーン単位 | OK | 複数レイヤー混在 | 因果関係で追える | OK |
+| 全部1コミット | OK | 差分が巨大 | 追いにくい | OK |
+
+## 学び
+
+1. **DDD のレイヤー境界とコンパイル安全なコミット境界は一致しない。** DDD の依存方向（外→内）があるため、どの方向から削除しても隣接レイヤーとの型不整合が発生する。
+
+2. **「型の依存チェーン」がコミットの自然な単位。** レイヤーではなく「シグネチャ変更 + その caller」をセットにすることで、各コミットの型安全性を保てる。
+
+3. **pre-commit hook の制約が設計を決める。** `tsc --noEmit` がなければ Inside-out でも実用上問題ないが、CI/pre-commit に型チェックがある場合は依存チェーン単位が必須になる。
+
+4. **理論上美しい順序と実務上安全な順序は異なることがある。** Inside-out は DDD の思想に忠実だが、実務では「各コミットがグリーンであること」の方が重要。
+
+## 参考
+
+- 関連 Issue: #120（Department.displayOrder 削除）
+- 影響ファイル数: 約40ファイル
+- プロジェクトの pre-commit hook: `pnpm lint-staged` / `pnpm tsc --noEmit` / `pnpm test`

--- a/prisma/migrations/20260318000000_remove_department_display_order/migration.sql
+++ b/prisma/migrations/20260318000000_remove_department_display_order/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "departments" DROP COLUMN "display_order";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,6 @@ model Department {
   departmentCd String  @unique @map("department_cd") // DEPT001 形式
   name         String
   abbreviation String  // 略称
-  displayOrder Int     @default(0) @map("display_order")
   isActive     Boolean @default(true) @map("is_active")
 
   // 階層構造（自己参照）

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -147,35 +147,30 @@ const DEPARTMENTS = [
     departmentCd: "DEPT001",
     name: "営業部",
     abbreviation: "営業",
-    displayOrder: 1,
   },
   {
     id: "dept-002",
     departmentCd: "DEPT002",
     name: "開発部",
     abbreviation: "開発",
-    displayOrder: 2,
   },
   {
     id: "dept-003",
     departmentCd: "DEPT003",
     name: "総務部",
     abbreviation: "総務",
-    displayOrder: 3,
   },
   {
     id: "dept-004",
     departmentCd: "DEPT004",
     name: "人事部",
     abbreviation: "人事",
-    displayOrder: 4,
   },
   {
     id: "dept-005",
     departmentCd: "DEPT005",
     name: "経理部",
     abbreviation: "経理",
-    displayOrder: 5,
   },
 ];
 
@@ -905,7 +900,6 @@ async function main() {
         departmentCd: dept.departmentCd,
         name: dept.name,
         abbreviation: dept.abbreviation,
-        displayOrder: dept.displayOrder,
         isActive: true,
       },
     });

--- a/src/app/(features)/departments/[departmentCd]/DepartmentUpdateForm.tsx
+++ b/src/app/(features)/departments/[departmentCd]/DepartmentUpdateForm.tsx
@@ -10,7 +10,6 @@ type Department = {
   departmentCd: string;
   name: string;
   abbreviation: string;
-  displayOrder: number;
   isActive: boolean;
   parentId: string | null;
 };
@@ -31,7 +30,6 @@ export function DepartmentUpdateForm({ department, canUpdate, parentDepartmentSe
     defaultValue: {
       name: department.name,
       abbreviation: department.abbreviation,
-      displayOrder: department.displayOrder,
       parentId: department.parentId ?? "",
       isActive: department.isActive,
     },
@@ -104,25 +102,6 @@ export function DepartmentUpdateForm({ department, canUpdate, parentDepartmentSe
           {fields.abbreviation.errors && (
             <p className="text-red-500 text-xs mt-1" id={fields.abbreviation.errorId}>
               {fields.abbreviation.errors[0]}
-            </p>
-          )}
-        </div>
-
-        <div>
-          <label
-            htmlFor={fields.displayOrder.id}
-            className="block text-gray-700 text-sm font-bold mb-2"
-          >
-            表示順
-          </label>
-          <input
-            {...getInputProps(fields.displayOrder, { type: "number" })}
-            disabled={isPending || !canUpdate}
-            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
-          />
-          {fields.displayOrder.errors && (
-            <p className="text-red-500 text-xs mt-1" id={fields.displayOrder.errorId}>
-              {fields.displayOrder.errors[0]}
             </p>
           )}
         </div>

--- a/src/app/(features)/departments/[departmentCd]/actions.ts
+++ b/src/app/(features)/departments/[departmentCd]/actions.ts
@@ -40,7 +40,7 @@ export async function updateDepartment(
     return submission.reply();
   }
 
-  const { name, abbreviation, displayOrder, parentId, isActive } = submission.value;
+  const { name, abbreviation, parentId, isActive } = submission.value;
 
   // departmentCdからidを取得
   const queryService = new PrismaDepartmentQueryService();
@@ -60,7 +60,6 @@ export async function updateDepartment(
       id,
       name,
       abbreviation,
-      displayOrder,
       parentId: parentId ?? null,
       isActive,
     });

--- a/src/app/(features)/departments/_components/columns.tsx
+++ b/src/app/(features)/departments/_components/columns.tsx
@@ -10,7 +10,6 @@ export type DepartmentRow = {
   name: string;
   abbreviation: string;
   parentDepartmentName: string;
-  displayOrder: number;
   isActive: boolean;
 };
 
@@ -38,10 +37,6 @@ export const columns: ColumnDef<DepartmentRow, unknown>[] = [
   {
     accessorKey: "parentDepartmentName",
     header: "親部署名",
-  },
-  {
-    accessorKey: "displayOrder",
-    header: "表示順",
   },
   {
     accessorKey: "isActive",

--- a/src/app/(features)/departments/_shared/schema.ts
+++ b/src/app/(features)/departments/_shared/schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 /**
  * 部署フォームの基盤スキーマ
- * 作成・編集で共通のフィールド（name, abbreviation, displayOrder, parentId）
+ * 作成・編集で共通のフィールド（name, abbreviation, parentId）
  */
 export const departmentBaseSchema = z.object({
   name: z
@@ -15,10 +15,6 @@ export const departmentBaseSchema = z.object({
     .trim()
     .min(1, { error: "略称を入力してください" })
     .max(20, { error: "略称は20文字以内で入力してください" }),
-  displayOrder: z.coerce
-    .number({ error: "数値を入力してください" })
-    .int({ error: "整数を入力してください" })
-    .min(0, { error: "表示順は0以上で入力してください" }),
   parentId: z
     .string()
     .optional()

--- a/src/app/(features)/departments/new/DepartmentCreateForm.tsx
+++ b/src/app/(features)/departments/new/DepartmentCreateForm.tsx
@@ -90,26 +90,6 @@ export function DepartmentCreateForm({ parentDepartmentSelectSlot }: Props) {
         </div>
 
         <div>
-          <label
-            htmlFor={fields.displayOrder.id}
-            className="block text-gray-700 text-sm font-bold mb-2"
-          >
-            表示順
-          </label>
-          <input
-            {...getInputProps(fields.displayOrder, { type: "number" })}
-            defaultValue={0}
-            disabled={isPending}
-            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
-          />
-          {fields.displayOrder.errors && (
-            <p className="text-red-500 text-xs mt-1" id={fields.displayOrder.errorId}>
-              {fields.displayOrder.errors[0]}
-            </p>
-          )}
-        </div>
-
-        <div>
           <label htmlFor="parentId" className="block text-gray-700 text-sm font-bold mb-2">
             親部署
           </label>

--- a/src/app/(features)/departments/new/actions.ts
+++ b/src/app/(features)/departments/new/actions.ts
@@ -26,7 +26,7 @@ export async function createDepartment(prevState: unknown, formData: FormData) {
     return submission.reply();
   }
 
-  const { departmentCd, name, abbreviation, displayOrder, parentId } = submission.value;
+  const { departmentCd, name, abbreviation, parentId } = submission.value;
 
   try {
     const command = createDepartmentCommandFactory();
@@ -35,7 +35,6 @@ export async function createDepartment(prevState: unknown, formData: FormData) {
       departmentCd,
       name,
       abbreviation,
-      displayOrder,
       parentId,
     });
 

--- a/src/app/(features)/departments/page.tsx
+++ b/src/app/(features)/departments/page.tsx
@@ -69,7 +69,6 @@ export default async function DepartmentPage({
     name: dept.name,
     abbreviation: dept.abbreviation,
     parentDepartmentName: dept.parentId ? (parentNameMap.get(dept.parentId) ?? "-") : "-",
-    displayOrder: dept.displayOrder,
     isActive: dept.isActive,
   }));
 

--- a/src/app/_components/form/DepartmentSelectField.tsx
+++ b/src/app/_components/form/DepartmentSelectField.tsx
@@ -9,13 +9,13 @@ type DepartmentSelectFieldProps = Omit<SelectFieldProps, "options"> & {
 /**
  * 部署選択用セレクトボックスコンポーネント（Server Component）
  *
- * DBから有効な部署を取得し、表示順でソートして表示する。
+ * DBから有効な部署を取得し、部署コード順でソートして表示する。
  * Container/Presentation パターンの Container 部分。
  */
 export async function DepartmentSelectField({ excludeIds, ...props }: DepartmentSelectFieldProps) {
   const queryService = new PrismaDepartmentQueryService();
   const departments = await queryService.findActive({
-    orderBy: { field: "displayOrder", direction: "asc" },
+    orderBy: { field: "departmentCd", direction: "asc" },
   });
 
   const options = departments

--- a/src/server/subdomains/department/application/commands/CreateDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/CreateDepartmentCommand.ts
@@ -10,7 +10,6 @@ export type CreateDepartmentInput = {
   departmentCd: string;
   name: string;
   abbreviation: string;
-  displayOrder?: number;
   parentId?: string | null;
 };
 
@@ -53,7 +52,6 @@ export class CreateDepartmentCommand {
       departmentCd,
       name,
       abbreviation,
-      input.displayOrder ?? 0,
       input.parentId ?? null
     );
 

--- a/src/server/subdomains/department/application/commands/UpdateDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/UpdateDepartmentCommand.ts
@@ -9,7 +9,6 @@ export type UpdateDepartmentInput = {
   id: string;
   name?: string;
   abbreviation?: string;
-  displayOrder?: number;
   parentId?: string | null;
   isActive?: boolean;
 };
@@ -34,11 +33,6 @@ export class UpdateDepartmentCommand {
     // 略称の更新
     if (input.abbreviation !== undefined) {
       department.changeAbbreviation(new Abbreviation(input.abbreviation));
-    }
-
-    // 表示順の更新
-    if (input.displayOrder !== undefined) {
-      department.changeDisplayOrder(input.displayOrder);
     }
 
     // 親部署の更新

--- a/src/server/subdomains/department/application/commands/__tests__/CreateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/CreateDepartmentCommand.test.ts
@@ -46,11 +46,10 @@ describe("CreateDepartmentCommand", () => {
     expect(saved?.departmentCd.value).toBe(TEST_CODES[0]);
     expect(saved?.name.value).toBe("テスト営業部");
     expect(saved?.abbreviation.value).toBe("テスト営業");
-    expect(saved?.displayOrder).toBe(0);
     expect(saved?.parentId).toBeNull();
   });
 
-  it("表示順と親部署を指定して登録できる", async () => {
+  it("親部署を指定して登録できる", async () => {
     const parentId = createId();
     await prisma.department.create({
       data: {
@@ -58,7 +57,6 @@ describe("CreateDepartmentCommand", () => {
         departmentCd: TEST_CODES[0],
         name: "親部署",
         abbreviation: "親",
-        displayOrder: 1,
         isActive: true,
       },
     });
@@ -67,13 +65,11 @@ describe("CreateDepartmentCommand", () => {
       departmentCd: TEST_CODES[1],
       name: "子部署",
       abbreviation: "子",
-      displayOrder: 10,
       parentId,
     });
 
     const saved = await repository.findByDepartmentCd(new DepartmentCd(TEST_CODES[1]));
     expect(saved).not.toBeNull();
-    expect(saved?.displayOrder).toBe(10);
     expect(saved?.parentId).toBe(parentId);
   });
 
@@ -112,7 +108,6 @@ describe("CreateDepartmentCommand", () => {
         departmentCd: TEST_CODES[0],
         name: "無効部署",
         abbreviation: "無効",
-        displayOrder: 1,
         isActive: false,
       },
     });

--- a/src/server/subdomains/department/application/commands/__tests__/DeleteDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/DeleteDepartmentCommand.test.ts
@@ -40,7 +40,6 @@ describe("DeleteDepartmentCommand", () => {
         departmentCd: TEST_CODES[0],
         name: "削除テスト部署",
         abbreviation: "削除テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });
@@ -65,7 +64,6 @@ describe("DeleteDepartmentCommand", () => {
         departmentCd: TEST_CODES[0],
         name: "親部署",
         abbreviation: "親",
-        displayOrder: 1,
         isActive: true,
       },
     });
@@ -75,7 +73,6 @@ describe("DeleteDepartmentCommand", () => {
         departmentCd: TEST_CODES[1],
         name: "子部署",
         abbreviation: "子",
-        displayOrder: 1,
         isActive: true,
         parentId,
       },

--- a/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
@@ -162,7 +162,6 @@ describe("UpdateDepartmentCommand", () => {
         departmentCd: TEST_CODES[1],
         name: "無効親部署",
         abbreviation: "無効親",
-        displayOrder: 1,
         isActive: false,
       },
     });

--- a/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
@@ -35,7 +35,6 @@ describe("UpdateDepartmentCommand", () => {
         departmentCd: TEST_CODES[0],
         name: "営業部",
         abbreviation: "営業",
-        displayOrder: 0,
         isActive: true,
       },
     });
@@ -61,15 +60,6 @@ describe("UpdateDepartmentCommand", () => {
     });
 
     expect(result.abbreviation.value).toBe("新営業");
-  });
-
-  it("表示順を更新できる", async () => {
-    const result = await command.execute({
-      id: baseDeptId,
-      displayOrder: 10,
-    });
-
-    expect(result.displayOrder).toBe(10);
   });
 
   it("存在しない部署を更新しようとするとエラー", async () => {
@@ -113,7 +103,6 @@ describe("UpdateDepartmentCommand", () => {
         departmentCd: TEST_CODES[1],
         name: "子部署",
         abbreviation: "子",
-        displayOrder: 1,
         isActive: true,
         parentId: baseDeptId,
       },
@@ -135,7 +124,6 @@ describe("UpdateDepartmentCommand", () => {
         departmentCd: TEST_CODES[1],
         name: "新親部署",
         abbreviation: "新親",
-        displayOrder: 1,
         isActive: true,
       },
     });
@@ -198,7 +186,6 @@ describe("UpdateDepartmentCommand", () => {
         departmentCd: TEST_CODES[1],
         name: "部署B",
         abbreviation: "B",
-        displayOrder: 1,
         isActive: true,
         parentId: baseDeptId,
       },
@@ -209,7 +196,6 @@ describe("UpdateDepartmentCommand", () => {
         departmentCd: TEST_CODES[2],
         name: "部署C",
         abbreviation: "C",
-        displayOrder: 2,
         isActive: true,
         parentId: deptBId,
       },

--- a/src/server/subdomains/department/application/queries/__tests__/GetActiveDepartmentsQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/GetActiveDepartmentsQuery.test.ts
@@ -14,7 +14,6 @@ describe("GetActiveDepartmentsQuery", () => {
     departmentCd: string;
     name: string;
     abbreviation: string;
-    displayOrder?: number;
     isActive?: boolean;
     parentId?: string | null;
   }): Promise<string> {

--- a/src/server/subdomains/department/application/queries/__tests__/GetAllDepartmentsQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/GetAllDepartmentsQuery.test.ts
@@ -14,7 +14,6 @@ describe("GetAllDepartmentsQuery", () => {
     departmentCd: string;
     name: string;
     abbreviation: string;
-    displayOrder?: number;
     isActive?: boolean;
     parentId?: string | null;
   }): Promise<string> {

--- a/src/server/subdomains/department/application/queries/__tests__/GetDepartmentByIdQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/GetDepartmentByIdQuery.test.ts
@@ -14,7 +14,6 @@ describe("GetDepartmentByIdQuery", () => {
     departmentCd: string;
     name: string;
     abbreviation: string;
-    displayOrder?: number;
     isActive?: boolean;
     parentId?: string | null;
   }): Promise<string> {
@@ -49,7 +48,6 @@ describe("GetDepartmentByIdQuery", () => {
       departmentCd: TEST_CODES[0],
       name: "取得テスト部署",
       abbreviation: "取得テスト",
-      displayOrder: 5,
     });
 
     const result = await query.execute({ id: deptId });
@@ -59,7 +57,6 @@ describe("GetDepartmentByIdQuery", () => {
     expect(result?.departmentCd).toBe(TEST_CODES[0]);
     expect(result?.name).toBe("取得テスト部署");
     expect(result?.abbreviation).toBe("取得テスト");
-    expect(result?.displayOrder).toBe(5);
     expect(result?.isActive).toBe(true);
     expect(result?.parentId).toBeNull();
   });

--- a/src/server/subdomains/department/application/queries/__tests__/GetDepartmentTreeQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/GetDepartmentTreeQuery.test.ts
@@ -14,7 +14,6 @@ describe("GetDepartmentTreeQuery", () => {
     departmentCd: string;
     name: string;
     abbreviation: string;
-    displayOrder?: number;
     isActive?: boolean;
     parentId?: string | null;
   }): Promise<string> {
@@ -49,14 +48,12 @@ describe("GetDepartmentTreeQuery", () => {
       departmentCd: TEST_CODES[0],
       name: "ルート部署",
       abbreviation: "ルート",
-      displayOrder: 1,
       isActive: true,
     });
     const childId = await createTestDepartment({
       departmentCd: TEST_CODES[1],
       name: "子部署",
       abbreviation: "子",
-      displayOrder: 1,
       isActive: true,
       parentId: rootId,
     });
@@ -64,7 +61,6 @@ describe("GetDepartmentTreeQuery", () => {
       departmentCd: TEST_CODES[2],
       name: "孫部署",
       abbreviation: "孫",
-      displayOrder: 1,
       isActive: true,
       parentId: childId,
     });
@@ -88,14 +84,12 @@ describe("GetDepartmentTreeQuery", () => {
       departmentCd: TEST_CODES[0],
       name: "ルート部署",
       abbreviation: "ルート",
-      displayOrder: 1,
       isActive: true,
     });
     await createTestDepartment({
       departmentCd: TEST_CODES[1],
       name: "子部署",
       abbreviation: "子",
-      displayOrder: 1,
       isActive: true,
       parentId: rootId,
     });
@@ -113,14 +107,12 @@ describe("GetDepartmentTreeQuery", () => {
       departmentCd: TEST_CODES[0],
       name: "有効ルート部署",
       abbreviation: "有効ルート",
-      displayOrder: 1,
       isActive: true,
     });
     await createTestDepartment({
       departmentCd: TEST_CODES[1],
       name: "無効子部署",
       abbreviation: "無効子",
-      displayOrder: 1,
       isActive: false,
       parentId: rootId,
     });

--- a/src/server/subdomains/department/application/queries/__tests__/SearchDepartmentsQuery.test.ts
+++ b/src/server/subdomains/department/application/queries/__tests__/SearchDepartmentsQuery.test.ts
@@ -14,7 +14,6 @@ describe("SearchDepartmentsQuery", () => {
     departmentCd: string;
     name: string;
     abbreviation: string;
-    displayOrder?: number;
     isActive?: boolean;
     parentId?: string | null;
   }): Promise<string> {

--- a/src/server/subdomains/department/application/queries/dto/DepartmentDTO.ts
+++ b/src/server/subdomains/department/application/queries/dto/DepartmentDTO.ts
@@ -7,7 +7,6 @@ export type DepartmentDTO = {
   departmentCd: string;
   name: string;
   abbreviation: string;
-  displayOrder: number;
   isActive: boolean;
   parentId: string | null;
   createdAt: Date;

--- a/src/server/subdomains/department/application/queries/dto/DepartmentSearchCriteria.ts
+++ b/src/server/subdomains/department/application/queries/dto/DepartmentSearchCriteria.ts
@@ -34,7 +34,6 @@ export type DepartmentSortField =
   | "name"
   | "departmentCd"
   | "abbreviation"
-  | "displayOrder"
   | "createdAt"
   | "updatedAt";
 

--- a/src/server/subdomains/department/domain/entities/Department.ts
+++ b/src/server/subdomains/department/domain/entities/Department.ts
@@ -2,7 +2,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { DepartmentCd } from "../values/DepartmentCd";
 import { DepartmentName } from "../values/DepartmentName";
 import { Abbreviation } from "../values/Abbreviation";
-import { ValidationError, BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
 
 /**
  * 部署エンティティ
@@ -18,7 +18,6 @@ export class Department {
     private readonly _departmentCd: DepartmentCd,
     private _name: DepartmentName,
     private _abbreviation: Abbreviation,
-    private _displayOrder: number,
     private _isActive: boolean,
     private _parentId: string | null,
     private readonly _createdAt: Date,
@@ -31,7 +30,6 @@ export class Department {
    * @param departmentCd 部署コード
    * @param name 部署名
    * @param abbreviation 略称
-   * @param displayOrder 表示順（デフォルト: 0）
    * @param parentId 親部署ID（ルート部署の場合は null）
    * @returns 部署エンティティ
    */
@@ -39,11 +37,8 @@ export class Department {
     departmentCd: DepartmentCd,
     name: DepartmentName,
     abbreviation: Abbreviation,
-    displayOrder: number = 0,
     parentId: string | null = null
   ): Department {
-    Department.validateDisplayOrder(displayOrder);
-
     const now = new Date();
 
     return new Department(
@@ -51,7 +46,6 @@ export class Department {
       departmentCd,
       name,
       abbreviation,
-      displayOrder,
       true, // 新規作成時は有効
       parentId,
       now,
@@ -66,7 +60,6 @@ export class Department {
    * @param departmentCd 部署コード
    * @param name 部署名
    * @param abbreviation 略称
-   * @param displayOrder 表示順
    * @param isActive 有効フラグ
    * @param parentId 親部署ID
    * @param createdAt 作成日時
@@ -78,7 +71,6 @@ export class Department {
     departmentCd: DepartmentCd,
     name: DepartmentName,
     abbreviation: Abbreviation,
-    displayOrder: number,
     isActive: boolean,
     parentId: string | null,
     createdAt: Date,
@@ -89,25 +81,11 @@ export class Department {
       departmentCd,
       name,
       abbreviation,
-      displayOrder,
       isActive,
       parentId,
       createdAt,
       updatedAt
     );
-  }
-
-  // ========================================
-  // バリデーション
-  // ========================================
-
-  private static validateDisplayOrder(displayOrder: number): void {
-    if (!Number.isInteger(displayOrder)) {
-      throw new ValidationError("表示順は整数である必要があります");
-    }
-    if (displayOrder < 0) {
-      throw new ValidationError("表示順は0以上である必要があります");
-    }
   }
 
   // ========================================
@@ -127,15 +105,6 @@ export class Department {
    */
   changeAbbreviation(newAbbreviation: Abbreviation): void {
     this._abbreviation = newAbbreviation;
-    this._updatedAt = new Date();
-  }
-
-  /**
-   * 表示順を変更
-   */
-  changeDisplayOrder(newDisplayOrder: number): void {
-    Department.validateDisplayOrder(newDisplayOrder);
-    this._displayOrder = newDisplayOrder;
     this._updatedAt = new Date();
   }
 
@@ -194,10 +163,6 @@ export class Department {
 
   get abbreviation(): Abbreviation {
     return this._abbreviation;
-  }
-
-  get displayOrder(): number {
-    return this._displayOrder;
   }
 
   get isActive(): boolean {

--- a/src/server/subdomains/department/domain/entities/__tests__/Department.test.ts
+++ b/src/server/subdomains/department/domain/entities/__tests__/Department.test.ts
@@ -1,4 +1,4 @@
-import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
 import { describe, expect, it } from "vitest";
 import { Abbreviation } from "../../values/Abbreviation";
 import { DepartmentCd } from "../../values/DepartmentCd";
@@ -11,14 +11,12 @@ describe("Department", () => {
     departmentCd?: DepartmentCd;
     name?: DepartmentName;
     abbreviation?: Abbreviation;
-    displayOrder?: number;
     parentId?: string | null;
   }) => {
     return Department.create(
       overrides?.departmentCd ?? new DepartmentCd("DEPT001"),
       overrides?.name ?? new DepartmentName("営業部"),
       overrides?.abbreviation ?? new Abbreviation("営業"),
-      overrides?.displayOrder ?? 0,
       overrides?.parentId ?? null
     );
   };
@@ -31,7 +29,6 @@ describe("Department", () => {
       expect(dept.departmentCd.value).toBe("DEPT001");
       expect(dept.name.value).toBe("営業部");
       expect(dept.abbreviation.value).toBe("営業");
-      expect(dept.displayOrder).toBe(0);
       expect(dept.isActive).toBe(true);
       expect(dept.parentId).toBeNull();
       expect(dept.createdAt).toBeInstanceOf(Date);
@@ -43,26 +40,6 @@ describe("Department", () => {
       const dept = createTestDepartment({ parentId });
 
       expect(dept.parentId).toBe(parentId);
-    });
-
-    it("表示順を指定して作成できる", () => {
-      const dept = createTestDepartment({ displayOrder: 10 });
-
-      expect(dept.displayOrder).toBe(10);
-    });
-
-    it("表示順が負の値だとエラー", () => {
-      expect(() => createTestDepartment({ displayOrder: -1 })).toThrow(ValidationError);
-      expect(() => createTestDepartment({ displayOrder: -1 })).toThrow(
-        "表示順は0以上である必要があります"
-      );
-    });
-
-    it("表示順が小数だとエラー", () => {
-      expect(() => createTestDepartment({ displayOrder: 1.5 })).toThrow(ValidationError);
-      expect(() => createTestDepartment({ displayOrder: 1.5 })).toThrow(
-        "表示順は整数である必要があります"
-      );
     });
   });
 
@@ -77,7 +54,6 @@ describe("Department", () => {
         new DepartmentCd("DEPT001"),
         new DepartmentName("営業部"),
         new Abbreviation("営業"),
-        5,
         false,
         "parent-id",
         createdAt,
@@ -88,7 +64,6 @@ describe("Department", () => {
       expect(dept.departmentCd.value).toBe("DEPT001");
       expect(dept.name.value).toBe("営業部");
       expect(dept.abbreviation.value).toBe("営業");
-      expect(dept.displayOrder).toBe(5);
       expect(dept.isActive).toBe(false);
       expect(dept.parentId).toBe("parent-id");
       expect(dept.createdAt).toBe(createdAt);
@@ -116,22 +91,6 @@ describe("Department", () => {
       dept.changeAbbreviation(new Abbreviation("総務"));
 
       expect(dept.abbreviation.value).toBe("総務");
-    });
-  });
-
-  describe("changeDisplayOrder", () => {
-    it("表示順を変更できる", () => {
-      const dept = createTestDepartment();
-
-      dept.changeDisplayOrder(10);
-
-      expect(dept.displayOrder).toBe(10);
-    });
-
-    it("負の値はエラー", () => {
-      const dept = createTestDepartment();
-
-      expect(() => dept.changeDisplayOrder(-1)).toThrow(ValidationError);
     });
   });
 
@@ -176,7 +135,6 @@ describe("Department", () => {
         new DepartmentCd("DEPT001"),
         new DepartmentName("営業部"),
         new Abbreviation("営業"),
-        0,
         false, // 無効状態で再構築
         null,
         new Date(),

--- a/src/server/subdomains/department/infrastructure/mappers/DepartmentMapper.ts
+++ b/src/server/subdomains/department/infrastructure/mappers/DepartmentMapper.ts
@@ -26,7 +26,6 @@ export class DepartmentMapper {
       departmentCd,
       name,
       abbreviation,
-      prismaDepartment.displayOrder,
       prismaDepartment.isActive,
       prismaDepartment.parentId,
       prismaDepartment.createdAt,
@@ -46,7 +45,6 @@ export class DepartmentMapper {
       departmentCd: department.departmentCd.value,
       name: department.name.value,
       abbreviation: department.abbreviation.value,
-      displayOrder: department.displayOrder,
       isActive: department.isActive,
       parentId: department.parentId,
     };
@@ -62,7 +60,6 @@ export class DepartmentMapper {
     return {
       name: department.name.value,
       abbreviation: department.abbreviation.value,
-      displayOrder: department.displayOrder,
       isActive: department.isActive,
       parentId: department.parentId,
       updatedAt: department.updatedAt,

--- a/src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts
+++ b/src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts
@@ -78,7 +78,7 @@ export class PrismaDepartmentRepository implements DepartmentRepository {
   async findChildren(parentId: string): Promise<Department[]> {
     const prismaDepartments = await prisma.department.findMany({
       where: { parentId: parentId },
-      orderBy: { displayOrder: "asc" },
+      orderBy: { departmentCd: "asc" },
     });
 
     return prismaDepartments.map(DepartmentMapper.toDomain);
@@ -92,7 +92,7 @@ export class PrismaDepartmentRepository implements DepartmentRepository {
   async findRootDepartments(): Promise<Department[]> {
     const prismaDepartments = await prisma.department.findMany({
       where: { parentId: null },
-      orderBy: { displayOrder: "asc" },
+      orderBy: { departmentCd: "asc" },
     });
 
     return prismaDepartments.map(DepartmentMapper.toDomain);

--- a/src/server/subdomains/department/infrastructure/queries/PrismaDepartmentQueryService.ts
+++ b/src/server/subdomains/department/infrastructure/queries/PrismaDepartmentQueryService.ts
@@ -80,7 +80,7 @@ export class PrismaDepartmentQueryService implements DepartmentQueryService {
   }
 
   async findChildren(parentId: string, options?: DepartmentListOptions): Promise<DepartmentDTO[]> {
-    const orderBy = this.buildOrderBy(options) ?? { displayOrder: "asc" as const };
+    const orderBy = this.buildOrderBy(options) ?? { departmentCd: "asc" as const };
 
     const departments = await prisma.department.findMany({
       where: { parentId },
@@ -94,7 +94,7 @@ export class PrismaDepartmentQueryService implements DepartmentQueryService {
   }
 
   async findRootDepartments(options?: DepartmentListOptions): Promise<DepartmentDTO[]> {
-    const orderBy = this.buildOrderBy(options) ?? { displayOrder: "asc" as const };
+    const orderBy = this.buildOrderBy(options) ?? { departmentCd: "asc" as const };
 
     const departments = await prisma.department.findMany({
       where: { parentId: null },
@@ -112,7 +112,7 @@ export class PrismaDepartmentQueryService implements DepartmentQueryService {
     const allDepartments = await prisma.department.findMany({
       where: { isActive: true },
       select: this.getSelectFields(),
-      orderBy: { displayOrder: "asc" },
+      orderBy: { departmentCd: "asc" },
     });
 
     const departmentDTOs = allDepartments.map((d) => this.toDTO(d));
@@ -193,7 +193,6 @@ export class PrismaDepartmentQueryService implements DepartmentQueryService {
       departmentCd: true,
       name: true,
       abbreviation: true,
-      displayOrder: true,
       isActive: true,
       parentId: true,
       createdAt: true,
@@ -209,7 +208,6 @@ export class PrismaDepartmentQueryService implements DepartmentQueryService {
     departmentCd: string;
     name: string;
     abbreviation: string;
-    displayOrder: number;
     isActive: boolean;
     parentId: string | null;
     createdAt: Date;
@@ -220,7 +218,6 @@ export class PrismaDepartmentQueryService implements DepartmentQueryService {
       departmentCd: department.departmentCd,
       name: department.name,
       abbreviation: department.abbreviation,
-      displayOrder: department.displayOrder,
       isActive: department.isActive,
       parentId: department.parentId,
       createdAt: department.createdAt,

--- a/src/server/subdomains/employee/application/commands/__tests__/CreateEmployeeCommand.test.ts
+++ b/src/server/subdomains/employee/application/commands/__tests__/CreateEmployeeCommand.test.ts
@@ -32,7 +32,6 @@ describe("CreateEmployeeCommand", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/application/commands/__tests__/DeleteEmployeeCommand.test.ts
+++ b/src/server/subdomains/employee/application/commands/__tests__/DeleteEmployeeCommand.test.ts
@@ -31,7 +31,6 @@ describe("DeleteEmployeeCommand", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/application/commands/__tests__/UpdateEmployeeCommand.test.ts
+++ b/src/server/subdomains/employee/application/commands/__tests__/UpdateEmployeeCommand.test.ts
@@ -36,7 +36,6 @@ describe("UpdateEmployeeCommand", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/application/queries/__tests__/CountEmployeesQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/CountEmployeesQuery.test.ts
@@ -67,7 +67,6 @@ describe("CountEmployeesQuery", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/application/queries/__tests__/GetAllEmployeesQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetAllEmployeesQuery.test.ts
@@ -67,7 +67,6 @@ describe("GetAllEmployeesQuery", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmailQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmailQuery.test.ts
@@ -67,7 +67,6 @@ describe("GetEmployeeByEmailQuery", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmployeeCdQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmployeeCdQuery.test.ts
@@ -67,7 +67,6 @@ describe("GetEmployeeByEmployeeCdQuery", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByIdQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByIdQuery.test.ts
@@ -67,7 +67,6 @@ describe("GetEmployeeByIdQuery", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/application/queries/__tests__/SearchEmployeesQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/SearchEmployeesQuery.test.ts
@@ -67,7 +67,6 @@ describe("SearchEmployeesQuery", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/domain/services/__tests__/EmployeeCdDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/employee/domain/services/__tests__/EmployeeCdDuplicationCheckDomainService.test.ts
@@ -32,7 +32,6 @@ describe("EmployeeCdDuplicationCheckDomainService", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/domain/services/__tests__/MailAddressDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/employee/domain/services/__tests__/MailAddressDuplicationCheckDomainService.test.ts
@@ -32,7 +32,6 @@ describe("MailAddressDuplicationCheckDomainService", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });

--- a/src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts
+++ b/src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts
@@ -29,7 +29,6 @@ describe("PrismaEmployeeRepository", () => {
         departmentCd: "DEPT001",
         name: "テスト部署",
         abbreviation: "テスト",
-        displayOrder: 1,
         isActive: true,
       },
     });


### PR DESCRIPTION
## Summary

`Department` テーブルの `displayOrder`（表示順）カラムを DB・BE・FE の全レイヤーから完全に削除。デフォルトソート順を `departmentCd`（asc）に変更。41ファイル変更、全402テストパス、ビルド成功を確認済み。

Closes #120

## Implementation Notes

計画は4ステップ・4コミットで設計したが、TypeScript の型依存チェーンにより3コミットに統合された。

### 逸脱1: Step 1 に Presentation 層の actions.ts を含める必要があった

**計画:** Step 1 は Domain Entity + Commands + Mapper のみ
**実際:** `CreateDepartmentInput` / `UpdateDepartmentInput` の型変更が、それを直接参照する actions.ts に即座に型エラーを波及させた。
**対応:** Step 1 のコミットに actions.ts 2ファイルを追加。

### 逸脱2: Step 2 と Step 3 を1コミットに統合

**計画:** Step 2（DTO + QueryService + Repository）と Step 3（UI）は別コミット
**実際:** `DepartmentDTO` から `displayOrder` を削除すると、その型を参照する全UIコンポーネントが型エラーになり分離不可。
**対応:** Step 2 + Step 3 を1コミットに統合。

### 逸脱3: Prisma migrate dev が非対話環境で実行不可

**対応:** マイグレーション SQL を手動作成し `prisma migrate deploy` で適用。

### 逸脱4: UpdateDepartmentCommand.test.ts に fixture 残存

**実際:** `replace_all` のパターンマッチで `isActive: false` パターンの1箇所が漏れた。
**対応:** Step 4 のコミットで修正。

### 最終コミット構成

| コミット | 内容 |
|---------|------|
| `c233eba` | Entity + Commands + Mapper + Actions |
| `b5a05a2` | DTO + Query + Repository + UI |
| `63ba066` | Prisma schema + migration + seed + employee fixtures |

## Test Plan

- [x] `pnpm test` — 全59テストファイル・402テストがパス
- [x] `pnpm lint` — エラーなし（既存の warning 1件のみ）
- [x] `pnpm build` — ビルド成功
- [x] `tsc --noEmit` — 各コミットで型チェック通過を確認
- [x] コードベース全体で `displayOrder` への参照がゼロ（migration の DROP COLUMN 文を除く）

---

Generated with [Claude Code](https://claude.ai/code)