### PR TITLE
refactor: auto-implementスキルのSkill呼び出しをAgent委譲に切り替え

### DIFF
--- a/.claude/skills/auto-implement/SKILL.md
+++ b/.claude/skills/auto-implement/SKILL.md
@@ -29,23 +29,10 @@ user-invocable: true
 
 ### 1.2 Issue 作成（説明文モードのみ）
 
-Agent ツールを使用してサブエージェントに Issue 作成を委譲する:
+`Skill(create-issue, args: "{$ARGUMENTS の内容}")` で Issue 作成を委譲する。
 
-- **description:** `"Create GitHub issue"`
-- **prompt:**
-
-```
-まず `.claude/skills/create-issue/SKILL.md` を Read で読み、その手順に従って GitHub Issue を作成してください。
-
-作成する内容: {$ARGUMENTS}
-
-重要:
-- SKILL.md の手順（タイプ判定・ラベルチェック・テンプレート選択）に従うこと
-- ユーザーへの確認は不要（そのまま作成する）
-- 作成後、Issue 番号（数字のみ）だけを返すこと（他の説明は不要）
-```
-
-Agent の返却値から Issue 番号を取得して処理を継続する。
+- create-issue は `context: fork` により自動的にサブエージェントとして実行される
+- 返却値から Issue 番号を抽出して処理を継続する
 
 ### 1.3 Issue 情報取得 & ブランチタイプ判定
 
@@ -220,24 +207,11 @@ pnpm test
 
 ### 4.1 PR 作成
 
-Agent ツールを使用してサブエージェントに PR 作成を委譲する:
+`Skill(create-pr, args: "#{number}")` で PR 作成を委譲する。
 
-- **description:** `"Create pull request"`
-- **prompt:**
-
-```
-まず `.claude/skills/create-pr/SKILL.md` を Read で読み、その手順に従って PR を作成してください。
-
-対象 Issue: #{number}
-{lint/test が通らなかった場合は以下を追記: ドラフト PR として作成すること（--draft フラグを使用）}
-
-重要:
-- SKILL.md の手順（コンテキスト収集・タイトル生成・description生成）に従うこと
-- ユーザーへの確認は不要（そのまま作成する）
-- 作成後、PR の URL のみを返すこと（他の説明は不要）
-```
-
-Agent の返却値から PR URL を取得して最終報告に使用する。
+- create-pr は `context: fork` により自動的にサブエージェントとして実行される
+- lint/test が通らなかった場合: `Skill(create-pr, args: "--draft #{number}")` でドラフト PR を作成する
+- 返却値から PR URL を取得して最終報告に使用する
 
 ### 4.2 最終報告
 

--- a/.claude/skills/auto-implement/SKILL.md
+++ b/.claude/skills/auto-implement/SKILL.md
@@ -29,39 +29,23 @@ user-invocable: true
 
 ### 1.2 Issue 作成（説明文モードのみ）
 
-**Skill(create-issue) は使用しない**（Skill 呼び出しはプロンプトがロードされ、完了報告で処理が停止するため）。
-以下の手順でインライン作成する:
+Agent ツールを使用してサブエージェントに Issue 作成を委譲する:
 
-**① タイプ判定** — `$ARGUMENTS` のキーワードからタイプを推定する:
+- **description:** `"Create GitHub issue"`
+- **prompt:**
 
