### PR TITLE
feat: 役割管理のバックエンド実装（Domain/Application/Infrastructure層）

### DIFF
--- a/docs/claude-plans/issue-174/zesty-noodling-pond.md
+++ b/docs/claude-plans/issue-174/zesty-noodling-pond.md
@@ -1,0 +1,281 @@
+# Plan: 役割・役職管理バックエンド実装 (Issue #174)
+
+## Context
+
+役割（Role）のCRUD機能と役職（Position）の読み取り機能のバックエンド実装。承認フローの基盤となる役割階層を正しく管理するため、DDDレイヤリングルールに従ってDomain/Application/Infrastructure層を実装する。
+
+Departmentサブドメインの実装パターンを踏襲し、一貫したアーキテクチャを維持する。
+
+**前提**: Issue #179により、Role/Positionモデルに`createdAt`/`updatedAt`カラムが追加済み。
+
+## 設計上の重要な判断
+
+### 1. Positionサブドメインのスコープ
+
+役職は固定4種（課長・部長・本部長・社長）のため、Create/Update/Deleteは不要。読み取り専用のQuery層のみ実装する。ただしDomain層（エンティティ・値オブジェクト・リポジトリインターフェース）は定義する（Roleドメインでの検証に必要なため）。
+
+### 2. Cross-subdomain依存の解決
+
+Roleの「上位役割は上位役職に属する役割のみ」バリデーションにはPositionデータが必要。Roleドメイン内に最小限の`PositionRepository`インターフェース（`findSuperiorPositionId`, `exists`の2メソッド）を定義し、Infrastructure層でPrisma実装する。Positionサブドメインとは独立を保つ。
+
+### 3. 役割名の一意性
+
+DBに`@unique`制約がないため、ドメインサービスで一意性を保証する。
+
+---
+
+## Step 1: Positionサブドメイン - Domain層（エンティティ・値オブジェクト・リポジトリ）
+
+### Files
+- `src/server/subdomains/position/domain/values/PositionCd.ts`
+- `src/server/subdomains/position/domain/values/PositionName.ts`
+- `src/server/subdomains/position/domain/values/__tests__/PositionCd.test.ts`
+- `src/server/subdomains/position/domain/values/__tests__/PositionName.test.ts`
+- `src/server/subdomains/position/domain/entities/Position.ts`
+- `src/server/subdomains/position/domain/entities/__tests__/Position.test.ts`
+- `src/server/subdomains/position/domain/repositories/PositionRepository.ts`
+
+### Details
+- **PositionCd**: `POS` + 3桁数字（POS001〜POS999）。`StringValueObject<"PositionCd">`
+- **PositionName**: 1〜50文字。`StringValueObject<"PositionName">`
+- **Positionエンティティ**: `_id`, `_positionCd`, `_name`, `_superiorPositionId`, `_createdAt`, `_updatedAt`
+  - 固定4種のため`create()`は不要、`reconstruct()`のみ
+  - ビジネスロジック: `isTopLevel(): boolean`（社長かどうか）
+  - `static readonly ENTITY_NAME = "役職"`
+- **PositionRepository**: `findById(id)`, `findByPositionCd(cd)`, `findAll()`
+
+### Reuse
+- `src/server/shared/StringValueObject.ts`
+- `src/server/subdomains/department/domain/values/DepartmentCd.ts` - Cdパターン参考
+- `src/server/subdomains/department/domain/entities/Department.ts` - エンティティパターン参考
+
+---
+
+## Step 2: Positionサブドメイン - Infrastructure層 + Application層（Query）
+
+### Files
+- `src/server/subdomains/position/infrastructure/mappers/PositionMapper.ts`
+- `src/server/subdomains/position/infrastructure/prisma/PrismaPositionRepository.ts`
+- `src/server/subdomains/position/application/queries/dto/PositionDTO.ts`
+- `src/server/subdomains/position/application/queries/PositionQueryService.ts`
+- `src/server/subdomains/position/application/queries/GetAllPositionsQuery.ts`
+- `src/server/subdomains/position/application/queries/GetPositionByIdQuery.ts`
+- `src/server/subdomains/position/infrastructure/queries/PrismaPositionQueryService.ts`
+- `src/server/subdomains/position/application/factories/positionQueryFactory.ts`
+- `src/server/subdomains/position/application/factories/index.ts`
+
+### Details
+
+**PositionMapper**: `toDomain(prismaPosition)` のみ（Create/Updateなし）
+
+**PositionDTO**:
+```typescript
+type PositionDTO = {
+  id: string;
+  positionCd: string;
+  name: string;
+  superiorPositionId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+**PositionQueryService**: `findById`, `findAll`（固定4種のためsearchは不要）
+
+### Reuse
+- `src/server/subdomains/department/infrastructure/mappers/DepartmentMapper.ts`
+- `src/server/subdomains/department/infrastructure/queries/PrismaDepartmentQueryService.ts`
+
+---
+
+## Step 3: Roleサブドメイン - Domain層 値オブジェクト（RoleCd, RoleName）
+
+### Files
+- `src/server/subdomains/role/domain/values/RoleCd.ts`
+- `src/server/subdomains/role/domain/values/RoleName.ts`
+- `src/server/subdomains/role/domain/values/__tests__/RoleCd.test.ts`
+- `src/server/subdomains/role/domain/values/__tests__/RoleName.test.ts`
+
+### Details
+- **RoleCd**: `ROLE` + 3桁数字（ROLE001〜ROLE999）。`StringValueObject<"RoleCd">`
+- **RoleName**: 1〜100文字。`StringValueObject<"RoleName">`
+
+### Reuse
+- `src/server/shared/StringValueObject.ts`
+- `src/server/subdomains/department/domain/values/DepartmentCd.ts`
+
+---
+
+## Step 4: Roleサブドメイン - Domain層 エンティティ
+
+### Files
+- `src/server/subdomains/role/domain/entities/Role.ts`
+- `src/server/subdomains/role/domain/entities/__tests__/Role.test.ts`
+
+### Details
+- Private constructor + `static create()` + `static reconstruct()`
+- フィールド: `_id`, `_roleCd`, `_name`, `_positionId`, `_superiorRoleId`, `_createdAt`, `_updatedAt`
+- ビジネスロジック:
+  - `changeName(newName: RoleName): void` - `_updatedAt`更新
+  - `changeSuperiorRole(newSuperiorRoleId: string | null): void` - 自己参照チェック + `_updatedAt`更新
+- `static readonly ENTITY_NAME = "役割"`
+
+### Reuse
+- `src/server/subdomains/department/domain/entities/Department.ts`
+
+---
+
+## Step 5: Roleサブドメイン - Domain層 リポジトリインターフェース + ドメインサービス
+
+### Files
+- `src/server/subdomains/role/domain/repositories/RoleRepository.ts`
+- `src/server/subdomains/role/domain/repositories/PositionRepository.ts`
+- `src/server/subdomains/role/domain/services/RoleCdDuplicationCheckDomainService.ts`
+- `src/server/subdomains/role/domain/services/RoleNameDuplicationCheckDomainService.ts`
+- `src/server/subdomains/role/domain/services/SuperiorRoleValidationDomainService.ts`
+- `src/server/subdomains/role/domain/services/__tests__/RoleCdDuplicationCheckDomainService.test.ts`
+- `src/server/subdomains/role/domain/services/__tests__/RoleNameDuplicationCheckDomainService.test.ts`
+- `src/server/subdomains/role/domain/services/__tests__/SuperiorRoleValidationDomainService.test.ts`
+
+### Details
+
+**RoleRepository**:
+```
+save(role: Role): Promise<Role>
+delete(id: string): Promise<void>
+findById(id: string): Promise<Role | null>
+findByRoleCd(roleCd: RoleCd): Promise<Role | null>
+findByName(name: string): Promise<Role | null>
+findSubordinates(superiorRoleId: string): Promise<Role[]>
+isInUse(roleId: string): Promise<boolean>
+```
+
+**PositionRepository**（Roleドメインが必要とする最小限）:
+```
+findSuperiorPositionId(positionId: string): Promise<string | null>
+exists(positionId: string): Promise<boolean>
+```
+
+**SuperiorRoleValidationDomainService**:
+1. `positionRepository.findSuperiorPositionId(positionId)`で上位役職IDを取得
+2. 上位役職がnull（社長）→ 上位役割設定不可エラー
+3. `roleRepository.findById(superiorRoleId)`で上位役割を取得
+4. 上位役割の`positionId`が上位役職IDと一致するか検証
+
+**RoleNameDuplicationCheckDomainService**: `execute(name: string, excludeId?: string)`
+
+### Reuse
+- `src/server/subdomains/department/domain/repositories/DepartmentRepository.ts`
+- `src/server/subdomains/department/domain/services/DepartmentCdDuplicationCheckDomainService.ts`
+
+---
+
+## Step 6: Roleサブドメイン - Infrastructure層（マッパー・リポジトリ）
+
+### Files
+- `src/server/subdomains/role/infrastructure/mappers/RoleMapper.ts`
+- `src/server/subdomains/role/infrastructure/prisma/PrismaRoleRepository.ts`
+- `src/server/subdomains/role/infrastructure/prisma/PrismaPositionRepository.ts`
+
+### Details
+
+**RoleMapper**: `toDomain`, `toPrismaCreate`, `toPrismaUpdate`
+
+**PrismaRoleRepository**: upsertパターン、`isInUse()`は`EmployeeRole`+`Employee.superiorRoleId`チェック
+
+**PrismaPositionRepository**: Roleドメインの`PositionRepository`インターフェースを実装
+
+### Reuse
+- `src/server/subdomains/department/infrastructure/mappers/DepartmentMapper.ts`
+- `src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts`
+
+---
+
+## Step 7: Roleサブドメイン - Application層 Command（作成・更新・削除）
+
+### Files
+- `src/server/subdomains/role/application/commands/CreateRoleCommand.ts`
+- `src/server/subdomains/role/application/commands/UpdateRoleCommand.ts`
+- `src/server/subdomains/role/application/commands/DeleteRoleCommand.ts`
+- `src/server/subdomains/role/application/commands/__tests__/CreateRoleCommand.test.ts`
+- `src/server/subdomains/role/application/commands/__tests__/UpdateRoleCommand.test.ts`
+- `src/server/subdomains/role/application/commands/__tests__/DeleteRoleCommand.test.ts`
+
+### Details
+
+**CreateRoleCommand**: Input `{ roleCd, name, positionId, superiorRoleId? }`
+- Cd重複、名前重複、Position存在確認、上位役割バリデーション
+
+**UpdateRoleCommand**: Input `{ id, name?, superiorRoleId? }`
+- 名前重複（excludeId）、上位役割バリデーション、循環参照チェック
+
+**DeleteRoleCommand**: Input `{ id }`
+- 下位役割チェック、使用中チェック（isInUse）
+
+### Reuse
+- `src/server/subdomains/department/application/commands/UpdateDepartmentCommand.ts` - 循環参照チェック
+
+---
+
+## Step 8: Roleサブドメイン - Application層 Query + Infrastructure Query Service
+
+### Files
+- `src/server/subdomains/role/application/queries/dto/RoleDTO.ts`
+- `src/server/subdomains/role/application/queries/dto/RoleSearchCriteria.ts`
+- `src/server/subdomains/role/application/queries/RoleQueryService.ts`
+- `src/server/subdomains/role/application/queries/GetRoleByIdQuery.ts`
+- `src/server/subdomains/role/application/queries/GetAllRolesQuery.ts`
+- `src/server/subdomains/role/application/queries/SearchRolesQuery.ts`
+- `src/server/subdomains/role/application/queries/GetRolesByPositionQuery.ts`
+- `src/server/subdomains/role/infrastructure/queries/PrismaRoleQueryService.ts`
+- `src/server/subdomains/role/application/queries/__tests__/GetRoleByIdQuery.test.ts`
+- `src/server/subdomains/role/application/queries/__tests__/GetAllRolesQuery.test.ts`
+- `src/server/subdomains/role/application/queries/__tests__/SearchRolesQuery.test.ts`
+- `src/server/subdomains/role/application/queries/__tests__/GetRolesByPositionQuery.test.ts`
+
+### Details
+
+**RoleDTO**:
+```typescript
+type RoleDTO = {
+  id: string;
+  roleCd: string;
+  name: string;
+  positionId: string;
+  positionName: string;
+  superiorRoleId: string | null;
+  superiorRoleName: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+**PrismaRoleQueryService**: Position, superiorRoleをJOINして`positionName`, `superiorRoleName`取得
+
+### Reuse
+- `src/server/subdomains/department/application/queries/` - 全体パターン
+- `src/server/subdomains/department/infrastructure/queries/PrismaDepartmentQueryService.ts`
+
+---
+
+## Step 9: Roleサブドメイン - Factory
+
+### Files
+- `src/server/subdomains/role/application/factories/createRoleCommandFactory.ts`
+- `src/server/subdomains/role/application/factories/updateRoleCommandFactory.ts`
+- `src/server/subdomains/role/application/factories/deleteRoleCommandFactory.ts`
+- `src/server/subdomains/role/application/factories/roleQueryFactory.ts`
+- `src/server/subdomains/role/application/factories/index.ts`
+
+### Reuse
+- `src/server/subdomains/department/application/factories/`
+
+---
+
+## Verification
+
+1. `pnpm test` - 全テストパス
+2. `pnpm lint` - リントエラーなし
+3. `pnpm build` - ビルド成功
+4. Domain層に外部ライブラリのimportがないことを確認
+5. Application層がリポジトリインターフェース経由のみでデータアクセスしていることを確認

--- a/src/server/subdomains/position/application/factories/index.ts
+++ b/src/server/subdomains/position/application/factories/index.ts
@@ -1,0 +1,1 @@
+export { getAllPositionsQueryFactory, getPositionByIdQueryFactory } from "./positionQueryFactory";

--- a/src/server/subdomains/position/application/factories/positionQueryFactory.ts
+++ b/src/server/subdomains/position/application/factories/positionQueryFactory.ts
@@ -1,0 +1,13 @@
+import { GetAllPositionsQuery } from "../queries/GetAllPositionsQuery";
+import { GetPositionByIdQuery } from "../queries/GetPositionByIdQuery";
+import { PrismaPositionQueryService } from "../../infrastructure/queries/PrismaPositionQueryService";
+
+export function getAllPositionsQueryFactory(): GetAllPositionsQuery {
+  const queryService = new PrismaPositionQueryService();
+  return new GetAllPositionsQuery(queryService);
+}
+
+export function getPositionByIdQueryFactory(): GetPositionByIdQuery {
+  const queryService = new PrismaPositionQueryService();
+  return new GetPositionByIdQuery(queryService);
+}

--- a/src/server/subdomains/position/application/queries/GetAllPositionsQuery.ts
+++ b/src/server/subdomains/position/application/queries/GetAllPositionsQuery.ts
@@ -1,0 +1,13 @@
+import { PositionDTO } from "./dto/PositionDTO";
+import { PositionQueryService } from "./PositionQueryService";
+
+/**
+ * 全役職取得クエリ
+ */
+export class GetAllPositionsQuery {
+  public constructor(private readonly positionQueryService: PositionQueryService) {}
+
+  async execute(): Promise<PositionDTO[]> {
+    return await this.positionQueryService.findAll();
+  }
+}

--- a/src/server/subdomains/position/application/queries/GetPositionByIdQuery.ts
+++ b/src/server/subdomains/position/application/queries/GetPositionByIdQuery.ts
@@ -1,0 +1,17 @@
+import { PositionDTO } from "./dto/PositionDTO";
+import { PositionQueryService } from "./PositionQueryService";
+
+export type GetPositionByIdInput = {
+  id: string;
+};
+
+/**
+ * ID指定役職取得クエリ
+ */
+export class GetPositionByIdQuery {
+  public constructor(private readonly positionQueryService: PositionQueryService) {}
+
+  async execute(input: GetPositionByIdInput): Promise<PositionDTO | null> {
+    return await this.positionQueryService.findById(input.id);
+  }
+}

--- a/src/server/subdomains/position/application/queries/PositionQueryService.ts
+++ b/src/server/subdomains/position/application/queries/PositionQueryService.ts
@@ -1,0 +1,19 @@
+import { PositionDTO } from "./dto/PositionDTO";
+
+/**
+ * 役職クエリサービスインターフェース
+ *
+ * 読み取り専用の取得機能を提供。
+ * 役職は固定4種のマスタデータのため、検索機能は不要。
+ */
+export interface PositionQueryService {
+  /**
+   * IDで役職を取得
+   */
+  findById(id: string): Promise<PositionDTO | null>;
+
+  /**
+   * 全役職を取得
+   */
+  findAll(): Promise<PositionDTO[]>;
+}

--- a/src/server/subdomains/position/application/queries/dto/PositionDTO.ts
+++ b/src/server/subdomains/position/application/queries/dto/PositionDTO.ts
@@ -1,0 +1,12 @@
+/**
+ * 役職データ転送オブジェクト
+ * 読み取り専用のデータ表現（軽量）
+ */
+export type PositionDTO = {
+  id: string;
+  positionCd: string;
+  name: string;
+  superiorPositionId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/server/subdomains/position/domain/entities/Position.ts
+++ b/src/server/subdomains/position/domain/entities/Position.ts
@@ -1,0 +1,71 @@
+import { PositionCd } from "../values/PositionCd";
+import { PositionName } from "../values/PositionName";
+
+/**
+ * 役職エンティティ
+ *
+ * 組織における役職（課長・部長・本部長・社長）を表現する。
+ * 固定4種のマスタデータのため、create() は提供せず reconstruct() のみ。
+ */
+export class Position {
+  /** エンティティ名（エラーメッセージ用） */
+  static readonly ENTITY_NAME = "役職";
+
+  private constructor(
+    private readonly _id: string,
+    private readonly _positionCd: PositionCd,
+    private readonly _name: PositionName,
+    private readonly _superiorPositionId: string | null,
+    private readonly _createdAt: Date,
+    private readonly _updatedAt: Date
+  ) {}
+
+  /**
+   * DBから役職を再構築
+   */
+  static reconstruct(
+    id: string,
+    positionCd: PositionCd,
+    name: PositionName,
+    superiorPositionId: string | null,
+    createdAt: Date,
+    updatedAt: Date
+  ): Position {
+    return new Position(id, positionCd, name, superiorPositionId, createdAt, updatedAt);
+  }
+
+  /**
+   * 最上位の役職かどうか（社長 = superiorPositionId が null）
+   */
+  isTopLevel(): boolean {
+    return this._superiorPositionId === null;
+  }
+
+  // ========================================
+  // ゲッター
+  // ========================================
+
+  get id(): string {
+    return this._id;
+  }
+
+  get positionCd(): PositionCd {
+    return this._positionCd;
+  }
+
+  get name(): PositionName {
+    return this._name;
+  }
+
+  get superiorPositionId(): string | null {
+    return this._superiorPositionId;
+  }
+
+  get createdAt(): Date {
+    return this._createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+}

--- a/src/server/subdomains/position/domain/entities/__tests__/Position.test.ts
+++ b/src/server/subdomains/position/domain/entities/__tests__/Position.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { Position } from "../Position";
+import { PositionCd } from "../../values/PositionCd";
+import { PositionName } from "../../values/PositionName";
+
+describe("Position", () => {
+  const createTestPosition = (overrides?: {
+    id?: string;
+    positionCd?: PositionCd;
+    name?: PositionName;
+    superiorPositionId?: string | null;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) => {
+    const now = new Date();
+    return Position.reconstruct(
+      overrides?.id ?? "test-id-001",
+      overrides?.positionCd ?? new PositionCd("POS001"),
+      overrides?.name ?? new PositionName("課長"),
+      overrides?.superiorPositionId !== undefined ? overrides.superiorPositionId : "test-id-002",
+      overrides?.createdAt ?? now,
+      overrides?.updatedAt ?? now
+    );
+  };
+
+  describe("reconstruct", () => {
+    it("役職を再構築できる", () => {
+      const position = createTestPosition();
+
+      expect(position.id).toBe("test-id-001");
+      expect(position.positionCd.value).toBe("POS001");
+      expect(position.name.value).toBe("課長");
+      expect(position.superiorPositionId).toBe("test-id-002");
+    });
+
+    it("上位役職がnullの場合も再構築できる", () => {
+      const position = createTestPosition({ superiorPositionId: null });
+
+      expect(position.superiorPositionId).toBeNull();
+    });
+
+    it("タイムスタンプが保持される", () => {
+      const createdAt = new Date("2025-01-01");
+      const updatedAt = new Date("2025-06-01");
+      const position = createTestPosition({ createdAt, updatedAt });
+
+      expect(position.createdAt).toEqual(createdAt);
+      expect(position.updatedAt).toEqual(updatedAt);
+    });
+  });
+
+  describe("isTopLevel", () => {
+    it("上位役職がnullの場合はtrueを返す（社長）", () => {
+      const position = createTestPosition({ superiorPositionId: null });
+
+      expect(position.isTopLevel()).toBe(true);
+    });
+
+    it("上位役職がある場合はfalseを返す", () => {
+      const position = createTestPosition({ superiorPositionId: "superior-id" });
+
+      expect(position.isTopLevel()).toBe(false);
+    });
+  });
+
+  describe("ENTITY_NAME", () => {
+    it("エンティティ名が正しい", () => {
+      expect(Position.ENTITY_NAME).toBe("役職");
+    });
+  });
+});

--- a/src/server/subdomains/position/domain/repositories/PositionRepository.ts
+++ b/src/server/subdomains/position/domain/repositories/PositionRepository.ts
@@ -1,0 +1,25 @@
+import { Position } from "../entities/Position";
+import { PositionCd } from "../values/PositionCd";
+
+/**
+ * 役職リポジトリインターフェース
+ *
+ * 役職は固定4種のマスタデータのため、読み取り専用。
+ * 書き込み操作（save, delete）は提供しない。
+ */
+export interface PositionRepository {
+  /**
+   * IDで役職を取得
+   */
+  findById(id: string): Promise<Position | null>;
+
+  /**
+   * 役職コードで役職を取得
+   */
+  findByPositionCd(positionCd: PositionCd): Promise<Position | null>;
+
+  /**
+   * 全役職を取得
+   */
+  findAll(): Promise<Position[]>;
+}

--- a/src/server/subdomains/position/domain/values/PositionCd.ts
+++ b/src/server/subdomains/position/domain/values/PositionCd.ts
@@ -1,0 +1,64 @@
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * 役職コード値オブジェクト
+ *
+ * 形式: POS + 3桁の数字（POS001 〜 POS999）
+ */
+export class PositionCd extends StringValueObject<"PositionCd"> {
+  private static readonly PREFIX = "POS";
+  private static readonly NUMERIC_LENGTH = 3;
+  private static readonly TOTAL_LENGTH = 6; // "POS" + 3桁 = 6文字
+  private static readonly NUMERIC_MIN = 1;
+  private static readonly NUMERIC_MAX = Math.pow(10, PositionCd.NUMERIC_LENGTH) - 1;
+
+  protected static readonly REGEX = new RegExp(
+    `^${PositionCd.PREFIX}\\d{${PositionCd.NUMERIC_LENGTH}}$`,
+    "i"
+  );
+  protected static readonly MIN_LENGTH = PositionCd.TOTAL_LENGTH;
+  protected static readonly MAX_LENGTH = PositionCd.TOTAL_LENGTH;
+  protected static readonly ERROR_MESSAGE_EMPTY = "役職コードは必須です";
+  protected static readonly ERROR_MESSAGE_TOO_SHORT =
+    "役職コードは POS + 3桁の数字である必要があります";
+  protected static readonly ERROR_MESSAGE_TOO_LONG =
+    "役職コードは POS + 3桁の数字である必要があります";
+  protected static readonly ERROR_MESSAGE_INVALID_FORMAT =
+    "役職コードは POS + 3桁の数字である必要があります";
+
+  constructor(value: string) {
+    super(value.toUpperCase().trim());
+  }
+
+  get numericPart(): number {
+    return PositionCd.extractNumericPart(this._value);
+  }
+
+  protected validate(value: string): void {
+    super.validate(value);
+
+    const numericPart = PositionCd.extractNumericPart(value);
+    if (numericPart < PositionCd.NUMERIC_MIN) {
+      throw new ValidationError(`役職コードは ${PositionCd.NUMERIC_MIN} 以上である必要があります`);
+    }
+    if (numericPart > PositionCd.NUMERIC_MAX) {
+      throw new ValidationError(`役職コードは ${PositionCd.NUMERIC_MAX} 以下である必要があります`);
+    }
+  }
+
+  private static extractNumericPart(value: string): number {
+    return parseInt(value.substring(PositionCd.PREFIX.length), 10);
+  }
+
+  static fromNumber(num: number): PositionCd {
+    if (num < PositionCd.NUMERIC_MIN || num > PositionCd.NUMERIC_MAX) {
+      throw new ValidationError(
+        `役職コードは ${PositionCd.NUMERIC_MIN} 〜 ${PositionCd.NUMERIC_MAX} の範囲である必要があります`
+      );
+    }
+
+    const paddedNumber = num.toString().padStart(PositionCd.NUMERIC_LENGTH, "0");
+    return new PositionCd(`${PositionCd.PREFIX}${paddedNumber}`);
+  }
+}

--- a/src/server/subdomains/position/domain/values/PositionName.ts
+++ b/src/server/subdomains/position/domain/values/PositionName.ts
@@ -1,0 +1,18 @@
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * 役職名値オブジェクト
+ *
+ * バリデーション:
+ * - 1〜50文字
+ * - 空白のみは不可
+ */
+export class PositionName extends StringValueObject<"PositionName"> {
+  protected static readonly LABEL = "役職名";
+  protected static readonly MIN_LENGTH = 1;
+  protected static readonly MAX_LENGTH = 50;
+
+  constructor(value: string) {
+    super(value.trim());
+  }
+}

--- a/src/server/subdomains/position/domain/values/__tests__/PositionCd.test.ts
+++ b/src/server/subdomains/position/domain/values/__tests__/PositionCd.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { PositionCd } from "../PositionCd";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("PositionCd", () => {
+  describe("正常系", () => {
+    it("POS001 形式の役職コードを作成できる", () => {
+      const cd = new PositionCd("POS001");
+      expect(cd.value).toBe("POS001");
+    });
+
+    it("小文字で入力しても大文字に変換される", () => {
+      const cd = new PositionCd("pos001");
+      expect(cd.value).toBe("POS001");
+    });
+
+    it("前後の空白はトリムされる", () => {
+      const cd = new PositionCd("  POS001  ");
+      expect(cd.value).toBe("POS001");
+    });
+
+    it("POS999 まで作成できる", () => {
+      const cd = new PositionCd("POS999");
+      expect(cd.value).toBe("POS999");
+    });
+
+    it("numericPart で数値部分を取得できる", () => {
+      const cd = new PositionCd("POS123");
+      expect(cd.numericPart).toBe(123);
+    });
+  });
+
+  describe("fromNumber", () => {
+    it("数値から役職コードを生成できる", () => {
+      const cd = PositionCd.fromNumber(1);
+      expect(cd.value).toBe("POS001");
+    });
+
+    it("3桁の数値から役職コードを生成できる", () => {
+      const cd = PositionCd.fromNumber(123);
+      expect(cd.value).toBe("POS123");
+    });
+
+    it("0を指定するとエラー", () => {
+      expect(() => PositionCd.fromNumber(0)).toThrow(ValidationError);
+    });
+
+    it("1000以上を指定するとエラー", () => {
+      expect(() => PositionCd.fromNumber(1000)).toThrow(ValidationError);
+    });
+  });
+
+  describe("異常系", () => {
+    it("空文字列はエラー", () => {
+      expect(() => new PositionCd("")).toThrow(ValidationError);
+      expect(() => new PositionCd("")).toThrow("役職コードは必須です");
+    });
+
+    it("POS000 はエラー（0は無効）", () => {
+      expect(() => new PositionCd("POS000")).toThrow(ValidationError);
+    });
+
+    it("プレフィックスが違うとエラー", () => {
+      expect(() => new PositionCd("DEPT001")).toThrow(ValidationError);
+    });
+
+    it("数字が足りないとエラー", () => {
+      expect(() => new PositionCd("POS01")).toThrow(ValidationError);
+    });
+
+    it("数字が多すぎるとエラー", () => {
+      expect(() => new PositionCd("POS0001")).toThrow(ValidationError);
+    });
+
+    it("数字以外が含まれるとエラー", () => {
+      expect(() => new PositionCd("POSABC")).toThrow(ValidationError);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値の役職コードは等しい", () => {
+      const cd1 = new PositionCd("POS001");
+      const cd2 = new PositionCd("POS001");
+      expect(cd1.equals(cd2)).toBe(true);
+    });
+
+    it("異なる値の役職コードは等しくない", () => {
+      const cd1 = new PositionCd("POS001");
+      const cd2 = new PositionCd("POS002");
+      expect(cd1.equals(cd2)).toBe(false);
+    });
+  });
+});

--- a/src/server/subdomains/position/domain/values/__tests__/PositionName.test.ts
+++ b/src/server/subdomains/position/domain/values/__tests__/PositionName.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { PositionName } from "../PositionName";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("PositionName", () => {
+  describe("正常系", () => {
+    it("役職名を作成できる", () => {
+      const name = new PositionName("課長");
+      expect(name.value).toBe("課長");
+    });
+
+    it("前後の空白はトリムされる", () => {
+      const name = new PositionName("  部長  ");
+      expect(name.value).toBe("部長");
+    });
+
+    it("50文字の役職名を作成できる", () => {
+      const longName = "あ".repeat(50);
+      const name = new PositionName(longName);
+      expect(name.value).toBe(longName);
+    });
+  });
+
+  describe("異常系", () => {
+    it("空文字列はエラー", () => {
+      expect(() => new PositionName("")).toThrow(ValidationError);
+      expect(() => new PositionName("")).toThrow("役職名は必須です");
+    });
+
+    it("空白のみはエラー", () => {
+      expect(() => new PositionName("   ")).toThrow(ValidationError);
+    });
+
+    it("51文字以上はエラー", () => {
+      const tooLong = "あ".repeat(51);
+      expect(() => new PositionName(tooLong)).toThrow(ValidationError);
+      expect(() => new PositionName(tooLong)).toThrow("役職名は50文字以内で入力してください");
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値の役職名は等しい", () => {
+      const name1 = new PositionName("課長");
+      const name2 = new PositionName("課長");
+      expect(name1.equals(name2)).toBe(true);
+    });
+
+    it("異なる値の役職名は等しくない", () => {
+      const name1 = new PositionName("課長");
+      const name2 = new PositionName("部長");
+      expect(name1.equals(name2)).toBe(false);
+    });
+  });
+});

--- a/src/server/subdomains/position/infrastructure/mappers/PositionMapper.ts
+++ b/src/server/subdomains/position/infrastructure/mappers/PositionMapper.ts
@@ -1,0 +1,29 @@
+import { Position } from "@subdomains/position/domain/entities/Position";
+import { PositionCd } from "@subdomains/position/domain/values/PositionCd";
+import { PositionName } from "@subdomains/position/domain/values/PositionName";
+import { Position as PrismaPosition } from "@generated/prisma/client";
+
+/**
+ * PositionMapper
+ *
+ * PrismaのPositionモデルとドメインのPositionエンティティを相互変換する。
+ * Positionは固定マスタデータのため toDomain() のみ提供。
+ */
+export class PositionMapper {
+  /**
+   * Prismaモデルからドメインエンティティへ変換
+   */
+  static toDomain(prismaPosition: PrismaPosition): Position {
+    const positionCd = new PositionCd(prismaPosition.positionCd);
+    const name = new PositionName(prismaPosition.name);
+
+    return Position.reconstruct(
+      prismaPosition.id,
+      positionCd,
+      name,
+      prismaPosition.superiorPositionId,
+      prismaPosition.createdAt,
+      prismaPosition.updatedAt
+    );
+  }
+}

--- a/src/server/subdomains/position/infrastructure/prisma/PrismaPositionRepository.ts
+++ b/src/server/subdomains/position/infrastructure/prisma/PrismaPositionRepository.ts
@@ -1,0 +1,36 @@
+import { Position } from "@subdomains/position/domain/entities/Position";
+import { PositionRepository } from "@subdomains/position/domain/repositories/PositionRepository";
+import { PositionCd } from "@subdomains/position/domain/values/PositionCd";
+import { PositionMapper } from "@subdomains/position/infrastructure/mappers/PositionMapper";
+import prisma from "@server/prisma";
+
+/**
+ * Prismaを使用した役職リポジトリ実装
+ *
+ * 読み取り専用（Positionは固定マスタデータ）
+ */
+export class PrismaPositionRepository implements PositionRepository {
+  async findById(id: string): Promise<Position | null> {
+    const prismaPosition = await prisma.position.findUnique({
+      where: { id },
+    });
+
+    return prismaPosition ? PositionMapper.toDomain(prismaPosition) : null;
+  }
+
+  async findByPositionCd(positionCd: PositionCd): Promise<Position | null> {
+    const prismaPosition = await prisma.position.findUnique({
+      where: { positionCd: positionCd.value },
+    });
+
+    return prismaPosition ? PositionMapper.toDomain(prismaPosition) : null;
+  }
+
+  async findAll(): Promise<Position[]> {
+    const prismaPositions = await prisma.position.findMany({
+      orderBy: { positionCd: "asc" },
+    });
+
+    return prismaPositions.map(PositionMapper.toDomain);
+  }
+}

--- a/src/server/subdomains/position/infrastructure/queries/PrismaPositionQueryService.ts
+++ b/src/server/subdomains/position/infrastructure/queries/PrismaPositionQueryService.ts
@@ -1,0 +1,55 @@
+import { PositionDTO } from "@subdomains/position/application/queries/dto/PositionDTO";
+import { PositionQueryService } from "@subdomains/position/application/queries/PositionQueryService";
+import prisma from "@server/prisma";
+
+/**
+ * Prismaを使用した役職クエリサービス実装
+ */
+export class PrismaPositionQueryService implements PositionQueryService {
+  async findById(id: string): Promise<PositionDTO | null> {
+    const position = await prisma.position.findUnique({
+      where: { id },
+      select: this.getSelectFields(),
+    });
+
+    return position ? this.toDTO(position) : null;
+  }
+
+  async findAll(): Promise<PositionDTO[]> {
+    const positions = await prisma.position.findMany({
+      select: this.getSelectFields(),
+      orderBy: { positionCd: "asc" },
+    });
+
+    return positions.map((p) => this.toDTO(p));
+  }
+
+  private getSelectFields() {
+    return {
+      id: true,
+      positionCd: true,
+      name: true,
+      superiorPositionId: true,
+      createdAt: true,
+      updatedAt: true,
+    } as const;
+  }
+
+  private toDTO(position: {
+    id: string;
+    positionCd: string;
+    name: string;
+    superiorPositionId: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): PositionDTO {
+    return {
+      id: position.id,
+      positionCd: position.positionCd,
+      name: position.name,
+      superiorPositionId: position.superiorPositionId,
+      createdAt: position.createdAt,
+      updatedAt: position.updatedAt,
+    };
+  }
+}

--- a/src/server/subdomains/role/application/commands/CreateRoleCommand.ts
+++ b/src/server/subdomains/role/application/commands/CreateRoleCommand.ts
@@ -1,0 +1,62 @@
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleRepository } from "@subdomains/role/domain/repositories/RoleRepository";
+import { PositionRepository } from "@subdomains/role/domain/repositories/PositionRepository";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { RoleCdDuplicationCheckDomainService } from "@subdomains/role/domain/services/RoleCdDuplicationCheckDomainService";
+import { RoleNameDuplicationCheckDomainService } from "@subdomains/role/domain/services/RoleNameDuplicationCheckDomainService";
+import { SuperiorRoleValidationDomainService } from "@subdomains/role/domain/services/SuperiorRoleValidationDomainService";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+export type CreateRoleInput = {
+  roleCd: string;
+  name: string;
+  positionId: string;
+  superiorRoleId?: string | null;
+};
+
+/**
+ * 役割作成コマンド
+ */
+export class CreateRoleCommand {
+  public constructor(
+    private readonly roleRepository: RoleRepository,
+    private readonly positionRepository: PositionRepository,
+    private readonly roleCdDuplicationCheckDomainService: RoleCdDuplicationCheckDomainService,
+    private readonly roleNameDuplicationCheckDomainService: RoleNameDuplicationCheckDomainService,
+    private readonly superiorRoleValidationDomainService: SuperiorRoleValidationDomainService
+  ) {}
+
+  async execute(input: CreateRoleInput): Promise<Role> {
+    const roleCd = new RoleCd(input.roleCd);
+    const roleName = new RoleName(input.name);
+
+    // 役割コード重複チェック
+    const isCdDuplicated = await this.roleCdDuplicationCheckDomainService.execute(roleCd);
+    if (isCdDuplicated) {
+      throw new ValidationError(`既に存在する役割コードです: CD=${roleCd.value}`);
+    }
+
+    // 役割名重複チェック
+    const isNameDuplicated = await this.roleNameDuplicationCheckDomainService.execute(input.name);
+    if (isNameDuplicated) {
+      throw new ValidationError(`既に存在する役割名です: ${input.name}`);
+    }
+
+    // 役職存在確認
+    const positionExists = await this.positionRepository.exists(input.positionId);
+    if (!positionExists) {
+      throw new ValidationError(`役職が存在しません: ID=${input.positionId}`);
+    }
+
+    // 上位役割バリデーション
+    const superiorRoleId = input.superiorRoleId ?? null;
+    if (superiorRoleId) {
+      await this.superiorRoleValidationDomainService.execute(input.positionId, superiorRoleId);
+    }
+
+    const newRole = Role.create(roleCd, roleName, input.positionId, superiorRoleId);
+
+    return await this.roleRepository.save(newRole);
+  }
+}

--- a/src/server/subdomains/role/application/commands/DeleteRoleCommand.ts
+++ b/src/server/subdomains/role/application/commands/DeleteRoleCommand.ts
@@ -1,0 +1,42 @@
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleRepository } from "@subdomains/role/domain/repositories/RoleRepository";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+
+export type DeleteRoleInput = {
+  id: string;
+};
+
+/**
+ * 役割削除コマンド
+ *
+ * 下位役割がある場合や使用中の場合は削除できない。
+ */
+export class DeleteRoleCommand {
+  public constructor(private readonly roleRepository: RoleRepository) {}
+
+  async execute(input: DeleteRoleInput): Promise<void> {
+    const role = await this.roleRepository.findById(input.id);
+    if (!role) {
+      throw new NotFoundEntityError(Role, { id: input.id });
+    }
+
+    // 下位役割がある場合は削除できない
+    const subordinates = await this.roleRepository.findSubordinates(input.id);
+    if (subordinates.length > 0) {
+      throw new BusinessRuleViolationError(
+        "下位役割が存在するため、この役割を削除できません。先に下位役割を削除してください。"
+      );
+    }
+
+    // 使用中の場合は削除できない
+    const inUse = await this.roleRepository.isInUse(input.id);
+    if (inUse) {
+      throw new BusinessRuleViolationError(
+        "この役割は従業員に割り当てられているため削除できません。先に割り当てを解除してください。"
+      );
+    }
+
+    await this.roleRepository.delete(input.id);
+  }
+}

--- a/src/server/subdomains/role/application/commands/UpdateRoleCommand.ts
+++ b/src/server/subdomains/role/application/commands/UpdateRoleCommand.ts
@@ -63,6 +63,11 @@ export class UpdateRoleCommand {
   /**
    * 循環参照がないことを検証
    * 指定した上位役割が、自分自身または自分の下位役割でないことを確認
+   *
+   * 注: 現在の役職階層（課長 < 部長 < 本部長 < 社長）では、
+   * SuperiorRoleValidationDomainService の役職レベルチェックにより
+   * 祖先チェーンの循環は構造的に発生しない。
+   * 自己参照チェックと祖先走査は防御的プログラミングとして残す。
    */
   private async validateNoCircularReference(
     roleId: string,

--- a/src/server/subdomains/role/application/commands/UpdateRoleCommand.ts
+++ b/src/server/subdomains/role/application/commands/UpdateRoleCommand.ts
@@ -1,0 +1,90 @@
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleRepository } from "@subdomains/role/domain/repositories/RoleRepository";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { RoleNameDuplicationCheckDomainService } from "@subdomains/role/domain/services/RoleNameDuplicationCheckDomainService";
+import { SuperiorRoleValidationDomainService } from "@subdomains/role/domain/services/SuperiorRoleValidationDomainService";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+export type UpdateRoleInput = {
+  id: string;
+  name?: string;
+  superiorRoleId?: string | null;
+};
+
+/**
+ * 役割更新コマンド
+ *
+ * positionId, roleCd は変更不可。
+ */
+export class UpdateRoleCommand {
+  public constructor(
+    private readonly roleRepository: RoleRepository,
+    private readonly roleNameDuplicationCheckDomainService: RoleNameDuplicationCheckDomainService,
+    private readonly superiorRoleValidationDomainService: SuperiorRoleValidationDomainService
+  ) {}
+
+  async execute(input: UpdateRoleInput): Promise<Role> {
+    const role = await this.roleRepository.findById(input.id);
+    if (!role) {
+      throw new NotFoundEntityError(Role, { id: input.id });
+    }
+
+    // 役割名の更新
+    if (input.name !== undefined) {
+      const isNameDuplicated = await this.roleNameDuplicationCheckDomainService.execute(
+        input.name,
+        role.id
+      );
+      if (isNameDuplicated) {
+        throw new ValidationError(`既に存在する役割名です: ${input.name}`);
+      }
+      role.changeName(new RoleName(input.name));
+    }
+
+    // 上位役割の更新
+    if (input.superiorRoleId !== undefined) {
+      if (input.superiorRoleId !== null) {
+        // 上位役割バリデーション
+        await this.superiorRoleValidationDomainService.execute(
+          role.positionId,
+          input.superiorRoleId
+        );
+        // 循環参照チェック
+        await this.validateNoCircularReference(role.id, input.superiorRoleId);
+      }
+      role.changeSuperiorRole(input.superiorRoleId);
+    }
+
+    return await this.roleRepository.save(role);
+  }
+
+  /**
+   * 循環参照がないことを検証
+   * 指定した上位役割が、自分自身または自分の下位役割でないことを確認
+   */
+  private async validateNoCircularReference(
+    roleId: string,
+    newSuperiorRoleId: string
+  ): Promise<void> {
+    if (roleId === newSuperiorRoleId) {
+      throw new BusinessRuleViolationError("自分自身を上位役割にすることはできません");
+    }
+
+    // 新しい上位役割の祖先を辿って、自分自身がいないことを確認
+    let currentSuperiorId: string | null = newSuperiorRoleId;
+    while (currentSuperiorId !== null) {
+      const superiorRole = await this.roleRepository.findById(currentSuperiorId);
+      if (!superiorRole) {
+        break;
+      }
+      currentSuperiorId = superiorRole.superiorRoleId;
+      if (currentSuperiorId === roleId) {
+        throw new BusinessRuleViolationError(
+          "循環参照が発生するため、この上位役割は設定できません"
+        );
+      }
+    }
+  }
+}

--- a/src/server/subdomains/role/application/commands/__tests__/CreateRoleCommand.test.ts
+++ b/src/server/subdomains/role/application/commands/__tests__/CreateRoleCommand.test.ts
@@ -1,0 +1,131 @@
+import prisma from "@server/prisma";
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { PrismaPositionRepository } from "@subdomains/role/infrastructure/prisma/PrismaPositionRepository";
+import { RoleCdDuplicationCheckDomainService } from "@subdomains/role/domain/services/RoleCdDuplicationCheckDomainService";
+import { RoleNameDuplicationCheckDomainService } from "@subdomains/role/domain/services/RoleNameDuplicationCheckDomainService";
+import { SuperiorRoleValidationDomainService } from "@subdomains/role/domain/services/SuperiorRoleValidationDomainService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CreateRoleCommand } from "../CreateRoleCommand";
+
+describe("CreateRoleCommand", () => {
+  let command: CreateRoleCommand;
+  let roleRepository: PrismaRoleRepository;
+
+  const TEST_ROLE_CDS = ["ROLE981", "ROLE982"];
+
+  let kachouPositionId: string;
+  let buchouPositionId: string;
+
+  async function cleanup() {
+    await prisma.role.updateMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+      data: { superiorRoleId: null },
+    });
+    await prisma.role.deleteMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const [kachou, buchou] = await Promise.all([
+      prisma.position.findUnique({ where: { positionCd: "POS001" } }),
+      prisma.position.findUnique({ where: { positionCd: "POS002" } }),
+    ]);
+    kachouPositionId = kachou!.id;
+    buchouPositionId = buchou!.id;
+
+    roleRepository = new PrismaRoleRepository();
+    const positionRepository = new PrismaPositionRepository();
+    command = new CreateRoleCommand(
+      roleRepository,
+      positionRepository,
+      new RoleCdDuplicationCheckDomainService(roleRepository),
+      new RoleNameDuplicationCheckDomainService(roleRepository),
+      new SuperiorRoleValidationDomainService(roleRepository, positionRepository)
+    );
+  });
+
+  afterEach(cleanup);
+
+  it("役割を新規登録できる", async () => {
+    await command.execute({
+      roleCd: TEST_ROLE_CDS[0],
+      name: "登録テスト課長",
+      positionId: kachouPositionId,
+    });
+
+    const saved = await roleRepository.findByRoleCd(new RoleCd(TEST_ROLE_CDS[0]));
+    expect(saved).not.toBeNull();
+    expect(saved?.roleCd.value).toBe(TEST_ROLE_CDS[0]);
+    expect(saved?.name.value).toBe("登録テスト課長");
+    expect(saved?.positionId).toBe(kachouPositionId);
+    expect(saved?.superiorRoleId).toBeNull();
+  });
+
+  it("上位役割を指定して登録できる", async () => {
+    // 先に部長役割を作成
+    await command.execute({
+      roleCd: TEST_ROLE_CDS[0],
+      name: "登録テスト部長",
+      positionId: buchouPositionId,
+    });
+    const buchouRole = await roleRepository.findByRoleCd(new RoleCd(TEST_ROLE_CDS[0]));
+
+    // 課長役割を部長の下に作成
+    await command.execute({
+      roleCd: TEST_ROLE_CDS[1],
+      name: "登録テスト課長2",
+      positionId: kachouPositionId,
+      superiorRoleId: buchouRole!.id,
+    });
+
+    const saved = await roleRepository.findByRoleCd(new RoleCd(TEST_ROLE_CDS[1]));
+    expect(saved?.superiorRoleId).toBe(buchouRole!.id);
+  });
+
+  it("既に存在する役割コードの場合はエラー", async () => {
+    await command.execute({
+      roleCd: TEST_ROLE_CDS[0],
+      name: "最初の役割",
+      positionId: kachouPositionId,
+    });
+
+    await expect(
+      command.execute({
+        roleCd: TEST_ROLE_CDS[0],
+        name: "重複役割",
+        positionId: kachouPositionId,
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("既に存在する役割名の場合はエラー", async () => {
+    await command.execute({
+      roleCd: TEST_ROLE_CDS[0],
+      name: "重複テスト役割名",
+      positionId: kachouPositionId,
+    });
+
+    await expect(
+      command.execute({
+        roleCd: TEST_ROLE_CDS[1],
+        name: "重複テスト役割名",
+        positionId: kachouPositionId,
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("存在しない役職を指定するとエラー", async () => {
+    await expect(
+      command.execute({
+        roleCd: TEST_ROLE_CDS[0],
+        name: "登録テスト役割",
+        positionId: "non-existent-id",
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+});

--- a/src/server/subdomains/role/application/commands/__tests__/DeleteRoleCommand.test.ts
+++ b/src/server/subdomains/role/application/commands/__tests__/DeleteRoleCommand.test.ts
@@ -1,0 +1,86 @@
+import prisma from "@server/prisma";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DeleteRoleCommand } from "../DeleteRoleCommand";
+
+describe("DeleteRoleCommand", () => {
+  let command: DeleteRoleCommand;
+  let roleRepository: PrismaRoleRepository;
+
+  const TEST_ROLE_CDS = ["ROLE961", "ROLE962"];
+
+  let kachouPositionId: string;
+  let buchouPositionId: string;
+
+  async function cleanup() {
+    // 下位役割のFK参照を解除してから削除
+    await prisma.role.updateMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+      data: { superiorRoleId: null },
+    });
+    await prisma.role.deleteMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const [kachou, buchou] = await Promise.all([
+      prisma.position.findUnique({ where: { positionCd: "POS001" } }),
+      prisma.position.findUnique({ where: { positionCd: "POS002" } }),
+    ]);
+    kachouPositionId = kachou!.id;
+    buchouPositionId = buchou!.id;
+
+    roleRepository = new PrismaRoleRepository();
+    command = new DeleteRoleCommand(roleRepository);
+  });
+
+  afterEach(cleanup);
+
+  it("役割を削除できる", async () => {
+    const role = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("削除テスト役割"),
+      kachouPositionId
+    );
+    await roleRepository.save(role);
+
+    await command.execute({ id: role.id });
+
+    const deleted = await roleRepository.findById(role.id);
+    expect(deleted).toBeNull();
+  });
+
+  it("存在しない役割を削除しようとするとエラー", async () => {
+    await expect(command.execute({ id: "non-existent-id" })).rejects.toThrow(NotFoundEntityError);
+  });
+
+  it("下位役割がある場合は削除できない", async () => {
+    const buchouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("テスト部長"),
+      buchouPositionId
+    );
+    await roleRepository.save(buchouRole);
+
+    const kachouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("テスト課長"),
+      kachouPositionId,
+      buchouRole.id
+    );
+    await roleRepository.save(kachouRole);
+
+    await expect(command.execute({ id: buchouRole.id })).rejects.toThrow(
+      BusinessRuleViolationError
+    );
+    await expect(command.execute({ id: buchouRole.id })).rejects.toThrow("下位役割が存在するため");
+  });
+});

--- a/src/server/subdomains/role/application/commands/__tests__/UpdateRoleCommand.test.ts
+++ b/src/server/subdomains/role/application/commands/__tests__/UpdateRoleCommand.test.ts
@@ -139,8 +139,7 @@ describe("UpdateRoleCommand", () => {
     expect(updated.name.value).toBe("テスト役割");
   });
 
-  it("循環参照が発生する上位役割を指定するとエラー", async () => {
-    // buchou -> kachou の順番で作成し、kachouの上位をbuchouにする
+  it("自分自身を上位役割に指定するとエラー", async () => {
     const buchouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("テスト部長"),
@@ -148,21 +147,59 @@ describe("UpdateRoleCommand", () => {
     );
     await roleRepository.save(buchouRole);
 
+    await expect(
+      command.execute({
+        id: buchouRole.id,
+        superiorRoleId: buchouRole.id,
+      })
+    ).rejects.toThrow(BusinessRuleViolationError);
+  });
+
+  it("下位役割を上位役割に指定するとエラー（チェーン循環防止）", async () => {
+    // 部長 ← 課長 の階層で、部長の上位を課長にしようとする → B → K → B の循環
+    const buchouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("循環テスト部長"),
+      buchouPositionId
+    );
+    await roleRepository.save(buchouRole);
+
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
-      new RoleName("テスト課長"),
+      new RoleName("循環テスト課長"),
       kachouPositionId,
       buchouRole.id
     );
     await roleRepository.save(kachouRole);
 
-    // buchouの上位をkachouにしようとする → 循環参照エラー
-    // ただし役職チェックで先に弾かれる可能性があるため、
-    // 同じ役職レベルでテストする
     await expect(
       command.execute({
         id: buchouRole.id,
-        superiorRoleId: buchouRole.id,
+        superiorRoleId: kachouRole.id,
+      })
+    ).rejects.toThrow(BusinessRuleViolationError);
+  });
+
+  it("同一役職レベルの役割を上位役割に指定するとエラー", async () => {
+    const kachouRole1 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("同一レベルA課長"),
+      kachouPositionId
+    );
+    await roleRepository.save(kachouRole1);
+
+    const kachouRole2 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("同一レベルB課長"),
+      kachouPositionId
+    );
+    await roleRepository.save(kachouRole2);
+
+    // 課長の上位は部長でなければならないため、同一役職レベルは設定不可
+    await expect(
+      command.execute({
+        id: kachouRole1.id,
+        superiorRoleId: kachouRole2.id,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
   });

--- a/src/server/subdomains/role/application/commands/__tests__/UpdateRoleCommand.test.ts
+++ b/src/server/subdomains/role/application/commands/__tests__/UpdateRoleCommand.test.ts
@@ -1,0 +1,169 @@
+import prisma from "@server/prisma";
+import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { PrismaPositionRepository } from "@subdomains/role/infrastructure/prisma/PrismaPositionRepository";
+import { RoleNameDuplicationCheckDomainService } from "@subdomains/role/domain/services/RoleNameDuplicationCheckDomainService";
+import { SuperiorRoleValidationDomainService } from "@subdomains/role/domain/services/SuperiorRoleValidationDomainService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { UpdateRoleCommand } from "../UpdateRoleCommand";
+
+describe("UpdateRoleCommand", () => {
+  let command: UpdateRoleCommand;
+  let roleRepository: PrismaRoleRepository;
+
+  const TEST_ROLE_CDS = ["ROLE971", "ROLE972", "ROLE973"];
+
+  let kachouPositionId: string;
+  let buchouPositionId: string;
+
+  async function cleanup() {
+    // 下位役割から削除（FK制約のため）
+    await prisma.role.updateMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+      data: { superiorRoleId: null },
+    });
+    await prisma.role.deleteMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const [kachou, buchou] = await Promise.all([
+      prisma.position.findUnique({ where: { positionCd: "POS001" } }),
+      prisma.position.findUnique({ where: { positionCd: "POS002" } }),
+    ]);
+    kachouPositionId = kachou!.id;
+    buchouPositionId = buchou!.id;
+
+    roleRepository = new PrismaRoleRepository();
+    const positionRepository = new PrismaPositionRepository();
+    command = new UpdateRoleCommand(
+      roleRepository,
+      new RoleNameDuplicationCheckDomainService(roleRepository),
+      new SuperiorRoleValidationDomainService(roleRepository, positionRepository)
+    );
+  });
+
+  afterEach(cleanup);
+
+  it("役割名を更新できる", async () => {
+    const role = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("更新前の名前"),
+      kachouPositionId
+    );
+    await roleRepository.save(role);
+
+    const updated = await command.execute({
+      id: role.id,
+      name: "更新後の名前",
+    });
+
+    expect(updated.name.value).toBe("更新後の名前");
+  });
+
+  it("上位役割を更新できる", async () => {
+    const buchouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("テスト部長"),
+      buchouPositionId
+    );
+    await roleRepository.save(buchouRole);
+
+    const kachouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("テスト課長"),
+      kachouPositionId
+    );
+    await roleRepository.save(kachouRole);
+
+    const updated = await command.execute({
+      id: kachouRole.id,
+      superiorRoleId: buchouRole.id,
+    });
+
+    expect(updated.superiorRoleId).toBe(buchouRole.id);
+  });
+
+  it("存在しない役割を更新しようとするとエラー", async () => {
+    await expect(
+      command.execute({
+        id: "non-existent-id",
+        name: "テスト",
+      })
+    ).rejects.toThrow(NotFoundEntityError);
+  });
+
+  it("重複する役割名に更新しようとするとエラー", async () => {
+    const role1 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("既存の役割名"),
+      kachouPositionId
+    );
+    await roleRepository.save(role1);
+
+    const role2 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("変更前の名前"),
+      kachouPositionId
+    );
+    await roleRepository.save(role2);
+
+    await expect(
+      command.execute({
+        id: role2.id,
+        name: "既存の役割名",
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("自分自身の名前で更新しても重複エラーにならない", async () => {
+    const role = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("テスト役割"),
+      kachouPositionId
+    );
+    await roleRepository.save(role);
+
+    const updated = await command.execute({
+      id: role.id,
+      name: "テスト役割",
+    });
+
+    expect(updated.name.value).toBe("テスト役割");
+  });
+
+  it("循環参照が発生する上位役割を指定するとエラー", async () => {
+    // buchou -> kachou の順番で作成し、kachouの上位をbuchouにする
+    const buchouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("テスト部長"),
+      buchouPositionId
+    );
+    await roleRepository.save(buchouRole);
+
+    const kachouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("テスト課長"),
+      kachouPositionId,
+      buchouRole.id
+    );
+    await roleRepository.save(kachouRole);
+
+    // buchouの上位をkachouにしようとする → 循環参照エラー
+    // ただし役職チェックで先に弾かれる可能性があるため、
+    // 同じ役職レベルでテストする
+    await expect(
+      command.execute({
+        id: buchouRole.id,
+        superiorRoleId: buchouRole.id,
+      })
+    ).rejects.toThrow(BusinessRuleViolationError);
+  });
+});

--- a/src/server/subdomains/role/application/factories/createRoleCommandFactory.ts
+++ b/src/server/subdomains/role/application/factories/createRoleCommandFactory.ts
@@ -1,0 +1,29 @@
+import { CreateRoleCommand } from "../commands/CreateRoleCommand";
+import { RoleCdDuplicationCheckDomainService } from "../../domain/services/RoleCdDuplicationCheckDomainService";
+import { RoleNameDuplicationCheckDomainService } from "../../domain/services/RoleNameDuplicationCheckDomainService";
+import { SuperiorRoleValidationDomainService } from "../../domain/services/SuperiorRoleValidationDomainService";
+import { PrismaRoleRepository } from "../../infrastructure/prisma/PrismaRoleRepository";
+import { PrismaPositionRepository } from "../../infrastructure/prisma/PrismaPositionRepository";
+
+/**
+ * CreateRoleCommand のファクトリ関数
+ *
+ * 5つの依存を解決する Composition Root:
+ * - RoleRepository (save, findByRoleCd, findByName)
+ * - PositionRepository (exists - 役職存在確認)
+ * - RoleCdDuplicationCheckDomainService
+ * - RoleNameDuplicationCheckDomainService
+ * - SuperiorRoleValidationDomainService (上位役割の役職レベルチェック)
+ */
+export function createRoleCommandFactory(): CreateRoleCommand {
+  const roleRepository = new PrismaRoleRepository();
+  const positionRepository = new PrismaPositionRepository();
+
+  return new CreateRoleCommand(
+    roleRepository,
+    positionRepository,
+    new RoleCdDuplicationCheckDomainService(roleRepository),
+    new RoleNameDuplicationCheckDomainService(roleRepository),
+    new SuperiorRoleValidationDomainService(roleRepository, positionRepository)
+  );
+}

--- a/src/server/subdomains/role/application/factories/deleteRoleCommandFactory.ts
+++ b/src/server/subdomains/role/application/factories/deleteRoleCommandFactory.ts
@@ -1,0 +1,11 @@
+import { DeleteRoleCommand } from "../commands/DeleteRoleCommand";
+import { PrismaRoleRepository } from "../../infrastructure/prisma/PrismaRoleRepository";
+
+/**
+ * DeleteRoleCommand のファクトリ関数
+ */
+export function deleteRoleCommandFactory(): DeleteRoleCommand {
+  const repository = new PrismaRoleRepository();
+
+  return new DeleteRoleCommand(repository);
+}

--- a/src/server/subdomains/role/application/factories/index.ts
+++ b/src/server/subdomains/role/application/factories/index.ts
@@ -1,0 +1,9 @@
+export { createRoleCommandFactory } from "./createRoleCommandFactory";
+export { updateRoleCommandFactory } from "./updateRoleCommandFactory";
+export { deleteRoleCommandFactory } from "./deleteRoleCommandFactory";
+export {
+  getAllRolesQueryFactory,
+  getRoleByIdQueryFactory,
+  searchRolesQueryFactory,
+  getRolesByPositionQueryFactory,
+} from "./roleQueryFactory";

--- a/src/server/subdomains/role/application/factories/roleQueryFactory.ts
+++ b/src/server/subdomains/role/application/factories/roleQueryFactory.ts
@@ -1,0 +1,29 @@
+import { GetAllRolesQuery } from "../queries/GetAllRolesQuery";
+import { GetRoleByIdQuery } from "../queries/GetRoleByIdQuery";
+import { GetRolesByPositionQuery } from "../queries/GetRolesByPositionQuery";
+import { SearchRolesQuery } from "../queries/SearchRolesQuery";
+import { PrismaRoleQueryService } from "../../infrastructure/queries/PrismaRoleQueryService";
+
+/**
+ * 役割クエリ関連のファクトリ関数
+ */
+
+export function getAllRolesQueryFactory(): GetAllRolesQuery {
+  const queryService = new PrismaRoleQueryService();
+  return new GetAllRolesQuery(queryService);
+}
+
+export function getRoleByIdQueryFactory(): GetRoleByIdQuery {
+  const queryService = new PrismaRoleQueryService();
+  return new GetRoleByIdQuery(queryService);
+}
+
+export function searchRolesQueryFactory(): SearchRolesQuery {
+  const queryService = new PrismaRoleQueryService();
+  return new SearchRolesQuery(queryService);
+}
+
+export function getRolesByPositionQueryFactory(): GetRolesByPositionQuery {
+  const queryService = new PrismaRoleQueryService();
+  return new GetRolesByPositionQuery(queryService);
+}

--- a/src/server/subdomains/role/application/factories/updateRoleCommandFactory.ts
+++ b/src/server/subdomains/role/application/factories/updateRoleCommandFactory.ts
@@ -1,0 +1,19 @@
+import { UpdateRoleCommand } from "../commands/UpdateRoleCommand";
+import { RoleNameDuplicationCheckDomainService } from "../../domain/services/RoleNameDuplicationCheckDomainService";
+import { SuperiorRoleValidationDomainService } from "../../domain/services/SuperiorRoleValidationDomainService";
+import { PrismaRoleRepository } from "../../infrastructure/prisma/PrismaRoleRepository";
+import { PrismaPositionRepository } from "../../infrastructure/prisma/PrismaPositionRepository";
+
+/**
+ * UpdateRoleCommand のファクトリ関数
+ */
+export function updateRoleCommandFactory(): UpdateRoleCommand {
+  const roleRepository = new PrismaRoleRepository();
+  const positionRepository = new PrismaPositionRepository();
+
+  return new UpdateRoleCommand(
+    roleRepository,
+    new RoleNameDuplicationCheckDomainService(roleRepository),
+    new SuperiorRoleValidationDomainService(roleRepository, positionRepository)
+  );
+}

--- a/src/server/subdomains/role/application/queries/GetAllRolesQuery.ts
+++ b/src/server/subdomains/role/application/queries/GetAllRolesQuery.ts
@@ -1,0 +1,18 @@
+import { RoleDTO } from "./dto/RoleDTO";
+import { RoleListOptions } from "./dto/RoleSearchCriteria";
+import { RoleQueryService } from "./RoleQueryService";
+
+export type GetAllRolesInput = {
+  options?: RoleListOptions;
+};
+
+/**
+ * 全役割取得クエリ
+ */
+export class GetAllRolesQuery {
+  public constructor(private readonly roleQueryService: RoleQueryService) {}
+
+  async execute(input: GetAllRolesInput): Promise<RoleDTO[]> {
+    return await this.roleQueryService.findAll(input.options);
+  }
+}

--- a/src/server/subdomains/role/application/queries/GetRoleByIdQuery.ts
+++ b/src/server/subdomains/role/application/queries/GetRoleByIdQuery.ts
@@ -1,0 +1,17 @@
+import { RoleDTO } from "./dto/RoleDTO";
+import { RoleQueryService } from "./RoleQueryService";
+
+export type GetRoleByIdInput = {
+  id: string;
+};
+
+/**
+ * ID指定役割取得クエリ
+ */
+export class GetRoleByIdQuery {
+  public constructor(private readonly roleQueryService: RoleQueryService) {}
+
+  async execute(input: GetRoleByIdInput): Promise<RoleDTO | null> {
+    return await this.roleQueryService.findById(input.id);
+  }
+}

--- a/src/server/subdomains/role/application/queries/GetRolesByPositionQuery.ts
+++ b/src/server/subdomains/role/application/queries/GetRolesByPositionQuery.ts
@@ -1,0 +1,19 @@
+import { RoleDTO } from "./dto/RoleDTO";
+import { RoleListOptions } from "./dto/RoleSearchCriteria";
+import { RoleQueryService } from "./RoleQueryService";
+
+export type GetRolesByPositionInput = {
+  positionId: string;
+  options?: RoleListOptions;
+};
+
+/**
+ * 役職別役割取得クエリ
+ */
+export class GetRolesByPositionQuery {
+  public constructor(private readonly roleQueryService: RoleQueryService) {}
+
+  async execute(input: GetRolesByPositionInput): Promise<RoleDTO[]> {
+    return await this.roleQueryService.findByPositionId(input.positionId, input.options);
+  }
+}

--- a/src/server/subdomains/role/application/queries/RoleQueryService.ts
+++ b/src/server/subdomains/role/application/queries/RoleQueryService.ts
@@ -1,0 +1,30 @@
+import { RoleDTO } from "./dto/RoleDTO";
+import { RoleSearchCriteria, RoleListOptions } from "./dto/RoleSearchCriteria";
+
+/**
+ * 役割クエリサービスインターフェース
+ *
+ * 読み取り専用の検索・取得機能を提供
+ * 軽量なDTOで結果を返す（position名, superiorRole名をJOIN）
+ */
+export interface RoleQueryService {
+  /**
+   * IDで役割を取得
+   */
+  findById(id: string): Promise<RoleDTO | null>;
+
+  /**
+   * 検索条件に基づいて役割を検索
+   */
+  search(criteria: RoleSearchCriteria, options?: RoleListOptions): Promise<RoleDTO[]>;
+
+  /**
+   * 全役割を取得
+   */
+  findAll(options?: RoleListOptions): Promise<RoleDTO[]>;
+
+  /**
+   * 役職IDで役割を取得
+   */
+  findByPositionId(positionId: string, options?: RoleListOptions): Promise<RoleDTO[]>;
+}

--- a/src/server/subdomains/role/application/queries/SearchRolesQuery.ts
+++ b/src/server/subdomains/role/application/queries/SearchRolesQuery.ts
@@ -1,0 +1,19 @@
+import { RoleDTO } from "./dto/RoleDTO";
+import { RoleSearchCriteria, RoleListOptions } from "./dto/RoleSearchCriteria";
+import { RoleQueryService } from "./RoleQueryService";
+
+export type SearchRolesInput = {
+  criteria: RoleSearchCriteria;
+  options?: RoleListOptions;
+};
+
+/**
+ * 役割検索クエリ
+ */
+export class SearchRolesQuery {
+  public constructor(private readonly roleQueryService: RoleQueryService) {}
+
+  async execute(input: SearchRolesInput): Promise<RoleDTO[]> {
+    return await this.roleQueryService.search(input.criteria, input.options);
+  }
+}

--- a/src/server/subdomains/role/application/queries/__tests__/GetAllRolesQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetAllRolesQuery.test.ts
@@ -1,0 +1,83 @@
+import prisma from "@server/prisma";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetAllRolesQuery } from "../GetAllRolesQuery";
+
+describe("GetAllRolesQuery", () => {
+  let query: GetAllRolesQuery;
+  let roleRepository: PrismaRoleRepository;
+
+  const TEST_ROLE_CDS = ["ROLE941", "ROLE942"];
+
+  let kachouPositionId: string;
+
+  async function cleanup() {
+    await prisma.role.updateMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+      data: { superiorRoleId: null },
+    });
+    await prisma.role.deleteMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const kachou = await prisma.position.findUnique({ where: { positionCd: "POS001" } });
+    kachouPositionId = kachou!.id;
+
+    roleRepository = new PrismaRoleRepository();
+    query = new GetAllRolesQuery(new PrismaRoleQueryService());
+  });
+
+  afterEach(cleanup);
+
+  it("全役割を取得できる", async () => {
+    const role1 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("全取得テストA"),
+      kachouPositionId
+    );
+    const role2 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("全取得テストB"),
+      kachouPositionId
+    );
+    await roleRepository.save(role1);
+    await roleRepository.save(role2);
+
+    const result = await query.execute({});
+
+    const roleCds = result.map((r) => r.roleCd);
+    expect(roleCds).toContain(TEST_ROLE_CDS[0]);
+    expect(roleCds).toContain(TEST_ROLE_CDS[1]);
+  });
+
+  it("ソートオプションを指定できる", async () => {
+    const role1 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("全取得ソートA"),
+      kachouPositionId
+    );
+    const role2 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("全取得ソートB"),
+      kachouPositionId
+    );
+    await roleRepository.save(role1);
+    await roleRepository.save(role2);
+
+    const result = await query.execute({
+      options: { orderBy: { field: "roleCd", direction: "desc" } },
+    });
+
+    const testResults = result.filter((r) => TEST_ROLE_CDS.includes(r.roleCd));
+    expect(testResults[0].roleCd).toBe(TEST_ROLE_CDS[1]);
+    expect(testResults[1].roleCd).toBe(TEST_ROLE_CDS[0]);
+  });
+});

