### PR TITLE
feat: 役割管理画面のフロントエンド実装（Presentation層）

### DIFF
--- a/docs/claude-plans/issue-175/snuggly-doodling-valiant.md
+++ b/docs/claude-plans/issue-175/snuggly-doodling-valiant.md
@@ -1,0 +1,154 @@
+# Issue #175: 役割管理画面のフロントエンド実装（Presentation層）
+
+## Context
+
+PR #181 で実装済みのバックエンド（Domain/Application/Infrastructure層）に対して、Next.js App Router を用いた CRUD 管理画面を構築する。既存の部署管理・従業員管理と同じパターンに従う。
+
+**固有の課題**: 役職選択に連動した上位役割の動的フィルタリング。課長を選ぶと上位役割は部長の役割のみ表示、社長を選ぶと上位役割は非表示、という制約をUIで実現する必要がある。
+
+## 設計判断
+
+### 1. 上位役割の動的フィルタリング方式
+
+**採用**: 全データ事前ロード + クライアントサイドフィルタリング
+
+- `new/page.tsx`（Server Component）で全Positionと全Roleを取得
+- Client Componentにpropsとして渡す
+- `useState` で選択中の役職を管理し、`useMemo` で上位役割候補をフィルタ
+- 理由: 固定4役職 + 役割数も少数 → サーバーリクエスト不要
+
+**作成ページ**: Position変更時にSuperior Role選択肢を動的に切り替え（slot パターン不可 → 直接 `<select>` をClient Component内に配置）
+
+**編集ページ**: Position不変なので、事前にサーバー側で上位役割候補を計算してpropsで渡す（動的フィルタ不要）
+
+### 2. roleCd から RoleDTO の取得
+
+**採用**: `RoleQueryService.findByRoleCd(roleCd)` を使用
+
+- #184 で `RoleQueryService` に `findByRoleCd` メソッドが追加される前提
+- 部署管理の `PrismaDepartmentQueryService.findByDepartmentCd()` と同一パターン
+- 詳細ページ (`[roleCd]/page.tsx`) と更新アクション (`[roleCd]/actions.ts`) で使用
+- `PrismaRoleQueryService` を直接インスタンス化して呼び出す
+
+### 3. Conform と制御select の共存
+
+Position `<select>` は `onChange` ハンドラが必要（動的フィルタ用）。Conform の `getSelectProps` は使わず、`name` 属性を直接設定。Conform は FormData からバリデーションするため問題なし。
+
+## 実装ステップ
+
+### Step 1: 共通基盤（リダイレクト理由・Zodスキーマ）
+
+**修正するファイル:**
+- `src/shared/constants/redirect-reasons.ts` — `ROLE_CREATED`, `ROLE_UPDATED`, `ROLE_DELETED` 追加
+- `src/app/_components/redirect-reason-toast.tsx` — 役割用フラッシュメッセージ3件追加
+
+**新規ファイル:**
+- `src/app/(features)/roles/_shared/schema.ts` — 基本Zodスキーマ（name, superiorRoleId）
+
+### Step 2: 一覧ページ
+
+**新規ファイル:**
+- `src/app/(features)/roles/layout.tsx` — メタデータ設定（部署layoutと同形式）
+- `src/app/(features)/roles/_components/columns.tsx` — DataTableカラム定義（roleCd, name, positionName, superiorRoleName）
+- `src/app/(features)/roles/page.tsx` — 一覧ページ
+
+一覧ページの実装ポイント:
+- `searchRolesQueryFactory` で検索実行
+- 検索フィールド: 役割名（部分一致）、役割コード（完全一致）、役職（select）
+- 役職selectの選択肢は `getAllPositionsQueryFactory` で取得
+- `RoleDTO` は `positionName`, `superiorRoleName` を含むため Map 構築不要
+
+### Step 3: 新規作成ページ
+
+**新規ファイル:**
+- `src/app/(features)/roles/new/schema.ts` — 作成用スキーマ（base + roleCd + positionId）
+- `src/app/(features)/roles/new/actions.ts` — createRole サーバーアクション
+- `src/app/(features)/roles/new/page.tsx` — 作成ページラッパー
+- `src/app/(features)/roles/new/RoleCreateForm.tsx` — 作成フォーム（動的フィルタリング含む）
+
+RoleCreateForm の実装ポイント:
+```
+Props: positions: {id, name, superiorPositionId}[], allRoles: {id, name, positionId}[]
+State: selectedPositionId (useState)
+Derived: superiorRoleOptions (useMemo) — 選択した役職の上位役職に属する役割のみ
+```
+- 役職変更時: 上位役割selectをリセット（`key={selectedPositionId}` で再マウント）
+- 上位役職がnull（社長）の場合: 上位役割selectを非表示
+- `name` 属性で Conform に値を渡す（`getSelectProps` 不使用）
+
+Server Action (`createRole`):
+- `verifyAdmin()` → `parseWithZod` → `createRoleCommandFactory().execute()` → `revalidatePath` → `redirect`
+- `superiorRoleId`: undefined → null 変換
+
+### Step 4: 詳細・編集・削除ページ
+
+**新規ファイル:**
+- `src/app/(features)/roles/[roleCd]/schema.ts` — 更新用スキーマ（= baseスキーマ）
+- `src/app/(features)/roles/[roleCd]/actions.ts` — updateRole, deleteRole サーバーアクション
+- `src/app/(features)/roles/[roleCd]/page.tsx` — 詳細ページ
+- `src/app/(features)/roles/[roleCd]/RoleUpdateForm.tsx` — 更新フォーム
+- `src/app/(features)/roles/[roleCd]/RoleDeleteForm.tsx` — 削除フォーム
+
+詳細ページの実装ポイント:
+- `PrismaRoleQueryService.findByRoleCd(roleCd)` で RoleDTO 取得（部署管理と同一パターン）
+- `getAllPositionsQueryFactory` で全Position取得 → 当該roleの上位役職ID特定
+- 上位役職IDがある場合: `getRolesByPositionQueryFactory` で上位役割候補を取得しpropsへ
+- `canUpdate`, `canDelete` は `isAdmin(session)` で判定
+
+RoleUpdateForm:
+- roleCd: 読み取り専用（disabled input）
+- positionName: 読み取り専用（disabled input）
+- name: 編集可能
+- superiorRoleId: 事前計算済みの候補からselect（候補なしなら非表示）
+- `useServerForm` + `updateRole.bind(null, role.roleCd)`
+
+RoleDeleteForm:
+- `DepartmentDeleteForm` と同一パターン
+- `useActionState(deleteRole, { success: true })`
+- hidden input で id 送信
+
+### Step 5: ダッシュボード導線追加
+
+**修正するファイル:**
+- `src/app/(features)/dashboard/page.tsx` — `navigationItems` に役割管理カード追加
+
+## 検証方法
+
+1. `pnpm build` — ビルド成功確認
+2. `pnpm dev` で以下を手動確認:
+   - ダッシュボードから役割管理へ遷移
+   - 一覧表示（検索・フィルタ動作）
+   - 新規作成（役職選択 → 上位役割フィルタリング動作）
+   - 詳細表示（roleCdクリックで遷移）
+   - 編集（名前・上位役割の変更）
+   - 削除（使用中の役割はエラー表示）
+3. `pnpm lint` — lint通過確認
+
+## ファイル一覧
+
+| ファイル | 操作 | Step |
+|---------|------|------|
+| `src/shared/constants/redirect-reasons.ts` | 修正 | 1 |
+| `src/app/_components/redirect-reason-toast.tsx` | 修正 | 1 |
+| `src/app/(features)/roles/_shared/schema.ts` | 新規 | 1 |
+| `src/app/(features)/roles/layout.tsx` | 新規 | 2 |
+| `src/app/(features)/roles/_components/columns.tsx` | 新規 | 2 |
+| `src/app/(features)/roles/page.tsx` | 新規 | 2 |
+| `src/app/(features)/roles/new/schema.ts` | 新規 | 3 |
+| `src/app/(features)/roles/new/actions.ts` | 新規 | 3 |
+| `src/app/(features)/roles/new/page.tsx` | 新規 | 3 |
+| `src/app/(features)/roles/new/RoleCreateForm.tsx` | 新規 | 3 |
+| `src/app/(features)/roles/[roleCd]/schema.ts` | 新規 | 4 |
+| `src/app/(features)/roles/[roleCd]/actions.ts` | 新規 | 4 |
+| `src/app/(features)/roles/[roleCd]/page.tsx` | 新規 | 4 |
+| `src/app/(features)/roles/[roleCd]/RoleUpdateForm.tsx` | 新規 | 4 |
+| `src/app/(features)/roles/[roleCd]/RoleDeleteForm.tsx` | 新規 | 4 |
+| `src/app/(features)/dashboard/page.tsx` | 修正 | 5 |
+
+## 主要参考ファイル
+
+- `src/app/(features)/departments/` — 全体構造のテンプレート
+- `src/app/_hooks/useServerForm.ts` — フォーム状態管理フック
+- `src/app/(features)/_shared/error-handler.ts` — ドメインエラー変換
+- `src/server/subdomains/role/application/factories/index.ts` — バックエンドファクトリ
+- `src/server/subdomains/position/application/factories/positionQueryFactory.ts` — Position取得

