### PR TITLE
feat: 役職・役割テーブルの追加および従業員テーブルへの上位役割ID追加

### DIFF
--- a/docs/claude-plans/issue-160/dreamy-gliding-babbage.md
+++ b/docs/claude-plans/issue-160/dreamy-gliding-babbage.md
@@ -1,0 +1,175 @@
+# Issue #160: 役職・役割テーブルの追加および従業員テーブルへの上位役割ID追加
+
+## Context
+
+承認フロー実装の基盤として、役職（Position）・役割（Role）・従業員役割（EmployeeRole）テーブルを追加する。
+承認チェーンは従業員の上位役割を起点に、役割の自己参照を辿って構築される（ADR-003）。
+現在のスキーマにはこれらのモデルが存在しないため、スキーマ定義・マイグレーション・シードデータの投入を行う。
+
+**スコープ**: スキーマ + マイグレーション + シードデータのみ。ドメイン層のエンティティ・リポジトリ等は承認フロー実装時に追加する。
+
+## 設計判断
+
+- **EmployeeRole は Employee を参照**（User ではない）。承認フローはドメインエンティティである Employee を起点とするため。
+- **ドメイン層の変更は本issueのスコープ外**。Employee エンティティへの `superiorRoleId` 追加は、承認フローの実装時に行う。
+- **Position/Role にタイムスタンプは不要**。静的なマスタデータのため。
+- **ID は CUID を使用せず、ハードコード文字列ID**（シードデータ）。既存の Department パターン（`"dept-001"`）に合わせる。
+
+---
+
+## Step 1: Position モデルを schema.prisma に追加
+
+**ファイル**: `prisma/schema.prisma`
+
+Employee セクションの前に「役職・役割関連」セクションを追加。
+
+```prisma
+// ========================================
+// 役職・役割関連
+// ========================================
+
+model Position {
+  id   String @id // シードデータで固定ID
+  name String @unique // 役職名（課長・部長・本部長・社長）
+
+  // 上位役職（自己参照）：社長は NULL
+  superiorPositionId String?    @map("superior_position_id")
+  superiorPosition   Position?  @relation("PositionHierarchy", fields: [superiorPositionId], references: [id])
+  subordinates       Position[] @relation("PositionHierarchy")
+
+  // 逆参照
+  roles Role[]
+
+  @@map("positions")
+}
+```
+
+## Step 2: Role モデルを schema.prisma に追加
+
+```prisma
+model Role {
+  id   String @id // ドメイン層でCUID生成
+  name String // 役割名（大阪市南課長・大阪市部長など）
+
+  // 上位役割（自己参照）
+  superiorRoleId String? @map("superior_role_id")
+  superiorRole   Role?   @relation("RoleHierarchy", fields: [superiorRoleId], references: [id])
+  subordinates   Role[]  @relation("RoleHierarchy")
+
+  // 所属役職
+  positionId String   @map("position_id")
+  position   Position @relation(fields: [positionId], references: [id])
+
+  // 逆参照
+  employeeRoles       EmployeeRole[]
+  employeesAsSuperior Employee[]     @relation("EmployeeSuperiorRole")
+
+  @@index([positionId])
+  @@map("roles")
+}
+```
+
+## Step 3: EmployeeRole モデルを schema.prisma に追加
+
+```prisma
+model EmployeeRole {
+  // 複合PK（従業員ID + 役割ID）
+  employeeId String   @map("employee_id")
+  employee   Employee @relation(fields: [employeeId], references: [id])
+  roleId     String   @map("role_id")
+  role       Role     @relation(fields: [roleId], references: [id])
+
+  @@id([employeeId, roleId])
+  @@map("employee_roles")
+}
+```
+
+## Step 4: Employee モデルに superiorRoleId を追加
+
+**ファイル**: `prisma/schema.prisma` の Employee モデル
+
+```prisma
+// 上位役割（承認フローの起点）
+superiorRoleId String? @map("superior_role_id")
+superiorRole   Role?   @relation("EmployeeSuperiorRole", fields: [superiorRoleId], references: [id])
+
+// 従業員役割（逆参照）
+employeeRoles EmployeeRole[]
+```
+
+`@@index` に `superiorRoleId` を追加:
+```prisma
+@@index([superiorRoleId])
+```
+
+## Step 5: マイグレーション作成・適用
+
+```bash
+pnpm db:migrate --name add_position_role_tables
+pnpm db:generate
+```
+
+## Step 6: シードデータに役職マスタ4件を追加
+
+**ファイル**: `prisma/seed.ts`
+
+### 6a: POSITIONS 定数を追加
+
+```typescript
+const POSITIONS = [
+  { id: "pos-001", name: "課長", superiorPositionId: "pos-002" },
+  { id: "pos-002", name: "部長", superiorPositionId: "pos-003" },
+  { id: "pos-003", name: "本部長", superiorPositionId: "pos-004" },
+  { id: "pos-004", name: "社長", superiorPositionId: null },
+];
+```
+
+### 6b: seedPositions() 関数を追加
+
+FK制約を考慮して上位から作成（社長 → 本部長 → 部長 → 課長）。
+
+```typescript
+async function seedPositions() {
+  // 上位から作成（FK制約を考慮）
+  const ordered = [...POSITIONS].sort((a, b) => {
+    if (a.superiorPositionId === null) return -1;
+    if (b.superiorPositionId === null) return 1;
+    return b.id.localeCompare(a.id);
+  });
+  for (const pos of ordered) {
+    await prisma.position.create({ data: pos });
+  }
+}
+```
+
+### 6c: deleteMany に追加（FK制約順序を考慮）
+
+`employee.deleteMany()` の前に以下を追加:
+```typescript
+await prisma.employeeRole.deleteMany();
+// employee.deleteMany() は既存のまま
+// employee の後に:
+await prisma.role.deleteMany();
+await prisma.position.deleteMany();
+```
+
+### 6d: main() で seedPositions() を呼び出し
+
+部署作成の後、得意先・従業員作成の前に配置。
+
+---
+
+## 対象ファイル一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `prisma/schema.prisma` | Position, Role, EmployeeRole 追加、Employee 修正 |
+| `prisma/seed.ts` | 役職シードデータ追加、deleteMany 順序修正 |
+
+## 検証
+
+1. `pnpm db:migrate` - マイグレーション正常適用
+2. `pnpm db:generate` - Prisma Client 再生成
+3. `pnpm db:seed` - シードデータ投入（役職4件含む）
+4. `pnpm build` - ビルド成功
+5. `pnpm test` - 既存テスト全パス