--- a/src/server/subdomains/role/application/queries/__tests__/GetRoleByIdQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetRoleByIdQuery.test.ts
@@ -1,0 +1,66 @@
+import prisma from "@server/prisma";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetRoleByIdQuery } from "../GetRoleByIdQuery";
+
+describe("GetRoleByIdQuery", () => {
+  let query: GetRoleByIdQuery;
+  let roleRepository: PrismaRoleRepository;
+
+  const TEST_ROLE_CDS = ["ROLE931"];
+
+  let kachouPositionId: string;
+
+  async function cleanup() {
+    await prisma.role.updateMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+      data: { superiorRoleId: null },
+    });
+    await prisma.role.deleteMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const kachou = await prisma.position.findUnique({ where: { positionCd: "POS001" } });
+    kachouPositionId = kachou!.id;
+
+    roleRepository = new PrismaRoleRepository();
+    query = new GetRoleByIdQuery(new PrismaRoleQueryService());
+  });
+
+  afterEach(cleanup);
+
+  it("IDで役割を取得できる", async () => {
+    const role = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("ID取得テスト役割"),
+      kachouPositionId
+    );
+    await roleRepository.save(role);
+
+    const result = await query.execute({ id: role.id });
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(role.id);
+    expect(result?.roleCd).toBe(TEST_ROLE_CDS[0]);
+    expect(result?.name).toBe("ID取得テスト役割");
+    expect(result?.positionId).toBe(kachouPositionId);
+    expect(result?.positionName).toBe("課長");
+    expect(result?.superiorRoleId).toBeNull();
+    expect(result?.superiorRoleName).toBeNull();
+    expect(result?.createdAt).toBeInstanceOf(Date);
+    expect(result?.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it("存在しないIDの場合nullを返す", async () => {
+    const result = await query.execute({ id: "non-existent-id" });
+    expect(result).toBeNull();
+  });
+});

