### PR TITLE
feat: create-prスキルに実装計画と逸脱記録を含める (#121)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -115,6 +115,15 @@
             "command": "bash -c 'BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo \"unknown\"); INPUT=$(cat); if ! command -v jq &>/dev/null; then if echo \"$INPUT\" | grep -q \"git\"; then echo \"❌ ERROR: git commands blocked (jq not installed for safety check).\" >&2; exit 2; fi; exit 0; fi; CMD=$(echo \"$INPUT\" | jq -r \".tool_input.command // empty\" 2>/dev/null); if [ -z \"$CMD\" ]; then exit 0; fi; if echo \"$CMD\" | grep -qE \"git\\s+(push|commit)\"; then if [ \"$BRANCH\" = \"main\" ] || [ \"$BRANCH\" = \"master\" ] || [ \"$BRANCH\" = \"develop\" ]; then echo \"❌ ERROR: git push/commit to $BRANCH branch is blocked.\" >&2; echo \"Please use a feature branch or git worktree for development.\" >&2; exit 2; fi; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'INPUT=$(cat); if ! command -v jq &>/dev/null; then exit 0; fi; CMD=$(echo \"$INPUT\" | jq -r \".tool_input.command // empty\" 2>/dev/null); if [ -z \"$CMD\" ]; then exit 0; fi; if ! echo \"$CMD\" | grep -qE \"git\\s+commit\"; then exit 0; fi; SETTINGS=\".claude/settings.local.json\"; if [ ! -f \"$SETTINGS\" ]; then exit 0; fi; PLANS_DIR=$(jq -r \".plansDirectory // empty\" \"$SETTINGS\" 2>/dev/null); if [ -z \"$PLANS_DIR\" ]; then exit 0; fi; PLAN_FILES=$(find \"$PLANS_DIR\" -maxdepth 1 -name \"*.md\" ! -name \"deviations.md\" 2>/dev/null); if [ -z \"$PLAN_FILES\" ]; then exit 0; fi; echo \"📋 リマインド: 実装計画が存在します。計画からの逸脱があれば ${PLANS_DIR}/deviations.md に追記してください。\"; exit 0'"
+          }
+        ]
       }
     ]
   },

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -39,11 +39,14 @@ git log --oneline develop..HEAD
 git diff develop..HEAD --stat
 ```
 
-### 逸脱記録
+### 実装計画・逸脱記録
 
-メモリファイル `implementation-deviations.md` を読み取る。
+`.claude/settings.local.json` を読み、`plansDirectory` の値を取得する。
 
-- ファイルが存在しない、または空の場合は「計画通りに完了」として扱う
+1. `plansDirectory` が設定されていて、ディレクトリ内に `.md` ファイルがある場合:
+   - `deviations.md` 以外の `.md` ファイルを全て **planファイル** として読み取る
+   - `deviations.md` があれば **逸脱記録** として読み取る
+2. 未設定 or ディレクトリが空 → 計画なしとして扱う
 
 ## ステップ 3: PR タイトル生成
 
@@ -66,6 +69,7 @@ git diff develop..HEAD --stat
 ## ステップ 4: PR description 生成
 
 以下のテンプレートに沿って PR description を生成する。
+条件に応じてセクションの出力を制御すること。
 
 ```markdown
 ## Summary
@@ -74,16 +78,27 @@ git diff develop..HEAD --stat
 
 Closes #{issue_number}
 
-## Implementation Notes
+## 実装計画
 
-(implementation-deviations.md の内容を整理して記述)
+<details>
+<summary>plan mode で作成した実装計画（クリックで展開）</summary>
 
-- 計画からの逸脱点
-- 試行錯誤した点
-- 不確実性の高い箇所
+（plansDirectory 内の plan ファイルの内容）
+（複数ファイルがある場合はファイル名を見出しにして掲載）
 
-※逸脱記録がない場合は以下を記述:
+</details>
+
+※計画ファイルが存在しない場合はこのセクション自体を省略
+
+## 計画からの逸脱
+
+（plansDirectory/deviations.md の内容を整理して記述）
+
+※逸脱記録がなく計画がある場合:
 「計画通りに実装が完了しました。特筆すべき逸脱はありません。」