-| タイプ | キーワード例 | タイトル接頭辞 | ラベル |
-|--------|-------------|---------------|--------|
-| enhancement | 機能追加, 実装, 新規, feat, 追加 | `feat:` | `Type: enhancement` |
-| bug | バグ, エラー, 不具合, 修正, fix, 壊れ | `fix:` | `Type: bug` |
-| refactor | リファクタ, 整理, 削除, cleanup, 統合, 分離 | `refactor:` | `Type: refactor` |
-| documentation | ドキュメント, 記録, docs, README | `docs:` | `Type: documentation` |
-| その他 | — | `feat:` | `Type: enhancement` |
+```
+まず `.claude/skills/create-issue/SKILL.md` を Read で読み、その手順に従って GitHub Issue を作成してください。
 
-**② Issue 作成** — `gh issue create` で直接作成する:
+作成する内容: {$ARGUMENTS}
 
-```bash
-gh issue create \
-  --title "{prefix}: {タイトル}" \
-  --label "Type: {type}" \
-  --body "## 概要
-
-{$ARGUMENTS の内容を要約}
-
-## 実装タスク
-
-- [ ] （$ARGUMENTS から推定）
-
-## 受け入れ条件
-
-- [ ] （$ARGUMENTS から推定）"
+重要:
+- SKILL.md の手順（タイプ判定・ラベルチェック・テンプレート選択）に従うこと
+- ユーザーへの確認は不要（そのまま作成する）
+- 作成後、Issue 番号（数字のみ）だけを返すこと（他の説明は不要）
 ```
 
-**③ 番号取得** — 作成コマンドの出力から Issue 番号を取得する
+Agent の返却値から Issue 番号を取得して処理を継続する。
 
 ### 1.3 Issue 情報取得 & ブランチタイプ判定
 
@@ -236,8 +220,24 @@ pnpm test
 
 ### 4.1 PR 作成
 
-- `Skill(create-pr, args: "#{number}")` で PR 作成を委譲する
-- lint/test が通らなかった場合: PR タイトルの末尾に `[draft]` を付与し、ドラフト PR として作成するよう指示する
+Agent ツールを使用してサブエージェントに PR 作成を委譲する:
+
+- **description:** `"Create pull request"`
+- **prompt:**
+
+```
+まず `.claude/skills/create-pr/SKILL.md` を Read で読み、その手順に従って PR を作成してください。
+
+対象 Issue: #{number}
+{lint/test が通らなかった場合は以下を追記: ドラフト PR として作成すること（--draft フラグを使用）}
+
+重要:
+- SKILL.md の手順（コンテキスト収集・タイトル生成・description生成）に従うこと
+- ユーザーへの確認は不要（そのまま作成する）
+- 作成後、PR の URL のみを返すこと（他の説明は不要）
+```
+
+Agent の返却値から PR URL を取得して最終報告に使用する。
 
 ### 4.2 最終報告
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: create-issue
 description: GitHub issue を作成（タイプ自動判定・ラベル自動付与）。Use when issueの作成、issueの作成を依頼されたとき。
+context: fork
 ---
 
 # プロンプト内容
@@ -29,7 +30,7 @@ description: GitHub issue を作成（タイプ自動判定・ラベル自動付
 ## ステップ 2: ラベル存在チェック
 
 `gh label list --search "Type: xxx"` でラベルの存在を確認する。
-ラベルが存在しない場合はユーザーに報告し、ラベルなしで作成するか確認する。
+ラベルが存在しない場合はラベルなしで作成する（確認不要）。
 
 ## ステップ 3: 優先度判定（オプション）
 
@@ -220,6 +221,6 @@ gh issue create \
 - `$ARGUMENTS` の内容を分析してテンプレートの各セクションを埋める
 - 関連 issue があれば本文中にリンクする
 
-## ステップ 6: ユーザーに通知
+## ステップ 6: 結果を返す
 
-作成した issue の番号と URL を簡潔に通知する。
+作成した issue の番号と URL を簡潔に返す。

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: create-pr
 description: GitHub PRを作成する。Use when PRの作成、プルリクエストの作成を依頼されたとき。実装振り返りレポート付きで作成する。
 user-invocable: true
+context: fork
 ---
 
 # プロンプト内容
@@ -15,7 +16,7 @@ user-invocable: true
 
 - `#123` や `123` のような番号が含まれていればそれを使う
 - 番号がない場合はブランチ名（`feat/issue-87` など）から issue 番号を抽出する
-- どちらでも特定できない場合はユーザーに確認する
+- どちらでも特定できない場合はエラーとして処理を終了し、理由を返す
 
 ```bash
 gh issue view {番号}
@@ -127,7 +128,8 @@ gh pr create --base develop --title "{title}" --body "{body}"
 ```
 
 - base は必ず `develop`（CLAUDE.md の規約）
+- `$ARGUMENTS` に `--draft` が含まれている場合は `gh pr create --draft` フラグを使用する
 