--- a/src/server/subdomains/role/application/queries/__tests__/GetRolesByPositionQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetRolesByPositionQuery.test.ts
@@ -1,0 +1,70 @@
+import prisma from "@server/prisma";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetRolesByPositionQuery } from "../GetRolesByPositionQuery";
+
+describe("GetRolesByPositionQuery", () => {
+  let query: GetRolesByPositionQuery;
+  let roleRepository: PrismaRoleRepository;
+
+  const TEST_ROLE_CDS = ["ROLE921", "ROLE922"];
+
+  let kachouPositionId: string;
+  let buchouPositionId: string;
+
+  async function cleanup() {
+    await prisma.role.updateMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+      data: { superiorRoleId: null },
+    });
+    await prisma.role.deleteMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const [kachou, buchou] = await Promise.all([
+      prisma.position.findUnique({ where: { positionCd: "POS001" } }),
+      prisma.position.findUnique({ where: { positionCd: "POS002" } }),
+    ]);
+    kachouPositionId = kachou!.id;
+    buchouPositionId = buchou!.id;
+
+    roleRepository = new PrismaRoleRepository();
+    query = new GetRolesByPositionQuery(new PrismaRoleQueryService());
+  });
+
+  afterEach(cleanup);
+
+  it("役職IDで役割を取得できる", async () => {
+    const role1 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("役職別テスト課長"),
+      kachouPositionId
+    );
+    const role2 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("役職別テスト部長"),
+      buchouPositionId
+    );
+    await roleRepository.save(role1);
+    await roleRepository.save(role2);
+
+    const result = await query.execute({ positionId: kachouPositionId });
+
+    const roleCds = result.map((r) => r.roleCd);
+    expect(roleCds).toContain(TEST_ROLE_CDS[0]);
+    expect(roleCds).not.toContain(TEST_ROLE_CDS[1]);
+  });
+
+  it("該当する役割がない場合は空配列を返す", async () => {
+    const result = await query.execute({ positionId: "non-existent-position-id" });
+    expect(result).toEqual([]);
+  });
+});