--- a/learning/server-component-slot-vs-dynamic-filtering.md
+++ b/learning/server-component-slot-vs-dynamic-filtering.md
@@ -1,0 +1,96 @@
+# Server Component slot パターンと動的フィルタリングの使い分け
+
+作成日: 2026-04-03
+
+## 概要
+
+Next.js App Router で Server Component と Client Component を組み合わせる際、select フィールドの選択肢をどう供給するかには2つのアプローチがある。選択肢が固定か、他の入力に連動して変わるかで使い分ける。
+
+## 詳細
+
+### 1. Server Component slot パターン（選択肢が固定の場合）
+
+Server Component で DB からデータを取得し、ReactNode として Client Component の props に渡す。
+
+```tsx
+// Server Component (page.tsx)
+<DepartmentCreateForm
+  parentDepartmentSelectSlot={
+    <DepartmentSelectField name="parentId" />  // Server Component
+  }
+/>
+
+// DepartmentSelectField (Server Component)
+export async function DepartmentSelectField(props) {
+  const departments = await queryService.findActive();  // DB アクセス
+  return <SelectField options={...} />;  // Client Component を返す
+}
+
+// Client Component (DepartmentCreateForm.tsx)
+type Props = { parentDepartmentSelectSlot: React.ReactNode };
+// JSX 内で {parentDepartmentSelectSlot} と描画するだけ
+```
+
+**利点**: Client Component は DB アクセスの詳細を知らない。バンドルサイズに影響しない。
+**制約**: slot の中身はサーバーレンダリング時に1回だけ確定する。クライアント側から差し替えられない。
+
+### 2. データ props + クライアントサイドフィルタリング（選択肢が連動する場合）
+
+Server Component で全データを取得し、プレーンなオブジェクト配列として Client Component に渡す。Client Component 内で `useState` + `useMemo` を使い、ユーザー操作に応じて選択肢をフィルタする。
+
+```tsx
+// Server Component (page.tsx)
+const positions = await getAllPositionsQueryFactory().execute();
+const allRoles = await getAllRolesQueryFactory().execute({});
+<RoleCreateForm
+  positions={positions.map(p => ({ id: p.id, name: p.name, superiorPositionId: p.superiorPositionId }))}
+  allRoles={allRoles.map(r => ({ id: r.id, name: r.name, positionId: r.positionId }))}
+/>
+
+// Client Component (RoleCreateForm.tsx)
+const [selectedPositionId, setSelectedPositionId] = useState("");
+
+const superiorPositionId = useMemo(
+  () => positions.find(p => p.id === selectedPositionId)?.superiorPositionId ?? null,
+  [positions, selectedPositionId]
+);
+
+const superiorRoleOptions = useMemo(
+  () => superiorPositionId ? allRoles.filter(r => r.positionId === superiorPositionId) : [],
+  [allRoles, superiorPositionId]
+);
+```
+
+**利点**: ユーザー操作にリアルタイムで反応できる。
+**注意**: DTO の Date オブジェクトはシリアライズできないため、必要なフィールドだけ抽出した軽量オブジェクトに変換して渡す。
+
+### 3. 非制御コンポーネントのリセットに useRef を使う
+
+連動する select で、親の値が変わったとき子の選択値をクリアする必要がある。Conform は FormData からバリデーションするため、select は非制御コンポーネント（`defaultValue`）で動作させるのが自然。非制御コンポーネントの値をプログラムからリセットするには `useRef` で DOM を直接操作する。
+
+```tsx
+const superiorRoleSelectRef = useRef<HTMLSelectElement>(null);
+
+const handlePositionChange = (e) => {
+  setSelectedPositionId(e.target.value);
+  if (superiorRoleSelectRef.current) {
+    superiorRoleSelectRef.current.value = "";  // DOM 直接リセット
+  }
+};
+```
+
+`useState` で制御コンポーネントにすると、Conform の FormData ベースのバリデーションと二重管理になり複雑になる。
+
+### 使い分けの判断基準
+
+| 条件 | パターン |
+|------|---------|
+| 選択肢が固定（ページ表示時に確定） | Server Component slot |
+| 他の入力に連動して選択肢が変わる | データ props + クライアントフィルタ |
+
+## 参考
+
+- slot パターンの実例: `src/app/_components/form/DepartmentSelectField.tsx`
+- 動的フィルタリングの実例: `src/app/(features)/roles/new/RoleCreateForm.tsx`
+- slot を使う側: `src/app/(features)/departments/new/page.tsx`
+- データ props を使う側: `src/app/(features)/roles/new/page.tsx`