+
+※計画も逸脱記録もない場合:
+「実装計画なしで実装を行いました。」
 
 ## Test Plan
 
@@ -97,7 +112,8 @@ Generated with [Claude Code](https://claude.ai/code)
 ```
 
 - Summary はコミット履歴と issue 内容を元に簡潔にまとめる
-- Implementation Notes は逸脱記録を開発者が読みやすい形に整理する
+- 実装計画は `<details>` で折りたたんでレビュアーが必要に応じて展開できるようにする
+- 計画からの逸脱は逸脱記録を開発者が読みやすい形に整理する
 - Test Plan はテスト関連の変更から自動生成し、不足があれば追記する
 
 ## ステップ 5: Push & PR 作成（確認不要）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ PRを作成する際は必ず `/create-pr` スキルを使用すること。`gh 
 When implementing with a plan (plan mode), follow these rules:
 
 - **Commit at each plan step**: Create a commit when each step of the plan is completed. Do not implement everything at once and squash into a single commit.
-- **Record deviations from the plan**: When something does not go as planned during implementation (test failures requiring fixes, design changes, unexpected issues, etc.), record it in the memory file `implementation-deviations.md`.
+- **Record deviations from the plan**: When something does not go as planned during implementation (test failures requiring fixes, design changes, unexpected issues, etc.), record it in `{plansDirectory}/deviations.md`. The `plansDirectory` is configured in `.claude/settings.local.json` (e.g. `docs/claude-plans/issue-121`). Create the file only when deviations occur; append each deviation as it happens.
 
 ## Critical: DDD Layering Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,6 @@ PRを作成する際は必ず `/create-pr` スキルを使用すること。`gh 
 When implementing with a plan (plan mode), follow these rules:
 
 - **Commit at each plan step**: Create a commit when each step of the plan is completed. Do not implement everything at once and squash into a single commit.
-- **Record deviations from the plan**: When something does not go as planned during implementation (test failures requiring fixes, design changes, unexpected issues, etc.), record it in `{plansDirectory}/deviations.md`. The `plansDirectory` is configured in `.claude/settings.local.json` (e.g. `docs/claude-plans/issue-121`). Create the file only when deviations occur; append each deviation as it happens.
 
 ## Critical: DDD Layering Rules
 


### PR DESCRIPTION
## Summary

create-prスキルを改修し、PR descriptionに実装計画（planファイル）と逸脱記録を含めるようにした。また、git commit時に逸脱記録の追記を促すリマインドhookを追加した。

Closes #121

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### Context

issue #120 の実装で、PRに実装計画が残らない・逸脱記録を書き忘れるという課題が発覚した。
create-pr スキルを改修して、planファイルと逸脱記録をPR descriptionに含め、レビュアーが「何を計画し、実際にどう変わったか」を確認できるようにする。

### Step 1: create-pr スキルの改修
- ステップ2: `settings.local.json` の `plansDirectory` から plan ファイル・逸脱記録を読み取るロジックに変更
- ステップ4: PR description テンプレートに「実装計画」（`<details>` 折りたたみ）と「計画からの逸脱」セクションを追加

### Step 2: 逸脱記録リマインドhookの追加
- `PreToolUse` の `Bash` matcher に新エントリを追加
- `git commit` 検知時、plan ファイルが存在する場合のみリマインド表示（exit 0 でブロックしない）

### Step 3: CLAUDE.md の更新
- 逸脱記録の保存先を Serena メモリから `plansDirectory/deviations.md` に変更

</details>

## 計画からの逸脱

計画の Step 3 で CLAUDE.md の逸脱記録ルールを更新したが、その後の検討で hookと重複していることが判明し、逸脱記録ルール自体を削除した。ステップごとコミットのルールのみ残す形に整理。

## Test Plan

- [ ] `settings.local.json` に `plansDirectory` が設定された状態で `git commit` → リマインドメッセージが表示されること
- [ ] `plansDirectory` が未設定 or plan ファイルなしで `git commit` → リマインドなしで通常通りコミットされること
- [ ] `/create-pr` 実行時に plan ファイルが PR description に `<details>` 折りたたみで含まれること
- [ ] 逸脱記録がある場合、計画と逸脱が並んで表示されること

---

Generated with [Claude Code](https://claude.ai/code)