--- a/src/server/subdomains/role/application/queries/__tests__/SearchRolesQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/SearchRolesQuery.test.ts
@@ -1,0 +1,195 @@
+import prisma from "@server/prisma";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SearchRolesQuery } from "../SearchRolesQuery";
+
+describe("SearchRolesQuery", () => {
+  let query: SearchRolesQuery;
+  let roleRepository: PrismaRoleRepository;
+
+  const TEST_ROLE_CDS = ["ROLE951", "ROLE952", "ROLE953"];
+
+  let kachouPositionId: string;
+  let buchouPositionId: string;
+
+  async function cleanup() {
+    await prisma.role.updateMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+      data: { superiorRoleId: null },
+    });
+    await prisma.role.deleteMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const [kachou, buchou] = await Promise.all([
+      prisma.position.findUnique({ where: { positionCd: "POS001" } }),
+      prisma.position.findUnique({ where: { positionCd: "POS002" } }),
+    ]);
+    kachouPositionId = kachou!.id;
+    buchouPositionId = buchou!.id;
+
+    roleRepository = new PrismaRoleRepository();
+    query = new SearchRolesQuery(new PrismaRoleQueryService());
+  });
+
+  afterEach(cleanup);
+
+  it("役割名で部分一致検索できる", async () => {
+    const role1 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("検索大阪営業課長"),
+      kachouPositionId
+    );
+    const role2 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("検索東京開発課長"),
+      kachouPositionId
+    );
+    await roleRepository.save(role1);
+    await roleRepository.save(role2);
+
+    const result = await query.execute({ criteria: { name: "大阪" } });
+
+    const roleCds = result.map((r) => r.roleCd);
+    expect(roleCds).toContain(TEST_ROLE_CDS[0]);
+    expect(roleCds).not.toContain(TEST_ROLE_CDS[1]);
+  });
+
+  it("役割コードで完全一致検索できる", async () => {
+    const role = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("検索コードテスト"),
+      kachouPositionId
+    );
+    await roleRepository.save(role);
+
+    const result = await query.execute({ criteria: { roleCd: TEST_ROLE_CDS[0] } });
+
+    expect(result.length).toBe(1);
+    expect(result[0].roleCd).toBe(TEST_ROLE_CDS[0]);
+  });
+
+  it("役職IDで検索できる", async () => {
+    const role1 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("検索役職課長"),
+      kachouPositionId
+    );
+    const role2 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("検索役職部長"),
+      buchouPositionId
+    );
+    await roleRepository.save(role1);
+    await roleRepository.save(role2);
+
+    const result = await query.execute({ criteria: { positionId: kachouPositionId } });
+
+    const roleCds = result.map((r) => r.roleCd);
+    expect(roleCds).toContain(TEST_ROLE_CDS[0]);
+    expect(roleCds).not.toContain(TEST_ROLE_CDS[1]);
+  });
+
+  it("上位役割IDで検索できる", async () => {
+    const buchouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("検索上位部長"),
+      buchouPositionId
+    );
+    await roleRepository.save(buchouRole);
+
+    const kachouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("検索上位課長"),
+      kachouPositionId,
+      buchouRole.id
+    );
+    await roleRepository.save(kachouRole);
+
+    const result = await query.execute({ criteria: { superiorRoleId: buchouRole.id } });
+
+    const roleCds = result.map((r) => r.roleCd);
+    expect(roleCds).toContain(TEST_ROLE_CDS[1]);
+    expect(roleCds).not.toContain(TEST_ROLE_CDS[0]);
+  });
+
+  it("上位役割がnullのルート役割のみ検索できる", async () => {
+    const buchouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("検索ルート部長"),
+      buchouPositionId
+    );
+    await roleRepository.save(buchouRole);
+
+    const kachouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("検索ルート課長"),
+      kachouPositionId,
+      buchouRole.id
+    );
+    await roleRepository.save(kachouRole);
+
+    const result = await query.execute({ criteria: { superiorRoleId: null } });
+
+    const roleCds = result.map((r) => r.roleCd);
+    expect(roleCds).toContain(TEST_ROLE_CDS[0]);
+    expect(roleCds).not.toContain(TEST_ROLE_CDS[1]);
+  });
+
+  it("上位役割名がDTOに含まれる", async () => {
+    const buchouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("検索DTO部長"),
+      buchouPositionId
+    );
+    await roleRepository.save(buchouRole);
+
+    const kachouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("検索DTO課長"),
+      kachouPositionId,
+      buchouRole.id
+    );
+    await roleRepository.save(kachouRole);
+
+    const result = await query.execute({ criteria: { roleCd: TEST_ROLE_CDS[1] } });
+
+    expect(result[0].superiorRoleName).toBe("検索DTO部長");
+    expect(result[0].positionName).toBe("課長");
+  });
+
+  it("条件に一致する役割がない場合は空配列を返す", async () => {
+    const result = await query.execute({ criteria: { name: "存在しない検索役割名" } });
+    expect(result).toEqual([]);
+  });
+
+  it("検索条件とオプションを組み合わせて検索できる", async () => {
+    const role1 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("検索オプA課長"),
+      kachouPositionId
+    );
+    const role2 = Role.create(
+      new RoleCd(TEST_ROLE_CDS[1]),
+      new RoleName("検索オプB課長"),
+      kachouPositionId
+    );
+    await roleRepository.save(role1);
+    await roleRepository.save(role2);
+
+    const result = await query.execute({
+      criteria: { name: "検索オプ" },
+      options: { limit: 1, orderBy: { field: "roleCd", direction: "asc" } },
+    });
+
+    expect(result.length).toBe(1);
+  });
+});