--- a/prisma/migrations/20260331034424_add_position_role_tables/migration.sql
+++ b/prisma/migrations/20260331034424_add_position_role_tables/migration.sql
@@ -1,0 +1,56 @@
+-- AlterTable
+ALTER TABLE "employees" ADD COLUMN     "superior_role_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "positions" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "superior_position_id" TEXT,
+
+    CONSTRAINT "positions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "roles" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "superior_role_id" TEXT,
+    "position_id" TEXT NOT NULL,
+
+    CONSTRAINT "roles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "employee_roles" (
+    "employee_id" TEXT NOT NULL,
+    "role_id" TEXT NOT NULL,
+
+    CONSTRAINT "employee_roles_pkey" PRIMARY KEY ("employee_id","role_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "positions_name_key" ON "positions"("name");
+
+-- CreateIndex
+CREATE INDEX "roles_position_id_idx" ON "roles"("position_id");
+
+-- CreateIndex
+CREATE INDEX "employees_superior_role_id_idx" ON "employees"("superior_role_id");
+
+-- AddForeignKey
+ALTER TABLE "positions" ADD CONSTRAINT "positions_superior_position_id_fkey" FOREIGN KEY ("superior_position_id") REFERENCES "positions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "roles" ADD CONSTRAINT "roles_superior_role_id_fkey" FOREIGN KEY ("superior_role_id") REFERENCES "roles"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "roles" ADD CONSTRAINT "roles_position_id_fkey" FOREIGN KEY ("position_id") REFERENCES "positions"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "employee_roles" ADD CONSTRAINT "employee_roles_employee_id_fkey" FOREIGN KEY ("employee_id") REFERENCES "employees"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "employee_roles" ADD CONSTRAINT "employee_roles_role_id_fkey" FOREIGN KEY ("role_id") REFERENCES "roles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "employees" ADD CONSTRAINT "employees_superior_role_id_fkey" FOREIGN KEY ("superior_role_id") REFERENCES "roles"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260331140000_add_position_cd_role_cd/migration.sql
+++ b/prisma/migrations/20260331140000_add_position_cd_role_cd/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "positions" ADD COLUMN "position_cd" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "roles" ADD COLUMN "role_cd" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "positions_position_cd_key" ON "positions"("position_cd");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "roles_role_cd_key" ON "roles"("role_cd");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,8 +19,9 @@ datasource db {
 // ========================================
 
 model Position {
-  id   String @id // シードデータで固定ID
-  name String @unique // 役職名（課長・部長・本部長・社長）
+  id         String @id // ドメイン層でCUID生成
+  positionCd String @unique @map("position_cd") // POS001 形式
+  name       String @unique // 役職名（課長・部長・本部長・社長）
 
   // 上位役職（自己参照）：社長は NULL
   superiorPositionId String?    @map("superior_position_id")
@@ -34,8 +35,9 @@ model Position {
 }
 
 model Role {
-  id   String @id // ドメイン層でCUID生成
-  name String // 役割名（大阪市南課長・大阪市部長など）
+  id     String @id // ドメイン層でCUID生成
+  roleCd String @unique @map("role_cd") // ROLE001 形式
+  name   String // 役割名（大阪市南課長・大阪市部長など）
 
   // 上位役割（自己参照）
   superiorRoleId String? @map("superior_role_id")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,57 @@ datasource db {
 }
 
 // ========================================
+// 役職・役割関連
+// ========================================
+
+model Position {
+  id   String @id // シードデータで固定ID
+  name String @unique // 役職名（課長・部長・本部長・社長）
+
+  // 上位役職（自己参照）：社長は NULL
+  superiorPositionId String?    @map("superior_position_id")
+  superiorPosition   Position?  @relation("PositionHierarchy", fields: [superiorPositionId], references: [id])
+  subordinates       Position[] @relation("PositionHierarchy")
+
+  // 逆参照
+  roles Role[]
+
+  @@map("positions")
+}
+
+model Role {
+  id   String @id // ドメイン層でCUID生成
+  name String // 役割名（大阪市南課長・大阪市部長など）
+
+  // 上位役割（自己参照）
+  superiorRoleId String? @map("superior_role_id")
+  superiorRole   Role?   @relation("RoleHierarchy", fields: [superiorRoleId], references: [id])
+  subordinates   Role[]  @relation("RoleHierarchy")
+
+  // 所属役職
+  positionId String   @map("position_id")
+  position   Position @relation(fields: [positionId], references: [id])
+
+  // 逆参照
+  employeeRoles       EmployeeRole[]
+  employeesAsSuperior Employee[]     @relation("EmployeeSuperiorRole")
+
+  @@index([positionId])
+  @@map("roles")
+}
+
+model EmployeeRole {
+  // 複合PK（従業員ID + 役割ID）
+  employeeId String   @map("employee_id")
+  employee   Employee @relation(fields: [employeeId], references: [id])
+  roleId     String   @map("role_id")
+  role       Role     @relation(fields: [roleId], references: [id])
+
+  @@id([employeeId, roleId])
+  @@map("employee_roles")
+}
+
+// ========================================
 // 従業員関連
 // ========================================
 
@@ -29,6 +80,13 @@ model Employee {
   departmentId String     @map("department_id")
   department   Department @relation(fields: [departmentId], references: [id])
 
+  // 上位役割（承認フローの起点）
+  superiorRoleId String? @map("superior_role_id")
+  superiorRole   Role?   @relation("EmployeeSuperiorRole", fields: [superiorRoleId], references: [id])
+
+  // 従業員役割（逆参照）
+  employeeRoles EmployeeRole[]
+
   // タイムスタンプ
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
@@ -37,6 +95,7 @@ model Employee {
   user User?
 
   @@index([departmentId])
+  @@index([superiorRoleId])
   @@map("employees")
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -138,6 +138,8 @@ interface SeedUser {
   name: string;
   role: UserRole;
   departmentId: string;
+  superiorRoleId: string | null;
+  assignedRoleId?: string; // 役割を持つ従業員の場合
 }
 
 // 部署リスト
@@ -181,6 +183,57 @@ const POSITIONS = [
   { id: "pos-003", name: "本部長", superiorPositionId: "pos-004" as string | null },
   { id: "pos-004", name: "社長", superiorPositionId: null },
 ];
+
+// 役割リスト（FK制約を考慮して上位から定義）
+const ROLES: { id: string; name: string; positionId: string; superiorRoleId: string | null }[] = [
+  // 社長（最上位）
+  { id: "role-01", name: "社長", positionId: "pos-004", superiorRoleId: null },
+  // 本部長
+  { id: "role-02", name: "営業本部長", positionId: "pos-003", superiorRoleId: "role-01" },
+  { id: "role-03", name: "管理本部長", positionId: "pos-003", superiorRoleId: "role-01" },
+  // 部長
+  { id: "role-04", name: "営業部長", positionId: "pos-002", superiorRoleId: "role-02" },
+  { id: "role-05", name: "開発部長", positionId: "pos-002", superiorRoleId: "role-03" },
+  { id: "role-06", name: "総務部長", positionId: "pos-002", superiorRoleId: "role-03" },
+  { id: "role-07", name: "人事部長", positionId: "pos-002", superiorRoleId: "role-03" },
+  { id: "role-08", name: "経理部長", positionId: "pos-002", superiorRoleId: "role-03" },
+  // 課長
+  { id: "role-09", name: "営業一課長", positionId: "pos-001", superiorRoleId: "role-04" },
+  { id: "role-10", name: "営業二課長", positionId: "pos-001", superiorRoleId: "role-04" },
+  { id: "role-11", name: "開発一課長", positionId: "pos-001", superiorRoleId: "role-05" },
+  { id: "role-12", name: "開発二課長", positionId: "pos-001", superiorRoleId: "role-05" },
+  { id: "role-13", name: "総務課長", positionId: "pos-001", superiorRoleId: "role-06" },
+  { id: "role-14", name: "人事課長", positionId: "pos-001", superiorRoleId: "role-07" },
+  { id: "role-15", name: "経理課長", positionId: "pos-001", superiorRoleId: "role-08" },
+];
+
+// 役割を持つ従業員の設定（EMP000001〜EMP000015）
+const ROLE_EMPLOYEE_CONFIGS = [
+  { roleId: "role-01", departmentId: "dept-001" }, // 社長 → 営業部（便宜上）
+  { roleId: "role-02", departmentId: "dept-001" }, // 営業本部長 → 営業部
+  { roleId: "role-03", departmentId: "dept-003" }, // 管理本部長 → 総務部
+  { roleId: "role-04", departmentId: "dept-001" }, // 営業部長 → 営業部
+  { roleId: "role-05", departmentId: "dept-002" }, // 開発部長 → 開発部
+  { roleId: "role-06", departmentId: "dept-003" }, // 総務部長 → 総務部
+  { roleId: "role-07", departmentId: "dept-004" }, // 人事部長 → 人事部
+  { roleId: "role-08", departmentId: "dept-005" }, // 経理部長 → 経理部
+  { roleId: "role-09", departmentId: "dept-001" }, // 営業一課長 → 営業部
+  { roleId: "role-10", departmentId: "dept-001" }, // 営業二課長 → 営業部
+  { roleId: "role-11", departmentId: "dept-002" }, // 開発一課長 → 開発部
+  { roleId: "role-12", departmentId: "dept-002" }, // 開発二課長 → 開発部
+  { roleId: "role-13", departmentId: "dept-003" }, // 総務課長 → 総務部
+  { roleId: "role-14", departmentId: "dept-004" }, // 人事課長 → 人事部
+  { roleId: "role-15", departmentId: "dept-005" }, // 経理課長 → 経理部
+];
+
+// 部署ごとの一般従業員の上位役割候補
+const DEPARTMENT_SUPERIOR_ROLES = new Map<string, string[]>([
+  ["dept-001", ["role-09", "role-10"]], // 営業部 → 営業一課長 or 営業二課長
+  ["dept-002", ["role-11", "role-12"]], // 開発部 → 開発一課長 or 開発二課長
+  ["dept-003", ["role-13"]], // 総務部 → 総務課長
+  ["dept-004", ["role-14"]], // 人事部 → 人事課長
+  ["dept-005", ["role-15"]], // 経理部 → 経理課長
+]);
 
 // 得意先・納品先データ
 const CUSTOMERS = [
@@ -739,13 +792,32 @@ function determineRole(index: number): UserRole {
 function generateSeedUsers(count: number): SeedUser[] {
   const users: SeedUser[] = [];
   for (let i = 1; i <= count; i++) {
-    users.push({
-      employeeCd: generateEmployeeCd(i),
-      email: generateEmail(i),
-      name: generateName(),
-      role: determineRole(i),
-      departmentId: randomChoice(DEPARTMENTS).id,
-    });
+    if (i <= ROLE_EMPLOYEE_CONFIGS.length) {
+      // 役割を持つ従業員（EMP000001〜EMP000015）
+      const config = ROLE_EMPLOYEE_CONFIGS[i - 1];
+      const assignedRole = ROLES.find((r) => r.id === config.roleId)!;
+      users.push({
+        employeeCd: generateEmployeeCd(i),
+        email: generateEmail(i),
+        name: generateName(),
+        role: i === 1 ? USER_ROLES.ADMIN : determineRole(i),
+        departmentId: config.departmentId,
+        superiorRoleId: assignedRole.superiorRoleId,
+        assignedRoleId: config.roleId,
+      });
+    } else {
+      // 一般従業員（部署に応じた課長を上位役割に設定）
+      const departmentId = randomChoice(DEPARTMENTS).id;
+      const candidates = DEPARTMENT_SUPERIOR_ROLES.get(departmentId)!;
+      users.push({
+        employeeCd: generateEmployeeCd(i),
+        email: generateEmail(i),
+        name: generateName(),
+        role: determineRole(i),
+        departmentId,
+        superiorRoleId: randomChoice(candidates),
+      });
+    }
   }
   return users;
 }
@@ -765,6 +837,7 @@ async function createUserWithEmployee(userData: SeedUser, hashedPassword: string
         email: userData.email,
         name: userData.name,
         departmentId: userData.departmentId,
+        superiorRoleId: userData.superiorRoleId,
       },
     });
 
@@ -927,6 +1000,14 @@ async function main() {
   console.log(`Created ${POSITIONS.length} positions`);
   console.log("");
 
+  // 役割を作成（ID順 = 上位から作成でFK制約を満たす）
+  console.log("Creating roles...");
+  for (const role of ROLES) {
+    await prisma.role.create({ data: role });
+  }
+  console.log(`Created ${ROLES.length} roles`);
+  console.log("");
+
   // 得意先・納品先を作成
   const { customerCount, deliveryLocationCount } = await seedCustomersAndDeliveryLocations();
 
@@ -944,10 +1025,16 @@ async function main() {
   // 各ユーザーを作成（バッチごとに進捗表示）
   console.log("Creating users...");
   const startTime = Date.now();
+  const employeeRoleData: { employeeId: string; roleId: string }[] = [];
 
   for (let i = 0; i < users.length; i++) {
     const userData = users[i];
-    await createUserWithEmployee(userData, hashedPassword);
+    const { employee } = await createUserWithEmployee(userData, hashedPassword);
+
+    // 役割を持つ従業員の場合、EmployeeRole 用のデータを収集
+    if (userData.assignedRoleId) {
+      employeeRoleData.push({ employeeId: employee.id, roleId: userData.assignedRoleId });
+    }
 
     if (userData.role === USER_ROLES.ADMIN) {
       adminCount++;
@@ -965,6 +1052,14 @@ async function main() {
     }
   }
 
+  // 従業員役割を作成
+  console.log("");
+  console.log("Creating employee roles...");
+  for (const data of employeeRoleData) {
+    await prisma.employeeRole.create({ data });
+  }
+  console.log(`Created ${employeeRoleData.length} employee role assignments`);
+
   const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
   console.log("");
   console.log("");
@@ -975,6 +1070,8 @@ async function main() {
   console.log(`  - Admins: ${adminCount}`);
   console.log(`  - Users: ${userCount}`);
   console.log(`Created ${POSITIONS.length} positions`);
+  console.log(`Created ${ROLES.length} roles`);
+  console.log(`Created ${employeeRoleData.length} employee role assignments`);
   console.log(`Created ${customerCount} customers`);
   console.log(`Created ${deliveryLocationCount} delivery locations`);
   console.log(`Default password for all users: ${DEFAULT_PASSWORD}`);

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -174,6 +174,14 @@ const DEPARTMENTS = [
   },
 ];
 
+// 役職リスト
+const POSITIONS = [
+  { id: "pos-001", name: "課長", superiorPositionId: "pos-002" as string | null },
+  { id: "pos-002", name: "部長", superiorPositionId: "pos-003" as string | null },
+  { id: "pos-003", name: "本部長", superiorPositionId: "pos-004" as string | null },
+  { id: "pos-004", name: "社長", superiorPositionId: null },
+];
+
 // 得意先・納品先データ
 const CUSTOMERS = [
   {
@@ -886,7 +894,10 @@ async function main() {
   await prisma.account.deleteMany();
   await prisma.session.deleteMany();
   await prisma.user.deleteMany();
+  await prisma.employeeRole.deleteMany();
   await prisma.employee.deleteMany();
+  await prisma.role.deleteMany();
+  await prisma.position.deleteMany();
   await prisma.department.deleteMany();
   console.log("Deleted existing data");
   console.log("");
@@ -905,6 +916,15 @@ async function main() {
     });
   }
   console.log(`Created ${DEPARTMENTS.length} departments`);
+  console.log("");
+
+  // 役職を作成（FK制約を考慮して上位から作成）
+  console.log("Creating positions...");
+  const positionsOrdered = [...POSITIONS].reverse();
+  for (const pos of positionsOrdered) {
+    await prisma.position.create({ data: pos });
+  }
+  console.log(`Created ${POSITIONS.length} positions`);
   console.log("");
 
   // 得意先・納品先を作成
@@ -954,6 +974,7 @@ async function main() {
   console.log(`Created ${TOTAL_EMPLOYEES} employees:`);
   console.log(`  - Admins: ${adminCount}`);
   console.log(`  - Users: ${userCount}`);
+  console.log(`Created ${POSITIONS.length} positions`);
   console.log(`Created ${customerCount} customers`);
   console.log(`Created ${deliveryLocationCount} delivery locations`);
   console.log(`Default password for all users: ${DEFAULT_PASSWORD}`);

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -176,63 +176,93 @@ const DEPARTMENTS = [
   },
 ];
 
-// 役職リスト
+// 役職リスト（cdで定義、idはシード時にCUID生成）
 const POSITIONS = [
-  { id: "pos-001", name: "課長", superiorPositionId: "pos-002" as string | null },
-  { id: "pos-002", name: "部長", superiorPositionId: "pos-003" as string | null },
-  { id: "pos-003", name: "本部長", superiorPositionId: "pos-004" as string | null },
-  { id: "pos-004", name: "社長", superiorPositionId: null },
+  { cd: "POS001", name: "課長", superiorCd: "POS002" as string | null },
+  { cd: "POS002", name: "部長", superiorCd: "POS003" as string | null },
+  { cd: "POS003", name: "本部長", superiorCd: "POS004" as string | null },
+  { cd: "POS004", name: "社長", superiorCd: null },
 ];
 
-// 役割リスト（FK制約を考慮して上位から定義）
-const ROLES: { id: string; name: string; positionId: string; superiorRoleId: string | null }[] = [
+// 役割リスト（cdで定義、FK参照はcd経由で解決）
+const ROLES = [
   // 社長（最上位）
-  { id: "role-01", name: "社長", positionId: "pos-004", superiorRoleId: null },
+  { cd: "ROLE001", name: "社長", positionCd: "POS004", superiorCd: null as string | null },
   // 本部長
-  { id: "role-02", name: "営業本部長", positionId: "pos-003", superiorRoleId: "role-01" },
-  { id: "role-03", name: "管理本部長", positionId: "pos-003", superiorRoleId: "role-01" },
+  {
+    cd: "ROLE002",
+    name: "営業本部長",
+    positionCd: "POS003",
+    superiorCd: "ROLE001" as string | null,
+  },
+  {
+    cd: "ROLE003",
+    name: "管理本部長",
+    positionCd: "POS003",
+    superiorCd: "ROLE001" as string | null,
+  },
   // 部長
-  { id: "role-04", name: "営業部長", positionId: "pos-002", superiorRoleId: "role-02" },
-  { id: "role-05", name: "開発部長", positionId: "pos-002", superiorRoleId: "role-03" },
-  { id: "role-06", name: "総務部長", positionId: "pos-002", superiorRoleId: "role-03" },
-  { id: "role-07", name: "人事部長", positionId: "pos-002", superiorRoleId: "role-03" },
-  { id: "role-08", name: "経理部長", positionId: "pos-002", superiorRoleId: "role-03" },
+  { cd: "ROLE004", name: "営業部長", positionCd: "POS002", superiorCd: "ROLE002" as string | null },
+  { cd: "ROLE005", name: "開発部長", positionCd: "POS002", superiorCd: "ROLE003" as string | null },
+  { cd: "ROLE006", name: "総務部長", positionCd: "POS002", superiorCd: "ROLE003" as string | null },
+  { cd: "ROLE007", name: "人事部長", positionCd: "POS002", superiorCd: "ROLE003" as string | null },
+  { cd: "ROLE008", name: "経理部長", positionCd: "POS002", superiorCd: "ROLE003" as string | null },
   // 課長
-  { id: "role-09", name: "営業一課長", positionId: "pos-001", superiorRoleId: "role-04" },
-  { id: "role-10", name: "営業二課長", positionId: "pos-001", superiorRoleId: "role-04" },
-  { id: "role-11", name: "開発一課長", positionId: "pos-001", superiorRoleId: "role-05" },
-  { id: "role-12", name: "開発二課長", positionId: "pos-001", superiorRoleId: "role-05" },
-  { id: "role-13", name: "総務課長", positionId: "pos-001", superiorRoleId: "role-06" },
-  { id: "role-14", name: "人事課長", positionId: "pos-001", superiorRoleId: "role-07" },
-  { id: "role-15", name: "経理課長", positionId: "pos-001", superiorRoleId: "role-08" },
+  {
+    cd: "ROLE009",
+    name: "営業一課長",
+    positionCd: "POS001",
+    superiorCd: "ROLE004" as string | null,
+  },
+  {
+    cd: "ROLE010",
+    name: "営業二課長",
+    positionCd: "POS001",
+    superiorCd: "ROLE004" as string | null,
+  },
+  {
+    cd: "ROLE011",
+    name: "開発一課長",
+    positionCd: "POS001",
+    superiorCd: "ROLE005" as string | null,
+  },
+  {
+    cd: "ROLE012",
+    name: "開発二課長",
+    positionCd: "POS001",
+    superiorCd: "ROLE005" as string | null,
+  },
+  { cd: "ROLE013", name: "総務課長", positionCd: "POS001", superiorCd: "ROLE006" as string | null },
+  { cd: "ROLE014", name: "人事課長", positionCd: "POS001", superiorCd: "ROLE007" as string | null },
+  { cd: "ROLE015", name: "経理課長", positionCd: "POS001", superiorCd: "ROLE008" as string | null },
 ];
 
 // 役割を持つ従業員の設定（EMP000001〜EMP000015）
 const ROLE_EMPLOYEE_CONFIGS = [
-  { roleId: "role-01", departmentId: "dept-001" }, // 社長 → 営業部（便宜上）
-  { roleId: "role-02", departmentId: "dept-001" }, // 営業本部長 → 営業部
-  { roleId: "role-03", departmentId: "dept-003" }, // 管理本部長 → 総務部
-  { roleId: "role-04", departmentId: "dept-001" }, // 営業部長 → 営業部
-  { roleId: "role-05", departmentId: "dept-002" }, // 開発部長 → 開発部
-  { roleId: "role-06", departmentId: "dept-003" }, // 総務部長 → 総務部
-  { roleId: "role-07", departmentId: "dept-004" }, // 人事部長 → 人事部
-  { roleId: "role-08", departmentId: "dept-005" }, // 経理部長 → 経理部
-  { roleId: "role-09", departmentId: "dept-001" }, // 営業一課長 → 営業部
-  { roleId: "role-10", departmentId: "dept-001" }, // 営業二課長 → 営業部
-  { roleId: "role-11", departmentId: "dept-002" }, // 開発一課長 → 開発部
-  { roleId: "role-12", departmentId: "dept-002" }, // 開発二課長 → 開発部
-  { roleId: "role-13", departmentId: "dept-003" }, // 総務課長 → 総務部
-  { roleId: "role-14", departmentId: "dept-004" }, // 人事課長 → 人事部
-  { roleId: "role-15", departmentId: "dept-005" }, // 経理課長 → 経理部
+  { roleCd: "ROLE001", departmentId: "dept-001" }, // 社長 → 営業部（便宜上）
+  { roleCd: "ROLE002", departmentId: "dept-001" }, // 営業本部長 → 営業部
+  { roleCd: "ROLE003", departmentId: "dept-003" }, // 管理本部長 → 総務部
+  { roleCd: "ROLE004", departmentId: "dept-001" }, // 営業部長 → 営業部
+  { roleCd: "ROLE005", departmentId: "dept-002" }, // 開発部長 → 開発部
+  { roleCd: "ROLE006", departmentId: "dept-003" }, // 総務部長 → 総務部
+  { roleCd: "ROLE007", departmentId: "dept-004" }, // 人事部長 → 人事部
+  { roleCd: "ROLE008", departmentId: "dept-005" }, // 経理部長 → 経理部
+  { roleCd: "ROLE009", departmentId: "dept-001" }, // 営業一課長 → 営業部
+  { roleCd: "ROLE010", departmentId: "dept-001" }, // 営業二課長 → 営業部
+  { roleCd: "ROLE011", departmentId: "dept-002" }, // 開発一課長 → 開発部
+  { roleCd: "ROLE012", departmentId: "dept-002" }, // 開発二課長 → 開発部
+  { roleCd: "ROLE013", departmentId: "dept-003" }, // 総務課長 → 総務部
+  { roleCd: "ROLE014", departmentId: "dept-004" }, // 人事課長 → 人事部
+  { roleCd: "ROLE015", departmentId: "dept-005" }, // 経理課長 → 経理部
 ];
 
-// 部署ごとの一般従業員の上位役割候補
-const DEPARTMENT_SUPERIOR_ROLES = new Map<string, string[]>([
-  ["dept-001", ["role-09", "role-10"]], // 営業部 → 営業一課長 or 営業二課長
-  ["dept-002", ["role-11", "role-12"]], // 開発部 → 開発一課長 or 開発二課長
-  ["dept-003", ["role-13"]], // 総務部 → 総務課長
-  ["dept-004", ["role-14"]], // 人事部 → 人事課長
-  ["dept-005", ["role-15"]], // 経理部 → 経理課長
+// 部署ごとの一般従業員の上位役割候補（roleCdで指定）
+const DEPARTMENT_SUPERIOR_ROLE_CDS = new Map<string, string[]>([
+  ["dept-001", ["ROLE009", "ROLE010"]], // 営業部 → 営業一課長 or 営業二課長
+  ["dept-002", ["ROLE011", "ROLE012"]], // 開発部 → 開発一課長 or 開発二課長
+  ["dept-003", ["ROLE013"]], // 総務部 → 総務課長
+  ["dept-004", ["ROLE014"]], // 人事部 → 人事課長
+  ["dept-005", ["ROLE015"]], // 経理部 → 経理課長
 ]);
 
 // 得意先・納品先データ
@@ -788,34 +818,38 @@ function determineRole(index: number): UserRole {
   return Math.random() < ADMIN_RATIO ? USER_ROLES.ADMIN : USER_ROLES.USER;
 }
 
-// シードユーザーデータを生成
-function generateSeedUsers(count: number): SeedUser[] {
+// シードユーザーデータを生成（roleIdMap: roleCd → CUID）
+function generateSeedUsers(count: number, roleIdMap: Map<string, string>): SeedUser[] {
   const users: SeedUser[] = [];
   for (let i = 1; i <= count; i++) {
     if (i <= ROLE_EMPLOYEE_CONFIGS.length) {
       // 役割を持つ従業員（EMP000001〜EMP000015）
       const config = ROLE_EMPLOYEE_CONFIGS[i - 1];
-      const assignedRole = ROLES.find((r) => r.id === config.roleId)!;
+      const assignedRole = ROLES.find((r) => r.cd === config.roleCd)!;
+      const superiorRoleId = assignedRole.superiorCd
+        ? roleIdMap.get(assignedRole.superiorCd)!
+        : null;
       users.push({
         employeeCd: generateEmployeeCd(i),
         email: generateEmail(i),
         name: generateName(),
         role: i === 1 ? USER_ROLES.ADMIN : determineRole(i),
         departmentId: config.departmentId,
-        superiorRoleId: assignedRole.superiorRoleId,
-        assignedRoleId: config.roleId,
+        superiorRoleId,
+        assignedRoleId: roleIdMap.get(config.roleCd),
       });
     } else {
       // 一般従業員（部署に応じた課長を上位役割に設定）
       const departmentId = randomChoice(DEPARTMENTS).id;
-      const candidates = DEPARTMENT_SUPERIOR_ROLES.get(departmentId)!;
+      const candidateCds = DEPARTMENT_SUPERIOR_ROLE_CDS.get(departmentId)!;
+      const superiorRoleCd = randomChoice(candidateCds);
       users.push({
         employeeCd: generateEmployeeCd(i),
         email: generateEmail(i),
         name: generateName(),
         role: determineRole(i),
         departmentId,
-        superiorRoleId: randomChoice(candidates),
+        superiorRoleId: roleIdMap.get(superiorRoleCd)!,
       });
     }
   }
@@ -993,17 +1027,38 @@ async function main() {
 
   // 役職を作成（FK制約を考慮して上位から作成）
   console.log("Creating positions...");
+  const positionIdMap = new Map<string, string>(); // cd → CUID
   const positionsOrdered = [...POSITIONS].reverse();
   for (const pos of positionsOrdered) {
-    await prisma.position.create({ data: pos });
+    const id = createId();
+    positionIdMap.set(pos.cd, id);
+    await prisma.position.create({
+      data: {
+        id,
+        positionCd: pos.cd,
+        name: pos.name,
+        superiorPositionId: pos.superiorCd ? (positionIdMap.get(pos.superiorCd) ?? null) : null,
+      },
+    });
   }
   console.log(`Created ${POSITIONS.length} positions`);
   console.log("");
 
-  // 役割を作成（ID順 = 上位から作成でFK制約を満たす）
+  // 役割を作成（定義順 = 上位から作成でFK制約を満たす）
   console.log("Creating roles...");
+  const roleIdMap = new Map<string, string>(); // cd → CUID
   for (const role of ROLES) {
-    await prisma.role.create({ data: role });
+    const id = createId();
+    roleIdMap.set(role.cd, id);
+    await prisma.role.create({
+      data: {
+        id,
+        roleCd: role.cd,
+        name: role.name,
+        positionId: positionIdMap.get(role.positionCd)!,
+        superiorRoleId: role.superiorCd ? (roleIdMap.get(role.superiorCd) ?? null) : null,
+      },
+    });
   }
   console.log(`Created ${ROLES.length} roles`);
   console.log("");
@@ -1018,7 +1073,7 @@ async function main() {
   console.log("");
 
   // ユーザーデータを生成
-  const users = generateSeedUsers(TOTAL_EMPLOYEES);
+  const users = generateSeedUsers(TOTAL_EMPLOYEES, roleIdMap);
   let adminCount = 0;
   let userCount = 0;
 


### PR DESCRIPTION
## Summary

承認フロー実装の基盤として、役職（Position）・役割（Role）・従業員役割（EmployeeRole）テーブルを schema.prisma に追加し、従業員（Employee）テーブルに上位役割ID（superiorRoleId）を追加しました。

- 役職マスタ4件（課長・部長・本部長・社長）
- 役割15件（社長1、本部長2、部長5、課長7）の階層構造
- 全2000従業員への superiorRoleId 設定と、先頭15名への役割割り当て
- Position/Role の ID を CUID 化し、positionCd/roleCd カラムを追加（Employee/Department パターンに統一）

Closes #160

## 設計判断

| 判断 | 理由 |
|------|------|
| EmployeeRole は Employee を参照（User ではない） | 承認フローはドメインエンティティである Employee を起点とするため |
| ドメイン層の変更は本issueのスコープ外 | Employee エンティティへの superiorRoleId 追加は承認フロー実装時に対応 |
| Position/Role にタイムスタンプは不要 | 静的なマスタデータのため |
| ID は CUID + Code パターンに統一 | Employee/Department と同じ `id(CUID) + xxxCd(人間が読めるコード)` パターン |

## 変更内容

### スキーマ変更 (`prisma/schema.prisma`)
- **Position**: `id(CUID)` + `positionCd(POS001形式, UNIQUE)` + `name(UNIQUE)` + 自己参照（上位役職）
- **Role**: `id(CUID)` + `roleCd(ROLE001形式, UNIQUE)` + `name` + 自己参照（上位役割）+ Position FK
- **EmployeeRole**: `(employeeId, roleId)` 複合PK。従業員と役割の多対多中間テーブル
- **Employee**: `superiorRoleId`（nullable FK → Role）を追加。承認フローの起点

### シードデータ (`prisma/seed.ts`)
- 役職4件: 課長 → 部長 → 本部長 → 社長（階層構造）
- 役割15件: 組織階層に沿った役割定義
  ```
  社長
  ├── 営業本部長 → 営業部長 → 営業一課長 / 営業二課長
  └── 管理本部長 → 開発部長 → 開発一課長 / 開発二課長
                  → 総務部長 → 総務課長
                  → 人事部長 → 人事課長
                  → 経理部長 → 経理課長
  ```
- EMP000001〜EMP000015 に役割を割り当て（EmployeeRole）
- 全従業員に superiorRoleId を設定（役割持ち: 上位役割、一般: 所属部署の課長）
- ID は `createId()` で CUID 生成、`Map<cd, CUID>` で FK 参照を解決

## コミット履歴

| # | コミット | 内容 |
|---|---------|------|
| 1 | `cdf67fd` | 実装計画の作成 |
| 2 | `4c736b5` | Position, Role, EmployeeRole テーブル追加 + Employee に superiorRoleId 追加 |
| 3 | `2b73041` | 役職マスタ4件のシードデータ追加 |
| 4 | `8a75671` | 役割15件 + 従業員役割のシードデータ追加 |
| 5 | `d24f510` | Position/Role の ID を CUID 化し positionCd/roleCd カラム追加 |

## Test Plan

- [x] `pnpm db:migrate` でマイグレーションが正常に適用される
- [x] `pnpm db:generate` で Prisma Client が正常に再生成される
- [x] `pnpm db:seed` でシードデータが正常に投入される（役職4件 + 役割15件 + 従業員役割15件）
- [x] `pnpm build` でビルドが成功する
- [x] `pnpm test` で既存テスト全402件がパスする
- [x] Position テーブルに4行の正しい自己参照データがある（課長→部長→本部長→社長）
- [x] Role テーブルに15行の正しい階層データがある
- [x] EmployeeRole テーブルに15行の従業員-役割割り当てがある
- [x] 全従業員の superiorRoleId が設定されている
- [x] 承認チェーンが再帰CTEで正しく辿れる（例: 経理部一般社員 → 経理課長 → 経理部長 → 管理本部長 → 社長）

---

🤖 Generated with [Claude Code](https://claude.ai/code)