### PR TITLE
feat: RoleQueryServiceにfindByRoleCdメソッドを追加 (#184)

### DIFF
--- a/docs/claude-plans/issue-184/plan.md
+++ b/docs/claude-plans/issue-184/plan.md
@@ -1,0 +1,30 @@
+# Issue #184: RoleQueryServiceにfindByRoleCdメソッドを追加 — 実装計画
+
+## 概要
+
+RoleQueryServiceインターフェースおよびPrismaRoleQueryServiceに、役割コード（RoleCd）による単一取得メソッド `findByRoleCd` を追加する。RoleCdはPrismaスキーマで `@unique` 制約があるため、`findUnique` を使用して単一のRoleDTOまたはnullを返す。
+
+## ステップ
+
+### Step 1: RoleQueryServiceインターフェースにfindByRoleCdを追加 & PrismaRoleQueryServiceに実装
+- 対象ファイル:
+  - `src/server/subdomains/role/application/queries/RoleQueryService.ts`
+  - `src/server/subdomains/role/infrastructure/queries/PrismaRoleQueryService.ts`
+- 作業内容: インターフェースに `findByRoleCd(roleCd: string): Promise<RoleDTO | null>` を追加し、PrismaRoleQueryServiceに `findUnique` を使った実装を追加
+- コミットメッセージ: feat: RoleQueryServiceにfindByRoleCdメソッドを追加
+
+### Step 2: GetRoleByRoleCdQueryクラスとファクトリ関数を追加
+- 対象ファイル:
+  - `src/server/subdomains/role/application/queries/GetRoleByRoleCdQuery.ts`（新規）
+  - `src/server/subdomains/role/application/factories/roleQueryFactory.ts`
+- 作業内容: 既存のGetRoleByIdQueryパターンに倣い、クエリクラスとファクトリ関数を作成
+- コミットメッセージ: feat: GetRoleByRoleCdQueryクラスとファクトリ関数を追加
+
+### Step 3: ユニットテストを追加
+- 対象ファイル:
+  - `src/server/subdomains/role/application/queries/__tests__/GetRoleByRoleCdQuery.test.ts`（新規）
+- 作業内容: 既存のGetRoleByIdQuery.test.tsパターンに倣い、存在するRoleCd・存在しないRoleCdの両ケースをテスト
+- コミットメッセージ: test: GetRoleByRoleCdQueryのユニットテストを追加
+
+### Step 4: lint・テスト実行による検証
+- 作業内容: `pnpm lint` と `pnpm test` を実行して全体の整合性を確認

--- a/src/server/subdomains/role/application/factories/roleQueryFactory.ts
+++ b/src/server/subdomains/role/application/factories/roleQueryFactory.ts
@@ -1,5 +1,6 @@
 import { GetAllRolesQuery } from "../queries/GetAllRolesQuery";
 import { GetRoleByIdQuery } from "../queries/GetRoleByIdQuery";
+import { GetRoleByRoleCdQuery } from "../queries/GetRoleByRoleCdQuery";
 import { GetRolesByPositionQuery } from "../queries/GetRolesByPositionQuery";
 import { SearchRolesQuery } from "../queries/SearchRolesQuery";
 import { PrismaRoleQueryService } from "../../infrastructure/queries/PrismaRoleQueryService";
@@ -21,6 +22,11 @@ export function getRoleByIdQueryFactory(): GetRoleByIdQuery {
 export function searchRolesQueryFactory(): SearchRolesQuery {
   const queryService = new PrismaRoleQueryService();
   return new SearchRolesQuery(queryService);
+}
+
+export function getRoleByRoleCdQueryFactory(): GetRoleByRoleCdQuery {
+  const queryService = new PrismaRoleQueryService();
+  return new GetRoleByRoleCdQuery(queryService);
 }
 
 export function getRolesByPositionQueryFactory(): GetRolesByPositionQuery {

--- a/src/server/subdomains/role/application/queries/GetRoleByRoleCdQuery.ts
+++ b/src/server/subdomains/role/application/queries/GetRoleByRoleCdQuery.ts
@@ -1,0 +1,17 @@
+import { RoleDTO } from "./dto/RoleDTO";
+import { RoleQueryService } from "./RoleQueryService";
+
+export type GetRoleByRoleCdInput = {
+  roleCd: string;
+};
+
+/**
+ * 役割コード指定役割取得クエリ
+ */
+export class GetRoleByRoleCdQuery {
+  public constructor(private readonly roleQueryService: RoleQueryService) {}
+
+  async execute(input: GetRoleByRoleCdInput): Promise<RoleDTO | null> {
+    return await this.roleQueryService.findByRoleCd(input.roleCd);
+  }
+}

--- a/src/server/subdomains/role/application/queries/RoleQueryService.ts
+++ b/src/server/subdomains/role/application/queries/RoleQueryService.ts
@@ -27,4 +27,9 @@ export interface RoleQueryService {
    * 役職IDで役割を取得
    */
   findByPositionId(positionId: string, options?: RoleListOptions): Promise<RoleDTO[]>;
+
+  /**
+   * 役割コードで役割を取得
+   */
+  findByRoleCd(roleCd: string): Promise<RoleDTO | null>;
 }

--- a/src/server/subdomains/role/application/queries/__tests__/GetRoleByRoleCdQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetRoleByRoleCdQuery.test.ts
@@ -1,0 +1,66 @@
+import prisma from "@server/prisma";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
+import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GetRoleByRoleCdQuery } from "../GetRoleByRoleCdQuery";
+
+describe("GetRoleByRoleCdQuery", () => {
+  let query: GetRoleByRoleCdQuery;
+  let roleRepository: PrismaRoleRepository;
+
+  const TEST_ROLE_CDS = ["ROLE941"];
+
+  let kachouPositionId: string;
+
+  async function cleanup() {
+    await prisma.role.updateMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+      data: { superiorRoleId: null },
+    });
+    await prisma.role.deleteMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const kachou = await prisma.position.findUnique({ where: { positionCd: "POS001" } });
+    kachouPositionId = kachou!.id;
+
+    roleRepository = new PrismaRoleRepository();
+    query = new GetRoleByRoleCdQuery(new PrismaRoleQueryService());
+  });
+
+  afterEach(cleanup);
+
+  it("役割コードで役割を取得できる", async () => {
+    const role = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("コード取得テスト役割"),
+      kachouPositionId
+    );
+    await roleRepository.save(role);
+
+    const result = await query.execute({ roleCd: TEST_ROLE_CDS[0] });
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(role.id);
+    expect(result?.roleCd).toBe(TEST_ROLE_CDS[0]);
+    expect(result?.name).toBe("コード取得テスト役割");
+    expect(result?.positionId).toBe(kachouPositionId);
+    expect(result?.positionName).toBe("課長");
+    expect(result?.superiorRoleId).toBeNull();
+    expect(result?.superiorRoleName).toBeNull();
+    expect(result?.createdAt).toBeInstanceOf(Date);
+    expect(result?.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it("存在しない役割コードの場合nullを返す", async () => {
+    const result = await query.execute({ roleCd: "NON_EXISTENT_CODE" });
+    expect(result).toBeNull();
+  });
+});

--- a/src/server/subdomains/role/infrastructure/queries/PrismaRoleQueryService.ts
+++ b/src/server/subdomains/role/infrastructure/queries/PrismaRoleQueryService.ts
@@ -50,6 +50,15 @@ export class PrismaRoleQueryService implements RoleQueryService {
     return roles.map((r) => this.toDTO(r));
   }
 
+  async findByRoleCd(roleCd: string): Promise<RoleDTO | null> {
+    const role = await prisma.role.findUnique({
+      where: { roleCd },
+      select: this.getSelectFields(),
+    });
+
+    return role ? this.toDTO(role) : null;
+  }
+
   async findByPositionId(positionId: string, options?: RoleListOptions): Promise<RoleDTO[]> {
     const orderBy = this.buildOrderBy(options) ?? { roleCd: "asc" as const };
 


### PR DESCRIPTION
## Summary

RoleQueryServiceインターフェースおよびPrismaRoleQueryServiceに、役割コード（RoleCd）による単一取得メソッド `findByRoleCd` を追加した。併せてGetRoleByRoleCdQueryクラス・ファクトリ関数・ユニットテストを実装。

Closes #184

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

# Issue #184: RoleQueryServiceにfindByRoleCdメソッドを追加 — 実装計画

## 概要

RoleQueryServiceインターフェースおよびPrismaRoleQueryServiceに、役割コード（RoleCd）による単一取得メソッド `findByRoleCd` を追加する。RoleCdはPrismaスキーマで `@unique` 制約があるため、`findUnique` を使用して単一のRoleDTOまたはnullを返す。

## ステップ

### Step 1: RoleQueryServiceインターフェースにfindByRoleCdを追加 & PrismaRoleQueryServiceに実装
- 対象ファイル:
  - `src/server/subdomains/role/application/queries/RoleQueryService.ts`
  - `src/server/subdomains/role/infrastructure/queries/PrismaRoleQueryService.ts`
- 作業内容: インターフェースに `findByRoleCd(roleCd: string): Promise<RoleDTO | null>` を追加し、PrismaRoleQueryServiceに `findUnique` を使った実装を追加
- コミットメッセージ: feat: RoleQueryServiceにfindByRoleCdメソッドを追加

### Step 2: GetRoleByRoleCdQueryクラスとファクトリ関数を追加
- 対象ファイル:
  - `src/server/subdomains/role/application/queries/GetRoleByRoleCdQuery.ts`（新規）
  - `src/server/subdomains/role/application/factories/roleQueryFactory.ts`
- 作業内容: 既存のGetRoleByIdQueryパターンに倣い、クエリクラスとファクトリ関数を作成
- コミットメッセージ: feat: GetRoleByRoleCdQueryクラスとファクトリ関数を追加

### Step 3: ユニットテストを追加
- 対象ファイル:
  - `src/server/subdomains/role/application/queries/__tests__/GetRoleByRoleCdQuery.test.ts`（新規）
- 作業内容: 既存のGetRoleByIdQuery.test.tsパターンに倣い、存在するRoleCd・存在しないRoleCdの両ケースをテスト
- コミットメッセージ: test: GetRoleByRoleCdQueryのユニットテストを追加

### Step 4: lint・テスト実行による検証
- 作業内容: `pnpm lint` と `pnpm test` を実行して全体の整合性を確認

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

- [ ] `GetRoleByRoleCdQuery` のユニットテスト — 存在するRoleCdでRoleDTOが返ること
- [ ] `GetRoleByRoleCdQuery` のユニットテスト — 存在しないRoleCdでnullが返ること
- [ ] `pnpm test` が全件パスすること
- [ ] `pnpm lint` がエラーなしで完了すること

---

Generated with [Claude Code](https://claude.ai/code)