-## ステップ 6: クリーンアップ & 通知
+## ステップ 6: 結果を返す
 
-- 作成した PR の番号と URL を簡潔に通知する
+- 作成した PR の番号と URL を簡潔に返す

--- a/docs/claude-plans/foamy-doodling-snail.md
+++ b/docs/claude-plans/foamy-doodling-snail.md
@@ -1,0 +1,69 @@
+# Issue #130: auto-implement スキルをオーケストレーター型に変更
+
+## Context
+
+auto-implement スキルは Issue 作成 → 実装 → PR 作成を全自動化するオーケストレーターだが、サブタスク（create-issue, create-pr）の呼び出しに「Agent + Read SKILL.md」というハックを使っている。これを Claude Code の正式機能で置き換える。
+
+**採用する2つのパターン:**
+
+| パターン | 用途 | 例 |
+|---------|------|-----|
+| `context: fork` | スキルの内容 = タスクそのもの | create-issue, create-pr |
+| Subagent + `skills` field | スキルの内容 = 知識・ガイドライン | ddd-architecture, testing-backend |
+
+`context: fork` は常に fork で動作する（ユーザー直接呼び出し時も fork）。create-issue / create-pr は自己完結型タスクなので問題ない。
+
+## ステップ
+
+### Step 1: create-issue に `context: fork` を追加し非対話化
+
+- 対象ファイル: `.claude/skills/create-issue/SKILL.md`
+- 作業内容:
+  - フロントマターに `context: fork` を追加
+  - ステップ 2: 「ラベルが存在しない場合はユーザーに確認する」→「ラベルなしで作成する（確認不要）」に変更
+  - ステップ 6: 返却値として Issue 番号と URL を返す旨を明記
+- コミットメッセージ: `refactor: create-issueスキルにcontext: forkを追加し非対話化`
+
+### Step 2: create-pr に `context: fork` を追加し非対話化
+
+- 対象ファイル: `.claude/skills/create-pr/SKILL.md`
+- 作業内容:
+  - フロントマターに `context: fork` を追加
+  - ステップ 1: 「ユーザーに確認する」→「エラーとして処理を終了し、理由を返す」に変更
+  - ステップ 5: `$ARGUMENTS` に `--draft` が含まれている場合は `gh pr create --draft` を使用する旨を追加
+- コミットメッセージ: `refactor: create-prスキルにcontext: forkを追加し非対話化`
+
+### Step 3: auto-implement Phase 1.2 を Skill 呼び出しに変更
+
+- 対象ファイル: `.claude/skills/auto-implement/SKILL.md`
+- 作業内容: Agent + Read ハックを Skill ツール呼び出しに置き換え
+  ```
+  Skill(create-issue, args: "{$ARGUMENTS の内容}")
+  → context: fork により自動的にサブエージェントとして実行
+  → 返却値から Issue 番号を抽出して処理を継続
+  ```
+- コミットメッセージ: `refactor: auto-implement Phase 1.2をSkill呼び出しに変更`
+
+### Step 4: auto-implement Phase 4.1 を Skill 呼び出しに変更
+
+- 対象ファイル: `.claude/skills/auto-implement/SKILL.md`
+- 作業内容: Agent + Read ハックを Skill ツール呼び出しに置き換え
+  ```
+  Skill(create-pr, args: "#{number}")
+  → lint/test 失敗時は args に --draft を追加
+  → 返却値から PR URL を取得して最終報告に使用
+  ```
+- コミットメッセージ: `refactor: auto-implement Phase 4.1をSkill呼び出しに変更`
+
+### Step 5（将来・別Issue）: implementer サブエージェントの作成
+
+- 対象ファイル: `.claude/agents/implementer.md`（新規作成）
+- 作業内容: `skills: [ddd-architecture, testing-backend]` を持つサブエージェント定義を作成し、auto-implement Phase 2+3 を委譲
+- このステップは本 PR のスコープ外。別 Issue として管理する。
+
+## 検証方法
+
+1. `/create-issue テスト用Issue` → fork コンテキストで Issue が作成され、番号と URL が返ること
+2. `/create-pr #xxx` → fork コンテキストで PR が作成され、URL が返ること
+3. `/auto-implement 説明文` → Phase 1.2 で Skill(create-issue) が fork 実行され、番号取得後に処理が継続すること
+4. `/auto-implement #xxx` → Phase 4.1 で Skill(create-pr) が fork 実行され、PR URL を含む最終報告が出ること

