### PR TITLE
fix: テスト並列実行時の部署マスタupsertレースコンディションの修正

### DIFF
--- a/docs/claude-plans/issue-194/plan.md
+++ b/docs/claude-plans/issue-194/plan.md
@@ -1,0 +1,29 @@
+# Issue #194: テスト並列実行時の部署マスタupsertレースコンディションの修正 -- 実装計画
+
+## 概要
+
+Vitestの並列実行時に複数テストファイルが同時に `prisma.department.upsert({ update: {} })` を実行し、unique constraint violation が発生するフレーキーテスト問題を修正する。共通ヘルパー `ensureTestDepartment()` を作成し、全9ファイルのボイラープレートを置換する。
+
+## ステップ
+
+### Step 1: 共通ヘルパー関数 `ensureTestDepartment` の作成
+
+- 対象ファイル: `src/server/__tests__/helpers/ensureTestDepartment.ts`（新規作成）
+- 作業内容:
+  - `ensureTestDepartment()` 関数を作成
+  - `update: { name: "テスト部署" }` で ON CONFLICT DO UPDATE を保証（方針A）
+  - try-catch で findUniqueOrThrow にフォールバック（方針B）
+- コミットメッセージ: feat: テスト用共通ヘルパー ensureTestDepartment を作成
+
+### Step 2: 全9テストファイルのボイラープレートを `ensureTestDepartment()` に置換
+
+- 対象ファイル: 9つのテストファイル（影響範囲に記載）
+- 作業内容:
+  - 各ファイルの beforeEach 内の department upsert コードを `ensureTestDepartment()` 呼び出しに置換
+  - 不要になった `generateId` インポートがあれば削除（他で使っていない場合のみ）
+- コミットメッセージ: fix: 部署マスタupsertのレースコンディションを修正 (#194)
+
+### Step 3: lint & テスト検証
+
+- 作業内容: `pnpm lint` と `pnpm test` を実行して検証
+- コミットメッセージ: （修正が必要な場合のみ）fix: lint/test修正

--- a/src/server/__tests__/helpers/ensureTestDepartment.ts
+++ b/src/server/__tests__/helpers/ensureTestDepartment.ts
@@ -1,0 +1,30 @@
+import prisma from "@server/prisma";
+import { generateId } from "@server/shared/generateId";
+
+/**
+ * テスト用の部署マスタレコードを確実に作成・取得する。
+ * 並列実行時のレースコンディションに対応:
+ * - update に値を指定し ON CONFLICT DO UPDATE を保証（空 update の DO NOTHING 問題を回避）
+ * - upsert 自体が失敗した場合は findUniqueOrThrow でフォールバック
+ */
+export async function ensureTestDepartment(): Promise<string> {
+  try {
+    const dept = await prisma.department.upsert({
+      where: { departmentCd: "TEST_DEPT" },
+      update: { name: "テスト部署" },
+      create: {
+        id: generateId(),
+        departmentCd: "TEST_DEPT",
+        name: "テスト部署",
+        abbreviation: "テスト",
+        isActive: true,
+      },
+    });
+    return dept.id;
+  } catch {
+    const dept = await prisma.department.findUniqueOrThrow({
+      where: { departmentCd: "TEST_DEPT" },
+    });
+    return dept.id;
+  }
+}

--- a/src/server/subdomains/employee/application/commands/__tests__/CreateEmployeeCommand.test.ts
+++ b/src/server/subdomains/employee/application/commands/__tests__/CreateEmployeeCommand.test.ts
@@ -1,4 +1,4 @@
-import { generateId } from "@server/shared/generateId";
+import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import { FakeUserManagementService } from "@server/shared/auth/fake/FakeUserManagementService";
 import { USER_ROLES } from "@server/shared/auth/types";
 import { ValidationError } from "@server/shared/errors/DomainError";
@@ -25,18 +25,7 @@ describe("CreateEmployeeCommand", () => {
       where: { employeeCd: { in: TEST_CODES } },
     });
 
-    const dept = await prisma.department.upsert({
-      where: { departmentCd: "TEST_DEPT" },
-      update: {},
-      create: {
-        id: generateId(),
-        departmentCd: "TEST_DEPT",
-        name: "テスト部署",
-        abbreviation: "テスト",
-        isActive: true,
-      },
-    });
-    TEST_DEPT_ID = dept.id;
+    TEST_DEPT_ID = await ensureTestDepartment();
 
     repository = new PrismaEmployeeRepository();
     cdDuplicationCheckService = new EmployeeCdDuplicationCheckDomainService(repository);

--- a/src/server/subdomains/employee/application/commands/__tests__/DeleteEmployeeCommand.test.ts
+++ b/src/server/subdomains/employee/application/commands/__tests__/DeleteEmployeeCommand.test.ts
@@ -1,4 +1,4 @@
-import { generateId } from "@server/shared/generateId";
+import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import prisma from "@server/prisma";
 import { FakeUserManagementService } from "@server/shared/auth/fake/FakeUserManagementService";
 import { USER_ROLES } from "@server/shared/auth/types";
@@ -24,19 +24,8 @@ describe("DeleteEmployeeCommand", () => {
       },
     });
 
