### PR TITLE
test: employees管理画面のE2Eテストを作成する (#124)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -76,7 +76,7 @@
   "model": "opus",
   "defaultMode": "acceptEdits",
   "sandbox": {
-    "enabled": false,
+    "enabled": true,
     "excludedCommands" :["pnpm", "vitest"],
     "filesystem": {
       "allowWrite": [".", "~/.local/share/pnpm", "~/.npm"],

--- a/docs/adr/app/admin-route-protection-in-proxy.md
+++ b/docs/adr/app/admin-route-protection-in-proxy.md
@@ -1,0 +1,68 @@
+# ADR: 管理者専用ルートの認可チェックをproxy.tsで行う
+
+## ステータス
+
+採用
+
+## コンテキスト
+
+`/employees/new`（従業員新規作成画面）は管理者のみがアクセスすべきページだが、ページレベルの認可チェックがなく、一般ユーザーでもアクセスできてしまっていた。Server Action（`createEmployeeAction`）内では`verifyAdmin()`で認可チェックしているため、実際のデータ作成は防がれるが、フォーム画面自体が表示される状態だった。
+
+## 検討した選択肢
+
+### A. `proxy.ts`に管理者専用ルートを定義する（採用）
+
+```typescript
+const adminRoutes = ["/employees/new"];
+
+if (session && adminRoutes.includes(path) && !isAdmin(session)) {
+  return NextResponse.redirect(new URL(`/signin?reason=${REDIRECT_REASON.FORBIDDEN}`, request.url));
+}
+```
+
+### B. `page.tsx`で`verifyAdmin()`を呼ぶ
+
+```typescript
+// src/app/(features)/employees/new/page.tsx
+export default async function EmployeeNewPage() {
+  await verifyAdmin();
+  // ...
+}
+```
+
+### C. `layout.tsx`で`verifyAdmin()`を呼ぶ
+
+```typescript
+// src/app/(features)/employees/layout.tsx
+export default async function EmployeesLayout({ children }) {
+  // ルートに応じた認可チェック
+}
+```
+
+## 決定
+
+**選択肢Aの`proxy.ts`での認可チェックを採用**する。
+
+## 根拠
+
+### 認証/認可の一貫性
+
+proxy.tsは既に認証チェック（未ログインユーザーのリダイレクト）を担っている。認可チェック（権限のないユーザーのリダイレクト）も同じレイヤーに置くことで、リクエストの認証・認可フローが一箇所で完結する。
+
+```
+リクエスト → proxy.ts（認証 + 認可） → ページレンダリング
+```
+
+### ページレンダリング前にブロックできる
+
+proxy.ts（Next.js 16のミドルウェア相当）はページのServer Componentが実行される前に動作する。不正なアクセスをページレンダリングの前段でブロックでき、不要なDB問い合わせやコンポーネントのレンダリングが発生しない。
+
+### 他の選択肢を不採用とした理由
+
+- **選択肢B（page.tsx）**: 各ページに`verifyAdmin()`を追加する必要があり、管理者専用ページが増えるたびに追加漏れのリスクがある。また、ページのレンダリングが開始された後にリダイレクトするため、無駄な処理が発生する
+- **選択肢C（layout.tsx）**: employeesのlayout.tsxは一覧・詳細・新規作成で共有されるが、一覧と詳細は一般ユーザーもアクセス可能であり、layoutレベルでの一律チェックは不適切。ルートに応じた条件分岐をlayoutに入れると責務が複雑化する
+
+## 影響
+
+- 管理者専用ルートを追加する際は`proxy.ts`の`adminRoutes`配列に追加するだけでよい
+- Server Action内の`verifyAdmin()`は多層防御として引き続き残す（proxyをバイパスされた場合の安全策）

--- a/docs/adr/app/use-sync-external-store-for-hydration-mismatch.md
+++ b/docs/adr/app/use-sync-external-store-for-hydration-mismatch.md
@@ -1,0 +1,79 @@
+# ADR: useSyncExternalStoreによるハイドレーションミスマッチの防止
+
+## ステータス
+
+採用
+
+## コンテキスト
+
+`UserDisplay`コンポーネントは`useSession()`フックでクライアントサイドのセッション情報を取得し、ユーザー名を表示するClient Componentである。
+
+`useSession()`はサーバーとクライアントで異なる初期値を返す:
+
+- **サーバーレンダリング時**: `isPending: true` → `<Loader2Icon>`（SVGスピナー）を描画
+- **クライアントハイドレーション時**: `isPending: false`（セッションがCookieから即座に取得可能）→ `<span>`（ユーザー名）を描画
+
+このDOM構造の不一致によりReactがハイドレーションミスマッチを検出し、最も近いSuspense境界（存在しない場合はルート）までのDOMツリーを再構築する。この再構築中に`<Link>`等のインタラクティブ要素が破棄→再作成されるため、ユーザーのクリックが消失する問題が発生していた。
+
+## 検討した選択肢
+
+### A. `useEffect` + `useState`パターン
+
+```tsx
+const [isClient, setIsClient] = useState(false);
+useEffect(() => { setIsClient(true); }, []);
+```
+
+- Next.js公式ドキュメントの[Solution 1](https://nextjs.org/docs/messages/react-hydration-error#solution-1-using-useeffect-to-run-on-the-client-only)として推奨
+- プロジェクトのESLintルール`react-hooks/set-state-in-effect`に抵触し、コミット不可
+- `eslint-disable`で回避可能だが、React公式の方向性（effect内でsetStateしない）に逆行する
+
+### B. `next/dynamic`による`ssr: false`
+
+```tsx
+const UserDisplay = dynamic(() => import("./user-display"), { ssr: false });
+```
+
+- Next.js公式ドキュメントの[Solution 2](https://nextjs.org/docs/messages/react-hydration-error#solution-2-disabling-ssr-on-specific-components)
+- ESLintルールに抵触しない
+- 修正箇所が利用側（header.tsx）になり、別の場所からUserDisplayを直接importすると同じ問題が再発する
+
+### C. `useSyncExternalStore`（採用）
+
+```tsx
+function useIsClient() {
+  return useSyncExternalStore(subscribe, () => true, () => false);
+}
+```
+
+- React公式ドキュメントの[Adding support for server rendering](https://react.dev/reference/react/useSyncExternalStore#adding-support-for-server-rendering)に記載されたパターン
+- ESLintルールに抵触しない
+- 修正がコンポーネント内で完結し、どこからimportしても安全
+
+## 決定
+
+**選択肢Cの`useSyncExternalStore`を採用**し、`useIsClient`カスタムフックとして`src/app/_hooks/useIsClient.ts`に切り出す。
+
+## 根拠
+
+### `useSyncExternalStore`の動作がこのユースケースに適合する
+
+React公式ドキュメントの`useOnlineStatus`の例と構造が同一である:
+
+| 観点 | useOnlineStatus（公式例） | useIsClient（今回） |
+|---|---|---|
+| 課題 | `navigator.onLine`がサーバーで使えない | `useSession()`がサーバーで正しい値を返さない |
+| `getSnapshot` | `navigator.onLine`（実際の値） | `true`（クライアントにいる） |
+| `getServerSnapshot` | `true`（安全なデフォルト） | `false`（スピナーを表示） |
+
+`getServerSnapshot`は**サーバーレンダリング時**と**クライアントのハイドレーション時**の両方で使用されるため、サーバーHTMLとハイドレーション時のレンダリングが一致し、ミスマッチが発生しない。
+
+### 他の選択肢を不採用とした理由
+
+- **選択肢A**: ESLintルール違反の回避に`eslint-disable`が必要。ルール自体はReact公式の方向性に沿ったものであり、無効化の正当性が弱い
+- **選択肢B**: 問題の原因はコンポーネント側にあるが、修正が利用側に漏れる設計になり、再発リスクがある
+
+## 影響
+
+- `useIsClient`フックは他のClient Componentでも再利用可能
+- `useSession()`以外にもサーバー/クライアントで異なる値を返すフックを使う場面で同じパターンを適用できる

--- a/docs/claude-plans/issue-124/squishy-seeking-barto.md
+++ b/docs/claude-plans/issue-124/squishy-seeking-barto.md
@@ -1,0 +1,168 @@
+# Issue #124: employees管理画面のE2Eテスト作成
+
+## Context
+
+employees管理画面（一覧・新規作成・詳細編集・削除）のE2Eテストを作成する。
+既存のコンポーネントテスト（EmployeeCreateForm.test.tsx, EmployeeUpdateForm.test.tsx）はVitest + RTLで
+Server Actionをモックした単体テストのみ。画面遷移・サーバーアクション連携・権限制御を含むE2Eテストは未整備。
+
+---
+
+## テスト境界の設計方針: コンポーネント統合テスト vs E2E テスト
+
+### 現状の既存テスト（コンポーネント単体テスト）がカバーしていること
+
+- フォームの描画（フィールド・ラベル・ヒント表示）
+- ユーザー入力操作（値の入力・セレクト変更）
+- フォーム送信時のFormData組み立て（モックされたServer Actionの呼び出し確認）
+- バリデーションエラーの表示（フィールドレベル・グローバル）
+- canUpdate=true/falseによるUI出し分け
+
+### 既存テストがカバーしていないこと（=E2Eで担保すべきこと）
+
+| カテゴリ | 具体例 |
+|---------|--------|
+| **実際のサーバーアクション** | Server Actionが本当にDB保存・バリデーション・リダイレクトするか |
+| **ページ間遷移** | 作成→一覧リダイレクト、一覧→詳細遷移、キャンセル→一覧戻り |
+| **権限制御** | admin/user/ownerによるアクセス制御・UI出し分けが実際に機能するか |
+| **検索機能** | URL駆動の検索がサーバーサイドで正しくフィルタリングされるか |
+| **トースト通知** | リダイレクト後のSonnerトーストが表示されるか |
+| **データ永続化** | 作成したデータが一覧に反映される、削除後に消えるなど |
+
+### コンポーネント統合テスト（中間層）は必要か？
+
+**結論: 現時点では不要。E2Eテストで十分カバーできる。**
+
+理由:
+- Next.js App Routerでは、Server Components / Server Actions / route権限チェックがすべてサーバーランタイムに依存
+- `cookies()`, `redirect()`, `verifySession()` 等はNext.jsサーバーなしでは動作せず、中間層テストで再現が困難
+- コンポーネント単体テスト + E2Eテストの2層で、投資対効果が最も高い
+- 将来的にフォームのインタラクションが複雑化した場合は、コンポーネント単体テスト側を拡充すればよい
+
+### テスト層の責務まとめ
+
+```
+コンポーネント単体テスト (Vitest + RTL)
+  → UIロジック、フォーム入力、モック境界での動作確認
+  → 高速・安定・大量に書ける
+
+E2Eテスト (Playwright)
+  → ユーザージャーニー、サーバー連携、権限、画面遷移
+  → 遅い・不安定になりやすいので、重要フローに絞る
+```
+
+---
+
+## E2Eテストケース設計
+
+### ファイル構成
+
+既存パターン（feature配下にco-locate）に従う:
+
+```
+src/app/(features)/employees/
+  employees-list.e2e.ts        # 一覧画面
+  employees-create.e2e.ts      # 新規作成画面
+  employees-detail.e2e.ts      # 詳細・編集・削除画面
+```
+
+### 前提: テストデータ
+
+- Seed: 2000件の従業員（EMP000001〜EMP002000）
+- Admin: employee1@example.com (EMP000001) → `playwright/.auth/admin.json`
+- User: employee2@example.com (EMP000002) → `playwright/.auth/user.json`
+- chromiumプロジェクトはデフォルトでadmin認証
+
+### A. `employees-list.e2e.ts` — 一覧画面 (7テスト)
+
+| # | テスト名 | 認証 | 検証内容 |
+|---|---------|------|---------|
+| 1 | 一覧が表示され、管理者には「新規登録」ボタンが見える | admin | heading「従業員管理」、「新規登録」リンク、DataTableの行が表示 |
+| 2 | 一般ユーザーには「新規登録」ボタンが見えない | user | 一覧は表示されるが「新規登録」リンクがない |
+| 3 | メールアドレスで検索（部分一致）できる | admin | 「employee1」で検索→URLに`?email=employee1`→結果にemployee1@example.comを含む |
+| 4 | 従業員コードで検索（完全一致）できる | admin | 「EMP000001」で検索→1件表示 |
+| 5 | 権限で検索できる | admin | 「管理者」選択→結果のバッジがすべて「管理者」 |
+| 6 | クリアボタンで検索条件がリセットされる | admin | 検索→クリア→URLパラメタなし |
+| 7 | 従業員コードリンクから詳細画面に遷移できる | admin | リンククリック→`/employees/EMP...`に遷移 |
+
+### B. `employees-create.e2e.ts` — 新規作成画面 (4テスト)
+
+| # | テスト名 | 認証 | 検証内容 |
+|---|---------|------|---------|
+| 1 | 管理者が新規従業員を作成できる（Happy Path） | admin | 一覧→新規登録→フォーム入力→登録→一覧にリダイレクト→トースト「従業員を登録しました。」→作成した従業員が検索で見つかる |
+| 2 | 一般ユーザーは新規作成画面にアクセスできない | user | `/employees/new`直接アクセス→`/signin?reason=forbidden`にリダイレクト |
+| 3 | 重複する従業員コードでエラーが表示される | admin | EMP000001で登録→エラーメッセージ表示 |
+| 4 | キャンセルボタンで一覧に戻れる | admin | キャンセルクリック→`/employees`に遷移 |
+
+### C. `employees-detail.e2e.ts` — 詳細・編集・削除画面 (6テスト)
+
+| # | テスト名 | 認証 | 検証内容 |
+|---|---------|------|---------|
+| 1 | 管理者が従業員情報を更新できる | admin | EMP000050の詳細→名前変更→更新→トースト「従業員情報を更新しました。」→変更が反映 |
+| 2 | 本人は自分の情報を編集できる（owner権限） | user | EMP000002（本人）→「従業員変更」表示→フィールド有効→「更新」ボタンあり |
+| 3 | 一般ユーザーは他人の情報を閲覧のみ | user | EMP000003→「従業員詳細」表示→フィールド無効→「更新」ボタンなし→「削除」ボタンなし |
+| 4 | 管理者には削除ボタンが表示される | admin | EMP000003の詳細→「削除」ボタンあり |
+| 5 | 管理者が従業員を削除できる | admin | テスト用従業員を作成→削除→一覧にリダイレクト→トースト「従業員を削除しました。」→検索で見つからない |
+| 6 | 存在しない従業員コードで404が表示される | admin | `/employees/EMP999999`→Not Foundページ |
+
+**合計: 17テスト**
+
+---
+
+## 実装ステップ
+
+### Step 1: employees-list.e2e.ts の作成
+- 一覧画面の7テストを実装
+- 既存のdashboard.e2e.tsをパターン参考にする
+- `test.use({ storageState })` でuser権限テストを実装
+
+### Step 2: employees-create.e2e.ts の作成
+- 新規作成画面の4テストを実装
+- Happy Pathテストで使う従業員コードは `EMP099901`（seed範囲外）
+- トーストの検証は `page.getByText("従業員を登録しました。")` で行う
+
+### Step 3: employees-detail.e2e.ts の作成
+- 詳細・編集・削除画面の6テストを実装
+- 削除テストはStep 2で作成した従業員を使うか、別途作成してから削除する
+- 更新テストはEMP000050など影響の少ないseed従業員を使用
+
+### Step 4: テスト実行・確認
+- `npx playwright test src/app/(features)/employees/` でemployeesテストのみ実行
+- 失敗があれば修正
+
+---
+
+## テストデータ戦略
+
+| 用途 | 使用する従業員 | 理由 |
+|------|-------------|------|
+| 一覧表示確認 | seed全体 | 件数を問わず「表示される」ことを確認 |
+| 検索テスト | seed内の既知データ | EMP000001（コード完全一致）、employee1（メール部分一致）、admin（権限フィルタ） |
+| 作成テスト | EMP099901（新規作成） | seed範囲(〜EMP002000)外で衝突回避 |
+| 更新テスト | EMP000050 | 認証アカウント(001,002)以外のseed従業員 |
+| 削除テスト | テスト内で作成した従業員 | 他テストへの影響を防ぐ |
+| 権限テスト | EMP000002(本人), EMP000003(他人) | user認証はEMP000002なので |
+
+## 重要ファイル
+
+- `src/app/(features)/dashboard/dashboard.e2e.ts` — E2Eテストの参考パターン
+- `src/app/(auth)/auth.setup.ts` — 認証セットアップ（admin.json, user.json生成）
+- `playwright.config.ts` — Playwright設定
+- `src/app/(features)/employees/page.tsx` — 一覧画面
+- `src/app/(features)/employees/new/page.tsx` — 新規作成画面
+- `src/app/(features)/employees/[employeeCd]/page.tsx` — 詳細画面
+- `src/app/_components/redirect-reason-toast.tsx` — トースト表示ロジック（reason→メッセージ変換）
+- `src/shared/constants/redirect-reasons.ts` — リダイレクト理由定数
+
+## 検証方法
+
+```bash
+# employeesのE2Eテストのみ実行
+npx playwright test src/app/(features)/employees/
+
+# 全E2Eテスト実行（回帰確認）
+npx playwright test
+
+# UIモードで確認（デバッグ用）
+npx playwright test --ui
+```

--- a/src/app/(features)/employees/employees-create.e2e.ts
+++ b/src/app/(features)/employees/employees-create.e2e.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+
+/** テストで使用する固定の従業員データ（seed範囲 EMP000001〜EMP002000 外） */
+const TEST_EMPLOYEE_CD = "EMP099901";
+const TEST_EMAIL = "e2e-create-test@example.com";
+
+test.describe("従業員新規作成（管理者）", () => {
+  test.describe("データ作成テスト", () => {
+    // 暫定対応: テストで作成した従業員をUIから削除する（#157 で改善予定）
+    test.afterEach(async ({ page }) => {
+      await page.goto(`/employees/${TEST_EMPLOYEE_CD}`);
+      const deleteButton = page.getByRole("button", { name: "削除" });
+      if (await deleteButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await deleteButton.click();
+        await expect(page).toHaveURL(/\/employees/, { timeout: 10000 });
+      }
+    });
+
+    test("管理者が新規従業員を作成できる", async ({ page }) => {
+      // 一覧画面から新規登録画面に遷移
+      await page.goto("/employees");
+      await page.getByRole("link", { name: "新規登録" }).click();
+      await expect(page).toHaveURL("/employees/new", { timeout: 10000 });
+      await expect(page.getByRole("heading", { name: "新規従業員登録" })).toBeVisible();
+
+      // フォーム入力
+      await page.getByLabel("名前").fill("E2Eテスト従業員");
+      await page.getByLabel("メールアドレス").fill(TEST_EMAIL);
+      await page.getByLabel("従業員コード").fill(TEST_EMPLOYEE_CD);
+      await page.getByLabel("所属部署").selectOption({ index: 1 }); // 最初の部署を選択
+      await page.getByLabel("パスワード").fill("testpass123");
+      // 権限はデフォルト「一般ユーザー」のまま
+
+      // 登録実行
+      await page.getByRole("button", { name: "登録" }).click();
+
+      // 一覧画面にリダイレクトされ、成功トーストが表示される
+      await expect(page).toHaveURL(/\/employees/, { timeout: 10000 });
+      await page.waitForLoadState("load");
+      await expect(page.getByText("従業員を登録しました。")).toBeVisible({ timeout: 10000 });
+
+      // 作成した従業員が検索で見つかる
+      await expect(page.locator("table tbody tr").first()).toBeVisible();
+      await page.getByLabel("従業員コード").fill(TEST_EMPLOYEE_CD);
+      await page.getByRole("button", { name: "検索" }).click();
+      await expect(page).toHaveURL(new RegExp(`employeeCd=${TEST_EMPLOYEE_CD}`), {
+        timeout: 10000,
+      });
+      await expect(page.getByRole("link", { name: TEST_EMPLOYEE_CD })).toBeVisible();
+    });
+  });
+
+  test("重複する従業員コードでエラーが表示される", async ({ page }) => {
+    await page.goto("/employees/new");
+
+    await page.getByLabel("名前").fill("重複テスト");
+    await page.getByLabel("メールアドレス").fill("e2e-duplicate-test@example.com");
+    await page.getByLabel("従業員コード").fill("EMP000001"); // 既存の従業員コード
+    await page.getByLabel("所属部署").selectOption({ index: 1 });
+    await page.getByLabel("パスワード").fill("testpass123");
+
+    await page.getByRole("button", { name: "登録" }).click();
+
+    // エラーメッセージが表示される（ページは遷移しない）
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(/\/employees\/new/);
+  });
+
+  test("キャンセルボタンで一覧に戻れる", async ({ page }) => {
+    await page.goto("/employees/new");
+
+    await page.getByRole("link", { name: "キャンセル" }).click();
+
+    await expect(page).toHaveURL(/\/employees$/, { timeout: 10000 });
+  });
+});
+
+test.describe("従業員新規作成（一般ユーザー）", () => {
+  test.use({ storageState: "playwright/.auth/user.json" });
+
+  test("一般ユーザーは新規作成画面にアクセスできない", async ({ page }) => {
+    await page.goto("/employees/new");
+
+    // 権限がないため /signin にリダイレクトされる
+    await expect(page).toHaveURL(/\/signin\?reason=forbidden/, { timeout: 10000 });
+  });
+});

--- a/src/app/(features)/employees/employees-detail.e2e.ts
+++ b/src/app/(features)/employees/employees-detail.e2e.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "@playwright/test";
+
+/** テストで使用する固定の従業員データ（seed範囲 EMP000001〜EMP002000 外） */
+const TEST_EMPLOYEE_CD = "EMP099902";
+const TEST_EMAIL = "e2e-detail-test@example.com";
+
+/**
+ * テスト用従業員を新規作成画面から作成し、一覧にリダイレクトされるまで待つ。
+ */
+async function createTestEmployee(
+  page: import("@playwright/test").Page,
+  data: { employeeCd: string; email: string; name: string }
+) {
+  await page.goto("/employees/new");
+  await expect(page.getByRole("heading", { name: "新規従業員登録" })).toBeVisible();
+  await page.getByLabel("名前").fill(data.name);
+  await page.getByLabel("メールアドレス").fill(data.email);
+  await page.getByLabel("従業員コード").fill(data.employeeCd);
+  await page.getByLabel("所属部署").selectOption({ index: 1 });
+  await page.getByLabel("パスワード").fill("testpass123");
+  await page.getByRole("button", { name: "登録" }).click();
+  await expect(page).toHaveURL(/\/employees/, { timeout: 10000 });
+}
+
+test.describe("従業員詳細・編集・削除（管理者）", () => {
+  test("管理者が従業員情報を更新できる", async ({ page }) => {
+    await page.goto("/employees/EMP000050");
+
+    // 編集モードで表示されること
+    await expect(page.getByRole("heading", { name: "従業員管理" })).toBeVisible();
+    await expect(page.getByText("従業員変更")).toBeVisible();
+
+    // 従業員コードが読み取り専用であること
+    await expect(page.locator("#employeeCd-display")).toBeDisabled();
+
+    // 名前を変更して更新
+    const nameField = page.getByLabel("名前");
+    await nameField.clear();
+    await nameField.fill("E2E更新テスト");
+    await page.getByRole("button", { name: "更新" }).click();
+
+    // 成功トーストが表示される
+    await expect(page.getByText("従業員情報を更新しました。")).toBeVisible({ timeout: 10000 });
+
+    // 変更が反映されていること
+    await expect(nameField).toHaveValue("E2E更新テスト");
+  });
+
+  test("管理者には削除ボタンが表示される", async ({ page }) => {
+    await page.goto("/employees/EMP000003");
+
+    await expect(page.getByRole("button", { name: "削除" })).toBeVisible();
+  });
+
+  test.describe("削除テスト", () => {
+    // 暫定対応: テスト用従業員をUIから作成する（#157 で改善予定）
+    test.beforeEach(async ({ page }) => {
+      await createTestEmployee(page, {
+        employeeCd: TEST_EMPLOYEE_CD,
+        email: TEST_EMAIL,
+        name: "削除テスト従業員",
+      });
+    });
+
+    test("管理者が従業員を削除できる", async ({ page }) => {
+      // 作成した従業員の詳細画面に遷移
+      await page.goto(`/employees/${TEST_EMPLOYEE_CD}`);
+      await expect(page.getByText("従業員変更")).toBeVisible();
+
+      // 削除実行
+      await page.getByRole("button", { name: "削除" }).click();
+
+      // 一覧画面にリダイレクトされ、成功トーストが表示される
+      await expect(page).toHaveURL(/\/employees/, { timeout: 10000 });
+      await expect(page.getByText("従業員を削除しました。")).toBeVisible({ timeout: 10000 });
+
+      // 削除した従業員が検索で見つからない
+      await expect(page.locator("table tbody tr").first()).toBeVisible();
+      await page.getByLabel("従業員コード").fill(TEST_EMPLOYEE_CD);
+      await page.getByRole("button", { name: "検索" }).click();
+      await expect(page).toHaveURL(new RegExp(`employeeCd=${TEST_EMPLOYEE_CD}`), {
+        timeout: 10000,
+      });
+      await expect(page.getByRole("link", { name: TEST_EMPLOYEE_CD })).not.toBeVisible();
+    });
+  });
+
+  test("存在しない従業員コードで404が表示される", async ({ page }) => {
+    await page.goto("/employees/EMP999999");
+
+    // 404ページが表示されること
+    await expect(page.getByText("404")).toBeVisible({ timeout: 10000 });
+  });
+});
+
+test.describe("従業員詳細（一般ユーザー）", () => {
+  test.use({ storageState: "playwright/.auth/user.json" });
+
+  test("本人は自分の情報を編集できる（owner権限）", async ({ page }) => {
+    // employee2 (EMP000002) は user 認証のアカウント
+    await page.goto("/employees/EMP000002");
+
+    await expect(page.getByText("従業員変更")).toBeVisible();
+    // フィールドが有効（disabled でない）
+    await expect(page.getByLabel("名前")).toBeEnabled();
+    await expect(page.getByLabel("メールアドレス")).toBeEnabled();
+    // 更新ボタンが表示される
+    await expect(page.getByRole("button", { name: "更新" })).toBeVisible();
+  });
+
+  test("一般ユーザーは他人の情報を閲覧のみ", async ({ page }) => {
+    await page.goto("/employees/EMP000003");
+
+    // 閲覧モードで表示されること
+    await expect(page.getByText("従業員詳細")).toBeVisible();
+    // フィールドが無効（disabled）
+    await expect(page.getByLabel("名前")).toBeDisabled();
+    await expect(page.getByLabel("メールアドレス")).toBeDisabled();
+    // 更新ボタンが表示されない
+    await expect(page.getByRole("button", { name: "更新" })).not.toBeVisible();
+    // 削除ボタンが表示されない
+    await expect(page.getByRole("button", { name: "削除" })).not.toBeVisible();
+  });
+});

--- a/src/app/(features)/employees/employees-list.e2e.ts
+++ b/src/app/(features)/employees/employees-list.e2e.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * 一覧画面のハイドレーション完了を待つ。
+ * SearchForm（"use client"）の onSubmit が機能するには React のハイドレーションが必要。
+ * DataTable の行が表示された時点で、ページ全体がインタラクティブになっていると判断する。
+ */
+async function waitForListReady(page: import("@playwright/test").Page) {
+  await expect(page.getByRole("heading", { name: "従業員管理" })).toBeVisible();
+  await expect(page.locator("table tbody tr").first()).toBeVisible();
+}
+
+test.describe("従業員一覧（管理者）", () => {
+  test("一覧が表示され、管理者には「新規登録」ボタンが見える", async ({ page }) => {
+    await page.goto("/employees");
+    await waitForListReady(page);
+
+    await expect(page.getByRole("heading", { name: "従業員管理" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "新規登録" })).toBeVisible();
+
+    // DataTableに行が表示されていること
+    await expect(page.getByRole("heading", { name: "従業員一覧" })).toBeVisible();
+    const rows = page.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible();
+  });
+
+  test("メールアドレスで検索（部分一致）できる", async ({ page }) => {
+    await page.goto("/employees");
+    await waitForListReady(page);
+
+    await page.getByLabel("メールアドレス").fill("employee1");
+    await page.getByRole("button", { name: "検索" }).click();
+
+    await expect(page).toHaveURL(/email=employee1/, { timeout: 10000 });
+    await expect(page.getByText("employee1@example.com")).toBeVisible();
+  });
+
+  test("従業員コードで検索（完全一致）できる", async ({ page }) => {
+    await page.goto("/employees");
+    await waitForListReady(page);
+
+    await page.getByLabel("従業員コード").fill("EMP000001");
+    await page.getByRole("button", { name: "検索" }).click();
+
+    await expect(page).toHaveURL(/employeeCd=EMP000001/, { timeout: 10000 });
+    // 検索結果が1行のみ表示されること
+    const rows = page.locator("table tbody tr");
+    await expect(rows).toHaveCount(1);
+    await expect(page.getByRole("link", { name: "EMP000001" })).toBeVisible();
+  });
+
+  test("権限で検索できる", async ({ page }) => {
+    await page.goto("/employees");
+    await waitForListReady(page);
+
+    await page.getByLabel("権限").selectOption("admin");
+    await page.getByRole("button", { name: "検索" }).click();
+
+    await expect(page).toHaveURL(/role=admin/, { timeout: 10000 });
+    // 表示されている権限バッジがすべて「管理者」であること
+    const roleCells = page.locator("table tbody tr td:nth-child(4) span");
+    const count = await roleCells.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(roleCells.nth(i)).toHaveText("管理者");
+    }
+  });
+
+  test("クリアボタンで検索条件がリセットされる", async ({ page }) => {
+    await page.goto("/employees?email=employee1");
+    await waitForListReady(page);
+
+    // 検索フィールドにデフォルト値が入っていること
+    await expect(page.getByLabel("メールアドレス")).toHaveValue("employee1");
+
+    await page.getByRole("button", { name: "クリア" }).click();
+
+    await expect(page).toHaveURL(/\/employees$/, { timeout: 10000 });
+    await expect(page.getByLabel("メールアドレス")).toHaveValue("");
+  });
+
+  test("従業員コードリンクから詳細画面に遷移できる", async ({ page }) => {
+    await page.goto("/employees?employeeCd=EMP000001");
+    await waitForListReady(page);
+
+    await page.getByRole("link", { name: "EMP000001" }).click();
+
+    await expect(page).toHaveURL(/\/employees\/EMP000001/, { timeout: 10000 });
+    await expect(page.getByRole("heading", { name: "従業員管理" })).toBeVisible();
+  });
+});
+
+test.describe("従業員一覧（一般ユーザー）", () => {
+  test.use({ storageState: "playwright/.auth/user.json" });
+
+  test("一般ユーザーには「新規登録」ボタンが見えない", async ({ page }) => {
+    await page.goto("/employees");
+
+    await expect(page.getByRole("heading", { name: "従業員管理" })).toBeVisible();
+    // DataTableの行は表示される
+    const rows = page.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible();
+    // 「新規登録」リンクは表示されない
+    await expect(page.getByRole("link", { name: "新規登録" })).not.toBeVisible();
+  });
+});

--- a/src/app/(features)/employees/page.tsx
+++ b/src/app/(features)/employees/page.tsx
@@ -1,3 +1,6 @@
+import { DataTable } from "@/app/_components/shared/DataTable";
+import { SearchForm, type SearchFieldDef } from "@/app/_components/shared/SearchForm";
+import { LIST_FETCH_LIMIT, getStringParam, type SearchParams } from "@/app/_lib/searchParams";
 import { verifySession } from "@/app/_lib/verifyAuthentication";
 import { isAdmin } from "@server/shared/auth";
 import { USER_ROLES, type UserRole } from "@server/shared/auth/types";
@@ -5,10 +8,7 @@ import { SearchEmployeesQuery } from "@subdomains/employee/application/queries/S
 import type { EmployeeSearchCriteria } from "@subdomains/employee/application/queries/dto/EmployeeSearchCriteria";
 import { PrismaEmployeeQueryService } from "@subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService";
 import Link from "next/link";
-import { SearchForm, type SearchFieldDef } from "@/app/_components/shared/SearchForm";
-import { DataTable } from "@/app/_components/shared/DataTable";
 import { columns } from "./_components/columns";
-import { type SearchParams, LIST_FETCH_LIMIT, getStringParam } from "@/app/_lib/searchParams";
 
 // NOTE: このページの検索機能の実装としては、URLのパスパラメタに基づいて検索を実行する。そのため初期検索は全件取得。
 // NOTE: 検索条件を入力して検索ボタンを押すと直接検索APIが実行されるのではなく、まず入力した検索条件をパスパラメタに設定してナビゲーションし、レンダリング時に検索処理が実行される。
@@ -58,7 +58,7 @@ export default async function EmployeePage({
   const searchQuery = new SearchEmployeesQuery(queryService);
   const employees = await searchQuery.execute({
     criteria,
-    options: { limit: LIST_FETCH_LIMIT },
+    options: { limit: LIST_FETCH_LIMIT, orderBy: { field: "employeeCd", direction: "asc" } },
   });
 
   // Client Componentに渡すdefaultValues

--- a/src/app/_components/shared/user-display.tsx
+++ b/src/app/_components/shared/user-display.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useIsClient } from "@/app/_hooks/useIsClient";
 import { useSession } from "@/app/_lib/auth-client";
 import { Loader2Icon } from "lucide-react";
 
@@ -12,9 +13,10 @@ import { Loader2Icon } from "lucide-react";
  * @see learning/auth-responsibilities-and-changeability.md
  */
 export const UserDisplay = () => {
+  const isClient = useIsClient();
   const { data: session, isPending } = useSession();
 
-  if (isPending) {
+  if (!isClient || isPending) {
     return <Loader2Icon className="size-4 animate-spin" />;
   }
 

--- a/src/app/_hooks/useIsClient.ts
+++ b/src/app/_hooks/useIsClient.ts
@@ -1,0 +1,20 @@
+import { useSyncExternalStore } from "react";
+
+const subscribe = () => () => {};
+
+/**
+ * クライアント環境かどうかを判定するフック。
+ *
+ * useSyncExternalStoreのgetServerSnapshotはサーバーレンダリング時と
+ * クライアントのハイドレーション時に使用されるため、サーバーHTMLと
+ * ハイドレーション時のレンダリングが一致し、ミスマッチを防止できる。
+ *
+ * @see https://react.dev/reference/react/useSyncExternalStore#adding-support-for-server-rendering
+ */
+export function useIsClient() {
+  return useSyncExternalStore(
+    subscribe,
+    () => true,
+    () => false
+  );
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,9 @@
-import { getCurrentSession } from "@server/shared/auth";
+import { getCurrentSession, isAdmin } from "@server/shared/auth";
 import { REDIRECT_REASON } from "@shared/constants/redirect-reasons";
 import { NextRequest, NextResponse } from "next/server";
 
 const publicRoutes = ["/signin", "/"];
+const adminRoutes = ["/employees/new"];
 
 export async function proxy(request: NextRequest) {
   const path = request.nextUrl.pathname;
@@ -16,6 +17,13 @@ export async function proxy(request: NextRequest) {
       new URL(`/signin?reason=${REDIRECT_REASON.SESSION_EXPIRED}`, request.url)
     );
   }
+
+  if (session && adminRoutes.includes(path) && !isAdmin(session)) {
+    return NextResponse.redirect(
+      new URL(`/signin?reason=${REDIRECT_REASON.FORBIDDEN}`, request.url)
+    );
+  }
+
   return NextResponse.next();
 }
 export const config = {


### PR DESCRIPTION
## Summary

employees管理画面（一覧・新規作成・詳細・編集・削除）のE2Eテストを17件作成しました。テスト作成過程で発見したバグ2件の修正と、テストに必要な機能追加1件を含みます。

- E2Eテスト17件: 一覧画面7件、新規作成画面4件、詳細・編集・削除画面6件
- バグ修正: UserDisplayのハイドレーションミスマッチ修正 (#154)、従業員一覧ソート修正 (#155)
- 機能追加: proxy.tsでの管理者専用ルート認可チェック追加 (#158)

Closes #124 #154 #155 #158

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### squishy-seeking-barto.md

#### テスト境界の設計方針

- 既存のコンポーネント単体テスト（Vitest + RTL）がカバーする範囲と、E2Eテストで担保すべき範囲を明確に分離
- コンポーネント統合テスト（中間層）は現時点では不要と判断。E2Eテストで十分カバー可能

#### E2Eテストケース設計（合計17テスト）

**A. employees-list.e2e.ts — 一覧画面 (7テスト)**
1. 一覧表示・管理者の「新規登録」ボタン表示
2. 一般ユーザーの「新規登録」ボタン非表示
3. メールアドレスで部分一致検索
4. 従業員コードで完全一致検索
5. 権限で検索
6. クリアボタンで検索条件リセット
7. 従業員コードリンクから詳細画面に遷移

**B. employees-create.e2e.ts — 新規作成画面 (4テスト)**
1. 管理者が新規従業員を作成（Happy Path）
2. 一般ユーザーは新規作成画面にアクセス不可
3. 重複する従業員コードでエラー表示
4. キャンセルボタンで一覧に戻る

**C. employees-detail.e2e.ts — 詳細・編集・削除画面 (6テスト)**
1. 管理者が従業員情報を更新
2. 本人は自分の情報を編集可能（owner権限）
3. 一般ユーザーは他人の情報を閲覧のみ
4. 管理者には削除ボタンが表示
5. 管理者が従業員を削除
6. 存在しない従業員コードで404表示

#### 実装ステップ
- Step 1: employees-list.e2e.ts の作成
- Step 2: employees-create.e2e.ts の作成
- Step 3: employees-detail.e2e.ts の作成
- Step 4: テスト実行・確認

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

- [ ] `npx playwright test src/app/(features)/employees/` でemployeesのE2Eテスト17件が全てパスする
- [ ] `npx playwright test` で既存E2Eテスト含め全テストが回帰なくパスする
- [ ] 管理者権限テスト: 新規作成・編集・削除が管理者のみ実行可能であることをE2Eで確認
- [ ] 一般ユーザー権限テスト: 閲覧のみ可能、新規作成画面アクセスでリダイレクトされることをE2Eで確認
- [ ] owner権限テスト: 本人は自分の情報を編集可能であることをE2Eで確認

---

Generated with [Claude Code](https://claude.ai/code)