--- a/docs/claude-plans/issue-130/plan.md
+++ b/docs/claude-plans/issue-130/plan.md
@@ -1,0 +1,19 @@
+# Issue #130: auto-implementスキルのSkill呼び出しをAgent委譲に切り替え — 実装計画
+
+## 概要
+
+auto-implementスキルの Phase 1.2（Issue作成）と Phase 4.1（PR作成）を、Skillツール呼び出しからAgentツールによるサブエージェント委譲に変更する。サブエージェントには各スキルのSKILL.mdをReadさせることでDRYを保つ。
+
+## ステップ
+
+### Step 1: Phase 1.2（Issue作成）をAgent委譲に書き換え
+
+- 対象ファイル: `.claude/skills/auto-implement/SKILL.md`
+- 作業内容: 現在のインラインロジック（タイプ判定・テンプレート・gh issue create）をAgent委譲の指示に置き換える。サブエージェントに `.claude/skills/create-issue/SKILL.md` をReadさせ、その手順に従ってIssueを作成し、番号のみを返すよう指示する。
+- コミットメッセージ: refactor: Phase 1.2のIssue作成をAgent委譲に変更
+
+### Step 2: Phase 4.1（PR作成）をAgent委譲に書き換え
+
+- 対象ファイル: `.claude/skills/auto-implement/SKILL.md`
+- 作業内容: `Skill(create-pr, args: "#{number}")` の参照をAgent委譲に置き換える。サブエージェントに `.claude/skills/create-pr/SKILL.md` をReadさせ、その手順に従ってPRを作成し、URLのみを返すよう指示する。ドラフトPR条件も含める。
+- コミットメッセージ: refactor: Phase 4.1のPR作成をAgent委譲に変更


### PR DESCRIPTION
## Summary

auto-implementスキルのサブタスク呼び出し方式を改善。create-issue / create-pr スキルに `context: fork` を追加して非対話化し、auto-implement内の「Agent + Read SKILL.md」ハックを正式な Skill ツール呼び出し（fork コンテキスト）に置き換えた。これにより、サブタスク実行後に制御が呼び出し元に正しく戻るようになる。

Closes #130

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### plan.md (issue-130)

- Step 1: Phase 1.2（Issue作成）をAgent委譲に書き換え
- Step 2: Phase 4.1（PR作成）をAgent委譲に書き換え

### foamy-doodling-snail.md (最終計画)

- Step 1: create-issue に `context: fork` を追加し非対話化
- Step 2: create-pr に `context: fork` を追加し非対話化
- Step 3: auto-implement Phase 1.2 を Skill 呼び出しに変更
- Step 4: auto-implement Phase 4.1 を Skill 呼び出しに変更
- Step 5（スコープ外）: implementer サブエージェントの作成は別 Issue で管理

</details>

## 計画からの逸脱

逸脱記録ファイルは存在しないが、実装の経緯から以下の変遷があった:

1. **初期計画（plan.md）**: Agent委譲方式でサブタスクを呼び出す計画だった
2. **最終計画（foamy-doodling-snail.md）**: `context: fork` という Claude Code の正式機能を活用する方式に変更。Agent + Read ハックではなく、Skill ツール呼び出し + fork コンテキストによるサブエージェント自動実行に切り替えた

最終的に最終計画に沿って実装が完了している。

## Test Plan

- [ ] `/create-issue テスト用Issue` が fork コンテキストで Issue を作成し、番号と URL を返すこと
- [ ] `/create-pr #xxx` が fork コンテキストで PR を作成し、URL を返すこと
- [ ] `/auto-implement 説明文` で Phase 1.2 の Skill(create-issue) が fork 実行され、番号取得後に処理が継続すること
- [ ] `/auto-implement #xxx` で Phase 4.1 の Skill(create-pr) が fork 実行され、PR URL を含む最終報告が出ること

---

Generated with [Claude Code](https://claude.ai/code)