--- a/src/server/subdomains/role/application/queries/dto/RoleDTO.ts
+++ b/src/server/subdomains/role/application/queries/dto/RoleDTO.ts
@@ -1,0 +1,16 @@
+/**
+ * 役割データ転送オブジェクト
+ * 読み取り専用のデータ表現（軽量）
+ * position, superiorRole の名前をJOINして返す
+ */
+export type RoleDTO = {
+  id: string;
+  roleCd: string;
+  name: string;
+  positionId: string;
+  positionName: string;
+  superiorRoleId: string | null;
+  superiorRoleName: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/server/subdomains/role/application/queries/dto/RoleSearchCriteria.ts
+++ b/src/server/subdomains/role/application/queries/dto/RoleSearchCriteria.ts
@@ -1,0 +1,37 @@
+import type { SortOrder } from "@server/shared/queries/SortOrder";
+
+/**
+ * 役割検索条件
+ */
+export type RoleSearchCriteria = {
+  /** 役割名での部分一致検索 */
+  name?: string;
+
+  /** 役割コードでの完全一致検索 */
+  roleCd?: string;
+
+  /** 役職IDでのフィルタ */
+  positionId?: string;
+
+  /** 上位役割IDでのフィルタ（nullでルート役割のみ） */
+  superiorRoleId?: string | null;
+};
+
+/**
+ * ソート可能なフィールド
+ */
+export type RoleSortField = "name" | "roleCd" | "createdAt" | "updatedAt";
+
+/**
+ * リスト取得のオプション
+ */
+export type RoleListOptions = {
+  /** 取得件数制限 */
+  limit?: number;
+
+  /** オフセット */
+  offset?: number;
+
+  /** ソート順 */
+  orderBy?: SortOrder<RoleSortField>;
+};

--- a/src/server/subdomains/role/domain/entities/Role.ts
+++ b/src/server/subdomains/role/domain/entities/Role.ts
@@ -1,0 +1,112 @@
+import { createId } from "@paralleldrive/cuid2";
+import { RoleCd } from "../values/RoleCd";
+import { RoleName } from "../values/RoleName";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+
+/**
+ * 役割エンティティ
+ *
+ * 組織内の具体的な役割（大阪市南課長、営業部長など）を表現する。
+ * 各役割は1つの役職に属し、上位役割への参照を持つ。
+ * 承認フローは上位役割チェーンを辿って構築される。
+ */
+export class Role {
+  /** エンティティ名（エラーメッセージ用） */
+  static readonly ENTITY_NAME = "役割";
+
+  private constructor(
+    private readonly _id: string,
+    private readonly _roleCd: RoleCd,
+    private _name: RoleName,
+    private readonly _positionId: string,
+    private _superiorRoleId: string | null,
+    private readonly _createdAt: Date,
+    private _updatedAt: Date
+  ) {}
+
+  /**
+   * 新規役割を作成
+   */
+  static create(
+    roleCd: RoleCd,
+    name: RoleName,
+    positionId: string,
+    superiorRoleId: string | null = null
+  ): Role {
+    const now = new Date();
+    return new Role(createId(), roleCd, name, positionId, superiorRoleId, now, now);
+  }
+
+  /**
+   * DBから役割を再構築
+   */
+  static reconstruct(
+    id: string,
+    roleCd: RoleCd,
+    name: RoleName,
+    positionId: string,
+    superiorRoleId: string | null,
+    createdAt: Date,
+    updatedAt: Date
+  ): Role {
+    return new Role(id, roleCd, name, positionId, superiorRoleId, createdAt, updatedAt);
+  }
+
+  // ========================================
+  // ビジネスロジック
+  // ========================================
+
+  /**
+   * 役割名を変更
+   */
+  changeName(newName: RoleName): void {
+    this._name = newName;
+    this._updatedAt = new Date();
+  }
+
+  /**
+   * 上位役割を変更
+   *
+   * 自分自身を上位役割に設定することはできない。
+   * 上位役職に属する役割かどうかの検証はドメインサービスで行う。
+   */
+  changeSuperiorRole(newSuperiorRoleId: string | null): void {
+    if (newSuperiorRoleId === this._id) {
+      throw new BusinessRuleViolationError("自分自身を上位役割にすることはできません");
+    }
+    this._superiorRoleId = newSuperiorRoleId;
+    this._updatedAt = new Date();
+  }
+
+  // ========================================
+  // ゲッター
+  // ========================================
+
+  get id(): string {
+    return this._id;
+  }
+
+  get roleCd(): RoleCd {
+    return this._roleCd;
+  }
+
+  get name(): RoleName {
+    return this._name;
+  }
+
+  get positionId(): string {
+    return this._positionId;
+  }
+
+  get superiorRoleId(): string | null {
+    return this._superiorRoleId;
+  }
+
+  get createdAt(): Date {
+    return this._createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+}

--- a/src/server/subdomains/role/domain/entities/__tests__/Role.test.ts
+++ b/src/server/subdomains/role/domain/entities/__tests__/Role.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { Role } from "../Role";
+import { RoleCd } from "../../values/RoleCd";
+import { RoleName } from "../../values/RoleName";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+
+describe("Role", () => {
+  const createTestRole = (overrides?: {
+    roleCd?: RoleCd;
+    name?: RoleName;
+    positionId?: string;
+    superiorRoleId?: string | null;
+  }) => {
+    return Role.create(
+      overrides?.roleCd ?? new RoleCd("ROLE001"),
+      overrides?.name ?? new RoleName("大阪市南課長"),
+      overrides?.positionId ?? "position-id-001",
+      overrides?.superiorRoleId !== undefined ? overrides.superiorRoleId : "superior-role-id"
+    );
+  };
+
+  describe("create", () => {
+    it("新規役割を作成できる", () => {
+      const role = createTestRole();
+
+      expect(role.id).toBeDefined();
+      expect(role.roleCd.value).toBe("ROLE001");
+      expect(role.name.value).toBe("大阪市南課長");
+      expect(role.positionId).toBe("position-id-001");
+      expect(role.superiorRoleId).toBe("superior-role-id");
+      expect(role.createdAt).toBeInstanceOf(Date);
+      expect(role.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it("上位役割なしで作成できる", () => {
+      const role = createTestRole({ superiorRoleId: null });
+
+      expect(role.superiorRoleId).toBeNull();
+    });
+  });
+
+  describe("reconstruct", () => {
+    it("DBから役割を再構築できる", () => {
+      const createdAt = new Date("2025-01-01");
+      const updatedAt = new Date("2025-06-01");
+
+      const role = Role.reconstruct(
+        "test-id",
+        new RoleCd("ROLE001"),
+        new RoleName("営業部長"),
+        "position-id",
+        "superior-id",
+        createdAt,
+        updatedAt
+      );
+
+      expect(role.id).toBe("test-id");
+      expect(role.roleCd.value).toBe("ROLE001");
+      expect(role.name.value).toBe("営業部長");
+      expect(role.positionId).toBe("position-id");
+      expect(role.superiorRoleId).toBe("superior-id");
+      expect(role.createdAt).toEqual(createdAt);
+      expect(role.updatedAt).toEqual(updatedAt);
+    });
+  });
+
+  describe("changeName", () => {
+    it("役割名を変更できる", () => {
+      const role = createTestRole();
+      const originalUpdatedAt = role.updatedAt;
+
+      role.changeName(new RoleName("新しい役割名"));
+
+      expect(role.name.value).toBe("新しい役割名");
+      expect(role.updatedAt.getTime()).toBeGreaterThanOrEqual(originalUpdatedAt.getTime());
+    });
+  });
+
+  describe("changeSuperiorRole", () => {
+    it("上位役割を変更できる", () => {
+      const role = createTestRole();
+      const originalUpdatedAt = role.updatedAt;
+
+      role.changeSuperiorRole("new-superior-id");
+
+      expect(role.superiorRoleId).toBe("new-superior-id");
+      expect(role.updatedAt.getTime()).toBeGreaterThanOrEqual(originalUpdatedAt.getTime());
+    });
+
+    it("上位役割をnullに変更できる", () => {
+      const role = createTestRole({ superiorRoleId: "some-id" });
+
+      role.changeSuperiorRole(null);
+
+      expect(role.superiorRoleId).toBeNull();
+    });
+
+    it("自分自身を上位役割にするとエラー", () => {
+      const role = createTestRole();
+
+      expect(() => role.changeSuperiorRole(role.id)).toThrow(BusinessRuleViolationError);
+      expect(() => role.changeSuperiorRole(role.id)).toThrow(
+        "自分自身を上位役割にすることはできません"
+      );
+    });
+  });
+
+  describe("ENTITY_NAME", () => {
+    it("エンティティ名が正しい", () => {
+      expect(Role.ENTITY_NAME).toBe("役割");
+    });
+  });
+});

--- a/src/server/subdomains/role/domain/repositories/PositionRepository.ts
+++ b/src/server/subdomains/role/domain/repositories/PositionRepository.ts
@@ -1,0 +1,18 @@
+/**
+ * 役割ドメインが必要とする役職リポジトリインターフェース
+ *
+ * Roleドメインの上位役割バリデーションに必要な最小限のメソッドのみ定義。
+ * Positionサブドメインの PositionRepository とは独立したインターフェース。
+ */
+export interface PositionRepository {
+  /**
+   * 指定した役職の上位役職IDを取得
+   * @returns 上位役職ID（最上位の場合は null）
+   */
+  findSuperiorPositionId(positionId: string): Promise<string | null>;
+
+  /**
+   * 指定した役職が存在するか確認
+   */
+  exists(positionId: string): Promise<boolean>;
+}

--- a/src/server/subdomains/role/domain/repositories/RoleRepository.ts
+++ b/src/server/subdomains/role/domain/repositories/RoleRepository.ts
@@ -1,0 +1,47 @@
+import { Role } from "../entities/Role";
+import { RoleCd } from "../values/RoleCd";
+
+/**
+ * 役割リポジトリインターフェース
+ *
+ * Repository は Entity の永続化・取得（完全な Entity の再構築）を担当する。
+ * 検索・一覧取得など読み取り専用の操作は RoleQueryService を使用すること。
+ */
+export interface RoleRepository {
+  /**
+   * 役割を保存（新規作成・更新）
+   */
+  save(role: Role): Promise<Role>;
+
+  /**
+   * 役割を削除
+   */
+  delete(id: string): Promise<void>;
+
+  /**
+   * IDで役割を取得
+   */
+  findById(id: string): Promise<Role | null>;
+
+  /**
+   * 役割コードで役割を取得（重複チェック等で Entity が必要な場合に使用）
+   */
+  findByRoleCd(roleCd: RoleCd): Promise<Role | null>;
+
+  /**
+   * 役割名で役割を取得（重複チェックで使用）
+   */
+  findByName(name: string): Promise<Role | null>;
+
+  /**
+   * 下位役割を取得
+   * @param superiorRoleId 上位役割ID
+   */
+  findSubordinates(superiorRoleId: string): Promise<Role[]>;
+
+  /**
+   * 役割が使用中かどうかを確認
+   * EmployeeRole または Employee.superiorRoleId で参照されている場合は true
+   */
+  isInUse(roleId: string): Promise<boolean>;
+}

--- a/src/server/subdomains/role/domain/services/RoleCdDuplicationCheckDomainService.ts
+++ b/src/server/subdomains/role/domain/services/RoleCdDuplicationCheckDomainService.ts
@@ -1,0 +1,14 @@
+import { RoleRepository } from "../repositories/RoleRepository";
+import { RoleCd } from "../values/RoleCd";
+
+/**
+ * 役割コード重複チェックドメインサービス
+ */
+export class RoleCdDuplicationCheckDomainService {
+  constructor(private readonly roleRepository: RoleRepository) {}
+
+  async execute(roleCd: RoleCd): Promise<boolean> {
+    const existingRole = await this.roleRepository.findByRoleCd(roleCd);
+    return !!existingRole;
+  }
+}

--- a/src/server/subdomains/role/domain/services/RoleNameDuplicationCheckDomainService.ts
+++ b/src/server/subdomains/role/domain/services/RoleNameDuplicationCheckDomainService.ts
@@ -1,0 +1,25 @@
+import { RoleRepository } from "../repositories/RoleRepository";
+
+/**
+ * 役割名重複チェックドメインサービス
+ */
+export class RoleNameDuplicationCheckDomainService {
+  constructor(private readonly roleRepository: RoleRepository) {}
+
+  /**
+   * @param name 検査する役割名
+   * @param excludeId 除外するID（更新時に自分自身を除外するため）
+   * @returns 重複がある場合 true
+   */
+  async execute(name: string, excludeId?: string): Promise<boolean> {
+    const existingRole = await this.roleRepository.findByName(name);
+    if (!existingRole) {
+      return false;
+    }
+    // 更新時: 自分自身は除外
+    if (excludeId && existingRole.id === excludeId) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/server/subdomains/role/domain/services/SuperiorRoleValidationDomainService.ts
+++ b/src/server/subdomains/role/domain/services/SuperiorRoleValidationDomainService.ts
@@ -1,0 +1,46 @@
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { RoleRepository } from "../repositories/RoleRepository";
+import { PositionRepository } from "../repositories/PositionRepository";
+
+/**
+ * 上位役割バリデーションドメインサービス
+ *
+ * 「上位役割に指定できるのは、選択した役職の上位役職に属する役割のみ」
+ * というビジネスルールを検証する。
+ */
+export class SuperiorRoleValidationDomainService {
+  constructor(
+    private readonly roleRepository: RoleRepository,
+    private readonly positionRepository: PositionRepository
+  ) {}
+
+  /**
+   * 上位役割の妥当性を検証
+   *
+   * @param positionId 当該役割の役職ID
+   * @param superiorRoleId 設定しようとする上位役割ID
+   * @throws BusinessRuleViolationError バリデーション失敗時
+   */
+  async execute(positionId: string, superiorRoleId: string): Promise<void> {
+    // 1. 当該役職の上位役職IDを取得
+    const superiorPositionId = await this.positionRepository.findSuperiorPositionId(positionId);
+
+    // 2. 最上位役職（社長）には上位役割を設定できない
+    if (superiorPositionId === null) {
+      throw new BusinessRuleViolationError("最上位の役職には上位役割を設定できません");
+    }
+
+    // 3. 上位役割を取得
+    const superiorRole = await this.roleRepository.findById(superiorRoleId);
+    if (!superiorRole) {
+      throw new BusinessRuleViolationError(`上位役割が存在しません: ID=${superiorRoleId}`);
+    }
+
+    // 4. 上位役割の役職が、当該役職の上位役職と一致するか検証
+    if (superiorRole.positionId !== superiorPositionId) {
+      throw new BusinessRuleViolationError(
+        "上位役割に指定できるのは、選択した役職の上位役職に属する役割のみです"
+      );
+    }
+  }
+}

--- a/src/server/subdomains/role/domain/services/__tests__/RoleCdDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/role/domain/services/__tests__/RoleCdDuplicationCheckDomainService.test.ts
@@ -1,0 +1,51 @@
+import prisma from "@server/prisma";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RoleCdDuplicationCheckDomainService } from "../RoleCdDuplicationCheckDomainService";
+
+describe("RoleCdDuplicationCheckDomainService", () => {
+  let service: RoleCdDuplicationCheckDomainService;
+  let repository: PrismaRoleRepository;
+
+  const TEST_ROLE_CD = "ROLE998";
+  const TEST_POSITION_CD = "POS001"; // シードデータの課長
+
+  let positionId: string;
+
+  async function cleanup() {
+    await prisma.role.deleteMany({
+      where: { roleCd: TEST_ROLE_CD },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    // シードデータのPositionを取得
+    const position = await prisma.position.findUnique({
+      where: { positionCd: TEST_POSITION_CD },
+    });
+    positionId = position!.id;
+
+    repository = new PrismaRoleRepository();
+    service = new RoleCdDuplicationCheckDomainService(repository);
+  });
+
+  afterEach(cleanup);
+
+  it("役割コードが存在しない場合は false を返す", async () => {
+    const isDuplicated = await service.execute(new RoleCd(TEST_ROLE_CD));
+    expect(isDuplicated).toBe(false);
+  });
+
+  it("役割コードが既に存在する場合は true を返す", async () => {
+    const role = Role.create(new RoleCd(TEST_ROLE_CD), new RoleName("テスト役割"), positionId);
+    await repository.save(role);
+
+    const isDuplicated = await service.execute(new RoleCd(TEST_ROLE_CD));
+    expect(isDuplicated).toBe(true);
+  });
+});

--- a/src/server/subdomains/role/domain/services/__tests__/RoleNameDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/role/domain/services/__tests__/RoleNameDuplicationCheckDomainService.test.ts
@@ -1,0 +1,59 @@
+import prisma from "@server/prisma";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RoleNameDuplicationCheckDomainService } from "../RoleNameDuplicationCheckDomainService";
+
+describe("RoleNameDuplicationCheckDomainService", () => {
+  let service: RoleNameDuplicationCheckDomainService;
+  let repository: PrismaRoleRepository;
+
+  const TEST_ROLE_CD = "ROLE997";
+  const TEST_ROLE_NAME = "テスト用ユニーク役割名";
+  const TEST_POSITION_CD = "POS001";
+
+  let positionId: string;
+
+  async function cleanup() {
+    await prisma.role.deleteMany({
+      where: { roleCd: TEST_ROLE_CD },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const position = await prisma.position.findUnique({
+      where: { positionCd: TEST_POSITION_CD },
+    });
+    positionId = position!.id;
+
+    repository = new PrismaRoleRepository();
+    service = new RoleNameDuplicationCheckDomainService(repository);
+  });
+
+  afterEach(cleanup);
+
+  it("役割名が存在しない場合は false を返す", async () => {
+    const isDuplicated = await service.execute(TEST_ROLE_NAME);
+    expect(isDuplicated).toBe(false);
+  });
+
+  it("役割名が既に存在する場合は true を返す", async () => {
+    const role = Role.create(new RoleCd(TEST_ROLE_CD), new RoleName(TEST_ROLE_NAME), positionId);
+    await repository.save(role);
+
+    const isDuplicated = await service.execute(TEST_ROLE_NAME);
+    expect(isDuplicated).toBe(true);
+  });
+
+  it("excludeIdで自分自身を除外できる", async () => {
+    const role = Role.create(new RoleCd(TEST_ROLE_CD), new RoleName(TEST_ROLE_NAME), positionId);
+    const savedRole = await repository.save(role);
+
+    const isDuplicated = await service.execute(TEST_ROLE_NAME, savedRole.id);
+    expect(isDuplicated).toBe(false);
+  });
+});

--- a/src/server/subdomains/role/domain/services/__tests__/SuperiorRoleValidationDomainService.test.ts
+++ b/src/server/subdomains/role/domain/services/__tests__/SuperiorRoleValidationDomainService.test.ts
@@ -1,0 +1,104 @@
+import prisma from "@server/prisma";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { PrismaPositionRepository } from "@subdomains/role/infrastructure/prisma/PrismaPositionRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SuperiorRoleValidationDomainService } from "../SuperiorRoleValidationDomainService";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+
+describe("SuperiorRoleValidationDomainService", () => {
+  let service: SuperiorRoleValidationDomainService;
+  let roleRepository: PrismaRoleRepository;
+
+  const TEST_ROLE_CDS = ["ROLE996", "ROLE997"];
+
+  // シードデータの役職ID
+  let kachouPositionId: string; // 課長 (POS001) - 上位: 部長
+  let buchouPositionId: string; // 部長 (POS002) - 上位: 本部長
+  let shachouPositionId: string; // 社長 (POS004) - 上位: null
+
+  async function cleanup() {
+    await prisma.role.deleteMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const [kachou, buchou, shachou] = await Promise.all([
+      prisma.position.findUnique({ where: { positionCd: "POS001" } }),
+      prisma.position.findUnique({ where: { positionCd: "POS002" } }),
+      prisma.position.findUnique({ where: { positionCd: "POS004" } }),
+    ]);
+    kachouPositionId = kachou!.id;
+    buchouPositionId = buchou!.id;
+    shachouPositionId = shachou!.id;
+
+    roleRepository = new PrismaRoleRepository();
+    const positionRepository = new PrismaPositionRepository();
+    service = new SuperiorRoleValidationDomainService(roleRepository, positionRepository);
+  });
+
+  afterEach(cleanup);
+
+  it("上位役職に属する役割を上位役割に指定できる", async () => {
+    // 部長ポジションの役割を作成（課長の上位役割候補）
+    const buchouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("テスト部長"),
+      buchouPositionId
+    );
+    await roleRepository.save(buchouRole);
+
+    // 課長ポジションから部長ポジションの役割を上位に指定 → OK
+    await expect(service.execute(kachouPositionId, buchouRole.id)).resolves.not.toThrow();
+  });
+
+  it("最上位の役職には上位役割を設定できない", async () => {
+    const someRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("テスト役割"),
+      buchouPositionId
+    );
+    await roleRepository.save(someRole);
+
+    // 社長ポジションから上位役割を指定 → エラー
+    await expect(service.execute(shachouPositionId, someRole.id)).rejects.toThrow(
+      BusinessRuleViolationError
+    );
+    await expect(service.execute(shachouPositionId, someRole.id)).rejects.toThrow(
+      "最上位の役職には上位役割を設定できません"
+    );
+  });
+
+  it("上位役職に属さない役割を上位に指定するとエラー", async () => {
+    // 課長ポジションの役割を作成
+    const kachouRole = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("テスト課長"),
+      kachouPositionId
+    );
+    await roleRepository.save(kachouRole);
+
+    // 課長ポジションから同じ課長ポジションの役割を上位に指定 → エラー
+    // （課長の上位は部長でなければならない）
+    await expect(service.execute(kachouPositionId, kachouRole.id)).rejects.toThrow(
+      BusinessRuleViolationError
+    );
+    await expect(service.execute(kachouPositionId, kachouRole.id)).rejects.toThrow(
+      "上位役割に指定できるのは、選択した役職の上位役職に属する役割のみです"
+    );
+  });
+
+  it("存在しない上位役割を指定するとエラー", async () => {
+    await expect(service.execute(kachouPositionId, "non-existent-id")).rejects.toThrow(
+      BusinessRuleViolationError
+    );
+    await expect(service.execute(kachouPositionId, "non-existent-id")).rejects.toThrow(
+      "上位役割が存在しません"
+    );
+  });
+});

--- a/src/server/subdomains/role/domain/values/RoleCd.ts
+++ b/src/server/subdomains/role/domain/values/RoleCd.ts
@@ -1,0 +1,64 @@
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * 役割コード値オブジェクト
+ *
+ * 形式: ROLE + 3桁の数字（ROLE001 〜 ROLE999）
+ */
+export class RoleCd extends StringValueObject<"RoleCd"> {
+  private static readonly PREFIX = "ROLE";
+  private static readonly NUMERIC_LENGTH = 3;
+  private static readonly TOTAL_LENGTH = 7; // "ROLE" + 3桁 = 7文字
+  private static readonly NUMERIC_MIN = 1;
+  private static readonly NUMERIC_MAX = Math.pow(10, RoleCd.NUMERIC_LENGTH) - 1;
+
+  protected static readonly REGEX = new RegExp(
+    `^${RoleCd.PREFIX}\\d{${RoleCd.NUMERIC_LENGTH}}$`,
+    "i"
+  );
+  protected static readonly MIN_LENGTH = RoleCd.TOTAL_LENGTH;
+  protected static readonly MAX_LENGTH = RoleCd.TOTAL_LENGTH;
+  protected static readonly ERROR_MESSAGE_EMPTY = "役割コードは必須です";
+  protected static readonly ERROR_MESSAGE_TOO_SHORT =
+    "役割コードは ROLE + 3桁の数字である必要があります";
+  protected static readonly ERROR_MESSAGE_TOO_LONG =
+    "役割コードは ROLE + 3桁の数字である必要があります";
+  protected static readonly ERROR_MESSAGE_INVALID_FORMAT =
+    "役割コードは ROLE + 3桁の数字である必要があります";
+
+  constructor(value: string) {
+    super(value.toUpperCase().trim());
+  }
+
+  get numericPart(): number {
+    return RoleCd.extractNumericPart(this._value);
+  }
+
+  protected validate(value: string): void {
+    super.validate(value);
+
+    const numericPart = RoleCd.extractNumericPart(value);
+    if (numericPart < RoleCd.NUMERIC_MIN) {
+      throw new ValidationError(`役割コードは ${RoleCd.NUMERIC_MIN} 以上である必要があります`);
+    }
+    if (numericPart > RoleCd.NUMERIC_MAX) {
+      throw new ValidationError(`役割コードは ${RoleCd.NUMERIC_MAX} 以下である必要があります`);
+    }
+  }
+
+  private static extractNumericPart(value: string): number {
+    return parseInt(value.substring(RoleCd.PREFIX.length), 10);
+  }
+
+  static fromNumber(num: number): RoleCd {
+    if (num < RoleCd.NUMERIC_MIN || num > RoleCd.NUMERIC_MAX) {
+      throw new ValidationError(
+        `役割コードは ${RoleCd.NUMERIC_MIN} 〜 ${RoleCd.NUMERIC_MAX} の範囲である必要があります`
+      );
+    }
+
+    const paddedNumber = num.toString().padStart(RoleCd.NUMERIC_LENGTH, "0");
+    return new RoleCd(`${RoleCd.PREFIX}${paddedNumber}`);
+  }
+}

--- a/src/server/subdomains/role/domain/values/RoleName.ts
+++ b/src/server/subdomains/role/domain/values/RoleName.ts
@@ -1,0 +1,18 @@
+import { StringValueObject } from "@server/shared/StringValueObject";
+
+/**
+ * 役割名値オブジェクト
+ *
+ * バリデーション:
+ * - 1〜100文字
+ * - 空白のみは不可
+ */
+export class RoleName extends StringValueObject<"RoleName"> {
+  protected static readonly LABEL = "役割名";
+  protected static readonly MIN_LENGTH = 1;
+  protected static readonly MAX_LENGTH = 100;
+
+  constructor(value: string) {
+    super(value.trim());
+  }
+}

--- a/src/server/subdomains/role/domain/values/__tests__/RoleCd.test.ts
+++ b/src/server/subdomains/role/domain/values/__tests__/RoleCd.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { RoleCd } from "../RoleCd";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("RoleCd", () => {
+  describe("正常系", () => {
+    it("ROLE001 形式の役割コードを作成できる", () => {
+      const cd = new RoleCd("ROLE001");
+      expect(cd.value).toBe("ROLE001");
+    });
+
+    it("小文字で入力しても大文字に変換される", () => {
+      const cd = new RoleCd("role001");
+      expect(cd.value).toBe("ROLE001");
+    });
+
+    it("前後の空白はトリムされる", () => {
+      const cd = new RoleCd("  ROLE001  ");
+      expect(cd.value).toBe("ROLE001");
+    });
+
+    it("ROLE999 まで作成できる", () => {
+      const cd = new RoleCd("ROLE999");
+      expect(cd.value).toBe("ROLE999");
+    });
+
+    it("numericPart で数値部分を取得できる", () => {
+      const cd = new RoleCd("ROLE123");
+      expect(cd.numericPart).toBe(123);
+    });
+  });
+
+  describe("fromNumber", () => {
+    it("数値から役割コードを生成できる", () => {
+      const cd = RoleCd.fromNumber(1);
+      expect(cd.value).toBe("ROLE001");
+    });
+
+    it("3桁の数値から役割コードを生成できる", () => {
+      const cd = RoleCd.fromNumber(123);
+      expect(cd.value).toBe("ROLE123");
+    });
+
+    it("0を指定するとエラー", () => {
+      expect(() => RoleCd.fromNumber(0)).toThrow(ValidationError);
+    });
+
+    it("1000以上を指定するとエラー", () => {
+      expect(() => RoleCd.fromNumber(1000)).toThrow(ValidationError);
+    });
+  });
+
+  describe("異常系", () => {
+    it("空文字列はエラー", () => {
+      expect(() => new RoleCd("")).toThrow(ValidationError);
+      expect(() => new RoleCd("")).toThrow("役割コードは必須です");
+    });
+
+    it("ROLE000 はエラー（0は無効）", () => {
+      expect(() => new RoleCd("ROLE000")).toThrow(ValidationError);
+    });
+
+    it("プレフィックスが違うとエラー", () => {
+      expect(() => new RoleCd("DEPT001")).toThrow(ValidationError);
+    });
+
+    it("数字が足りないとエラー", () => {
+      expect(() => new RoleCd("ROLE01")).toThrow(ValidationError);
+    });
+
+    it("数字が多すぎるとエラー", () => {
+      expect(() => new RoleCd("ROLE0001")).toThrow(ValidationError);
+    });
+
+    it("数字以外が含まれるとエラー", () => {
+      expect(() => new RoleCd("ROLEABC")).toThrow(ValidationError);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値の役割コードは等しい", () => {
+      const cd1 = new RoleCd("ROLE001");
+      const cd2 = new RoleCd("ROLE001");
+      expect(cd1.equals(cd2)).toBe(true);
+    });
+
+    it("異なる値の役割コードは等しくない", () => {
+      const cd1 = new RoleCd("ROLE001");
+      const cd2 = new RoleCd("ROLE002");
+      expect(cd1.equals(cd2)).toBe(false);
+    });
+  });
+});

--- a/src/server/subdomains/role/domain/values/__tests__/RoleName.test.ts
+++ b/src/server/subdomains/role/domain/values/__tests__/RoleName.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { RoleName } from "../RoleName";
+import { ValidationError } from "@server/shared/errors/DomainError";
+
+describe("RoleName", () => {
+  describe("正常系", () => {
+    it("役割名を作成できる", () => {
+      const name = new RoleName("大阪市南課長");
+      expect(name.value).toBe("大阪市南課長");
+    });
+
+    it("前後の空白はトリムされる", () => {
+      const name = new RoleName("  営業部長  ");
+      expect(name.value).toBe("営業部長");
+    });
+
+    it("100文字の役割名を作成できる", () => {
+      const longName = "あ".repeat(100);
+      const name = new RoleName(longName);
+      expect(name.value).toBe(longName);
+    });
+  });
+
+  describe("異常系", () => {
+    it("空文字列はエラー", () => {
+      expect(() => new RoleName("")).toThrow(ValidationError);
+      expect(() => new RoleName("")).toThrow("役割名は必須です");
+    });
+
+    it("空白のみはエラー", () => {
+      expect(() => new RoleName("   ")).toThrow(ValidationError);
+    });
+
+    it("101文字以上はエラー", () => {
+      const tooLong = "あ".repeat(101);
+      expect(() => new RoleName(tooLong)).toThrow(ValidationError);
+      expect(() => new RoleName(tooLong)).toThrow("役割名は100文字以内で入力してください");
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値の役割名は等しい", () => {
+      const name1 = new RoleName("大阪市南課長");
+      const name2 = new RoleName("大阪市南課長");
+      expect(name1.equals(name2)).toBe(true);
+    });
+
+    it("異なる値の役割名は等しくない", () => {
+      const name1 = new RoleName("大阪市南課長");
+      const name2 = new RoleName("営業部長");
+      expect(name1.equals(name2)).toBe(false);
+    });
+  });
+});

--- a/src/server/subdomains/role/infrastructure/mappers/RoleMapper.ts
+++ b/src/server/subdomains/role/infrastructure/mappers/RoleMapper.ts
@@ -1,0 +1,54 @@
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { Role as PrismaRole } from "@generated/prisma/client";
+
+/**
+ * RoleMapper
+ *
+ * PrismaのRoleモデルとドメインのRoleエンティティを相互変換する
+ */
+export class RoleMapper {
+  /**
+   * Prismaモデルからドメインエンティティへ変換
+   */
+  static toDomain(prismaRole: PrismaRole): Role {
+    const roleCd = new RoleCd(prismaRole.roleCd);
+    const name = new RoleName(prismaRole.name);
+
+    return Role.reconstruct(
+      prismaRole.id,
+      roleCd,
+      name,
+      prismaRole.positionId,
+      prismaRole.superiorRoleId,
+      prismaRole.createdAt,
+      prismaRole.updatedAt
+    );
+  }
+
+  /**
+   * ドメインエンティティからPrismaモデル用のデータへ変換（新規作成用）
+   */
+  static toPrismaCreate(role: Role) {
+    return {
+      id: role.id,
+      roleCd: role.roleCd.value,
+      name: role.name.value,
+      positionId: role.positionId,
+      superiorRoleId: role.superiorRoleId,
+    };
+  }
+
+  /**
+   * ドメインエンティティからPrismaモデル更新用のデータへ変換
+   * positionId, roleCd は変更不可
+   */
+  static toPrismaUpdate(role: Role) {
+    return {
+      name: role.name.value,
+      superiorRoleId: role.superiorRoleId,
+      updatedAt: role.updatedAt,
+    };
+  }
+}

--- a/src/server/subdomains/role/infrastructure/prisma/PrismaPositionRepository.ts
+++ b/src/server/subdomains/role/infrastructure/prisma/PrismaPositionRepository.ts
@@ -1,0 +1,29 @@
+import { PositionRepository } from "@subdomains/role/domain/repositories/PositionRepository";
+import prisma from "@server/prisma";
+
+/**
+ * Roleドメイン用のPrisma役職リポジトリ実装
+ *
+ * Roleドメインの PositionRepository インターフェースを実装する。
+ * 上位役割バリデーションに必要な最小限のメソッドのみ提供。
+ */
+export class PrismaPositionRepository implements PositionRepository {
+  async findSuperiorPositionId(positionId: string): Promise<string | null> {
+    const position = await prisma.position.findUnique({
+      where: { id: positionId },
+      select: { superiorPositionId: true },
+    });
+
+    // 役職が見つからない場合は null を返す
+    return position?.superiorPositionId ?? null;
+  }
+
+  async exists(positionId: string): Promise<boolean> {
+    const position = await prisma.position.findUnique({
+      where: { id: positionId },
+      select: { id: true },
+    });
+
+    return position !== null;
+  }
+}

--- a/src/server/subdomains/role/infrastructure/prisma/PrismaRoleRepository.ts
+++ b/src/server/subdomains/role/infrastructure/prisma/PrismaRoleRepository.ts
@@ -1,0 +1,65 @@
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleRepository } from "@subdomains/role/domain/repositories/RoleRepository";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleMapper } from "@subdomains/role/infrastructure/mappers/RoleMapper";
+import prisma from "@server/prisma";
+
+export class PrismaRoleRepository implements RoleRepository {
+  async save(role: Role): Promise<Role> {
+    const prismaRole = await prisma.role.upsert({
+      where: { id: role.id },
+      create: RoleMapper.toPrismaCreate(role),
+      update: RoleMapper.toPrismaUpdate(role),
+    });
+
+    return RoleMapper.toDomain(prismaRole);
+  }
+
+  async delete(id: string): Promise<void> {
+    await prisma.role.delete({
+      where: { id },
+    });
+  }
+
+  async findById(id: string): Promise<Role | null> {
+    const prismaRole = await prisma.role.findUnique({
+      where: { id },
+    });
+
+    return prismaRole ? RoleMapper.toDomain(prismaRole) : null;
+  }
+
+  async findByRoleCd(roleCd: RoleCd): Promise<Role | null> {
+    const prismaRole = await prisma.role.findUnique({
+      where: { roleCd: roleCd.value },
+    });
+
+    return prismaRole ? RoleMapper.toDomain(prismaRole) : null;
+  }
+
+  async findByName(name: string): Promise<Role | null> {
+    const prismaRole = await prisma.role.findFirst({
+      where: { name },
+    });
+
+    return prismaRole ? RoleMapper.toDomain(prismaRole) : null;
+  }
+
+  async findSubordinates(superiorRoleId: string): Promise<Role[]> {
+    const prismaRoles = await prisma.role.findMany({
+      where: { superiorRoleId },
+      orderBy: { roleCd: "asc" },
+    });
+
+    return prismaRoles.map(RoleMapper.toDomain);
+  }
+
+  async isInUse(roleId: string): Promise<boolean> {
+    const [employeeRoleCount, employeeSuperiorCount] = await Promise.all([
+      prisma.employeeRole.count({ where: { roleId } }),
+      prisma.employee.count({ where: { superiorRoleId: roleId } }),
+    ]);
+
+    return employeeRoleCount > 0 || employeeSuperiorCount > 0;
+  }
+}

--- a/src/server/subdomains/role/infrastructure/queries/PrismaRoleQueryService.ts
+++ b/src/server/subdomains/role/infrastructure/queries/PrismaRoleQueryService.ts
@@ -1,0 +1,136 @@
+import { RoleDTO } from "@subdomains/role/application/queries/dto/RoleDTO";
+import {
+  RoleSearchCriteria,
+  RoleListOptions,
+} from "@subdomains/role/application/queries/dto/RoleSearchCriteria";
+import { RoleQueryService } from "@subdomains/role/application/queries/RoleQueryService";
+import prisma from "@server/prisma";
+import { Prisma } from "@generated/prisma/client";
+
+/**
+ * Prismaを使用した役割クエリサービス実装
+ *
+ * position, superiorRole をJOINして名前付きDTOを返す
+ */
+export class PrismaRoleQueryService implements RoleQueryService {
+  async findById(id: string): Promise<RoleDTO | null> {
+    const role = await prisma.role.findUnique({
+      where: { id },
+      select: this.getSelectFields(),
+    });
+
+    return role ? this.toDTO(role) : null;
+  }
+
+  async search(criteria: RoleSearchCriteria, options?: RoleListOptions): Promise<RoleDTO[]> {
+    const where = this.buildWhereClause(criteria);
+    const orderBy = this.buildOrderBy(options);
+
+    const roles = await prisma.role.findMany({
+      where,
+      select: this.getSelectFields(),
+      orderBy,
+      take: options?.limit,
+      skip: options?.offset,
+    });
+
+    return roles.map((r) => this.toDTO(r));
+  }
+
+  async findAll(options?: RoleListOptions): Promise<RoleDTO[]> {
+    const orderBy = this.buildOrderBy(options);
+
+    const roles = await prisma.role.findMany({
+      select: this.getSelectFields(),
+      orderBy,
+      take: options?.limit,
+      skip: options?.offset,
+    });
+
+    return roles.map((r) => this.toDTO(r));
+  }
+
+  async findByPositionId(positionId: string, options?: RoleListOptions): Promise<RoleDTO[]> {
+    const orderBy = this.buildOrderBy(options) ?? { roleCd: "asc" as const };
+
+    const roles = await prisma.role.findMany({
+      where: { positionId },
+      select: this.getSelectFields(),
+      orderBy,
+      take: options?.limit,
+      skip: options?.offset,
+    });
+
+    return roles.map((r) => this.toDTO(r));
+  }
+
+  private buildWhereClause(criteria: RoleSearchCriteria): Prisma.RoleWhereInput {
+    const where: Prisma.RoleWhereInput = {};
+
+    if (criteria.name) {
+      where.name = { contains: criteria.name, mode: "insensitive" };
+    }
+
+    if (criteria.roleCd) {
+      where.roleCd = criteria.roleCd;
+    }
+
+    if (criteria.positionId) {
+      where.positionId = criteria.positionId;
+    }
+
+    if (criteria.superiorRoleId !== undefined) {
+      where.superiorRoleId = criteria.superiorRoleId;
+    }
+
+    return where;
+  }
+
+  private buildOrderBy(options?: RoleListOptions): Prisma.RoleOrderByWithRelationInput | undefined {
+    if (!options?.orderBy) {
+      return undefined;
+    }
+
+    return {
+      [options.orderBy.field]: options.orderBy.direction,
+    };
+  }
+
+  private getSelectFields() {
+    return {
+      id: true,
+      roleCd: true,
+      name: true,
+      positionId: true,
+      position: { select: { name: true } },
+      superiorRoleId: true,
+      superiorRole: { select: { name: true } },
+      createdAt: true,
+      updatedAt: true,
+    } as const;
+  }
+
+  private toDTO(role: {
+    id: string;
+    roleCd: string;
+    name: string;
+    positionId: string;
+    position: { name: string };
+    superiorRoleId: string | null;
+    superiorRole: { name: string } | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): RoleDTO {
+    return {
+      id: role.id,
+      roleCd: role.roleCd,
+      name: role.name,
+      positionId: role.positionId,
+      positionName: role.position.name,
+      superiorRoleId: role.superiorRoleId,
+      superiorRoleName: role.superiorRole?.name ?? null,
+      createdAt: role.createdAt,
+      updatedAt: role.updatedAt,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Role（役割）サブドメインのCRUDバックエンドと、Position（役職）サブドメインの読み取り専用バックエンドをDDDレイヤリングルールに従って実装。承認フローの基盤となる役割階層の管理機能を提供する。

- Position サブドメイン: Domain層（値オブジェクト・エンティティ・リポジトリIF）+ Infrastructure層 + Application層（Query）
- Role サブドメイン: Domain層（値オブジェクト・エンティティ・リポジトリIF・ドメインサービス）+ Infrastructure層（マッパー・リポジトリ）+ Application層（Command/Query/Factory）
- 上位役割の役職制約バリデーション、循環参照防止、役割名一意性チェック等のビジネスルールを実装

Closes #174

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### 実装計画: 役割・役職管理バックエンド実装 (Issue #174)

#### Context

役割（Role）のCRUD機能と役職（Position）の読み取り機能のバックエンド実装。承認フローの基盤となる役割階層を正しく管理するため、DDDレイヤリングルールに従ってDomain/Application/Infrastructure層を実装する。Departmentサブドメインの実装パターンを踏襲。

#### 設計上の重要な判断

1. **Positionサブドメインのスコープ**: 役職は固定4種のためCRUD不要。読み取り専用のQuery層のみ実装。ただしDomain層は定義（Roleドメインでの検証に必要）
2. **Cross-subdomain依存の解決**: Roleドメイン内に最小限の`PositionRepository`インターフェース（`findSuperiorPositionId`, `exists`の2メソッド）を定義。Dependency Inversion Principleに従い、サブドメイン間の独立性を保持
3. **役割名の一意性**: DBに`@unique`制約がないため、ドメインサービスで一意性を保証

#### Steps

1. Position サブドメイン - Domain層（値オブジェクト・エンティティ・リポジトリIF）
2. Position サブドメイン - Infrastructure層 + Application層（Query）
3. Role サブドメイン - Domain層 値オブジェクト（RoleCd, RoleName）
4. Role サブドメイン - Domain層 エンティティ
5. Role サブドメイン - Domain層 リポジトリIF + ドメインサービス
6. Role サブドメイン - Infrastructure層（マッパー・リポジトリ）
7. Role サブドメイン - Application層 Command（作成・更新・削除）
8. Role サブドメイン - Application層 Query + Infrastructure QueryService
9. Role サブドメイン - Factory

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

16件のテストファイルを新規追加（計1,529行）:

**Position Domain層テスト**
- [ ] Position エンティティテスト（reconstruct, isTopLevel）
- [ ] PositionCd 値オブジェクトテスト（バリデーション、正規化）
- [ ] PositionName 値オブジェクトテスト（バリデーション、トリム）

**Role Domain層テスト**
- [ ] Role エンティティテスト（create, reconstruct, changeName, changeSuperiorRole, 自己参照防止）
- [ ] RoleCd 値オブジェクトテスト（バリデーション、正規化、fromNumber）
- [ ] RoleName 値オブジェクトテスト（バリデーション、トリム）
- [ ] RoleCdDuplicationCheckDomainService テスト（重複検出）
- [ ] RoleNameDuplicationCheckDomainService テスト（重複検出、excludeId）
- [ ] SuperiorRoleValidationDomainService テスト（上位役職制約、循環参照防止）

**Role Application層テスト**
- [ ] CreateRoleCommand テスト（正常作成、Cd重複エラー、名前重複エラー、Position不存在エラー、上位役割バリデーションエラー）
- [ ] UpdateRoleCommand テスト（名前更新、上位役割更新、循環参照防止、存在しないロールエラー）
- [ ] DeleteRoleCommand テスト（正常削除、下位役割存在エラー、使用中エラー）
- [ ] GetAllRolesQuery テスト
- [ ] GetRoleByIdQuery テスト
- [ ] GetRolesByPositionQuery テスト
- [ ] SearchRolesQuery テスト（キーワード検索、役職フィルタ、ページネーション）

---

Generated with [Claude Code](https://claude.ai/code)