-    // テスト用部署を作成（存在しない場合）
-    const dept = await prisma.department.upsert({
-      where: { departmentCd: "TEST_DEPT" },
-      update: {},
-      create: {
-        id: generateId(),
-        departmentCd: "TEST_DEPT",
-        name: "テスト部署",
-        abbreviation: "テスト",
-        isActive: true,
-      },
-    });
-    TEST_DEPT_ID = dept.id;
+    // テスト用部署を確保
+    TEST_DEPT_ID = await ensureTestDepartment();
 
     repository = new PrismaEmployeeRepository();
     fakeUserManagementService = new FakeUserManagementService();

--- a/src/server/subdomains/employee/application/commands/__tests__/UpdateEmployeeCommand.test.ts
+++ b/src/server/subdomains/employee/application/commands/__tests__/UpdateEmployeeCommand.test.ts
@@ -1,4 +1,4 @@
-import { generateId } from "@server/shared/generateId";
+import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import prisma from "@server/prisma";
 import { FakeUserManagementService } from "@server/shared/auth/fake/FakeUserManagementService";
 import { USER_ROLES } from "@server/shared/auth/types";
@@ -29,19 +29,8 @@ describe("UpdateEmployeeCommand", () => {
       },
     });
 
-    // 2. テスト用部署を upsert
-    const dept = await prisma.department.upsert({
-      where: { departmentCd: "TEST_DEPT" },
-      update: {},
-      create: {
-        id: generateId(),
-        departmentCd: "TEST_DEPT",
-        name: "テスト部署",
-        abbreviation: "テスト",
-        isActive: true,
-      },
-    });
-    TEST_DEPT_ID = dept.id;
+    // 2. テスト用部署を確保
+    TEST_DEPT_ID = await ensureTestDepartment();
 
     // 3. 更新対象の既存従業員を作成
     await prisma.employee.create({

--- a/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmployeeCdQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmployeeCdQuery.test.ts
@@ -1,3 +1,4 @@
+import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import { generateId } from "@server/shared/generateId";
 import prisma from "@server/prisma";
 import type { UserRole } from "@server/shared/auth/types";
@@ -60,18 +61,7 @@ describe("GetEmployeeByEmployeeCdQuery", () => {
       where: { employeeCd: { in: TEST_CODES } },
     });
 
-    const dept = await prisma.department.upsert({
-      where: { departmentCd: "TEST_DEPT" },
-      update: {},
-      create: {
-        id: generateId(),
-        departmentCd: "TEST_DEPT",
-        name: "テスト部署",
-        abbreviation: "テスト",
-        isActive: true,
-      },
-    });
-    TEST_DEPT_ID = dept.id;
+    TEST_DEPT_ID = await ensureTestDepartment();
 
     query = new GetEmployeeByEmployeeCdQuery(new PrismaEmployeeQueryService());
   });

--- a/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByIdQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByIdQuery.test.ts
@@ -1,3 +1,4 @@
+import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import { generateId } from "@server/shared/generateId";
 import prisma from "@server/prisma";
 import type { UserRole } from "@server/shared/auth/types";
@@ -60,18 +61,7 @@ describe("GetEmployeeByIdQuery", () => {
       where: { employeeCd: { in: TEST_CODES } },
     });
 
-    const dept = await prisma.department.upsert({
-      where: { departmentCd: "TEST_DEPT" },
-      update: {},
-      create: {
-        id: generateId(),
-        departmentCd: "TEST_DEPT",
-        name: "テスト部署",
-        abbreviation: "テスト",
-        isActive: true,
-      },
-    });
-    TEST_DEPT_ID = dept.id;
+    TEST_DEPT_ID = await ensureTestDepartment();
 
     query = new GetEmployeeByIdQuery(new PrismaEmployeeQueryService());
   });

--- a/src/server/subdomains/employee/application/queries/__tests__/SearchEmployeesQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/SearchEmployeesQuery.test.ts
@@ -1,3 +1,4 @@
+import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import { generateId } from "@server/shared/generateId";
 import prisma from "@server/prisma";
 import type { UserRole } from "@server/shared/auth/types";
@@ -60,18 +61,7 @@ describe("SearchEmployeesQuery", () => {
       where: { employeeCd: { in: TEST_CODES } },
     });
 
-    const dept = await prisma.department.upsert({
-      where: { departmentCd: "TEST_DEPT" },
-      update: {},
-      create: {
-        id: generateId(),
-        departmentCd: "TEST_DEPT",
-        name: "テスト部署",
-        abbreviation: "テスト",
-        isActive: true,
-      },
-    });
-    TEST_DEPT_ID = dept.id;
+    TEST_DEPT_ID = await ensureTestDepartment();
 
     query = new SearchEmployeesQuery(new PrismaEmployeeQueryService());
   });