--- a/src/app/(features)/dashboard/page.tsx
+++ b/src/app/(features)/dashboard/page.tsx
@@ -12,6 +12,11 @@ const navigationItems = [
     title: "部署管理",
     description: "部署の一覧表示、登録、編集、削除を行います。",
   },
+  {
+    href: "/roles",
+    title: "役割管理",
+    description: "役割の一覧表示、登録、編集、削除を行います。",
+  },
 ] as const;
 
 export default async function DashboardPage() {

--- a/src/app/(features)/roles/[roleCd]/RoleDeleteForm.tsx
+++ b/src/app/(features)/roles/[roleCd]/RoleDeleteForm.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useActionState } from "react";
+import { deleteRole } from "./actions";
+
+type Props = {
+  roleId: string;
+};
+
+export function RoleDeleteForm({ roleId }: Props) {
+  const [deleteState, formAction, isPending] = useActionState(deleteRole, {
+    success: true,
+  });
+
+  return (
+    <div className="mt-4">
+      {/* エラーメッセージ表示 */}
+      {!deleteState.success && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+          role="alert"
+        >
+          <p className="font-bold">エラー</p>
+          <p>{deleteState.error}</p>
+        </div>
+      )}
+
+      <form noValidate action={formAction}>
+        {/* hidden inputでIDを渡す */}
+        <input type="hidden" name="id" value={roleId} />
+
+        <button
+          type="submit"
+          disabled={isPending}
+          className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+        >
+          {isPending ? "削除中..." : "削除"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(features)/roles/[roleCd]/RoleUpdateForm.tsx
+++ b/src/app/(features)/roles/[roleCd]/RoleUpdateForm.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { getFormProps, getInputProps } from "@conform-to/react";
+import { useServerForm } from "@/app/_hooks/useServerForm";
+import { updateRole } from "./actions";
+import { updateRoleSchema } from "./schema";
+
+type Role = {
+  id: string;
+  roleCd: string;
+  name: string;
+  positionName: string;
+  superiorRoleId: string | null;
+};
+
+type SuperiorRoleOption = {
+  id: string;
+  name: string;
+};
+
+type Props = {
+  role: Role;
+  canUpdate: boolean;
+  superiorRoleOptions: SuperiorRoleOption[];
+};
+
+export function RoleUpdateForm({ role, canUpdate, superiorRoleOptions }: Props) {
+  const updateRoleWithCd = updateRole.bind(null, role.roleCd);
+
+  const { form, fields, isPending } = useServerForm({
+    action: updateRoleWithCd,
+    schema: updateRoleSchema,
+    defaultValue: {
+      name: role.name,
+      superiorRoleId: role.superiorRoleId ?? "",
+    },
+  });
+
+  return (
+    <div className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+      <h2 className="text-xl font-semibold mb-4 text-gray-500">
+        {canUpdate ? "役割変更" : "役割詳細"}
+      </h2>
+
+      {/* 全体エラーメッセージ表示 */}
+      {form.errors && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+          role="alert"
+        >
+          <p className="font-bold">エラー</p>
+          <p>{form.errors}</p>
+        </div>
+      )}
+
+      <form {...getFormProps(form)} noValidate className="space-y-4">
+        <div>
+          <label htmlFor="roleCd-display" className="block text-gray-700 text-sm font-bold mb-2">
+            役割コード
+          </label>
+          <input
+            type="text"
+            id="roleCd-display"
+            value={role.roleCd}
+            disabled
+            readOnly
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline bg-gray-100"
+          />
+          <p className="text-gray-600 text-xs mt-1">形式: ROLE + 3桁の数字（変更不可）</p>
+        </div>
+
+        <div>
+          <label
+            htmlFor="positionName-display"
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            役職
+          </label>
+          <input
+            type="text"
+            id="positionName-display"
+            value={role.positionName}
+            disabled
+            readOnly
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline bg-gray-100"
+          />
+          <p className="text-gray-600 text-xs mt-1">変更不可</p>
+        </div>
+
+        <div>
+          <label htmlFor={fields.name.id} className="block text-gray-700 text-sm font-bold mb-2">
+            役割名
+          </label>
+          <input
+            {...getInputProps(fields.name, { type: "text" })}
+            disabled={isPending || !canUpdate}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+          />
+          {fields.name.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.name.errorId}>
+              {fields.name.errors[0]}
+            </p>
+          )}
+        </div>
+
+        {superiorRoleOptions.length > 0 && (
+          <div>
+            <label
+              htmlFor={fields.superiorRoleId.id}
+              className="block text-gray-700 text-sm font-bold mb-2"
+            >
+              上位役割
+            </label>
+            <select
+              name="superiorRoleId"
+              id={fields.superiorRoleId.id}
+              defaultValue={role.superiorRoleId ?? ""}
+              disabled={isPending || !canUpdate}
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+            >
+              <option value="">上位役割を選択してください</option>
+              {superiorRoleOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name}
+                </option>
+              ))}
+            </select>
+            {fields.superiorRoleId.errors && (
+              <p className="text-red-500 text-xs mt-1" id={fields.superiorRoleId.errorId}>
+                {fields.superiorRoleId.errors[0]}
+              </p>
+            )}
+          </div>
+        )}
+
+        {canUpdate && (
+          <div className="flex gap-4">
+            <button
+              type="submit"
+              disabled={isPending}
+              className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {isPending ? "更新中..." : "更新"}
+            </button>
+          </div>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/src/app/(features)/roles/[roleCd]/actions.ts
+++ b/src/app/(features)/roles/[roleCd]/actions.ts
@@ -1,0 +1,104 @@
+"use server";
+
+import { verifyAdmin } from "@/app/_lib/verifyAuthentication";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { REDIRECT_REASON } from "@shared/constants/redirect-reasons";
+import type { ActionResult } from "@shared/types/ActionResult";
+import {
+  deleteRoleCommandFactory,
+  updateRoleCommandFactory,
+} from "@subdomains/role/application/factories";
+import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { handleCommandError } from "../../_shared/error-handler";
+import { updateRoleSchema } from "./schema";
+
+// ========================================
+// 役割更新
+// ========================================
+
+/**
+ * 役割更新Server Action
+ * @param roleCd - URLパラメータから取得した役割コード（bind()で渡す）
+ * @param prevState - 前回の状態（Conform用）
+ * @param formData - フォームデータ
+ */
+export async function updateRole(roleCd: string, prevState: unknown, formData: FormData) {
+  // 認証・認可チェック: 管理者のみ
+  await verifyAdmin();
+
+  // Conformを使用してFormDataをパース・バリデーション
+  const submission = parseWithZod(formData, {
+    schema: updateRoleSchema,
+  });
+
+  // バリデーション失敗時はエラーを返却
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const { name, superiorRoleId } = submission.value;
+
+  // roleCdからidを取得
+  const queryService = new PrismaRoleQueryService();
+  const role = await queryService.findByRoleCd(roleCd);
+  if (!role) {
+    return submission.reply({
+      formErrors: ["役割が見つかりません"],
+    });
+  }
+
+  const { id } = role;
+
+  try {
+    const command = updateRoleCommandFactory();
+
+    await command.execute({
+      id,
+      name,
+      superiorRoleId: superiorRoleId ?? null,
+    });
+
+    revalidatePath("/roles");
+    revalidatePath(`/roles/${roleCd}`);
+  } catch (error) {
+    // ドメイン層エラーをConform形式に変換
+    const errorResult = handleCommandError(error);
+    const errorMessage = !errorResult.success && errorResult.error ? errorResult.error : undefined;
+    return submission.reply({
+      formErrors: errorMessage ? [errorMessage] : [],
+    });
+  }
+
+  // 成功時は同じページにリダイレクト（フォーム状態をリセット）
+  redirect(`/roles/${roleCd}?reason=${REDIRECT_REASON.ROLE_UPDATED}`);
+}
+
+// ========================================
+// 役割削除
+// ========================================
+export async function deleteRole(
+  _prevState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  // 認証・認可チェック: 管理者のみ
+  await verifyAdmin();
+
+  const id = formData.get("id") as string;
+
+  try {
+    const command = deleteRoleCommandFactory();
+
+    await command.execute({
+      id,
+    });
+
+    revalidatePath("/roles");
+  } catch (error) {
+    return handleCommandError(error);
+  }
+
+  // 成功時は一覧ページにリダイレクト
+  redirect(`/roles?reason=${REDIRECT_REASON.ROLE_DELETED}`);
+}

--- a/src/app/(features)/roles/[roleCd]/page.tsx
+++ b/src/app/(features)/roles/[roleCd]/page.tsx
@@ -1,0 +1,62 @@
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { isAdmin } from "@server/shared/auth";
+import { getRolesByPositionQueryFactory } from "@subdomains/role/application/factories";
+import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
+import { getAllPositionsQueryFactory } from "@subdomains/position/application/factories";
+import { notFound } from "next/navigation";
+import { RoleDeleteForm } from "./RoleDeleteForm";
+import { RoleUpdateForm } from "./RoleUpdateForm";
+
+export default async function Page({ params }: { params: Promise<{ roleCd: string }> }) {
+  const { roleCd } = await params;
+
+  const session = await verifySession();
+
+  // データ取得
+  const queryService = new PrismaRoleQueryService();
+  const role = await queryService.findByRoleCd(roleCd);
+  if (!role) {
+    notFound();
+  }
+
+  // 全役職を取得して、当該役割の上位役職IDを特定
+  const positions = await getAllPositionsQueryFactory().execute();
+  const currentPosition = positions.find((p) => p.id === role.positionId);
+  const superiorPositionId = currentPosition?.superiorPositionId ?? null;
+
+  // 上位役割候補を取得（上位役職がある場合のみ）
+  let superiorRoleOptions: { id: string; name: string }[] = [];
+  if (superiorPositionId) {
+    const getRolesByPositionQuery = getRolesByPositionQueryFactory();
+    const superiorRoles = await getRolesByPositionQuery.execute({
+      positionId: superiorPositionId,
+    });
+    superiorRoleOptions = superiorRoles.map((r) => ({ id: r.id, name: r.name }));
+  }
+
+  // 権限判定
+  const canUpdate = isAdmin(session);
+  const canDelete = isAdmin(session);
+
+  return (
+    <div className="container mx-auto p-8">
+      <h1 className="text-3xl font-bold mb-8">役割管理</h1>
+
+      {/* 更新フォーム（Client Component） */}
+      <RoleUpdateForm
+        role={{
+          id: role.id,
+          roleCd: role.roleCd,
+          name: role.name,
+          positionName: role.positionName,
+          superiorRoleId: role.superiorRoleId,
+        }}
+        canUpdate={canUpdate}
+        superiorRoleOptions={superiorRoleOptions}
+      />
+
+      {/* 削除フォーム（Client Component） */}
+      {canDelete && <RoleDeleteForm roleId={role.id} />}
+    </div>
+  );
+}

--- a/src/app/(features)/roles/[roleCd]/schema.ts
+++ b/src/app/(features)/roles/[roleCd]/schema.ts
@@ -1,0 +1,7 @@
+import { roleBaseSchema } from "../_shared/schema";
+
+/**
+ * 役割更新用スキーマ
+ * roleCd, positionId は不変のため含まない
+ */
+export const updateRoleSchema = roleBaseSchema;

--- a/src/app/(features)/roles/_components/columns.tsx
+++ b/src/app/(features)/roles/_components/columns.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { type ColumnDef } from "@/app/_components/shared/DataTable";
+
+export type RoleRow = {
+  id: string;
+  roleCd: string;
+  name: string;
+  positionName: string;
+  superiorRoleName: string;
+};
+
+export const columns: ColumnDef<RoleRow, unknown>[] = [
+  {
+    accessorKey: "roleCd",
+    header: "役割コード",
+    cell: ({ row }) => (
+      <Link
+        href={`/roles/${row.original.roleCd}`}
+        className="text-blue-600 hover:text-blue-800 hover:underline"
+      >
+        {row.original.roleCd}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: "name",
+    header: "役割名",
+  },
+  {
+    accessorKey: "positionName",
+    header: "役職",
+  },
+  {
+    accessorKey: "superiorRoleName",
+    header: "上位役割",
+  },
+];

--- a/src/app/(features)/roles/_shared/schema.ts
+++ b/src/app/(features)/roles/_shared/schema.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/**
+ * 役割フォームの基盤スキーマ
+ * 作成・編集で共通のフィールド（name, superiorRoleId）
+ */
+export const roleBaseSchema = z.object({
+  name: z
+    .string({ error: "必須入力です" })
+    .trim()
+    .min(1, { error: "役割名を入力してください" })
+    .max(100, { error: "役割名は100文字以内で入力してください" }),
+  superiorRoleId: z
+    .string()
+    .optional()
+    .transform((val) => (val === "" ? undefined : val)),
+});
+
+/**
+ * 役割コードのスキーマ（作成時のみ使用）
+ */
+export const roleCdSchema = z
+  .string({ error: "必須入力です" })
+  .trim()
+  .regex(/^ROLE\d{3}$/i, {
+    error: "役割コードはROLE + 3桁の数字で入力してください",
+  })
+  .refine(
+    (val) => parseInt(val.substring(4), 10) >= 1,
+    "役割コードは ROLE001 以上である必要があります"
+  );

--- a/src/app/(features)/roles/layout.tsx
+++ b/src/app/(features)/roles/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "役割管理 - ESM",
+};
+
+export default function RoleLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/src/app/(features)/roles/new/RoleCreateForm.tsx
+++ b/src/app/(features)/roles/new/RoleCreateForm.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState, useMemo, useRef } from "react";
+import { getFormProps, getInputProps } from "@conform-to/react";
+import { useServerForm } from "@/app/_hooks/useServerForm";
+import { createRole } from "./actions";
+import { createRoleSchema } from "./schema";
+
+type PositionOption = {
+  id: string;
+  name: string;
+  superiorPositionId: string | null;
+};
+
+type RoleOption = {
+  id: string;
+  name: string;
+  positionId: string;
+};
+
+type Props = {
+  positions: PositionOption[];
+  allRoles: RoleOption[];
+};
+
+export function RoleCreateForm({ positions, allRoles }: Props) {
+  const { form, fields, isPending } = useServerForm({
+    action: createRole,
+    schema: createRoleSchema,
+  });
+
+  const [selectedPositionId, setSelectedPositionId] = useState("");
+  const superiorRoleSelectRef = useRef<HTMLSelectElement>(null);
+
+  // 選択した役職の上位役職IDを特定し、その役職に属する役割を上位役割候補とする
+  const superiorPositionId = useMemo(
+    () => positions.find((p) => p.id === selectedPositionId)?.superiorPositionId ?? null,
+    [positions, selectedPositionId]
+  );
+
+  const superiorRoleOptions = useMemo(
+    () => (superiorPositionId ? allRoles.filter((r) => r.positionId === superiorPositionId) : []),
+    [allRoles, superiorPositionId]
+  );
+
+  const handlePositionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedPositionId(e.target.value);
+    // 役職変更時に上位役割の選択をリセット
+    if (superiorRoleSelectRef.current) {
+      superiorRoleSelectRef.current.value = "";
+    }
+  };
+
+  return (
+    <div className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+      {/* 全体エラーメッセージ表示 */}
+      {form.errors && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+          role="alert"
+        >
+          <p className="font-bold">エラー</p>
+          <p>{form.errors}</p>
+        </div>
+      )}
+
+      <form {...getFormProps(form)} noValidate className="space-y-4">
+        <div>
+          <label htmlFor={fields.roleCd.id} className="block text-gray-700 text-sm font-bold mb-2">
+            役割コード
+          </label>
+          <input
+            {...getInputProps(fields.roleCd, { type: "text" })}
+            disabled={isPending}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+            placeholder="ROLE001"
+          />
+          {fields.roleCd.errors ? (
+            <p className="text-red-500 text-xs mt-1" id={fields.roleCd.errorId}>
+              {fields.roleCd.errors[0]}
+            </p>
+          ) : (
+            <p className="text-gray-600 text-xs mt-1">形式: ROLE + 3桁の数字</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor={fields.name.id} className="block text-gray-700 text-sm font-bold mb-2">
+            役割名
+          </label>
+          <input
+            {...getInputProps(fields.name, { type: "text" })}
+            disabled={isPending}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+            placeholder="大阪市南課長"
+          />
+          {fields.name.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.name.errorId}>
+              {fields.name.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor={fields.positionId.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            役職
+          </label>
+          <select
+            name="positionId"
+            id={fields.positionId.id}
+            disabled={isPending}
+            onChange={handlePositionChange}
+            value={selectedPositionId}
+            aria-invalid={!!fields.positionId.errors}
+            aria-describedby={fields.positionId.errors ? fields.positionId.errorId : undefined}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+          >
+            <option value="" disabled>
+              役職を選択してください
+            </option>
+            {positions.map((position) => (
+              <option key={position.id} value={position.id}>
+                {position.name}
+              </option>
+            ))}
+          </select>
+          {fields.positionId.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.positionId.errorId}>
+              {fields.positionId.errors[0]}
+            </p>
+          )}
+        </div>
+
+        {selectedPositionId && superiorRoleOptions.length > 0 && (
+          <div>
+            <label
+              htmlFor={fields.superiorRoleId.id}
+              className="block text-gray-700 text-sm font-bold mb-2"
+            >
+              上位役割
+            </label>
+            <select
+              ref={superiorRoleSelectRef}
+              name="superiorRoleId"
+              id={fields.superiorRoleId.id}
+              disabled={isPending}
+              defaultValue=""
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+            >
+              <option value="">上位役割を選択してください</option>
+              {superiorRoleOptions.map((role) => (
+                <option key={role.id} value={role.id}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+            {fields.superiorRoleId.errors && (
+              <p className="text-red-500 text-xs mt-1" id={fields.superiorRoleId.errorId}>
+                {fields.superiorRoleId.errors[0]}
+              </p>
+            )}
+          </div>
+        )}
+
+        {selectedPositionId && superiorPositionId === null && (
+          <p className="text-gray-500 text-sm">
+            この役職には上位役職がないため、上位役割は設定できません。
+          </p>
+        )}
+
+        <div className="flex gap-4">
+          <button
+            type="submit"
+            disabled={isPending}
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            {isPending ? "登録中..." : "登録"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(features)/roles/new/actions.ts
+++ b/src/app/(features)/roles/new/actions.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { verifyAdmin } from "@/app/_lib/verifyAuthentication";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { REDIRECT_REASON } from "@shared/constants/redirect-reasons";
+import { createRoleCommandFactory } from "@subdomains/role/application/factories";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { handleCommandError } from "../../_shared/error-handler";
+import { createRoleSchema } from "./schema";
+
+// ========================================
+// 役割作成
+// ========================================
+export async function createRole(prevState: unknown, formData: FormData) {
+  // 認証・認可チェック: 管理者のみ
+  await verifyAdmin();
+
+  // Conformを使用してFormDataをパース・バリデーション
+  const submission = parseWithZod(formData, {
+    schema: createRoleSchema,
+  });
+
+  // バリデーション失敗時はエラーを返却
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const { roleCd, name, positionId, superiorRoleId } = submission.value;
+
+  try {
+    const command = createRoleCommandFactory();
+
+    await command.execute({
+      roleCd,
+      name,
+      positionId,
+      superiorRoleId: superiorRoleId ?? null,
+    });
+
+    revalidatePath("/roles");
+  } catch (error) {
+    const errorResult = handleCommandError(error);
+    const errorMessage = !errorResult.success && errorResult.error ? errorResult.error : undefined;
+    return submission.reply({
+      formErrors: errorMessage ? [errorMessage] : [],
+    });
+  }
+
+  redirect(`/roles?reason=${REDIRECT_REASON.ROLE_CREATED}`);
+}

--- a/src/app/(features)/roles/new/page.tsx
+++ b/src/app/(features)/roles/new/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { getAllPositionsQueryFactory } from "@subdomains/position/application/factories";
+import { getAllRolesQueryFactory } from "@subdomains/role/application/factories";
+import { RoleCreateForm } from "./RoleCreateForm";
+
+export default async function RoleNewPage() {
+  // 全役職・全役割を取得（動的フィルタリング用）
+  const [positions, allRoles] = await Promise.all([
+    getAllPositionsQueryFactory().execute(),
+    getAllRolesQueryFactory().execute({}),
+  ]);
+
+  // Client Componentに渡す軽量なオブジェクトに変換（Date除去）
+  const positionOptions = positions.map((p) => ({
+    id: p.id,
+    name: p.name,
+    superiorPositionId: p.superiorPositionId,
+  }));
+
+  const roleOptions = allRoles.map((r) => ({
+    id: r.id,
+    name: r.name,
+    positionId: r.positionId,
+  }));
+
+  return (
+    <div className="container mx-auto p-8">
+      <div className="mb-8">
+        <Link href="/roles" className="text-blue-600 hover:text-blue-800 hover:underline">
+          ← 役割一覧に戻る
+        </Link>
+      </div>
+
+      <h1 className="text-3xl font-bold mb-8">新規役割登録</h1>
+
+      <RoleCreateForm positions={positionOptions} allRoles={roleOptions} />
+
+      <div className="mt-4">
+        <Link
+          href="/roles"
+          className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline inline-block"
+        >
+          キャンセル
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(features)/roles/new/schema.ts
+++ b/src/app/(features)/roles/new/schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { roleBaseSchema, roleCdSchema } from "../_shared/schema";
+
+/**
+ * 役割作成用スキーマ
+ * 基盤スキーマに roleCd と positionId を追加
+ */
+export const createRoleSchema = roleBaseSchema.extend({
+  roleCd: roleCdSchema,
+  positionId: z
+    .string({ error: "役職を選択してください" })
+    .min(1, { error: "役職を選択してください" }),
+});

--- a/src/app/(features)/roles/page.tsx
+++ b/src/app/(features)/roles/page.tsx
@@ -1,0 +1,91 @@
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { isAdmin } from "@server/shared/auth";
+import { searchRolesQueryFactory } from "@subdomains/role/application/factories";
+import { getAllPositionsQueryFactory } from "@subdomains/position/application/factories";
+import type { RoleSearchCriteria } from "@subdomains/role/application/queries/dto/RoleSearchCriteria";
+import Link from "next/link";
+import { SearchForm, type SearchFieldDef } from "@/app/_components/shared/SearchForm";
+import { DataTable } from "@/app/_components/shared/DataTable";
+import { columns, type RoleRow } from "./_components/columns";
+import { type SearchParams, LIST_FETCH_LIMIT, getStringParam } from "@/app/_lib/searchParams";
+
+export default async function RolePage({ searchParams }: { searchParams: Promise<SearchParams> }) {
+  const session = await verifySession();
+  const params = await searchParams;
+
+  // 役職データの取得（検索フォームのセレクト用）
+  const getAllPositionsQuery = getAllPositionsQueryFactory();
+  const positions = await getAllPositionsQuery.execute();
+
+  // 検索条件の構築
+  const criteria: RoleSearchCriteria = {
+    name: getStringParam(params, "name"),
+    roleCd: getStringParam(params, "roleCd"),
+    positionId: getStringParam(params, "positionId"),
+  };
+
+  // 検索実行
+  const searchQuery = searchRolesQueryFactory();
+  const roles = await searchQuery.execute({
+    criteria,
+    options: { limit: LIST_FETCH_LIMIT },
+  });
+
+  // 表示用データに変換
+  const rows: RoleRow[] = roles.map((role) => ({
+    id: role.id,
+    roleCd: role.roleCd,
+    name: role.name,
+    positionName: role.positionName,
+    superiorRoleName: role.superiorRoleName ?? "-",
+  }));
+
+  // 検索フォームのフィールド定義
+  const searchFields: SearchFieldDef[] = [
+    { type: "text", key: "name", label: "役割名", placeholder: "部分一致" },
+    { type: "text", key: "roleCd", label: "役割コード", placeholder: "完全一致" },
+    {
+      type: "select",
+      key: "positionId",
+      label: "役職",
+      options: positions.map((p) => ({ value: p.id, label: p.name })),
+    },
+  ];
+
+  // Client Componentに渡すdefaultValues
+  const defaultSearchValues = {
+    name: getStringParam(params, "name") ?? "",
+    roleCd: getStringParam(params, "roleCd") ?? "",
+    positionId: getStringParam(params, "positionId") ?? "",
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex justify-between items-center mb-2 px-4 pt-4">
+        <h1 className="text-3xl font-bold">役割管理</h1>
+        {isAdmin(session) && (
+          <Link
+            href="/roles/new"
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          >
+            新規登録
+          </Link>
+        )}
+      </div>
+
+      {/* 検索フォーム */}
+      <div className="px-4">
+        <SearchForm fields={searchFields} defaultValues={defaultSearchValues} />
+      </div>
+
+      {/* 一覧表示 */}
+      <div className="flex-1 flex flex-col min-h-0 bg-white shadow-md rounded mx-4 mb-4 text-gray-500">
+        <div className="px-8 pt-6 pb-2">
+          <h2 className="text-xl font-semibold">役割一覧</h2>
+        </div>
+
+        <DataTable columns={columns} data={rows} emptyMessage="役割が登録されていません" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/redirect-reason-toast.tsx
+++ b/src/app/_components/redirect-reason-toast.tsx
@@ -45,6 +45,18 @@ const FLASH_MESSAGES: Record<RedirectReason, FlashMessage> = {
     type: FLASH_MESSAGE_TYPE.SUCCESS,
     message: "部署を削除しました。",
   },
+  [REDIRECT_REASON.ROLE_CREATED]: {
+    type: FLASH_MESSAGE_TYPE.SUCCESS,
+    message: "役割を登録しました。",
+  },
+  [REDIRECT_REASON.ROLE_UPDATED]: {
+    type: FLASH_MESSAGE_TYPE.SUCCESS,
+    message: "役割情報を更新しました。",
+  },
+  [REDIRECT_REASON.ROLE_DELETED]: {
+    type: FLASH_MESSAGE_TYPE.SUCCESS,
+    message: "役割を削除しました。",
+  },
 };
 
 function RedirectReasonToastInner() {

--- a/src/shared/constants/redirect-reasons.ts
+++ b/src/shared/constants/redirect-reasons.ts
@@ -11,6 +11,9 @@ export const REDIRECT_REASON = {
   DEPARTMENT_CREATED: "department_created",
   DEPARTMENT_UPDATED: "department_updated",
   DEPARTMENT_DELETED: "department_deleted",
+  ROLE_CREATED: "role_created",
+  ROLE_UPDATED: "role_updated",
+  ROLE_DELETED: "role_deleted",
 } as const;
 
 export type RedirectReason = (typeof REDIRECT_REASON)[keyof typeof REDIRECT_REASON];


### PR DESCRIPTION
## Summary

役割（Role）のCRUD管理画面のフロントエンド（Presentation層）を実装。Next.js App Router を使用し、既存の部署管理画面と同じパターンに従い、一覧・新規作成・詳細/編集・削除の各ページを構築した。役職選択に連動した上位役割の動的フィルタリングを新規作成ページにクライアントサイドで実装。

Closes #175

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

# Issue #175: 役割管理画面のフロントエンド実装（Presentation層）

## Context

PR #181 で実装済みのバックエンド（Domain/Application/Infrastructure層）に対して、Next.js App Router を用いた CRUD 管理画面を構築する。既存の部署管理・従業員管理と同じパターンに従う。

**固有の課題**: 役職選択に連動した上位役割の動的フィルタリング。課長を選ぶと上位役割は部長の役割のみ表示、社長を選ぶと上位役割は非表示、という制約をUIで実現する必要がある。

## 設計判断

### 1. 上位役割の動的フィルタリング方式

**採用**: 全データ事前ロード + クライアントサイドフィルタリング

- `new/page.tsx`（Server Component）で全Positionと全Roleを取得
- Client Componentにpropsとして渡す
- `useState` で選択中の役職を管理し、`useMemo` で上位役割候補をフィルタ
- 理由: 固定4役職 + 役割数も少数 → サーバーリクエスト不要

**作成ページ**: Position変更時にSuperior Role選択肢を動的に切り替え

**編集ページ**: Position不変なので、事前にサーバー側で上位役割候補を計算してpropsで渡す（動的フィルタ不要）

### 2. roleCd から RoleDTO の取得

**採用**: `RoleQueryService.findByRoleCd(roleCd)` を使用

### 3. Conform と制御select の共存

Position `<select>` は `onChange` ハンドラが必要（動的フィルタ用）。Conform の `getSelectProps` は使わず、`name` 属性を直接設定。

## 実装ステップ

### Step 1: 共通基盤（リダイレクト理由・Zodスキーマ）
- `redirect-reasons.ts` に `ROLE_CREATED`, `ROLE_UPDATED`, `ROLE_DELETED` 追加
- `redirect-reason-toast.tsx` に役割用フラッシュメッセージ3件追加
- `roles/_shared/schema.ts` に基本Zodスキーマ新規作成

### Step 2: 一覧ページ
- `roles/layout.tsx`, `roles/_components/columns.tsx`, `roles/page.tsx` 新規作成
- 検索フィールド: 役割名（部分一致）、役割コード（完全一致）、役職（select）

### Step 3: 新規作成ページ
- `roles/new/` 配下に schema, actions, page, RoleCreateForm を新規作成
- 役職変更時に上位役割selectを動的フィルタリング

### Step 4: 詳細・編集・削除ページ
- `roles/[roleCd]/` 配下に schema, actions, page, RoleUpdateForm, RoleDeleteForm を新規作成
- 編集ページでは役職は読み取り専用

### Step 5: ダッシュボード導線追加
- `dashboard/page.tsx` に役割管理カードを追加

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

- [ ] `pnpm build` でビルド成功を確認
- [ ] `pnpm lint` でlint通過を確認
- [ ] ダッシュボードから役割管理へ遷移できること
- [ ] 役割一覧が表示される（検索・フィルタ動作を含む）
- [ ] 役割を新規作成できる（役職選択→上位役割の動的フィルタリング動作を含む）
- [ ] 役割の詳細ページが表示される
- [ ] 役割を編集できる（名前・上位役割の変更）
- [ ] 使用中でない役割を削除できる
- [ ] 使用中の役割は削除時にエラーメッセージが表示される

---

Generated with [Claude Code](https://claude.ai/code)