--- a/src/server/subdomains/employee/domain/services/__tests__/EmployeeCdDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/employee/domain/services/__tests__/EmployeeCdDuplicationCheckDomainService.test.ts
@@ -1,4 +1,4 @@
-import { generateId } from "@server/shared/generateId";
+import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import prisma from "@server/prisma";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
@@ -24,19 +24,7 @@ describe("EmployeeCdDuplicationCheckDomainService", () => {
   beforeEach(async () => {
     await cleanup();
 
-    // 外部キー依存のフィクスチャ（upsert で冪等に作成）
-    const dept = await prisma.department.upsert({
-      where: { departmentCd: "TEST_DEPT" },
-      update: {},
-      create: {
-        id: generateId(),
-        departmentCd: "TEST_DEPT",
-        name: "テスト部署",
-        abbreviation: "テスト",
-        isActive: true,
-      },
-    });
-    TEST_DEPT_ID = dept.id;
+    TEST_DEPT_ID = await ensureTestDepartment();
 
     repository = new PrismaEmployeeRepository();
     service = new EmployeeCdDuplicationCheckDomainService(repository);

--- a/src/server/subdomains/employee/domain/services/__tests__/MailAddressDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/employee/domain/services/__tests__/MailAddressDuplicationCheckDomainService.test.ts
@@ -1,4 +1,4 @@
-import { generateId } from "@server/shared/generateId";
+import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import prisma from "@server/prisma";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
@@ -24,19 +24,7 @@ describe("MailAddressDuplicationCheckDomainService", () => {
   beforeEach(async () => {
     await cleanup();
 
-    // 外部キー依存のフィクスチャ（upsert で冪等に作成）
-    const dept = await prisma.department.upsert({
-      where: { departmentCd: "TEST_DEPT" },
-      update: {},
-      create: {
-        id: generateId(),
-        departmentCd: "TEST_DEPT",
-        name: "テスト部署",
-        abbreviation: "テスト",
-        isActive: true,
-      },
-    });
-    TEST_DEPT_ID = dept.id;
+    TEST_DEPT_ID = await ensureTestDepartment();
 
     repository = new PrismaEmployeeRepository();
     service = new MailAddressDuplicationCheckDomainService(repository);

--- a/src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts
+++ b/src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts
@@ -1,4 +1,4 @@
-import { generateId } from "@server/shared/generateId";
+import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
 import { EmployeeName } from "@subdomains/employee/domain/values/EmployeeName";
@@ -22,19 +22,8 @@ describe("PrismaEmployeeRepository", () => {
       },
     });
 
-    // テスト用部署を作成（存在しない場合）
-    const dept = await prisma.department.upsert({
-      where: { departmentCd: "TEST_DEPT" },
-      update: {},
-      create: {
-        id: generateId(),
-        departmentCd: "TEST_DEPT",
-        name: "テスト部署",
-        abbreviation: "テスト",
-        isActive: true,
-      },
-    });
-    TEST_DEPT_ID = dept.id;
+    // テスト用部署を確保
+    TEST_DEPT_ID = await ensureTestDepartment();
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary

テスト並列実行時に複数ファイルが同時に `prisma.department.upsert({ update: {} })` を実行することで発生するフレーキーな unique constraint violation を修正。共通ヘルパー `ensureTestDepartment()` を作成し、全9テストファイルのボイラープレートを置換した。

Closes #194

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

# Issue #194: テスト並列実行時の部署マスタupsertレースコンディションの修正 -- 実装計画

## 概要

Vitestの並列実行時に複数テストファイルが同時に `prisma.department.upsert({ update: {} })` を実行し、unique constraint violation が発生するフレーキーテスト問題を修正する。共通ヘルパー `ensureTestDepartment()` を作成し、全9ファイルのボイラープレートを置換する。

## ステップ

### Step 1: 共通ヘルパー関数 `ensureTestDepartment` の作成

- 対象ファイル: `src/server/__tests__/helpers/ensureTestDepartment.ts`（新規作成）
- 作業内容:
  - `ensureTestDepartment()` 関数を作成
  - `update: { name: "テスト部署" }` で ON CONFLICT DO UPDATE を保証（方針A）
  - try-catch で findUniqueOrThrow にフォールバック（方針B）
- コミットメッセージ: feat: テスト用共通ヘルパー ensureTestDepartment を作成

### Step 2: 全9テストファイルのボイラープレートを `ensureTestDepartment()` に置換

- 対象ファイル: 9つのテストファイル（影響範囲に記載）
- 作業内容:
  - 各ファイルの beforeEach 内の department upsert コードを `ensureTestDepartment()` 呼び出しに置換
  - 不要になった `generateId` インポートがあれば削除（他で使っていない場合のみ）
- コミットメッセージ: fix: 部署マスタupsertのレースコンディションを修正 (#194)

### Step 3: lint & テスト検証

- 作業内容: `pnpm lint` と `pnpm test` を実行して検証
- コミットメッセージ: （修正が必要な場合のみ）fix: lint/test修正

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

- [ ] `pnpm test` で全テストがパスすることを確認（特に並列実行時のフレーキーテストが解消されていること）
- [ ] 9つの対象テストファイルが `ensureTestDepartment()` を使用していることを確認
- [ ] 部署マスタの `TEST_DEPT` レコードを削除した状態でテストを複数回実行し、レースコンディションが再発しないことを確認

---

Generated with [Claude Code](https://claude.ai/code)