### PR TITLE
feat: UUIDv7 ID Value Object の導入による型安全なエンティティID (#189)

### DIFF
--- a/docs/claude-plans/issue-189/deviations.md
+++ b/docs/claude-plans/issue-189/deviations.md
@@ -1,0 +1,6 @@
+# 計画からの逸脱記録
+
+## 逸脱 1: Customer + DeliveryLocation サブドメインの同時コミット
+- **計画**: Step 4（Customer）と Step 5（DeliveryLocation）を個別にコミット
+- **実際**: 2つのサブドメインを1つのコミットにまとめて実施
+- **理由**: DeliveryLocation が Customer の `CustomerId` を外部キーとして参照しているため、Customer の ID を `string` → `CustomerId` に変更すると、DeliveryLocation 側の TypeScript コンパイルが失敗する。pre-commit フックで全体の型チェックが走るため、両サブドメインを同時に更新・コミットする必要があった。

--- a/docs/claude-plans/issue-189/plan.md
+++ b/docs/claude-plans/issue-189/plan.md
@@ -1,0 +1,140 @@
+# Issue #189: UUIDv7 ID Value Object の導入による型安全なエンティティID — 実装計画
+
+## 概要
+
+全エンティティのIDを生の `string` 型から型付き Value Object（`EmployeeId`, `CustomerId`, `DepartmentId` 等）に置き換え、型安全性を確保する。既存の `StringValueObject` を継承した `EntityId` 基底クラスを作成し、UUIDv7フォーマットバリデーション付きのIDクラスを各サブドメインに導入する。
+
+## 設計判断
+
+### CompanyIdの配置場所
+- A. customer サブドメインに配置
+- B. shared/domain/values に配置（Customer と DeliveryLocation の両方が使用するため）
+- 推奨: B（CompanyCode, CompanyName と同様に共有値オブジェクトとして扱う）
+
+### CustomerIdの配置場所
+- A. customer サブドメインのみに配置
+- B. shared/domain/values に配置（DeliveryLocation が外部キーとして参照するため）
+- 推奨: A（DDDではIDによるサブドメイン間参照は許容。DeliveryLocationからcustomerサブドメインのCustomerIdをimport）
+
+### EntityId.generate() のUUIDv7生成方式
+- A. EntityId内で直接 uuid ライブラリを使用
+- B. 既存の generateId() を内部で呼び出す
+- 推奨: B（既存パターンを踏襲し、変更箇所を最小化）
+
+## ステップ
+
+### Step 1: EntityId基底クラス + 全ID Value Object + テスト作成
+- 対象ファイル:
+  - `src/server/shared/domain/values/EntityId.ts`（新規）
+  - `src/server/shared/domain/values/CompanyId.ts`（新規）
+  - `src/server/subdomains/employee/domain/values/EmployeeId.ts`（新規）
+  - `src/server/subdomains/customer/domain/values/CustomerId.ts`（新規）
+  - `src/server/subdomains/department/domain/values/DepartmentId.ts`（新規）
+  - `src/server/subdomains/delivery-location/domain/values/DeliveryLocationId.ts`（新規）
+  - `src/server/subdomains/position/domain/values/PositionId.ts`（新規）
+  - `src/server/subdomains/role/domain/values/RoleId.ts`（新規）
+  - `src/server/shared/domain/values/__tests__/EntityId.test.ts`（新規）
+- 作業内容:
+  - StringValueObject を継承した EntityId 抽象クラス（UUIDv7正規表現バリデーション）を作成
+  - 各サブドメインに具体的なID Value Objectを作成（各クラスに generate() 静的メソッド）
+  - EntityId のバリデーション・generate・equals のユニットテスト作成
+- コミットメッセージ: feat: EntityId基底クラスと全ID Value Objectを作成
+
+### Step 2: Employee サブドメインの全レイヤー更新
+- 対象ファイル:
+  - `src/server/subdomains/employee/domain/entities/Employee.ts`
+  - `src/server/subdomains/employee/domain/repositories/EmployeeRepository.ts`
+  - `src/server/subdomains/employee/infrastructure/mappers/EmployeeMapper.ts`
+  - `src/server/subdomains/employee/infrastructure/prisma/PrismaEmployeeRepository.ts`
+  - `src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts`
+  - `src/server/subdomains/employee/application/commands/*.ts`
+  - `src/server/subdomains/employee/application/queries/*.ts`
+  - 関連テストファイル
+- 作業内容:
+  - Employee の _id を EmployeeId、_departmentId を DepartmentId に変更
+  - create() で EmployeeId.generate() を使用
+  - Repository インターフェースの引数型を更新
+  - Mapper, PrismaRepository, QueryService の ID 変換を更新
+  - Commands/Queries の入力型と処理を更新
+  - テストの更新
+- コミットメッセージ: feat: Employeeサブドメインの型安全なID Value Object適用
+
+### Step 3: Department サブドメインの全レイヤー更新
+- 対象ファイル:
+  - `src/server/subdomains/department/domain/entities/Department.ts`
+  - `src/server/subdomains/department/domain/repositories/DepartmentRepository.ts`
+  - `src/server/subdomains/department/infrastructure/mappers/DepartmentMapper.ts`
+  - `src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts`
+  - `src/server/subdomains/department/application/commands/*.ts`
+  - `src/server/subdomains/department/application/queries/*.ts`
+  - 関連テストファイル
+- 作業内容:
+  - Department の _id, _parentId を DepartmentId に変更
+  - Repository インターフェースとインフラ層の更新
+  - Commands/Queries の更新
+  - テストの更新
+- コミットメッセージ: feat: Departmentサブドメインの型安全なID Value Object適用
+
+### Step 4: Customer サブドメインの全レイヤー更新
+- 対象ファイル:
+  - `src/server/subdomains/customer/domain/entities/Customer.ts`
+  - `src/server/subdomains/customer/domain/repositories/CustomerRepository.ts`
+  - `src/server/subdomains/customer/infrastructure/mappers/CustomerMapper.ts`
+  - `src/server/subdomains/customer/infrastructure/prisma/PrismaCustomerRepository.ts`
+  - `src/server/subdomains/customer/infrastructure/queries/PrismaCustomerQueryService.ts`
+  - `src/server/subdomains/customer/application/commands/*.ts`
+  - `src/server/subdomains/customer/application/queries/*.ts`
+  - 関連テストファイル
+- 作業内容:
+  - Customer の _id を CustomerId、_companyId を CompanyId に変更
+  - Repository インターフェースとインフラ層の更新
+  - Commands/Queries の更新
+  - テストの更新
+- コミットメッセージ: feat: Customerサブドメインの型安全なID Value Object適用
+
+### Step 5: DeliveryLocation サブドメインの全レイヤー更新
+- 対象ファイル:
+  - `src/server/subdomains/delivery-location/domain/entities/DeliveryLocation.ts`
+  - `src/server/subdomains/delivery-location/domain/repositories/DeliveryLocationRepository.ts`
+  - `src/server/subdomains/delivery-location/infrastructure/mappers/DeliveryLocationMapper.ts`
+  - `src/server/subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository.ts`
+  - `src/server/subdomains/delivery-location/infrastructure/queries/PrismaDeliveryLocationQueryService.ts`
+  - `src/server/subdomains/delivery-location/application/commands/*.ts`
+  - `src/server/subdomains/delivery-location/application/queries/*.ts`
+  - 関連テストファイル
+- 作業内容:
+  - DeliveryLocation の _id を DeliveryLocationId、_companyId を CompanyId、_customerId を CustomerId に変更
+  - Repository インターフェースとインフラ層の更新
+  - Commands/Queries の更新
+  - テストの更新
+- コミットメッセージ: feat: DeliveryLocationサブドメインの型安全なID Value Object適用
+
+### Step 6: Position + Role サブドメインの全レイヤー更新
+- 対象ファイル:
+  - `src/server/subdomains/position/domain/entities/Position.ts`
+  - `src/server/subdomains/position/domain/repositories/PositionRepository.ts`
+  - `src/server/subdomains/position/infrastructure/mappers/PositionMapper.ts`
+  - `src/server/subdomains/position/infrastructure/prisma/PrismaPositionRepository.ts`
+  - `src/server/subdomains/role/domain/entities/Role.ts`
+  - `src/server/subdomains/role/domain/repositories/RoleRepository.ts`
+  - `src/server/subdomains/role/infrastructure/mappers/RoleMapper.ts`
+  - `src/server/subdomains/role/infrastructure/prisma/PrismaRoleRepository.ts`
+  - `src/server/subdomains/role/infrastructure/queries/PrismaRoleQueryService.ts`
+  - `src/server/subdomains/role/application/commands/*.ts`
+  - `src/server/subdomains/role/application/queries/*.ts`
+  - 関連テストファイル
+- 作業内容:
+  - Position の _id, _superiorPositionId を PositionId に変更
+  - Role の _id を RoleId、_positionId を PositionId、_superiorRoleId を RoleId に変更
+  - Repository インターフェースとインフラ層の更新
+  - Commands/Queries の更新
+  - テストの更新
+- コミットメッセージ: feat: Position+Roleサブドメインの型安全なID Value Object適用
+
+### Step 7: 最終検証
+- 対象ファイル: なし（検証のみ）
+- 作業内容:
+  - pnpm lint 実行
+  - pnpm test 実行
+  - 問題があれば修正
+- コミットメッセージ: （修正があれば）fix: lint/test修正

--- a/src/server/shared/domain/values/CompanyId.ts
+++ b/src/server/shared/domain/values/CompanyId.ts
@@ -1,0 +1,12 @@
+import { EntityId } from "@server/shared/domain/values/EntityId";
+
+/**
+ * 会社ID値オブジェクト
+ *
+ * Customer・DeliveryLocation が共有する Company テーブルのID。
+ */
+export class CompanyId extends EntityId<"CompanyId"> {
+  static generate(): CompanyId {
+    return new CompanyId(EntityId.generateValue());
+  }
+}

--- a/src/server/shared/domain/values/EntityId.ts
+++ b/src/server/shared/domain/values/EntityId.ts
@@ -1,0 +1,26 @@
+import { StringValueObject } from "@server/shared/StringValueObject";
+import { generateId } from "@server/shared/generateId";
+
+/**
+ * エンティティID値オブジェクトの基底クラス
+ *
+ * UUIDv7フォーマットのバリデーションを提供する。
+ * 各エンティティ固有のIDクラスはこのクラスを継承して作成する。
+ */
+export abstract class EntityId<U> extends StringValueObject<U> {
+  protected static readonly LABEL = "ID";
+  protected static readonly REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  protected static readonly MIN_LENGTH = 36;
+  protected static readonly MAX_LENGTH = 36;
+  protected static readonly ERROR_MESSAGE_INVALID_FORMAT = "不正なUUIDv7形式です";
+
+  /**
+   * UUIDv7を生成してIDインスタンスを返すヘルパー
+   *
+   * 各サブクラスの generate() から呼び出す。
+   */
+  protected static generateValue(): string {
+    return generateId();
+  }
+}

--- a/src/server/shared/domain/values/__tests__/EntityId.test.ts
+++ b/src/server/shared/domain/values/__tests__/EntityId.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { CompanyId } from "@server/shared/domain/values/CompanyId";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
+import { RoleId } from "@subdomains/role/domain/values/RoleId";
+
+/** テスト用の有効なUUIDv7 */
+const VALID_UUID_V7 = "019573a0-7a00-7000-8000-000000000001";
+const VALID_UUID_V7_2 = "019573a0-7a00-7000-8000-000000000002";
+
+describe("EntityId Value Objects", () => {
+  describe("バリデーション", () => {
+    it("有効なUUIDv7を受け入れる", () => {
+      const id = new EmployeeId(VALID_UUID_V7);
+      expect(id.value).toBe(VALID_UUID_V7);
+    });
+
+    it("大文字のUUIDv7を受け入れる", () => {
+      const upper = VALID_UUID_V7.toUpperCase();
+      const id = new EmployeeId(upper);
+      expect(id.value).toBe(upper);
+    });
+
+    it("空文字を拒否する", () => {
+      expect(() => new EmployeeId("")).toThrow(ValidationError);
+    });
+
+    it("不正な形式を拒否する", () => {
+      expect(() => new EmployeeId("not-a-uuid")).toThrow(ValidationError);
+    });
+
+    it("UUIDv4を拒否する（version nibbleが4）", () => {
+      expect(() => new EmployeeId("550e8400-e29b-41d4-a716-446655440000")).toThrow(ValidationError);
+    });
+
+    it("ハイフンなしのUUIDを拒否する", () => {
+      expect(() => new EmployeeId("019573a07a0070008000000000000001")).toThrow(ValidationError);
+    });
+  });
+
+  describe("generate", () => {
+    it("EmployeeId.generate() は有効なEmployeeIdを返す", () => {
+      const id = EmployeeId.generate();
+      expect(id).toBeInstanceOf(EmployeeId);
+      expect(id.value).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it("generate() は毎回異なるIDを返す", () => {
+      const id1 = EmployeeId.generate();
+      const id2 = EmployeeId.generate();
+      expect(id1.value).not.toBe(id2.value);
+    });
+
+    it("各ID型のgenerate()が正しい型を返す", () => {
+      expect(CustomerId.generate()).toBeInstanceOf(CustomerId);
+      expect(CompanyId.generate()).toBeInstanceOf(CompanyId);
+      expect(DepartmentId.generate()).toBeInstanceOf(DepartmentId);
+      expect(DeliveryLocationId.generate()).toBeInstanceOf(DeliveryLocationId);
+      expect(PositionId.generate()).toBeInstanceOf(PositionId);
+      expect(RoleId.generate()).toBeInstanceOf(RoleId);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値のIDは等しい", () => {
+      const a = new EmployeeId(VALID_UUID_V7);
+      const b = new EmployeeId(VALID_UUID_V7);
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("異なる値のIDは等しくない", () => {
+      const a = new EmployeeId(VALID_UUID_V7);
+      const b = new EmployeeId(VALID_UUID_V7_2);
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+
+  describe("型安全性", () => {
+    it("異なるID型のequalsはfalseを返す", () => {
+      const employeeId = new EmployeeId(VALID_UUID_V7);
+      const customerId = new CustomerId(VALID_UUID_V7);
+      // 同じ値でも異なるクラスなら false
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(employeeId.equals(customerId as any)).toBe(false);
+    });
+  });
+});

--- a/src/server/subdomains/customer/application/commands/DeleteCustomerCommand.ts
+++ b/src/server/subdomains/customer/application/commands/DeleteCustomerCommand.ts
@@ -1,6 +1,7 @@
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
 import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 
 export type DeleteCustomerInput = {
   id: string;
@@ -13,11 +14,12 @@ export class DeleteCustomerCommand {
   constructor(private readonly customerRepository: CustomerRepository) {}
 
   async execute(input: DeleteCustomerInput): Promise<void> {
-    const customer = await this.customerRepository.findById(input.id);
+    const customerId = new CustomerId(input.id);
+    const customer = await this.customerRepository.findById(customerId);
     if (!customer) {
       throw new NotFoundEntityError(Customer, { id: input.id });
     }
 
-    await this.customerRepository.delete(input.id);
+    await this.customerRepository.delete(customerId);
   }
 }

--- a/src/server/subdomains/customer/application/commands/UpdateCustomerCommand.ts
+++ b/src/server/subdomains/customer/application/commands/UpdateCustomerCommand.ts
@@ -7,6 +7,7 @@ import { Prefecture } from "@server/shared/domain/values/Prefecture";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
 import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { MarginRate } from "@subdomains/customer/domain/values/MarginRate";
 
 export type UpdateCustomerInput = {
@@ -31,7 +32,8 @@ export class UpdateCustomerCommand {
   constructor(private readonly customerRepository: CustomerRepository) {}
 
   async execute(input: UpdateCustomerInput): Promise<void> {
-    const customer = await this.customerRepository.findById(input.id);
+    const customerId = new CustomerId(input.id);
+    const customer = await this.customerRepository.findById(customerId);
     if (!customer) {
       throw new NotFoundEntityError(Customer, { id: input.id });
     }

--- a/src/server/subdomains/customer/application/commands/__tests__/DeleteCustomerCommand.test.ts
+++ b/src/server/subdomains/customer/application/commands/__tests__/DeleteCustomerCommand.test.ts
@@ -3,6 +3,7 @@ import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DeleteCustomerCommand } from "../DeleteCustomerCommand";
@@ -28,7 +29,7 @@ describe("DeleteCustomerCommand", () => {
       new CompanyName("削除テスト得意先")
     );
     const saved = await repository.save(customer);
-    testCustomerId = saved.id;
+    testCustomerId = saved.id.value;
   });
 
   afterEach(async () => {
@@ -40,7 +41,7 @@ describe("DeleteCustomerCommand", () => {
   it("得意先を削除できる", async () => {
     await command.execute({ id: testCustomerId });
 
-    const deleted = await repository.findById(testCustomerId);
+    const deleted = await repository.findById(new CustomerId(testCustomerId));
     expect(deleted).toBeNull();
   });
 

--- a/src/server/subdomains/customer/application/commands/__tests__/UpdateCustomerCommand.test.ts
+++ b/src/server/subdomains/customer/application/commands/__tests__/UpdateCustomerCommand.test.ts
@@ -3,6 +3,7 @@ import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { UpdateCustomerCommand } from "../UpdateCustomerCommand";
@@ -28,7 +29,7 @@ describe("UpdateCustomerCommand", () => {
       new CompanyName("更新前得意先")
     );
     const saved = await repository.save(customer);
-    testCustomerId = saved.id;
+    testCustomerId = saved.id.value;
   });
 
   afterEach(async () => {
@@ -43,7 +44,7 @@ describe("UpdateCustomerCommand", () => {
       name: "更新後得意先",
     });
 
-    const updated = await repository.findById(testCustomerId);
+    const updated = await repository.findById(new CustomerId(testCustomerId));
     expect(updated).not.toBeNull();
     expect(updated?.name.value).toBe("更新後得意先");
   });
@@ -61,7 +62,7 @@ describe("UpdateCustomerCommand", () => {
       marginRate: 20,
     });
 
-    const updated = await repository.findById(testCustomerId);
+    const updated = await repository.findById(new CustomerId(testCustomerId));
     expect(updated).not.toBeNull();
     expect(updated?.postalCode?.value).toBe("2000002");
     expect(updated?.prefecture?.value).toBe("大阪府");
@@ -80,7 +81,7 @@ describe("UpdateCustomerCommand", () => {
       isActive: false,
     });
 
-    let updated = await repository.findById(testCustomerId);
+    let updated = await repository.findById(new CustomerId(testCustomerId));
     expect(updated?.isActive).toBe(false);
 
     // activate
@@ -90,7 +91,7 @@ describe("UpdateCustomerCommand", () => {
       isActive: true,
     });
 
-    updated = await repository.findById(testCustomerId);
+    updated = await repository.findById(new CustomerId(testCustomerId));
     expect(updated?.isActive).toBe(true);
   });
 
@@ -121,7 +122,7 @@ describe("UpdateCustomerCommand", () => {
       marginRate: null,
     });
 
-    const updated = await repository.findById(testCustomerId);
+    const updated = await repository.findById(new CustomerId(testCustomerId));
     expect(updated).not.toBeNull();
     expect(updated?.postalCode).toBeNull();
     expect(updated?.prefecture).toBeNull();

--- a/src/server/subdomains/customer/domain/entities/Customer.ts
+++ b/src/server/subdomains/customer/domain/entities/Customer.ts
@@ -1,11 +1,12 @@
-import { generateId } from "@server/shared/generateId";
 import { Address } from "@server/shared/domain/values/Address";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyId } from "@server/shared/domain/values/CompanyId";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
 import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
 import { PostalCode } from "@server/shared/domain/values/PostalCode";
 import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { MarginRate } from "@subdomains/customer/domain/values/MarginRate";
 
 export type CustomerCreateOptions = {
@@ -28,8 +29,8 @@ export class Customer {
   static readonly ENTITY_NAME = "得意先";
 
   private constructor(
-    private readonly _id: string,
-    private readonly _companyId: string,
+    private readonly _id: CustomerId,
+    private readonly _companyId: CompanyId,
     private readonly _code: CompanyCode,
     private _name: CompanyName,
     private _postalCode: PostalCode | null,
@@ -51,8 +52,8 @@ export class Customer {
     const now = new Date();
 
     return new Customer(
-      generateId(),
-      generateId(),
+      CustomerId.generate(),
+      CompanyId.generate(),
       code,
       name,
       options?.postalCode ?? null,
@@ -72,8 +73,8 @@ export class Customer {
    * DBから得意先を再構築
    */
   static reconstruct(
-    id: string,
-    companyId: string,
+    id: CustomerId,
+    companyId: CompanyId,
     code: CompanyCode,
     name: CompanyName,
     postalCode: PostalCode | null,
@@ -155,11 +156,11 @@ export class Customer {
   // ゲッター
   // ========================================
 
-  get id(): string {
+  get id(): CustomerId {
     return this._id;
   }
 
-  get companyId(): string {
+  get companyId(): CompanyId {
     return this._companyId;
   }
 

--- a/src/server/subdomains/customer/domain/entities/__tests__/Customer.test.ts
+++ b/src/server/subdomains/customer/domain/entities/__tests__/Customer.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { Customer } from "../Customer";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyId } from "@server/shared/domain/values/CompanyId";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { MarginRate } from "@subdomains/customer/domain/values/MarginRate";
 import { PostalCode } from "@server/shared/domain/values/PostalCode";
 import { Prefecture } from "@server/shared/domain/values/Prefecture";
@@ -56,9 +58,11 @@ describe("Customer Entity", () => {
   describe("reconstruct", () => {
     it("DBからの再構築が正しく動作する", () => {
       const now = new Date();
+      const id = CustomerId.generate();
+      const companyId = CompanyId.generate();
       const customer = Customer.reconstruct(
-        "test-id",
-        "test-company-id",
+        id,
+        companyId,
         new CompanyCode("CUST001"),
         new CompanyName("株式会社テスト"),
         null,
@@ -73,8 +77,8 @@ describe("Customer Entity", () => {
         now
       );
 
-      expect(customer.id).toBe("test-id");
-      expect(customer.companyId).toBe("test-company-id");
+      expect(customer.id.value).toBe(id.value);
+      expect(customer.companyId.value).toBe(companyId.value);
       expect(customer.createdAt).toBe(now);
     });
   });

--- a/src/server/subdomains/customer/domain/repositories/CustomerRepository.ts
+++ b/src/server/subdomains/customer/domain/repositories/CustomerRepository.ts
@@ -1,5 +1,6 @@
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 
 /**
  * 得意先リポジトリインターフェース
@@ -15,12 +16,12 @@ export interface CustomerRepository {
   /**
    * 得意先を削除
    */
-  delete(id: string): Promise<void>;
+  delete(id: CustomerId): Promise<void>;
 
   /**
    * IDで得意先を取得
    */
-  findById(id: string): Promise<Customer | null>;
+  findById(id: CustomerId): Promise<Customer | null>;
 
   /**
    * 取引先コードで得意先を取得（重複チェック等で使用）

--- a/src/server/subdomains/customer/domain/values/CustomerId.ts
+++ b/src/server/subdomains/customer/domain/values/CustomerId.ts
@@ -1,0 +1,10 @@
+import { EntityId } from "@server/shared/domain/values/EntityId";
+
+/**
+ * 得意先ID値オブジェクト
+ */
+export class CustomerId extends EntityId<"CustomerId"> {
+  static generate(): CustomerId {
+    return new CustomerId(EntityId.generateValue());
+  }
+}

--- a/src/server/subdomains/customer/infrastructure/mappers/CustomerMapper.ts
+++ b/src/server/subdomains/customer/infrastructure/mappers/CustomerMapper.ts
@@ -1,11 +1,13 @@
 import { Address } from "@server/shared/domain/values/Address";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyId } from "@server/shared/domain/values/CompanyId";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
 import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
 import { PostalCode } from "@server/shared/domain/values/PostalCode";
 import { Prefecture } from "@server/shared/domain/values/Prefecture";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { MarginRate } from "@subdomains/customer/domain/values/MarginRate";
 import type { Company, Customer as PrismaCustomer } from "@generated/prisma/client";
 import { CompanyType, Prisma } from "@generated/prisma/client";
@@ -22,8 +24,8 @@ type PrismaCustomerWithCompany = PrismaCustomer & {
 export class CustomerMapper {
   static toDomain(data: PrismaCustomerWithCompany): Customer {
     return Customer.reconstruct(
-      data.id,
-      data.companyId,
+      new CustomerId(data.id),
+      new CompanyId(data.companyId),
       new CompanyCode(data.company.code),
       new CompanyName(data.company.name),
       data.company.postalCode ? new PostalCode(data.company.postalCode) : null,
@@ -41,12 +43,12 @@ export class CustomerMapper {
 
   static toPrismaCreate(customer: Customer) {
     return {
-      id: customer.id,
+      id: customer.id.value,
       marginRate:
         customer.marginRate !== null ? new Prisma.Decimal(customer.marginRate.value) : null,
       company: {
         create: {
-          id: customer.companyId,
+          id: customer.companyId.value,
           code: customer.code.value,
           name: customer.name.value,
           type: CompanyType.CUSTOMER,

--- a/src/server/subdomains/customer/infrastructure/prisma/PrismaCustomerRepository.ts
+++ b/src/server/subdomains/customer/infrastructure/prisma/PrismaCustomerRepository.ts
@@ -3,6 +3,7 @@ import { CompanyType } from "@generated/prisma/client";
 import prisma from "@server/prisma";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
 import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { CustomerMapper } from "@subdomains/customer/infrastructure/mappers/CustomerMapper";
 
 const INCLUDE_COMPANY = { company: true } as const;
@@ -10,14 +11,14 @@ const INCLUDE_COMPANY = { company: true } as const;
 export class PrismaCustomerRepository implements CustomerRepository {
   async save(customer: Customer): Promise<Customer> {
     const existing = await prisma.customer.findUnique({
-      where: { id: customer.id },
+      where: { id: customer.id.value },
     });
 
     let prismaCustomer;
 
     if (existing) {
       prismaCustomer = await prisma.customer.update({
-        where: { id: customer.id },
+        where: { id: customer.id.value },
         data: CustomerMapper.toPrismaUpdate(customer),
         include: INCLUDE_COMPANY,
       });
@@ -31,9 +32,9 @@ export class PrismaCustomerRepository implements CustomerRepository {
     return CustomerMapper.toDomain(prismaCustomer);
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: CustomerId): Promise<void> {
     const customer = await prisma.customer.findUnique({
-      where: { id },
+      where: { id: id.value },
       select: { companyId: true },
     });
 
@@ -45,9 +46,9 @@ export class PrismaCustomerRepository implements CustomerRepository {
     }
   }
 
-  async findById(id: string): Promise<Customer | null> {
+  async findById(id: CustomerId): Promise<Customer | null> {
     const prismaCustomer = await prisma.customer.findUnique({
-      where: { id },
+      where: { id: id.value },
       include: INCLUDE_COMPANY,
     });
 

--- a/src/server/subdomains/delivery-location/application/commands/CreateDeliveryLocationCommand.ts
+++ b/src/server/subdomains/delivery-location/application/commands/CreateDeliveryLocationCommand.ts
@@ -9,6 +9,7 @@ import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { ValidationError } from "@server/shared/errors/DomainError";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
 import { CustomerRepository } from "@subdomains/customer/domain/repositories/CustomerRepository";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
 import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
 import { DeliveryLocationCodeDuplicationCheckDomainService } from "@subdomains/delivery-location/domain/services/DeliveryLocationCodeDuplicationCheckDomainService";
@@ -39,7 +40,8 @@ export class CreateDeliveryLocationCommand {
 
   async execute(input: CreateDeliveryLocationInput): Promise<void> {
     // 親得意先の存在チェック
-    const customer = await this.customerRepository.findById(input.customerId);
+    const customerId = new CustomerId(input.customerId);
+    const customer = await this.customerRepository.findById(customerId);
     if (!customer) {
       throw new NotFoundEntityError(Customer, { id: input.customerId });
     }
@@ -58,7 +60,7 @@ export class CreateDeliveryLocationCommand {
     const deliveryLocation = DeliveryLocation.create(
       code,
       new CompanyName(input.name),
-      input.customerId,
+      customerId,
       {
         postalCode: input.postalCode ? new PostalCode(input.postalCode) : undefined,
         prefecture: input.prefecture ? new Prefecture(input.prefecture) : undefined,

--- a/src/server/subdomains/delivery-location/application/commands/DeleteDeliveryLocationCommand.ts
+++ b/src/server/subdomains/delivery-location/application/commands/DeleteDeliveryLocationCommand.ts
@@ -1,6 +1,7 @@
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
 import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
 
 export type DeleteDeliveryLocationInput = {
   id: string;
@@ -13,11 +14,12 @@ export class DeleteDeliveryLocationCommand {
   constructor(private readonly deliveryLocationRepository: DeliveryLocationRepository) {}
 
   async execute(input: DeleteDeliveryLocationInput): Promise<void> {
-    const deliveryLocation = await this.deliveryLocationRepository.findById(input.id);
+    const deliveryLocationId = new DeliveryLocationId(input.id);
+    const deliveryLocation = await this.deliveryLocationRepository.findById(deliveryLocationId);
     if (!deliveryLocation) {
       throw new NotFoundEntityError(DeliveryLocation, { id: input.id });
     }
 
-    await this.deliveryLocationRepository.delete(input.id);
+    await this.deliveryLocationRepository.delete(deliveryLocationId);
   }
 }

--- a/src/server/subdomains/delivery-location/application/commands/UpdateDeliveryLocationCommand.ts
+++ b/src/server/subdomains/delivery-location/application/commands/UpdateDeliveryLocationCommand.ts
@@ -7,6 +7,7 @@ import { Prefecture } from "@server/shared/domain/values/Prefecture";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
 import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
 import { DeliveryNotes } from "@subdomains/delivery-location/domain/values/DeliveryNotes";
 
 export type UpdateDeliveryLocationInput = {
@@ -31,7 +32,8 @@ export class UpdateDeliveryLocationCommand {
   constructor(private readonly deliveryLocationRepository: DeliveryLocationRepository) {}
 
   async execute(input: UpdateDeliveryLocationInput): Promise<void> {
-    const deliveryLocation = await this.deliveryLocationRepository.findById(input.id);
+    const deliveryLocationId = new DeliveryLocationId(input.id);
+    const deliveryLocation = await this.deliveryLocationRepository.findById(deliveryLocationId);
     if (!deliveryLocation) {
       throw new NotFoundEntityError(DeliveryLocation, { id: input.id });
     }

--- a/src/server/subdomains/delivery-location/application/commands/__tests__/CreateDeliveryLocationCommand.test.ts
+++ b/src/server/subdomains/delivery-location/application/commands/__tests__/CreateDeliveryLocationCommand.test.ts
@@ -4,6 +4,7 @@ import { ValidationError } from "@server/shared/errors/DomainError";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
 import { DeliveryLocationCodeDuplicationCheckDomainService } from "@subdomains/delivery-location/domain/services/DeliveryLocationCodeDuplicationCheckDomainService";
 import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
@@ -47,7 +48,7 @@ describe("CreateDeliveryLocationCommand", () => {
       new CompanyName("納品先テスト用得意先")
     );
     const saved = await customerRepository.save(customer);
-    testCustomerId = saved.id;
+    testCustomerId = saved.id.value;
   });
 
   afterEach(async () => {
@@ -70,7 +71,7 @@ describe("CreateDeliveryLocationCommand", () => {
     expect(saved).not.toBeNull();
     expect(saved?.name.value).toBe("テスト納品先A");
     expect(saved?.code.value).toBe(DL_TEST_CODES[0]);
-    expect(saved?.customerId).toBe(testCustomerId);
+    expect(saved?.customerId.value).toBe(testCustomerId);
     expect(saved?.isActive).toBe(true);
     expect(saved?.deliveryNotes).toBeNull();
   });
@@ -129,7 +130,7 @@ describe("CreateDeliveryLocationCommand", () => {
 
   it("親得意先が無効化されている場合は ValidationError", async () => {
     // 得意先を無効化
-    const customer = await customerRepository.findById(testCustomerId);
+    const customer = await customerRepository.findById(new CustomerId(testCustomerId));
     customer!.deactivate();
     await customerRepository.save(customer!);
 

--- a/src/server/subdomains/delivery-location/application/commands/__tests__/DeleteDeliveryLocationCommand.test.ts
+++ b/src/server/subdomains/delivery-location/application/commands/__tests__/DeleteDeliveryLocationCommand.test.ts
@@ -5,6 +5,7 @@ import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
 import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
 import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
 import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DeleteDeliveryLocationCommand } from "../DeleteDeliveryLocationCommand";
@@ -13,7 +14,6 @@ describe("DeleteDeliveryLocationCommand", () => {
   let command: DeleteDeliveryLocationCommand;
   let dlRepository: PrismaDeliveryLocationRepository;
   let customerRepository: PrismaCustomerRepository;
-  let testCustomerId: string;
   let testDeliveryLocationId: string;
 
   const DL_TEST_CODES = ["DL999914"];
@@ -37,16 +37,14 @@ describe("DeleteDeliveryLocationCommand", () => {
       new CompanyName("削除テスト用得意先")
     );
     const savedCustomer = await customerRepository.save(customer);
-    testCustomerId = savedCustomer.id;
-
     // テスト用納品先を事前作成
     const dl = DeliveryLocation.create(
       new CompanyCode(DL_TEST_CODES[0]),
       new CompanyName("削除テスト納品先"),
-      testCustomerId
+      savedCustomer.id
     );
     const savedDl = await dlRepository.save(dl);
-    testDeliveryLocationId = savedDl.id;
+    testDeliveryLocationId = savedDl.id.value;
   });
 
   afterEach(async () => {
@@ -61,7 +59,7 @@ describe("DeleteDeliveryLocationCommand", () => {
   it("納品先を削除できる", async () => {
     await command.execute({ id: testDeliveryLocationId });
 
-    const deleted = await dlRepository.findById(testDeliveryLocationId);
+    const deleted = await dlRepository.findById(new DeliveryLocationId(testDeliveryLocationId));
     expect(deleted).toBeNull();
   });
 

--- a/src/server/subdomains/delivery-location/application/commands/__tests__/UpdateDeliveryLocationCommand.test.ts
+++ b/src/server/subdomains/delivery-location/application/commands/__tests__/UpdateDeliveryLocationCommand.test.ts
@@ -5,6 +5,7 @@ import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
 import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
 import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
 import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { UpdateDeliveryLocationCommand } from "../UpdateDeliveryLocationCommand";
@@ -13,7 +14,6 @@ describe("UpdateDeliveryLocationCommand", () => {
   let command: UpdateDeliveryLocationCommand;
   let dlRepository: PrismaDeliveryLocationRepository;
   let customerRepository: PrismaCustomerRepository;
-  let testCustomerId: string;
   let testDeliveryLocationId: string;
 
   const DL_TEST_CODES = ["DL999913"];
@@ -37,16 +37,14 @@ describe("UpdateDeliveryLocationCommand", () => {
       new CompanyName("更新テスト用得意先")
     );
     const savedCustomer = await customerRepository.save(customer);
-    testCustomerId = savedCustomer.id;
-
     // テスト用納品先を事前作成
     const dl = DeliveryLocation.create(
       new CompanyCode(DL_TEST_CODES[0]),
       new CompanyName("更新前納品先"),
-      testCustomerId
+      savedCustomer.id
     );
     const savedDl = await dlRepository.save(dl);
-    testDeliveryLocationId = savedDl.id;
+    testDeliveryLocationId = savedDl.id.value;
   });
 
   afterEach(async () => {
@@ -64,7 +62,7 @@ describe("UpdateDeliveryLocationCommand", () => {
       name: "更新後納品先",
     });
 
-    const updated = await dlRepository.findById(testDeliveryLocationId);
+    const updated = await dlRepository.findById(new DeliveryLocationId(testDeliveryLocationId));
     expect(updated).not.toBeNull();
     expect(updated?.name.value).toBe("更新後納品先");
   });
@@ -82,7 +80,7 @@ describe("UpdateDeliveryLocationCommand", () => {
       deliveryNotes: "午前中のみ受付可能",
     });
 
-    const updated = await dlRepository.findById(testDeliveryLocationId);
+    const updated = await dlRepository.findById(new DeliveryLocationId(testDeliveryLocationId));
     expect(updated).not.toBeNull();
     expect(updated?.postalCode?.value).toBe("3000003");
     expect(updated?.prefecture?.value).toBe("愛知県");
@@ -101,7 +99,7 @@ describe("UpdateDeliveryLocationCommand", () => {
       isActive: false,
     });
 
-    let updated = await dlRepository.findById(testDeliveryLocationId);
+    let updated = await dlRepository.findById(new DeliveryLocationId(testDeliveryLocationId));
     expect(updated?.isActive).toBe(false);
 
     // activate
@@ -111,7 +109,7 @@ describe("UpdateDeliveryLocationCommand", () => {
       isActive: true,
     });
 
-    updated = await dlRepository.findById(testDeliveryLocationId);
+    updated = await dlRepository.findById(new DeliveryLocationId(testDeliveryLocationId));
     expect(updated?.isActive).toBe(true);
   });
 
@@ -142,7 +140,7 @@ describe("UpdateDeliveryLocationCommand", () => {
       deliveryNotes: null,
     });
 
-    const updated = await dlRepository.findById(testDeliveryLocationId);
+    const updated = await dlRepository.findById(new DeliveryLocationId(testDeliveryLocationId));
     expect(updated).not.toBeNull();
     expect(updated?.postalCode).toBeNull();
     expect(updated?.prefecture).toBeNull();

--- a/src/server/subdomains/delivery-location/domain/entities/DeliveryLocation.ts
+++ b/src/server/subdomains/delivery-location/domain/entities/DeliveryLocation.ts
@@ -1,11 +1,13 @@
-import { generateId } from "@server/shared/generateId";
 import { Address } from "@server/shared/domain/values/Address";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyId } from "@server/shared/domain/values/CompanyId";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
 import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
 import { PostalCode } from "@server/shared/domain/values/PostalCode";
 import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
 import { DeliveryNotes } from "@subdomains/delivery-location/domain/values/DeliveryNotes";
 
 export type DeliveryLocationCreateOptions = {
@@ -28,8 +30,8 @@ export class DeliveryLocation {
   static readonly ENTITY_NAME = "納品先";
 
   private constructor(
-    private readonly _id: string,
-    private readonly _companyId: string,
+    private readonly _id: DeliveryLocationId,
+    private readonly _companyId: CompanyId,
     private readonly _code: CompanyCode,
     private _name: CompanyName,
     private _postalCode: PostalCode | null,
@@ -39,7 +41,7 @@ export class DeliveryLocation {
     private _faxNumber: FaxNumber | null,
     private _contactPerson: string | null,
     private _isActive: boolean,
-    private readonly _customerId: string,
+    private readonly _customerId: CustomerId,
     private _deliveryNotes: DeliveryNotes | null,
     private readonly _createdAt: Date,
     private _updatedAt: Date
@@ -56,14 +58,14 @@ export class DeliveryLocation {
   static create(
     code: CompanyCode,
     name: CompanyName,
-    customerId: string,
+    customerId: CustomerId,
     options?: DeliveryLocationCreateOptions
   ): DeliveryLocation {
     const now = new Date();
 
     return new DeliveryLocation(
-      generateId(),
-      generateId(),
+      DeliveryLocationId.generate(),
+      CompanyId.generate(),
       code,
       name,
       options?.postalCode ?? null,
@@ -84,8 +86,8 @@ export class DeliveryLocation {
    * DBから納品先を再構築
    */
   static reconstruct(
-    id: string,
-    companyId: string,
+    id: DeliveryLocationId,
+    companyId: CompanyId,
     code: CompanyCode,
     name: CompanyName,
     postalCode: PostalCode | null,
@@ -95,7 +97,7 @@ export class DeliveryLocation {
     faxNumber: FaxNumber | null,
     contactPerson: string | null,
     isActive: boolean,
-    customerId: string,
+    customerId: CustomerId,
     deliveryNotes: DeliveryNotes | null,
     createdAt: Date,
     updatedAt: Date
@@ -169,11 +171,11 @@ export class DeliveryLocation {
   // ゲッター
   // ========================================
 
-  get id(): string {
+  get id(): DeliveryLocationId {
     return this._id;
   }
 
-  get companyId(): string {
+  get companyId(): CompanyId {
     return this._companyId;
   }
 
@@ -213,7 +215,7 @@ export class DeliveryLocation {
     return this._isActive;
   }
 
-  get customerId(): string {
+  get customerId(): CustomerId {
     return this._customerId;
   }
 

--- a/src/server/subdomains/delivery-location/domain/entities/__tests__/DeliveryLocation.test.ts
+++ b/src/server/subdomains/delivery-location/domain/entities/__tests__/DeliveryLocation.test.ts
@@ -1,16 +1,19 @@
 import { Address } from "@server/shared/domain/values/Address";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyId } from "@server/shared/domain/values/CompanyId";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
 import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
 import { PostalCode } from "@server/shared/domain/values/PostalCode";
 import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
 import { DeliveryNotes } from "@subdomains/delivery-location/domain/values/DeliveryNotes";
 import { describe, expect, it } from "vitest";
 import { DeliveryLocation } from "../DeliveryLocation";
 
 describe("DeliveryLocation Entity", () => {
-  const CUSTOMER_ID = "test-customer-id";
+  const CUSTOMER_ID = CustomerId.generate();
 
   const createTestDeliveryLocation = () =>
     DeliveryLocation.create(new CompanyCode("DL001"), new CompanyName("テスト納品先"), CUSTOMER_ID);
@@ -24,7 +27,7 @@ describe("DeliveryLocation Entity", () => {
       expect(dl.id).not.toBe(dl.companyId);
       expect(dl.code.value).toBe("DL001");
       expect(dl.name.value).toBe("テスト納品先");
-      expect(dl.customerId).toBe(CUSTOMER_ID);
+      expect(dl.customerId.value).toBe(CUSTOMER_ID.value);
       expect(dl.isActive).toBe(true);
       expect(dl.deliveryNotes).toBeNull();
     });
@@ -54,9 +57,11 @@ describe("DeliveryLocation Entity", () => {
   describe("reconstruct", () => {
     it("DBからの再構築が正しく動作する", () => {
       const now = new Date();
+      const id = DeliveryLocationId.generate();
+      const companyId = CompanyId.generate();
       const dl = DeliveryLocation.reconstruct(
-        "test-id",
-        "test-company-id",
+        id,
+        companyId,
         new CompanyCode("DL001"),
         new CompanyName("テスト納品先"),
         null,
@@ -72,9 +77,9 @@ describe("DeliveryLocation Entity", () => {
         now
       );
 
-      expect(dl.id).toBe("test-id");
-      expect(dl.companyId).toBe("test-company-id");
-      expect(dl.customerId).toBe(CUSTOMER_ID);
+      expect(dl.id.value).toBe(id.value);
+      expect(dl.companyId.value).toBe(companyId.value);
+      expect(dl.customerId.value).toBe(CUSTOMER_ID.value);
     });
   });
 

--- a/src/server/subdomains/delivery-location/domain/repositories/DeliveryLocationRepository.ts
+++ b/src/server/subdomains/delivery-location/domain/repositories/DeliveryLocationRepository.ts
@@ -1,5 +1,6 @@
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
 import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
 
 /**
  * 納品先リポジトリインターフェース
@@ -15,12 +16,12 @@ export interface DeliveryLocationRepository {
   /**
    * 納品先を削除
    */
-  delete(id: string): Promise<void>;
+  delete(id: DeliveryLocationId): Promise<void>;
 
   /**
    * IDで納品先を取得
    */
-  findById(id: string): Promise<DeliveryLocation | null>;
+  findById(id: DeliveryLocationId): Promise<DeliveryLocation | null>;
 
   /**
    * 取引先コードで納品先を取得（重複チェック等で使用）

--- a/src/server/subdomains/delivery-location/domain/services/__tests__/DeliveryLocationCodeDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/delivery-location/domain/services/__tests__/DeliveryLocationCodeDuplicationCheckDomainService.test.ts
@@ -2,6 +2,7 @@ import prisma from "@server/prisma";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
 import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
 import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
@@ -12,7 +13,7 @@ describe("DeliveryLocationCodeDuplicationCheckDomainService", () => {
   let service: DeliveryLocationCodeDuplicationCheckDomainService;
   let dlRepository: PrismaDeliveryLocationRepository;
   let customerRepository: PrismaCustomerRepository;
-  let customerId: string;
+  let customerId: CustomerId;
 
   const DL_TEST_CODES = ["DL999801", "DL999802"];
   const CUSTOMER_TEST_CODE = "CUST999811";

--- a/src/server/subdomains/delivery-location/domain/values/DeliveryLocationId.ts
+++ b/src/server/subdomains/delivery-location/domain/values/DeliveryLocationId.ts
@@ -1,0 +1,10 @@
+import { EntityId } from "@server/shared/domain/values/EntityId";
+
+/**
+ * 納品先ID値オブジェクト
+ */
+export class DeliveryLocationId extends EntityId<"DeliveryLocationId"> {
+  static generate(): DeliveryLocationId {
+    return new DeliveryLocationId(EntityId.generateValue());
+  }
+}

--- a/src/server/subdomains/delivery-location/infrastructure/mappers/DeliveryLocationMapper.ts
+++ b/src/server/subdomains/delivery-location/infrastructure/mappers/DeliveryLocationMapper.ts
@@ -1,11 +1,14 @@
 import { Address } from "@server/shared/domain/values/Address";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyId } from "@server/shared/domain/values/CompanyId";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { FaxNumber } from "@server/shared/domain/values/FaxNumber";
 import { PhoneNumber } from "@server/shared/domain/values/PhoneNumber";
 import { PostalCode } from "@server/shared/domain/values/PostalCode";
 import { Prefecture } from "@server/shared/domain/values/Prefecture";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
 import { DeliveryNotes } from "@subdomains/delivery-location/domain/values/DeliveryNotes";
 import type { Company, DeliveryLocation as PrismaDeliveryLocation } from "@generated/prisma/client";
 import { CompanyType } from "@generated/prisma/client";
@@ -22,8 +25,8 @@ type PrismaDeliveryLocationWithCompany = PrismaDeliveryLocation & {
 export class DeliveryLocationMapper {
   static toDomain(data: PrismaDeliveryLocationWithCompany): DeliveryLocation {
     return DeliveryLocation.reconstruct(
-      data.id,
-      data.companyId,
+      new DeliveryLocationId(data.id),
+      new CompanyId(data.companyId),
       new CompanyCode(data.company.code),
       new CompanyName(data.company.name),
       data.company.postalCode ? new PostalCode(data.company.postalCode) : null,
@@ -33,7 +36,7 @@ export class DeliveryLocationMapper {
       data.company.faxNumber ? new FaxNumber(data.company.faxNumber) : null,
       data.company.contactPerson,
       data.company.isActive,
-      data.customerId,
+      new CustomerId(data.customerId),
       data.deliveryNotes ? new DeliveryNotes(data.deliveryNotes) : null,
       data.createdAt,
       data.updatedAt
@@ -42,14 +45,14 @@ export class DeliveryLocationMapper {
 
   static toPrismaCreate(deliveryLocation: DeliveryLocation) {
     return {
-      id: deliveryLocation.id,
+      id: deliveryLocation.id.value,
       customer: {
-        connect: { id: deliveryLocation.customerId },
+        connect: { id: deliveryLocation.customerId.value },
       },
       deliveryNotes: deliveryLocation.deliveryNotes?.value ?? null,
       company: {
         create: {
-          id: deliveryLocation.companyId,
+          id: deliveryLocation.companyId.value,
           code: deliveryLocation.code.value,
           name: deliveryLocation.name.value,
           type: CompanyType.DELIVERY_LOCATION,

--- a/src/server/subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository.ts
+++ b/src/server/subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository.ts
@@ -3,6 +3,7 @@ import { CompanyType } from "@generated/prisma/client";
 import prisma from "@server/prisma";
 import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
 import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
 import { DeliveryLocationMapper } from "@subdomains/delivery-location/infrastructure/mappers/DeliveryLocationMapper";
 
 const INCLUDE_COMPANY = { company: true } as const;
@@ -10,14 +11,14 @@ const INCLUDE_COMPANY = { company: true } as const;
 export class PrismaDeliveryLocationRepository implements DeliveryLocationRepository {
   async save(deliveryLocation: DeliveryLocation): Promise<DeliveryLocation> {
     const existing = await prisma.deliveryLocation.findUnique({
-      where: { id: deliveryLocation.id },
+      where: { id: deliveryLocation.id.value },
     });
 
     let prismaDeliveryLocation;
 
     if (existing) {
       prismaDeliveryLocation = await prisma.deliveryLocation.update({
-        where: { id: deliveryLocation.id },
+        where: { id: deliveryLocation.id.value },
         data: DeliveryLocationMapper.toPrismaUpdate(deliveryLocation),
         include: INCLUDE_COMPANY,
       });
@@ -31,9 +32,9 @@ export class PrismaDeliveryLocationRepository implements DeliveryLocationReposit
     return DeliveryLocationMapper.toDomain(prismaDeliveryLocation);
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: DeliveryLocationId): Promise<void> {
     const deliveryLocation = await prisma.deliveryLocation.findUnique({
-      where: { id },
+      where: { id: id.value },
       select: { companyId: true },
     });
 
@@ -44,9 +45,9 @@ export class PrismaDeliveryLocationRepository implements DeliveryLocationReposit
     }
   }
 
-  async findById(id: string): Promise<DeliveryLocation | null> {
+  async findById(id: DeliveryLocationId): Promise<DeliveryLocation | null> {
     const prismaDeliveryLocation = await prisma.deliveryLocation.findUnique({
-      where: { id },
+      where: { id: id.value },
       include: INCLUDE_COMPANY,
     });
 

--- a/src/server/subdomains/department/application/commands/CreateDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/CreateDepartmentCommand.ts
@@ -2,6 +2,7 @@ import { Department } from "@subdomains/department/domain/entities/Department";
 import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
 import { DepartmentCdDuplicationCheckDomainService } from "@subdomains/department/domain/services/DepartmentCdDuplicationCheckDomainService";
 import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
 import { Abbreviation } from "@subdomains/department/domain/values/Abbreviation";
 import { ValidationError } from "@server/shared/errors/DomainError";
@@ -33,8 +34,9 @@ export class CreateDepartmentCommand {
     }
 
     // 親部署が指定されている場合、存在確認
-    if (input.parentId) {
-      const parentDepartment = await this.departmentRepository.findById(input.parentId);
+    const parentId = input.parentId ? new DepartmentId(input.parentId) : null;
+    if (parentId) {
+      const parentDepartment = await this.departmentRepository.findById(parentId);
       if (!parentDepartment) {
         throw new ValidationError(`親部署が存在しません: ID=${input.parentId}`);
       }
@@ -48,12 +50,7 @@ export class CreateDepartmentCommand {
     const name = new DepartmentName(input.name);
     const abbreviation = new Abbreviation(input.abbreviation);
 
-    const newDepartment = Department.create(
-      departmentCd,
-      name,
-      abbreviation,
-      input.parentId ?? null
-    );
+    const newDepartment = Department.create(departmentCd, name, abbreviation, parentId);
 
     return await this.departmentRepository.save(newDepartment);
   }

--- a/src/server/subdomains/department/application/commands/DeleteDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/DeleteDepartmentCommand.ts
@@ -1,5 +1,6 @@
 import { Department } from "@subdomains/department/domain/entities/Department";
 import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 
@@ -17,13 +18,14 @@ export class DeleteDepartmentCommand {
   public constructor(private readonly departmentRepository: DepartmentRepository) {}
 
   async execute(input: DeleteDepartmentInput): Promise<void> {
-    const department = await this.departmentRepository.findById(input.id);
+    const departmentId = new DepartmentId(input.id);
+    const department = await this.departmentRepository.findById(departmentId);
     if (!department) {
       throw new NotFoundEntityError(Department, { id: input.id });
     }
 
     // 子部署がある場合は削除できない
-    const children = await this.departmentRepository.findChildren(input.id);
+    const children = await this.departmentRepository.findChildren(departmentId);
     if (children.length > 0) {
       throw new BusinessRuleViolationError(
         "子部署が存在するため、この部署を削除できません。先に子部署を削除してください。"
@@ -34,6 +36,6 @@ export class DeleteDepartmentCommand {
     // 従業員側のドメインサービスまたはアプリケーションサービスで実装する
     // ここでは部署ドメイン内で完結する制約のみをチェック
 
-    await this.departmentRepository.delete(input.id);
+    await this.departmentRepository.delete(departmentId);
   }
 }

--- a/src/server/subdomains/department/application/commands/UpdateDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/UpdateDepartmentCommand.ts
@@ -1,5 +1,6 @@
 import { Department } from "@subdomains/department/domain/entities/Department";
 import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
 import { Abbreviation } from "@subdomains/department/domain/values/Abbreviation";
 import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
@@ -20,7 +21,8 @@ export class UpdateDepartmentCommand {
   public constructor(private readonly departmentRepository: DepartmentRepository) {}
 
   async execute(input: UpdateDepartmentInput): Promise<Department> {
-    const department = await this.departmentRepository.findById(input.id);
+    const departmentId = new DepartmentId(input.id);
+    const department = await this.departmentRepository.findById(departmentId);
     if (!department) {
       throw new NotFoundEntityError(Department, { id: input.id });
     }
@@ -37,11 +39,12 @@ export class UpdateDepartmentCommand {
 
     // 親部署の更新
     if (input.parentId !== undefined) {
+      const newParentId = input.parentId !== null ? new DepartmentId(input.parentId) : null;
       // 循環参照チェック
-      if (input.parentId !== null) {
-        await this.validateNoCircularReference(department.id, input.parentId);
+      if (newParentId !== null) {
+        await this.validateNoCircularReference(department.id, newParentId);
       }
-      department.changeParent(input.parentId);
+      department.changeParent(newParentId);
     }
 
     // 有効/無効の更新
@@ -69,30 +72,30 @@ export class UpdateDepartmentCommand {
    * 指定した親部署が、自分自身または自分の子孫でないことを確認
    */
   private async validateNoCircularReference(
-    departmentId: string,
-    newParentId: string
+    departmentId: DepartmentId,
+    newParentId: DepartmentId
   ): Promise<void> {
     // 自分自身を親にできない（これは Entity 側でもチェックしているが念のため）
-    if (departmentId === newParentId) {
+    if (departmentId.equals(newParentId)) {
       throw new BusinessRuleViolationError("自分自身を親部署にすることはできません");
     }
 
     // 新しい親部署が存在するか確認
     const newParent = await this.departmentRepository.findById(newParentId);
     if (!newParent) {
-      throw new BusinessRuleViolationError(`親部署が存在しません: ID=${newParentId}`);
+      throw new BusinessRuleViolationError(`親部署が存在しません: ID=${newParentId.value}`);
     }
 
     if (!newParent.isActive) {
       throw new BusinessRuleViolationError(
-        `無効な部署を親部署に設定することはできません: ID=${newParentId}`
+        `無効な部署を親部署に設定することはできません: ID=${newParentId.value}`
       );
     }
 
     // 新しい親部署の祖先を辿って、自分自身がいないことを確認
-    let currentParentId: string | null = newParent.parentId;
+    let currentParentId: DepartmentId | null = newParent.parentId;
     while (currentParentId !== null) {
-      if (currentParentId === departmentId) {
+      if (currentParentId.equals(departmentId)) {
         throw new BusinessRuleViolationError("循環参照が発生するため、この親部署は設定できません");
       }
       const parent = await this.departmentRepository.findById(currentParentId);

--- a/src/server/subdomains/department/application/commands/__tests__/CreateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/CreateDepartmentCommand.test.ts
@@ -70,7 +70,7 @@ describe("CreateDepartmentCommand", () => {
 
     const saved = await repository.findByDepartmentCd(new DepartmentCd(TEST_CODES[1]));
     expect(saved).not.toBeNull();
-    expect(saved?.parentId).toBe(parentId);
+    expect(saved?.parentId?.value).toBe(parentId);
   });
 
   it("既に存在する部署コードの場合はエラー", async () => {

--- a/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
@@ -133,7 +133,7 @@ describe("UpdateDepartmentCommand", () => {
       parentId: newParentId,
     });
 
-    expect(result.parentId).toBe(newParentId);
+    expect(result.parentId?.value).toBe(newParentId);
   });
 
   it("自分自身を親部署に設定するとエラー", async () => {

--- a/src/server/subdomains/department/domain/entities/Department.ts
+++ b/src/server/subdomains/department/domain/entities/Department.ts
@@ -1,4 +1,4 @@
-import { generateId } from "@server/shared/generateId";
+import { DepartmentId } from "../values/DepartmentId";
 import { DepartmentCd } from "../values/DepartmentCd";
 import { DepartmentName } from "../values/DepartmentName";
 import { Abbreviation } from "../values/Abbreviation";
@@ -14,12 +14,12 @@ export class Department {
   static readonly ENTITY_NAME = "部署";
 
   private constructor(
-    private readonly _id: string,
+    private readonly _id: DepartmentId,
     private readonly _departmentCd: DepartmentCd,
     private _name: DepartmentName,
     private _abbreviation: Abbreviation,
     private _isActive: boolean,
-    private _parentId: string | null,
+    private _parentId: DepartmentId | null,
     private readonly _createdAt: Date,
     private _updatedAt: Date
   ) {}
@@ -37,12 +37,12 @@ export class Department {
     departmentCd: DepartmentCd,
     name: DepartmentName,
     abbreviation: Abbreviation,
-    parentId: string | null = null
+    parentId: DepartmentId | null = null
   ): Department {
     const now = new Date();
 
     return new Department(
-      generateId(), // UUIDv7を生成
+      DepartmentId.generate(),
       departmentCd,
       name,
       abbreviation,
@@ -67,12 +67,12 @@ export class Department {
    * @returns 部署エンティティ
    */
   static reconstruct(
-    id: string,
+    id: DepartmentId,
     departmentCd: DepartmentCd,
     name: DepartmentName,
     abbreviation: Abbreviation,
     isActive: boolean,
-    parentId: string | null,
+    parentId: DepartmentId | null,
     createdAt: Date,
     updatedAt: Date
   ): Department {
@@ -113,9 +113,9 @@ export class Department {
    *
    * @param newParentId 新しい親部署ID（ルートにする場合は null）
    */
-  changeParent(newParentId: string | null): void {
+  changeParent(newParentId: DepartmentId | null): void {
     // 自分自身を親にすることはできない
-    if (newParentId === this._id) {
+    if (newParentId !== null && newParentId.equals(this._id)) {
       throw new BusinessRuleViolationError("自分自身を親部署にすることはできません");
     }
     this._parentId = newParentId;
@@ -149,7 +149,7 @@ export class Department {
   // ゲッター
   // ========================================
 
-  get id(): string {
+  get id(): DepartmentId {
     return this._id;
   }
 
@@ -169,7 +169,7 @@ export class Department {
     return this._isActive;
   }
 
-  get parentId(): string | null {
+  get parentId(): DepartmentId | null {
     return this._parentId;
   }
 

--- a/src/server/subdomains/department/domain/entities/__tests__/Department.test.ts
+++ b/src/server/subdomains/department/domain/entities/__tests__/Department.test.ts
@@ -2,6 +2,7 @@ import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
 import { describe, expect, it } from "vitest";
 import { Abbreviation } from "../../values/Abbreviation";
 import { DepartmentCd } from "../../values/DepartmentCd";
+import { DepartmentId } from "../../values/DepartmentId";
 import { DepartmentName } from "../../values/DepartmentName";
 import { Department } from "../Department";
 
@@ -11,7 +12,7 @@ describe("Department", () => {
     departmentCd?: DepartmentCd;
     name?: DepartmentName;
     abbreviation?: Abbreviation;
-    parentId?: string | null;
+    parentId?: DepartmentId | null;
   }) => {
     return Department.create(
       overrides?.departmentCd ?? new DepartmentCd("DEPT001"),
@@ -36,7 +37,7 @@ describe("Department", () => {
     });
 
     it("親部署を指定して作成できる", () => {
-      const parentId = "parent-dept-id";
+      const parentId = DepartmentId.generate();
       const dept = createTestDepartment({ parentId });
 
       expect(dept.parentId).toBe(parentId);
@@ -45,7 +46,8 @@ describe("Department", () => {
 
   describe("reconstruct", () => {
     it("DBから部署を再構築できる", () => {
-      const id = "test-id";
+      const id = DepartmentId.generate();
+      const parentId = DepartmentId.generate();
       const createdAt = new Date("2024-01-01");
       const updatedAt = new Date("2024-06-01");
 
@@ -55,7 +57,7 @@ describe("Department", () => {
         new DepartmentName("営業部"),
         new Abbreviation("営業"),
         false,
-        "parent-id",
+        parentId,
         createdAt,
         updatedAt
       );
@@ -65,7 +67,7 @@ describe("Department", () => {
       expect(dept.name.value).toBe("営業部");
       expect(dept.abbreviation.value).toBe("営業");
       expect(dept.isActive).toBe(false);
-      expect(dept.parentId).toBe("parent-id");
+      expect(dept.parentId).toBe(parentId);
       expect(dept.createdAt).toBe(createdAt);
       expect(dept.updatedAt).toBe(updatedAt);
     });
@@ -97,14 +99,15 @@ describe("Department", () => {
   describe("changeParent", () => {
     it("親部署を変更できる", () => {
       const dept = createTestDepartment();
+      const newParentId = DepartmentId.generate();
 
-      dept.changeParent("new-parent-id");
+      dept.changeParent(newParentId);
 
-      expect(dept.parentId).toBe("new-parent-id");
+      expect(dept.parentId).toBe(newParentId);
     });
 
     it("ルート部署に変更できる", () => {
-      const dept = createTestDepartment({ parentId: "some-parent" });
+      const dept = createTestDepartment({ parentId: DepartmentId.generate() });
 
       dept.changeParent(null);
 
@@ -131,7 +134,7 @@ describe("Department", () => {
 
     it("部署を有効化できる", () => {
       const dept = Department.reconstruct(
-        "test-id",
+        DepartmentId.generate(),
         new DepartmentCd("DEPT001"),
         new DepartmentName("営業部"),
         new Abbreviation("営業"),
@@ -156,7 +159,7 @@ describe("Department", () => {
     });
 
     it("parentIdがあればルート部署ではない", () => {
-      const dept = createTestDepartment({ parentId: "parent-id" });
+      const dept = createTestDepartment({ parentId: DepartmentId.generate() });
 
       expect(dept.isRoot()).toBe(false);
     });

--- a/src/server/subdomains/department/domain/repositories/DepartmentRepository.ts
+++ b/src/server/subdomains/department/domain/repositories/DepartmentRepository.ts
@@ -1,5 +1,6 @@
 import { Department } from "../entities/Department";
 import { DepartmentCd } from "../values/DepartmentCd";
+import { DepartmentId } from "../values/DepartmentId";
 
 /**
  * 部署リポジトリインターフェース
@@ -16,13 +17,13 @@ export interface DepartmentRepository {
   /**
    * 部署を削除
    */
-  delete(id: string): Promise<void>;
+  delete(id: DepartmentId): Promise<void>;
 
   /**
    * IDで部署を取得（Entity の完全な再構築が必要な場合に使用）
    * 単なる表示目的の場合は DepartmentQueryService を使用すること
    */
-  findById(id: string): Promise<Department | null>;
+  findById(id: DepartmentId): Promise<Department | null>;
 
   /**
    * 部署コードで部署を取得（重複チェック等で Entity が必要な場合に使用）
@@ -33,7 +34,7 @@ export interface DepartmentRepository {
    * 子部署を取得
    * @param parentId 親部署ID
    */
-  findChildren(parentId: string): Promise<Department[]>;
+  findChildren(parentId: DepartmentId): Promise<Department[]>;
 
   /**
    * ルート部署（parentIdがnull）を全て取得

--- a/src/server/subdomains/department/domain/values/DepartmentId.ts
+++ b/src/server/subdomains/department/domain/values/DepartmentId.ts
@@ -1,0 +1,10 @@
+import { EntityId } from "@server/shared/domain/values/EntityId";
+
+/**
+ * 部署ID値オブジェクト
+ */
+export class DepartmentId extends EntityId<"DepartmentId"> {
+  static generate(): DepartmentId {
+    return new DepartmentId(EntityId.generateValue());
+  }
+}

--- a/src/server/subdomains/department/infrastructure/mappers/DepartmentMapper.ts
+++ b/src/server/subdomains/department/infrastructure/mappers/DepartmentMapper.ts
@@ -1,5 +1,6 @@
 import { Department } from "@subdomains/department/domain/entities/Department";
 import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
 import { Abbreviation } from "@subdomains/department/domain/values/Abbreviation";
 import { Department as PrismaDepartment } from "@generated/prisma/client";
@@ -22,12 +23,12 @@ export class DepartmentMapper {
     const abbreviation = new Abbreviation(prismaDepartment.abbreviation);
 
     return Department.reconstruct(
-      prismaDepartment.id,
+      new DepartmentId(prismaDepartment.id),
       departmentCd,
       name,
       abbreviation,
       prismaDepartment.isActive,
-      prismaDepartment.parentId,
+      prismaDepartment.parentId ? new DepartmentId(prismaDepartment.parentId) : null,
       prismaDepartment.createdAt,
       prismaDepartment.updatedAt
     );
@@ -41,12 +42,12 @@ export class DepartmentMapper {
    */
   static toPrismaCreate(department: Department) {
     return {
-      id: department.id,
+      id: department.id.value,
       departmentCd: department.departmentCd.value,
       name: department.name.value,
       abbreviation: department.abbreviation.value,
       isActive: department.isActive,
-      parentId: department.parentId,
+      parentId: department.parentId?.value ?? null,
     };
   }
 
@@ -61,7 +62,7 @@ export class DepartmentMapper {
       name: department.name.value,
       abbreviation: department.abbreviation.value,
       isActive: department.isActive,
-      parentId: department.parentId,
+      parentId: department.parentId?.value ?? null,
       updatedAt: department.updatedAt,
     };
   }

--- a/src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts
+++ b/src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts
@@ -1,6 +1,7 @@
 import { Department } from "@subdomains/department/domain/entities/Department";
 import { DepartmentRepository } from "@subdomains/department/domain/repositories/DepartmentRepository";
 import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { DepartmentMapper } from "@subdomains/department/infrastructure/mappers/DepartmentMapper";
 import prisma from "@server/prisma";
 
@@ -14,10 +15,10 @@ export class PrismaDepartmentRepository implements DepartmentRepository {
   async save(department: Department): Promise<Department> {
     let prismaDepartment;
 
-    if (department.id) {
+    if (department.id.value) {
       // IDが存在する場合：upsert（更新 or 作成）
       prismaDepartment = await prisma.department.upsert({
-        where: { id: department.id },
+        where: { id: department.id.value },
         create: DepartmentMapper.toPrismaCreate(department),
         update: DepartmentMapper.toPrismaUpdate(department),
       });
@@ -35,9 +36,9 @@ export class PrismaDepartmentRepository implements DepartmentRepository {
    *
    * @param id 部署ID
    */
-  async delete(id: string): Promise<void> {
+  async delete(id: DepartmentId): Promise<void> {
     await prisma.department.delete({
-      where: { id: id },
+      where: { id: id.value },
     });
   }
 
@@ -47,9 +48,9 @@ export class PrismaDepartmentRepository implements DepartmentRepository {
    * @param id 部署ID
    * @returns 部署エンティティ（見つからない場合はnull）
    */
-  async findById(id: string): Promise<Department | null> {
+  async findById(id: DepartmentId): Promise<Department | null> {
     const prismaDepartment = await prisma.department.findUnique({
-      where: { id: id },
+      where: { id: id.value },
     });
 
     return prismaDepartment ? DepartmentMapper.toDomain(prismaDepartment) : null;
@@ -75,9 +76,9 @@ export class PrismaDepartmentRepository implements DepartmentRepository {
    * @param parentId 親部署ID
    * @returns 子部署の配列
    */
-  async findChildren(parentId: string): Promise<Department[]> {
+  async findChildren(parentId: DepartmentId): Promise<Department[]> {
     const prismaDepartments = await prisma.department.findMany({
-      where: { parentId: parentId },
+      where: { parentId: parentId.value },
       orderBy: { departmentCd: "asc" },
     });
 

--- a/src/server/subdomains/employee/application/commands/CreateEmployeeCommand.ts
+++ b/src/server/subdomains/employee/application/commands/CreateEmployeeCommand.ts
@@ -2,6 +2,7 @@ import type { UserManagementService } from "@server/shared/auth/UserManagementSe
 import type { UserRole } from "@server/shared/auth/types";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { ValidationError } from "@server/shared/errors/DomainError";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
 import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
 import { EmployeeCdDuplicationCheckDomainService } from "@subdomains/employee/domain/services/EmployeeCdDuplicationCheckDomainService";
@@ -53,7 +54,8 @@ export class CreateEmployeeCommand {
     }
 
     const employeeName = new EmployeeName(input.name);
-    const newEmployee = Employee.create(employeeCd, mailAddress, employeeName, input.departmentId);
+    const departmentId = new DepartmentId(input.departmentId);
+    const newEmployee = Employee.create(employeeCd, mailAddress, employeeName, departmentId);
 
     // Employee を保存
     await this.employeeRepository.save(newEmployee);
@@ -63,7 +65,7 @@ export class CreateEmployeeCommand {
       email: input.email,
       password: input.password,
       name: input.name,
-      employeeId: newEmployee.id,
+      employeeId: newEmployee.id.value,
       role: input.role,
     });
 

--- a/src/server/subdomains/employee/application/commands/DeleteEmployeeCommand.ts
+++ b/src/server/subdomains/employee/application/commands/DeleteEmployeeCommand.ts
@@ -1,6 +1,7 @@
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
 import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import type { UserManagementService } from "@server/shared/auth/UserManagementService";
 
 export type DeleteEmployeeInput = {
@@ -20,7 +21,8 @@ export class DeleteEmployeeCommand {
   ) {}
 
   async execute(input: DeleteEmployeeInput): Promise<void> {
-    const targetEmployee = await this.employeeRepository.findById(input.id);
+    const employeeId = new EmployeeId(input.id);
+    const targetEmployee = await this.employeeRepository.findById(employeeId);
     if (!targetEmployee) {
       throw new NotFoundEntityError(Employee, {
         id: input.id,
@@ -37,6 +39,6 @@ export class DeleteEmployeeCommand {
     }
 
     // Employee を削除
-    await this.employeeRepository.delete(input.id);
+    await this.employeeRepository.delete(employeeId);
   }
 }

--- a/src/server/subdomains/employee/application/commands/UpdateEmployeeCommand.ts
+++ b/src/server/subdomains/employee/application/commands/UpdateEmployeeCommand.ts
@@ -3,9 +3,11 @@ import type { UserRole } from "@server/shared/auth/types";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { ValidationError } from "@server/shared/errors/DomainError";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
 import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
 import { MailAddressDuplicationCheckDomainService } from "@subdomains/employee/domain/services/MailAddressDuplicationCheckDomainService";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import { EmployeeName } from "@subdomains/employee/domain/values/EmployeeName";
 
 export type UpdateEmployeeInput = {
@@ -32,7 +34,8 @@ export class UpdateEmployeeCommand {
   ) {}
 
   async execute(input: UpdateEmployeeInput): Promise<void> {
-    const targetEmployee = await this.employeeRepository.findById(input.id);
+    const employeeId = new EmployeeId(input.id);
+    const targetEmployee = await this.employeeRepository.findById(employeeId);
     if (!targetEmployee) {
       throw new NotFoundEntityError(Employee, {
         employeeCd: input.employeeCd,
@@ -53,7 +56,7 @@ export class UpdateEmployeeCommand {
 
     targetEmployee.changeName(new EmployeeName(input.name));
     targetEmployee.changeEmail(newMailAddress);
-    targetEmployee.changeDepartment(input.departmentId);
+    targetEmployee.changeDepartment(new DepartmentId(input.departmentId));
 
     await this.employeeRepository.save(targetEmployee);
 

--- a/src/server/subdomains/employee/application/commands/__tests__/CreateEmployeeCommand.test.ts
+++ b/src/server/subdomains/employee/application/commands/__tests__/CreateEmployeeCommand.test.ts
@@ -60,7 +60,7 @@ describe("CreateEmployeeCommand", () => {
     expect(saved).not.toBeNull();
     expect(saved?.email.value).toBe("test-create-cmd@example.com");
     expect(saved?.name.value).toBe("テスト太郎");
-    expect(saved?.departmentId).toBe(TEST_DEPT_ID);
+    expect(saved?.departmentId.value).toBe(TEST_DEPT_ID);
   });
 
   it("社員コードが重複している場合はエラー", async () => {

--- a/src/server/subdomains/employee/domain/entities/Employee.ts
+++ b/src/server/subdomains/employee/domain/entities/Employee.ts
@@ -1,7 +1,8 @@
-import { generateId } from "@server/shared/generateId";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
 import { EmployeeName } from "@subdomains/employee/domain/values/EmployeeName";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 
 /**
  * 従業員エンティティ
@@ -14,11 +15,11 @@ export class Employee {
   static readonly ENTITY_NAME = "従業員";
 
   private constructor(
-    private readonly _id: string,
+    private readonly _id: EmployeeId,
     private readonly _employeeCd: EmployeeCd,
     private _email: MailAddress,
     private _name: EmployeeName,
-    private _departmentId: string,
+    private _departmentId: DepartmentId,
     private readonly _createdAt: Date,
     private _updatedAt: Date
   ) {}
@@ -36,19 +37,11 @@ export class Employee {
     employeeCd: EmployeeCd,
     email: MailAddress,
     name: EmployeeName,
-    departmentId: string
+    departmentId: DepartmentId
   ): Employee {
     const now = new Date();
 
-    return new Employee(
-      generateId(), // UUIDv7を生成
-      employeeCd,
-      email,
-      name,
-      departmentId,
-      now,
-      now
-    );
+    return new Employee(EmployeeId.generate(), employeeCd, email, name, departmentId, now, now);
   }
 
   /**
@@ -64,11 +57,11 @@ export class Employee {
    * @returns 従業員エンティティ
    */
   static reconstruct(
-    id: string,
+    id: EmployeeId,
     employeeCd: EmployeeCd,
     email: MailAddress,
     name: EmployeeName,
-    departmentId: string,
+    departmentId: DepartmentId,
     createdAt: Date,
     updatedAt: Date
   ): Employee {
@@ -104,7 +97,7 @@ export class Employee {
    *
    * @param newDepartmentId 新しい部署ID
    */
-  changeDepartment(newDepartmentId: string): void {
+  changeDepartment(newDepartmentId: DepartmentId): void {
     this._departmentId = newDepartmentId;
     this._updatedAt = new Date();
   }
@@ -113,7 +106,7 @@ export class Employee {
   // ゲッター
   // ========================================
 
-  get id(): string {
+  get id(): EmployeeId {
     return this._id;
   }
 
@@ -129,7 +122,7 @@ export class Employee {
     return this._name;
   }
 
-  get departmentId(): string {
+  get departmentId(): DepartmentId {
     return this._departmentId;
   }
 

--- a/src/server/subdomains/employee/domain/entities/__tests__/Employee.test.ts
+++ b/src/server/subdomains/employee/domain/entities/__tests__/Employee.test.ts
@@ -1,7 +1,8 @@
-import { generateId } from "@server/shared/generateId";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
 import { EmployeeName } from "@subdomains/employee/domain/values/EmployeeName";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { describe, expect, it, beforeEach } from "vitest";
 import { Employee } from "../Employee";
 
@@ -9,13 +10,13 @@ describe("Employee エンティティ", () => {
   let employeeCd: EmployeeCd;
   let email: MailAddress;
   let name: EmployeeName;
-  let departmentId: string;
+  let departmentId: DepartmentId;
 
   beforeEach(() => {
     employeeCd = new EmployeeCd("EMP000001");
     email = new MailAddress("test@example.com");
     name = new EmployeeName("山田太郎");
-    departmentId = generateId();
+    departmentId = DepartmentId.generate();
   });
 
   describe("ファクトリメソッド", () => {
@@ -23,8 +24,8 @@ describe("Employee エンティティ", () => {
       it("新規従業員を作成できる", () => {
         const employee = Employee.create(employeeCd, email, name, departmentId);
 
-        expect(employee.id).toBeTruthy(); // IDが生成されている
-        expect(employee.id).not.toBe(""); // 空文字ではない
+        expect(employee.id).toBeInstanceOf(EmployeeId);
+        expect(employee.id.value).toBeTruthy();
         expect(employee.employeeCd.value).toBe("EMP000001");
         expect(employee.email.value).toBe("test@example.com");
         expect(employee.name.value).toBe("山田太郎");
@@ -42,13 +43,13 @@ describe("Employee エンティティ", () => {
         const employee1 = Employee.create(employeeCd, email, name, departmentId);
         const employee2 = Employee.create(employeeCd, email, name, departmentId);
 
-        expect(employee1.id).not.toBe(employee2.id);
+        expect(employee1.id.value).not.toBe(employee2.id.value);
       });
     });
 
     describe("reconstruct", () => {
       it("DBから従業員を再構築できる", () => {
-        const id = "clxyz123abc456def789";
+        const id = EmployeeId.generate();
         const createdAt = new Date("2025-01-01");
         const updatedAt = new Date("2025-01-02");
 
@@ -120,7 +121,7 @@ describe("Employee エンティティ", () => {
   describe("部署変更", () => {
     it("所属部署を変更できる", () => {
       const employee = Employee.create(employeeCd, email, name, departmentId);
-      const newDepartmentId = generateId();
+      const newDepartmentId = DepartmentId.generate();
 
       employee.changeDepartment(newDepartmentId);
 
@@ -130,7 +131,7 @@ describe("Employee エンティティ", () => {
     it("更新日時が更新される", () => {
       const employee = Employee.create(employeeCd, email, name, departmentId);
       const oldUpdatedAt = employee.updatedAt;
-      const newDepartmentId = generateId();
+      const newDepartmentId = DepartmentId.generate();
 
       setTimeout(() => {
         employee.changeDepartment(newDepartmentId);
@@ -141,7 +142,7 @@ describe("Employee エンティティ", () => {
 
   describe("ゲッター", () => {
     it("すべてのフィールドにアクセスできる", () => {
-      const id = "clxyz123abc456def789";
+      const id = EmployeeId.generate();
       const createdAt = new Date("2025-01-01");
       const updatedAt = new Date("2025-01-02");
 

--- a/src/server/subdomains/employee/domain/repositories/EmployeeRepository.ts
+++ b/src/server/subdomains/employee/domain/repositories/EmployeeRepository.ts
@@ -1,5 +1,6 @@
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 
 /**
@@ -19,13 +20,13 @@ export interface EmployeeRepository {
   /**
    * 従業員を削除
    */
-  delete(id: string): Promise<void>;
+  delete(id: EmployeeId): Promise<void>;
 
   /**
    * IDで従業員を取得（Entity の完全な再構築が必要な場合に使用）
    * 単なる表示目的の場合は EmployeeQueryService を使用すること
    */
-  findById(id: string): Promise<Employee | null>;
+  findById(id: EmployeeId): Promise<Employee | null>;
 
   /**
    * 従業員CDで従業員を取得（重複チェック等で Entity が必要な場合に使用）

--- a/src/server/subdomains/employee/domain/services/__tests__/EmployeeCdDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/employee/domain/services/__tests__/EmployeeCdDuplicationCheckDomainService.test.ts
@@ -1,6 +1,7 @@
 import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import prisma from "@server/prisma";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
 import { EmployeeName } from "@subdomains/employee/domain/values/EmployeeName";
@@ -13,7 +14,7 @@ describe("EmployeeCdDuplicationCheckDomainService", () => {
   let repository: PrismaEmployeeRepository;
 
   const TEST_CODES = ["EMP999821", "EMP999822"];
-  let TEST_DEPT_ID: string;
+  let TEST_DEPT_ID: DepartmentId;
 
   async function cleanup() {
     await prisma.employee.deleteMany({
@@ -24,7 +25,7 @@ describe("EmployeeCdDuplicationCheckDomainService", () => {
   beforeEach(async () => {
     await cleanup();
 
-    TEST_DEPT_ID = await ensureTestDepartment();
+    TEST_DEPT_ID = new DepartmentId(await ensureTestDepartment());
 
     repository = new PrismaEmployeeRepository();
     service = new EmployeeCdDuplicationCheckDomainService(repository);

--- a/src/server/subdomains/employee/domain/services/__tests__/MailAddressDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/employee/domain/services/__tests__/MailAddressDuplicationCheckDomainService.test.ts
@@ -1,6 +1,7 @@
 import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import prisma from "@server/prisma";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
 import { EmployeeName } from "@subdomains/employee/domain/values/EmployeeName";
@@ -13,7 +14,7 @@ describe("MailAddressDuplicationCheckDomainService", () => {
   let repository: PrismaEmployeeRepository;
 
   const TEST_CODES = ["EMP999831"];
-  let TEST_DEPT_ID: string;
+  let TEST_DEPT_ID: DepartmentId;
 
   async function cleanup() {
     await prisma.employee.deleteMany({
@@ -24,7 +25,7 @@ describe("MailAddressDuplicationCheckDomainService", () => {
   beforeEach(async () => {
     await cleanup();
 
-    TEST_DEPT_ID = await ensureTestDepartment();
+    TEST_DEPT_ID = new DepartmentId(await ensureTestDepartment());
 
     repository = new PrismaEmployeeRepository();
     service = new MailAddressDuplicationCheckDomainService(repository);

--- a/src/server/subdomains/employee/domain/values/EmployeeId.ts
+++ b/src/server/subdomains/employee/domain/values/EmployeeId.ts
@@ -1,0 +1,10 @@
+import { EntityId } from "@server/shared/domain/values/EntityId";
+
+/**
+ * 従業員ID値オブジェクト
+ */
+export class EmployeeId extends EntityId<"EmployeeId"> {
+  static generate(): EmployeeId {
+    return new EmployeeId(EntityId.generateValue());
+  }
+}

--- a/src/server/subdomains/employee/infrastructure/mappers/EmployeeMapper.ts
+++ b/src/server/subdomains/employee/infrastructure/mappers/EmployeeMapper.ts
@@ -1,7 +1,9 @@
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import { EmployeeName } from "@subdomains/employee/domain/values/EmployeeName";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { Employee as PrismaEmployee } from "@generated/prisma/client";
 
 /**
@@ -23,11 +25,11 @@ export class EmployeeMapper {
     const name = new EmployeeName(prismaEmployee.name);
 
     return Employee.reconstruct(
-      prismaEmployee.id,
+      new EmployeeId(prismaEmployee.id),
       employeeCd,
       email,
       name,
-      prismaEmployee.departmentId,
+      new DepartmentId(prismaEmployee.departmentId),
       prismaEmployee.createdAt,
       prismaEmployee.updatedAt
     );
@@ -41,11 +43,11 @@ export class EmployeeMapper {
    */
   static toPrismaCreate(employee: Employee) {
     return {
-      id: employee.id,
+      id: employee.id.value,
       employeeCd: employee.employeeCd.value,
       email: employee.email.value,
       name: employee.name.value,
-      departmentId: employee.departmentId,
+      departmentId: employee.departmentId.value,
     };
   }
 
@@ -59,7 +61,7 @@ export class EmployeeMapper {
     return {
       email: employee.email.value,
       name: employee.name.value,
-      departmentId: employee.departmentId,
+      departmentId: employee.departmentId.value,
       updatedAt: employee.updatedAt,
     };
   }

--- a/src/server/subdomains/employee/infrastructure/prisma/PrismaEmployeeRepository.ts
+++ b/src/server/subdomains/employee/infrastructure/prisma/PrismaEmployeeRepository.ts
@@ -1,6 +1,7 @@
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
 import { EmployeeRepository } from "@subdomains/employee/domain/repositories/EmployeeRepository";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { EmployeeMapper } from "@subdomains/employee/infrastructure/mappers/EmployeeMapper";
 import prisma from "@server/prisma";
@@ -18,10 +19,10 @@ export class PrismaEmployeeRepository implements EmployeeRepository {
   async save(employee: Employee): Promise<Employee> {
     let prismaEmployee;
 
-    if (employee.id) {
+    if (employee.id.value) {
       // IDが存在する場合：upsert（更新 or 作成）
       prismaEmployee = await prisma.employee.upsert({
-        where: { id: employee.id },
+        where: { id: employee.id.value },
         create: EmployeeMapper.toPrismaCreate(employee),
         update: EmployeeMapper.toPrismaUpdate(employee),
       });
@@ -39,9 +40,9 @@ export class PrismaEmployeeRepository implements EmployeeRepository {
    *
    * @param id
    */
-  async delete(id: string): Promise<void> {
+  async delete(id: EmployeeId): Promise<void> {
     await prisma.employee.delete({
-      where: { id: id },
+      where: { id: id.value },
     });
   }
 
@@ -51,9 +52,9 @@ export class PrismaEmployeeRepository implements EmployeeRepository {
    * @param id
    * @returns 従業員エンティティ（見つからない場合はnull）
    */
-  async findById(id: string): Promise<Employee | null> {
+  async findById(id: EmployeeId): Promise<Employee | null> {
     const prismaEmployee = await prisma.employee.findUnique({
-      where: { id: id },
+      where: { id: id.value },
     });
 
     return prismaEmployee ? EmployeeMapper.toDomain(prismaEmployee) : null;

--- a/src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts
+++ b/src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts
@@ -1,15 +1,17 @@
 import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
 import { Employee } from "@subdomains/employee/domain/entities/Employee";
 import { EmployeeCd } from "@subdomains/employee/domain/values/EmployeeCd";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import { EmployeeName } from "@subdomains/employee/domain/values/EmployeeName";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
+import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { PrismaEmployeeRepository } from "../PrismaEmployeeRepository";
 import prisma from "@server/prisma";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("PrismaEmployeeRepository", () => {
   let repository: PrismaEmployeeRepository;
-  let TEST_DEPT_ID: string;
+  let TEST_DEPT_ID: DepartmentId;
 
   beforeEach(async () => {
     repository = new PrismaEmployeeRepository();
@@ -23,7 +25,7 @@ describe("PrismaEmployeeRepository", () => {
     });
 
     // テスト用部署を確保
-    TEST_DEPT_ID = await ensureTestDepartment();
+    TEST_DEPT_ID = new DepartmentId(await ensureTestDepartment());
   });
 
   afterEach(async () => {
@@ -50,7 +52,7 @@ describe("PrismaEmployeeRepository", () => {
 
       // 保存されたエンティティを確認
       expect(savedEmployee).not.toBeNull();
-      expect(savedEmployee.id).toBeTruthy();
+      expect(savedEmployee.id.value).toBeTruthy();
       expect(savedEmployee.employeeCd.value).toBe("EMP999001");
       expect(savedEmployee.email.value).toBe("test-save@example.com");
       expect(savedEmployee.name.value).toBe("テスト太郎");
@@ -84,7 +86,7 @@ describe("PrismaEmployeeRepository", () => {
 
       // 更新されたエンティティを確認
       expect(updatedEmployee.name.value).toBe("更新後の名前");
-      expect(updatedEmployee.id).toBe(savedEmployee.id);
+      expect(updatedEmployee.id.value).toBe(savedEmployee.id.value);
 
       // DBから再取得して確認
       const updated = await prisma.employee.findUnique({
@@ -111,7 +113,7 @@ describe("PrismaEmployeeRepository", () => {
 
       // 削除されたことを確認
       const deleted = await prisma.employee.findUnique({
-        where: { id: savedEmployee.id },
+        where: { id: savedEmployee.id.value },
       });
       expect(deleted).toBeNull();
     });
@@ -132,14 +134,16 @@ describe("PrismaEmployeeRepository", () => {
       const found = await repository.findById(savedEmployee.id);
 
       expect(found).not.toBeNull();
-      expect(found?.id).toBe(savedEmployee.id);
+      expect(found?.id.value).toBe(savedEmployee.id.value);
       expect(found?.name.value).toBe("ID検索テスト");
       expect(found?.email.value).toBe("test-findbyid@example.com");
       expect(found?.employeeCd.value).toBe("EMP999001");
     });
 
     it("存在しないIDの場合nullを返す", async () => {
-      const found = await repository.findById("00000000-0000-7000-8000-000000000000");
+      const found = await repository.findById(
+        new EmployeeId("00000000-0000-7000-8000-000000000000")
+      );
 
       expect(found).toBeNull();
     });

--- a/src/server/subdomains/position/domain/entities/Position.ts
+++ b/src/server/subdomains/position/domain/entities/Position.ts
@@ -1,4 +1,5 @@
 import { PositionCd } from "../values/PositionCd";
+import { PositionId } from "../values/PositionId";
 import { PositionName } from "../values/PositionName";
 
 /**
@@ -12,10 +13,10 @@ export class Position {
   static readonly ENTITY_NAME = "役職";
 
   private constructor(
-    private readonly _id: string,
+    private readonly _id: PositionId,
     private readonly _positionCd: PositionCd,
     private readonly _name: PositionName,
-    private readonly _superiorPositionId: string | null,
+    private readonly _superiorPositionId: PositionId | null,
     private readonly _createdAt: Date,
     private readonly _updatedAt: Date
   ) {}
@@ -24,10 +25,10 @@ export class Position {
    * DBから役職を再構築
    */
   static reconstruct(
-    id: string,
+    id: PositionId,
     positionCd: PositionCd,
     name: PositionName,
-    superiorPositionId: string | null,
+    superiorPositionId: PositionId | null,
     createdAt: Date,
     updatedAt: Date
   ): Position {
@@ -45,7 +46,7 @@ export class Position {
   // ゲッター
   // ========================================
 
-  get id(): string {
+  get id(): PositionId {
     return this._id;
   }
 
@@ -57,7 +58,7 @@ export class Position {
     return this._name;
   }
 
-  get superiorPositionId(): string | null {
+  get superiorPositionId(): PositionId | null {
     return this._superiorPositionId;
   }
 

--- a/src/server/subdomains/position/domain/entities/__tests__/Position.test.ts
+++ b/src/server/subdomains/position/domain/entities/__tests__/Position.test.ts
@@ -1,23 +1,29 @@
 import { describe, it, expect } from "vitest";
 import { Position } from "../Position";
 import { PositionCd } from "../../values/PositionCd";
+import { PositionId } from "../../values/PositionId";
 import { PositionName } from "../../values/PositionName";
 
 describe("Position", () => {
+  const defaultId = PositionId.generate();
+  const defaultSuperiorId = PositionId.generate();
+
   const createTestPosition = (overrides?: {
-    id?: string;
+    id?: PositionId;
     positionCd?: PositionCd;
     name?: PositionName;
-    superiorPositionId?: string | null;
+    superiorPositionId?: PositionId | null;
     createdAt?: Date;
     updatedAt?: Date;
   }) => {
     const now = new Date();
     return Position.reconstruct(
-      overrides?.id ?? "test-id-001",
+      overrides?.id ?? defaultId,
       overrides?.positionCd ?? new PositionCd("POS001"),
       overrides?.name ?? new PositionName("課長"),
-      overrides?.superiorPositionId !== undefined ? overrides.superiorPositionId : "test-id-002",
+      overrides?.superiorPositionId !== undefined
+        ? overrides.superiorPositionId
+        : defaultSuperiorId,
       overrides?.createdAt ?? now,
       overrides?.updatedAt ?? now
     );
@@ -27,10 +33,10 @@ describe("Position", () => {
     it("役職を再構築できる", () => {
       const position = createTestPosition();
 
-      expect(position.id).toBe("test-id-001");
+      expect(position.id.value).toBe(defaultId.value);
       expect(position.positionCd.value).toBe("POS001");
       expect(position.name.value).toBe("課長");
-      expect(position.superiorPositionId).toBe("test-id-002");
+      expect(position.superiorPositionId?.value).toBe(defaultSuperiorId.value);
     });
 
     it("上位役職がnullの場合も再構築できる", () => {
@@ -57,7 +63,7 @@ describe("Position", () => {
     });
 
     it("上位役職がある場合はfalseを返す", () => {
-      const position = createTestPosition({ superiorPositionId: "superior-id" });
+      const position = createTestPosition({ superiorPositionId: PositionId.generate() });
 
       expect(position.isTopLevel()).toBe(false);
     });

--- a/src/server/subdomains/position/domain/repositories/PositionRepository.ts
+++ b/src/server/subdomains/position/domain/repositories/PositionRepository.ts
@@ -1,5 +1,6 @@
 import { Position } from "../entities/Position";
 import { PositionCd } from "../values/PositionCd";
+import { PositionId } from "../values/PositionId";
 
 /**
  * 役職リポジトリインターフェース
@@ -11,7 +12,7 @@ export interface PositionRepository {
   /**
    * IDで役職を取得
    */
-  findById(id: string): Promise<Position | null>;
+  findById(id: PositionId): Promise<Position | null>;
 
   /**
    * 役職コードで役職を取得

--- a/src/server/subdomains/position/domain/values/PositionId.ts
+++ b/src/server/subdomains/position/domain/values/PositionId.ts
@@ -1,0 +1,10 @@
+import { EntityId } from "@server/shared/domain/values/EntityId";
+
+/**
+ * 役職ID値オブジェクト
+ */
+export class PositionId extends EntityId<"PositionId"> {
+  static generate(): PositionId {
+    return new PositionId(EntityId.generateValue());
+  }
+}

--- a/src/server/subdomains/position/infrastructure/mappers/PositionMapper.ts
+++ b/src/server/subdomains/position/infrastructure/mappers/PositionMapper.ts
@@ -1,5 +1,6 @@
 import { Position } from "@subdomains/position/domain/entities/Position";
 import { PositionCd } from "@subdomains/position/domain/values/PositionCd";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PositionName } from "@subdomains/position/domain/values/PositionName";
 import { Position as PrismaPosition } from "@generated/prisma/client";
 
@@ -18,10 +19,10 @@ export class PositionMapper {
     const name = new PositionName(prismaPosition.name);
 
     return Position.reconstruct(
-      prismaPosition.id,
+      new PositionId(prismaPosition.id),
       positionCd,
       name,
-      prismaPosition.superiorPositionId,
+      prismaPosition.superiorPositionId ? new PositionId(prismaPosition.superiorPositionId) : null,
       prismaPosition.createdAt,
       prismaPosition.updatedAt
     );

--- a/src/server/subdomains/position/infrastructure/prisma/PrismaPositionRepository.ts
+++ b/src/server/subdomains/position/infrastructure/prisma/PrismaPositionRepository.ts
@@ -1,6 +1,7 @@
 import { Position } from "@subdomains/position/domain/entities/Position";
 import { PositionRepository } from "@subdomains/position/domain/repositories/PositionRepository";
 import { PositionCd } from "@subdomains/position/domain/values/PositionCd";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PositionMapper } from "@subdomains/position/infrastructure/mappers/PositionMapper";
 import prisma from "@server/prisma";
 
@@ -10,9 +11,9 @@ import prisma from "@server/prisma";
  * 読み取り専用（Positionは固定マスタデータ）
  */
 export class PrismaPositionRepository implements PositionRepository {
-  async findById(id: string): Promise<Position | null> {
+  async findById(id: PositionId): Promise<Position | null> {
     const prismaPosition = await prisma.position.findUnique({
-      where: { id },
+      where: { id: id.value },
     });
 
     return prismaPosition ? PositionMapper.toDomain(prismaPosition) : null;

--- a/src/server/subdomains/role/application/commands/CreateRoleCommand.ts
+++ b/src/server/subdomains/role/application/commands/CreateRoleCommand.ts
@@ -1,7 +1,9 @@
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleRepository } from "@subdomains/role/domain/repositories/RoleRepository";
 import { PositionRepository } from "@subdomains/role/domain/repositories/PositionRepository";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleId } from "@subdomains/role/domain/values/RoleId";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
 import { RoleCdDuplicationCheckDomainService } from "@subdomains/role/domain/services/RoleCdDuplicationCheckDomainService";
 import { RoleNameDuplicationCheckDomainService } from "@subdomains/role/domain/services/RoleNameDuplicationCheckDomainService";
@@ -44,18 +46,19 @@ export class CreateRoleCommand {
     }
 
     // 役職存在確認
-    const positionExists = await this.positionRepository.exists(input.positionId);
+    const positionId = new PositionId(input.positionId);
+    const positionExists = await this.positionRepository.exists(positionId);
     if (!positionExists) {
       throw new ValidationError(`役職が存在しません: ID=${input.positionId}`);
     }
 
     // 上位役割バリデーション
-    const superiorRoleId = input.superiorRoleId ?? null;
+    const superiorRoleId = input.superiorRoleId ? new RoleId(input.superiorRoleId) : null;
     if (superiorRoleId) {
-      await this.superiorRoleValidationDomainService.execute(input.positionId, superiorRoleId);
+      await this.superiorRoleValidationDomainService.execute(positionId, superiorRoleId);
     }
 
-    const newRole = Role.create(roleCd, roleName, input.positionId, superiorRoleId);
+    const newRole = Role.create(roleCd, roleName, positionId, superiorRoleId);
 
     return await this.roleRepository.save(newRole);
   }

--- a/src/server/subdomains/role/application/commands/DeleteRoleCommand.ts
+++ b/src/server/subdomains/role/application/commands/DeleteRoleCommand.ts
@@ -1,5 +1,6 @@
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleRepository } from "@subdomains/role/domain/repositories/RoleRepository";
+import { RoleId } from "@subdomains/role/domain/values/RoleId";
 import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
 import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 
@@ -16,13 +17,14 @@ export class DeleteRoleCommand {
   public constructor(private readonly roleRepository: RoleRepository) {}
 
   async execute(input: DeleteRoleInput): Promise<void> {
-    const role = await this.roleRepository.findById(input.id);
+    const roleId = new RoleId(input.id);
+    const role = await this.roleRepository.findById(roleId);
     if (!role) {
       throw new NotFoundEntityError(Role, { id: input.id });
     }
 
     // 下位役割がある場合は削除できない
-    const subordinates = await this.roleRepository.findSubordinates(input.id);
+    const subordinates = await this.roleRepository.findSubordinates(roleId);
     if (subordinates.length > 0) {
       throw new BusinessRuleViolationError(
         "下位役割が存在するため、この役割を削除できません。先に下位役割を削除してください。"
@@ -30,13 +32,13 @@ export class DeleteRoleCommand {
     }
 
     // 使用中の場合は削除できない
-    const inUse = await this.roleRepository.isInUse(input.id);
+    const inUse = await this.roleRepository.isInUse(roleId);
     if (inUse) {
       throw new BusinessRuleViolationError(
         "この役割は従業員に割り当てられているため削除できません。先に割り当てを解除してください。"
       );
     }
 
-    await this.roleRepository.delete(input.id);
+    await this.roleRepository.delete(roleId);
   }
 }

--- a/src/server/subdomains/role/application/commands/UpdateRoleCommand.ts
+++ b/src/server/subdomains/role/application/commands/UpdateRoleCommand.ts
@@ -1,5 +1,6 @@
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleRepository } from "@subdomains/role/domain/repositories/RoleRepository";
+import { RoleId } from "@subdomains/role/domain/values/RoleId";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
 import { RoleNameDuplicationCheckDomainService } from "@subdomains/role/domain/services/RoleNameDuplicationCheckDomainService";
 import { SuperiorRoleValidationDomainService } from "@subdomains/role/domain/services/SuperiorRoleValidationDomainService";
@@ -26,7 +27,8 @@ export class UpdateRoleCommand {
   ) {}
 
   async execute(input: UpdateRoleInput): Promise<Role> {
-    const role = await this.roleRepository.findById(input.id);
+    const roleId = new RoleId(input.id);
+    const role = await this.roleRepository.findById(roleId);
     if (!role) {
       throw new NotFoundEntityError(Role, { id: input.id });
     }
@@ -45,16 +47,15 @@ export class UpdateRoleCommand {
 
     // 上位役割の更新
     if (input.superiorRoleId !== undefined) {
-      if (input.superiorRoleId !== null) {
+      const newSuperiorRoleId =
+        input.superiorRoleId !== null ? new RoleId(input.superiorRoleId) : null;
+      if (newSuperiorRoleId !== null) {
         // 上位役割バリデーション
-        await this.superiorRoleValidationDomainService.execute(
-          role.positionId,
-          input.superiorRoleId
-        );
+        await this.superiorRoleValidationDomainService.execute(role.positionId, newSuperiorRoleId);
         // 循環参照チェック
-        await this.validateNoCircularReference(role.id, input.superiorRoleId);
+        await this.validateNoCircularReference(role.id, newSuperiorRoleId);
       }
-      role.changeSuperiorRole(input.superiorRoleId);
+      role.changeSuperiorRole(newSuperiorRoleId);
     }
 
     return await this.roleRepository.save(role);
@@ -70,22 +71,22 @@ export class UpdateRoleCommand {
    * 自己参照チェックと祖先走査は防御的プログラミングとして残す。
    */
   private async validateNoCircularReference(
-    roleId: string,
-    newSuperiorRoleId: string
+    roleId: RoleId,
+    newSuperiorRoleId: RoleId
   ): Promise<void> {
-    if (roleId === newSuperiorRoleId) {
+    if (roleId.equals(newSuperiorRoleId)) {
       throw new BusinessRuleViolationError("自分自身を上位役割にすることはできません");
     }
 
     // 新しい上位役割の祖先を辿って、自分自身がいないことを確認
-    let currentSuperiorId: string | null = newSuperiorRoleId;
+    let currentSuperiorId: RoleId | null = newSuperiorRoleId;
     while (currentSuperiorId !== null) {
       const superiorRole = await this.roleRepository.findById(currentSuperiorId);
       if (!superiorRole) {
         break;
       }
       currentSuperiorId = superiorRole.superiorRoleId;
-      if (currentSuperiorId === roleId) {
+      if (currentSuperiorId !== null && currentSuperiorId.equals(roleId)) {
         throw new BusinessRuleViolationError(
           "循環参照が発生するため、この上位役割は設定できません"
         );

--- a/src/server/subdomains/role/application/commands/__tests__/CreateRoleCommand.test.ts
+++ b/src/server/subdomains/role/application/commands/__tests__/CreateRoleCommand.test.ts
@@ -62,7 +62,7 @@ describe("CreateRoleCommand", () => {
     expect(saved).not.toBeNull();
     expect(saved?.roleCd.value).toBe(TEST_ROLE_CDS[0]);
     expect(saved?.name.value).toBe("登録テスト課長");
-    expect(saved?.positionId).toBe(kachouPositionId);
+    expect(saved?.positionId.value).toBe(kachouPositionId);
     expect(saved?.superiorRoleId).toBeNull();
   });
 
@@ -80,11 +80,11 @@ describe("CreateRoleCommand", () => {
       roleCd: TEST_ROLE_CDS[1],
       name: "登録テスト課長2",
       positionId: kachouPositionId,
-      superiorRoleId: buchouRole!.id,
+      superiorRoleId: buchouRole!.id.value,
     });
 
     const saved = await roleRepository.findByRoleCd(new RoleCd(TEST_ROLE_CDS[1]));
-    expect(saved?.superiorRoleId).toBe(buchouRole!.id);
+    expect(saved?.superiorRoleId?.value).toBe(buchouRole!.id.value);
   });
 
   it("既に存在する役割コードの場合はエラー", async () => {

--- a/src/server/subdomains/role/application/commands/__tests__/DeleteRoleCommand.test.ts
+++ b/src/server/subdomains/role/application/commands/__tests__/DeleteRoleCommand.test.ts
@@ -4,6 +4,7 @@ import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DeleteRoleCommand } from "../DeleteRoleCommand";
@@ -48,11 +49,11 @@ describe("DeleteRoleCommand", () => {
     const role = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("削除テスト役割"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role);
 
-    await command.execute({ id: role.id });
+    await command.execute({ id: role.id.value });
 
     const deleted = await roleRepository.findById(role.id);
     expect(deleted).toBeNull();
@@ -68,21 +69,23 @@ describe("DeleteRoleCommand", () => {
     const buchouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("テスト部長"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("テスト課長"),
-      kachouPositionId,
+      new PositionId(kachouPositionId),
       buchouRole.id
     );
     await roleRepository.save(kachouRole);
 
-    await expect(command.execute({ id: buchouRole.id })).rejects.toThrow(
+    await expect(command.execute({ id: buchouRole.id.value })).rejects.toThrow(
       BusinessRuleViolationError
     );
-    await expect(command.execute({ id: buchouRole.id })).rejects.toThrow("下位役割が存在するため");
+    await expect(command.execute({ id: buchouRole.id.value })).rejects.toThrow(
+      "下位役割が存在するため"
+    );
   });
 });

--- a/src/server/subdomains/role/application/commands/__tests__/UpdateRoleCommand.test.ts
+++ b/src/server/subdomains/role/application/commands/__tests__/UpdateRoleCommand.test.ts
@@ -4,6 +4,7 @@ import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
 import { PrismaPositionRepository } from "@subdomains/role/infrastructure/prisma/PrismaPositionRepository";
 import { RoleNameDuplicationCheckDomainService } from "@subdomains/role/domain/services/RoleNameDuplicationCheckDomainService";
@@ -56,12 +57,12 @@ describe("UpdateRoleCommand", () => {
     const role = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("更新前の名前"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role);
 
     const updated = await command.execute({
-      id: role.id,
+      id: role.id.value,
       name: "更新後の名前",
     });
 
@@ -72,23 +73,23 @@ describe("UpdateRoleCommand", () => {
     const buchouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("テスト部長"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("テスト課長"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(kachouRole);
 
     const updated = await command.execute({
-      id: kachouRole.id,
-      superiorRoleId: buchouRole.id,
+      id: kachouRole.id.value,
+      superiorRoleId: buchouRole.id.value,
     });
 
-    expect(updated.superiorRoleId).toBe(buchouRole.id);
+    expect(updated.superiorRoleId?.value).toBe(buchouRole.id.value);
   });
 
   it("存在しない役割を更新しようとするとエラー", async () => {
@@ -104,20 +105,20 @@ describe("UpdateRoleCommand", () => {
     const role1 = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("既存の役割名"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role1);
 
     const role2 = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("変更前の名前"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role2);
 
     await expect(
       command.execute({
-        id: role2.id,
+        id: role2.id.value,
         name: "既存の役割名",
       })
     ).rejects.toThrow(ValidationError);
@@ -127,12 +128,12 @@ describe("UpdateRoleCommand", () => {
     const role = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("テスト役割"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role);
 
     const updated = await command.execute({
-      id: role.id,
+      id: role.id.value,
       name: "テスト役割",
     });
 
@@ -143,14 +144,14 @@ describe("UpdateRoleCommand", () => {
     const buchouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("テスト部長"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(buchouRole);
 
     await expect(
       command.execute({
-        id: buchouRole.id,
-        superiorRoleId: buchouRole.id,
+        id: buchouRole.id.value,
+        superiorRoleId: buchouRole.id.value,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
   });
@@ -160,22 +161,22 @@ describe("UpdateRoleCommand", () => {
     const buchouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("循環テスト部長"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("循環テスト課長"),
-      kachouPositionId,
+      new PositionId(kachouPositionId),
       buchouRole.id
     );
     await roleRepository.save(kachouRole);
 
     await expect(
       command.execute({
-        id: buchouRole.id,
-        superiorRoleId: kachouRole.id,
+        id: buchouRole.id.value,
+        superiorRoleId: kachouRole.id.value,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
   });
@@ -184,22 +185,22 @@ describe("UpdateRoleCommand", () => {
     const kachouRole1 = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("同一レベルA課長"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(kachouRole1);
 
     const kachouRole2 = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("同一レベルB課長"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(kachouRole2);
 
     // 課長の上位は部長でなければならないため、同一役職レベルは設定不可
     await expect(
       command.execute({
-        id: kachouRole1.id,
-        superiorRoleId: kachouRole2.id,
+        id: kachouRole1.id.value,
+        superiorRoleId: kachouRole2.id.value,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
   });

--- a/src/server/subdomains/role/application/queries/__tests__/GetAllRolesQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetAllRolesQuery.test.ts
@@ -2,6 +2,7 @@ import prisma from "@server/prisma";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
 import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -41,12 +42,12 @@ describe("GetAllRolesQuery", () => {
     const role1 = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("全取得テストA"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     const role2 = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("全取得テストB"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role1);
     await roleRepository.save(role2);
@@ -62,12 +63,12 @@ describe("GetAllRolesQuery", () => {
     const role1 = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("全取得ソートA"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     const role2 = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("全取得ソートB"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role1);
     await roleRepository.save(role2);

--- a/src/server/subdomains/role/application/queries/__tests__/GetRoleByIdQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetRoleByIdQuery.test.ts
@@ -2,6 +2,7 @@ import prisma from "@server/prisma";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
 import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -41,14 +42,14 @@ describe("GetRoleByIdQuery", () => {
     const role = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("ID取得テスト役割"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role);
 
-    const result = await query.execute({ id: role.id });
+    const result = await query.execute({ id: role.id.value });
 
     expect(result).not.toBeNull();
-    expect(result?.id).toBe(role.id);
+    expect(result?.id).toBe(role.id.value);
     expect(result?.roleCd).toBe(TEST_ROLE_CDS[0]);
     expect(result?.name).toBe("ID取得テスト役割");
     expect(result?.positionId).toBe(kachouPositionId);

--- a/src/server/subdomains/role/application/queries/__tests__/GetRoleByRoleCdQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetRoleByRoleCdQuery.test.ts
@@ -2,6 +2,7 @@ import prisma from "@server/prisma";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
 import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -41,14 +42,14 @@ describe("GetRoleByRoleCdQuery", () => {
     const role = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("コード取得テスト役割"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role);
 
     const result = await query.execute({ roleCd: TEST_ROLE_CDS[0] });
 
     expect(result).not.toBeNull();
-    expect(result?.id).toBe(role.id);
+    expect(result?.id).toBe(role.id.value);
     expect(result?.roleCd).toBe(TEST_ROLE_CDS[0]);
     expect(result?.name).toBe("コード取得テスト役割");
     expect(result?.positionId).toBe(kachouPositionId);

--- a/src/server/subdomains/role/application/queries/__tests__/GetRolesByPositionQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetRolesByPositionQuery.test.ts
@@ -2,6 +2,7 @@ import prisma from "@server/prisma";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
 import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -46,12 +47,12 @@ describe("GetRolesByPositionQuery", () => {
     const role1 = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("役職別テスト課長"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     const role2 = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("役職別テスト部長"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(role1);
     await roleRepository.save(role2);

--- a/src/server/subdomains/role/application/queries/__tests__/SearchRolesQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/SearchRolesQuery.test.ts
@@ -2,6 +2,7 @@ import prisma from "@server/prisma";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
 import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -46,12 +47,12 @@ describe("SearchRolesQuery", () => {
     const role1 = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("検索大阪営業課長"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     const role2 = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("検索東京開発課長"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role1);
     await roleRepository.save(role2);
@@ -67,7 +68,7 @@ describe("SearchRolesQuery", () => {
     const role = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("検索コードテスト"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role);
 
@@ -81,12 +82,12 @@ describe("SearchRolesQuery", () => {
     const role1 = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("検索役職課長"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     const role2 = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("検索役職部長"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(role1);
     await roleRepository.save(role2);
@@ -102,19 +103,19 @@ describe("SearchRolesQuery", () => {
     const buchouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("検索上位部長"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("検索上位課長"),
-      kachouPositionId,
+      new PositionId(kachouPositionId),
       buchouRole.id
     );
     await roleRepository.save(kachouRole);
 
-    const result = await query.execute({ criteria: { superiorRoleId: buchouRole.id } });
+    const result = await query.execute({ criteria: { superiorRoleId: buchouRole.id.value } });
 
     const roleCds = result.map((r) => r.roleCd);
     expect(roleCds).toContain(TEST_ROLE_CDS[1]);
@@ -125,14 +126,14 @@ describe("SearchRolesQuery", () => {
     const buchouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("検索ルート部長"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("検索ルート課長"),
-      kachouPositionId,
+      new PositionId(kachouPositionId),
       buchouRole.id
     );
     await roleRepository.save(kachouRole);
@@ -148,14 +149,14 @@ describe("SearchRolesQuery", () => {
     const buchouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("検索DTO部長"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("検索DTO課長"),
-      kachouPositionId,
+      new PositionId(kachouPositionId),
       buchouRole.id
     );
     await roleRepository.save(kachouRole);
@@ -175,12 +176,12 @@ describe("SearchRolesQuery", () => {
     const role1 = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("検索オプA課長"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     const role2 = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("検索オプB課長"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(role1);
     await roleRepository.save(role2);

--- a/src/server/subdomains/role/domain/entities/Role.ts
+++ b/src/server/subdomains/role/domain/entities/Role.ts
@@ -1,7 +1,8 @@
-import { generateId } from "@server/shared/generateId";
-import { RoleCd } from "../values/RoleCd";
-import { RoleName } from "../values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { RoleCd } from "../values/RoleCd";
+import { RoleId } from "../values/RoleId";
+import { RoleName } from "../values/RoleName";
 
 /**
  * 役割エンティティ
@@ -15,11 +16,11 @@ export class Role {
   static readonly ENTITY_NAME = "役割";
 
   private constructor(
-    private readonly _id: string,
+    private readonly _id: RoleId,
     private readonly _roleCd: RoleCd,
     private _name: RoleName,
-    private readonly _positionId: string,
-    private _superiorRoleId: string | null,
+    private readonly _positionId: PositionId,
+    private _superiorRoleId: RoleId | null,
     private readonly _createdAt: Date,
     private _updatedAt: Date
   ) {}
@@ -30,22 +31,22 @@ export class Role {
   static create(
     roleCd: RoleCd,
     name: RoleName,
-    positionId: string,
-    superiorRoleId: string | null = null
+    positionId: PositionId,
+    superiorRoleId: RoleId | null = null
   ): Role {
     const now = new Date();
-    return new Role(generateId(), roleCd, name, positionId, superiorRoleId, now, now);
+    return new Role(RoleId.generate(), roleCd, name, positionId, superiorRoleId, now, now);
   }
 
   /**
    * DBから役割を再構築
    */
   static reconstruct(
-    id: string,
+    id: RoleId,
     roleCd: RoleCd,
     name: RoleName,
-    positionId: string,
-    superiorRoleId: string | null,
+    positionId: PositionId,
+    superiorRoleId: RoleId | null,
     createdAt: Date,
     updatedAt: Date
   ): Role {
@@ -70,8 +71,8 @@ export class Role {
    * 自分自身を上位役割に設定することはできない。
    * 上位役職に属する役割かどうかの検証はドメインサービスで行う。
    */
-  changeSuperiorRole(newSuperiorRoleId: string | null): void {
-    if (newSuperiorRoleId === this._id) {
+  changeSuperiorRole(newSuperiorRoleId: RoleId | null): void {
+    if (newSuperiorRoleId !== null && newSuperiorRoleId.equals(this._id)) {
       throw new BusinessRuleViolationError("自分自身を上位役割にすることはできません");
     }
     this._superiorRoleId = newSuperiorRoleId;
@@ -82,7 +83,7 @@ export class Role {
   // ゲッター
   // ========================================
 
-  get id(): string {
+  get id(): RoleId {
     return this._id;
   }
 
@@ -94,11 +95,11 @@ export class Role {
     return this._name;
   }
 
-  get positionId(): string {
+  get positionId(): PositionId {
     return this._positionId;
   }
 
-  get superiorRoleId(): string | null {
+  get superiorRoleId(): RoleId | null {
     return this._superiorRoleId;
   }
 

--- a/src/server/subdomains/role/domain/entities/__tests__/Role.test.ts
+++ b/src/server/subdomains/role/domain/entities/__tests__/Role.test.ts
@@ -1,21 +1,26 @@
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { describe, it, expect } from "vitest";
 import { Role } from "../Role";
 import { RoleCd } from "../../values/RoleCd";
+import { RoleId } from "../../values/RoleId";
 import { RoleName } from "../../values/RoleName";
 import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
 
 describe("Role", () => {
+  const defaultPositionId = PositionId.generate();
+  const defaultSuperiorRoleId = RoleId.generate();
+
   const createTestRole = (overrides?: {
     roleCd?: RoleCd;
     name?: RoleName;
-    positionId?: string;
-    superiorRoleId?: string | null;
+    positionId?: PositionId;
+    superiorRoleId?: RoleId | null;
   }) => {
     return Role.create(
       overrides?.roleCd ?? new RoleCd("ROLE001"),
       overrides?.name ?? new RoleName("大阪市南課長"),
-      overrides?.positionId ?? "position-id-001",
-      overrides?.superiorRoleId !== undefined ? overrides.superiorRoleId : "superior-role-id"
+      overrides?.positionId ?? defaultPositionId,
+      overrides?.superiorRoleId !== undefined ? overrides.superiorRoleId : defaultSuperiorRoleId
     );
   };
 
@@ -26,8 +31,8 @@ describe("Role", () => {
       expect(role.id).toBeDefined();
       expect(role.roleCd.value).toBe("ROLE001");
       expect(role.name.value).toBe("大阪市南課長");
-      expect(role.positionId).toBe("position-id-001");
-      expect(role.superiorRoleId).toBe("superior-role-id");
+      expect(role.positionId).toBe(defaultPositionId);
+      expect(role.superiorRoleId).toBe(defaultSuperiorRoleId);
       expect(role.createdAt).toBeInstanceOf(Date);
       expect(role.updatedAt).toBeInstanceOf(Date);
     });
@@ -44,21 +49,25 @@ describe("Role", () => {
       const createdAt = new Date("2025-01-01");
       const updatedAt = new Date("2025-06-01");
 
+      const roleId = RoleId.generate();
+      const positionId = PositionId.generate();
+      const superiorRoleId = RoleId.generate();
+
       const role = Role.reconstruct(
-        "test-id",
+        roleId,
         new RoleCd("ROLE001"),
         new RoleName("営業部長"),
-        "position-id",
-        "superior-id",
+        positionId,
+        superiorRoleId,
         createdAt,
         updatedAt
       );
 
-      expect(role.id).toBe("test-id");
+      expect(role.id).toBe(roleId);
       expect(role.roleCd.value).toBe("ROLE001");
       expect(role.name.value).toBe("営業部長");
-      expect(role.positionId).toBe("position-id");
-      expect(role.superiorRoleId).toBe("superior-id");
+      expect(role.positionId).toBe(positionId);
+      expect(role.superiorRoleId).toBe(superiorRoleId);
       expect(role.createdAt).toEqual(createdAt);
       expect(role.updatedAt).toEqual(updatedAt);
     });
@@ -80,15 +89,16 @@ describe("Role", () => {
     it("上位役割を変更できる", () => {
       const role = createTestRole();
       const originalUpdatedAt = role.updatedAt;
+      const newSuperiorRoleId = RoleId.generate();
 
-      role.changeSuperiorRole("new-superior-id");
+      role.changeSuperiorRole(newSuperiorRoleId);
 
-      expect(role.superiorRoleId).toBe("new-superior-id");
+      expect(role.superiorRoleId).toBe(newSuperiorRoleId);
       expect(role.updatedAt.getTime()).toBeGreaterThanOrEqual(originalUpdatedAt.getTime());
     });
 
     it("上位役割をnullに変更できる", () => {
-      const role = createTestRole({ superiorRoleId: "some-id" });
+      const role = createTestRole({ superiorRoleId: RoleId.generate() });
 
       role.changeSuperiorRole(null);
 

--- a/src/server/subdomains/role/domain/repositories/PositionRepository.ts
+++ b/src/server/subdomains/role/domain/repositories/PositionRepository.ts
@@ -1,3 +1,5 @@
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
+
 /**
  * 役割ドメインが必要とする役職リポジトリインターフェース
  *
@@ -9,10 +11,10 @@ export interface PositionRepository {
    * 指定した役職の上位役職IDを取得
    * @returns 上位役職ID（最上位の場合は null）
    */
-  findSuperiorPositionId(positionId: string): Promise<string | null>;
+  findSuperiorPositionId(positionId: PositionId): Promise<PositionId | null>;
 
   /**
    * 指定した役職が存在するか確認
    */
-  exists(positionId: string): Promise<boolean>;
+  exists(positionId: PositionId): Promise<boolean>;
 }

--- a/src/server/subdomains/role/domain/repositories/RoleRepository.ts
+++ b/src/server/subdomains/role/domain/repositories/RoleRepository.ts
@@ -1,5 +1,6 @@
 import { Role } from "../entities/Role";
 import { RoleCd } from "../values/RoleCd";
+import { RoleId } from "../values/RoleId";
 
 /**
  * 役割リポジトリインターフェース
@@ -16,12 +17,12 @@ export interface RoleRepository {
   /**
    * 役割を削除
    */
-  delete(id: string): Promise<void>;
+  delete(id: RoleId): Promise<void>;
 
   /**
    * IDで役割を取得
    */
-  findById(id: string): Promise<Role | null>;
+  findById(id: RoleId): Promise<Role | null>;
 
   /**
    * 役割コードで役割を取得（重複チェック等で Entity が必要な場合に使用）
@@ -37,11 +38,11 @@ export interface RoleRepository {
    * 下位役割を取得
    * @param superiorRoleId 上位役割ID
    */
-  findSubordinates(superiorRoleId: string): Promise<Role[]>;
+  findSubordinates(superiorRoleId: RoleId): Promise<Role[]>;
 
   /**
    * 役割が使用中かどうかを確認
    * EmployeeRole または Employee.superiorRoleId で参照されている場合は true
    */
-  isInUse(roleId: string): Promise<boolean>;
+  isInUse(roleId: RoleId): Promise<boolean>;
 }

--- a/src/server/subdomains/role/domain/services/RoleNameDuplicationCheckDomainService.ts
+++ b/src/server/subdomains/role/domain/services/RoleNameDuplicationCheckDomainService.ts
@@ -1,4 +1,5 @@
 import { RoleRepository } from "../repositories/RoleRepository";
+import { RoleId } from "../values/RoleId";
 
 /**
  * 役割名重複チェックドメインサービス
@@ -11,13 +12,13 @@ export class RoleNameDuplicationCheckDomainService {
    * @param excludeId 除外するID（更新時に自分自身を除外するため）
    * @returns 重複がある場合 true
    */
-  async execute(name: string, excludeId?: string): Promise<boolean> {
+  async execute(name: string, excludeId?: RoleId): Promise<boolean> {
     const existingRole = await this.roleRepository.findByName(name);
     if (!existingRole) {
       return false;
     }
     // 更新時: 自分自身は除外
-    if (excludeId && existingRole.id === excludeId) {
+    if (excludeId && existingRole.id.equals(excludeId)) {
       return false;
     }
     return true;

--- a/src/server/subdomains/role/domain/services/SuperiorRoleValidationDomainService.ts
+++ b/src/server/subdomains/role/domain/services/SuperiorRoleValidationDomainService.ts
@@ -1,4 +1,6 @@
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { RoleId } from "../values/RoleId";
 import { RoleRepository } from "../repositories/RoleRepository";
 import { PositionRepository } from "../repositories/PositionRepository";
 
@@ -21,7 +23,7 @@ export class SuperiorRoleValidationDomainService {
    * @param superiorRoleId 設定しようとする上位役割ID
    * @throws BusinessRuleViolationError バリデーション失敗時
    */
-  async execute(positionId: string, superiorRoleId: string): Promise<void> {
+  async execute(positionId: PositionId, superiorRoleId: RoleId): Promise<void> {
     // 1. 当該役職の上位役職IDを取得
     const superiorPositionId = await this.positionRepository.findSuperiorPositionId(positionId);
 
@@ -33,11 +35,11 @@ export class SuperiorRoleValidationDomainService {
     // 3. 上位役割を取得
     const superiorRole = await this.roleRepository.findById(superiorRoleId);
     if (!superiorRole) {
-      throw new BusinessRuleViolationError(`上位役割が存在しません: ID=${superiorRoleId}`);
+      throw new BusinessRuleViolationError(`上位役割が存在しません: ID=${superiorRoleId.value}`);
     }
 
     // 4. 上位役割の役職が、当該役職の上位役職と一致するか検証
-    if (superiorRole.positionId !== superiorPositionId) {
+    if (!superiorRole.positionId.equals(superiorPositionId)) {
       throw new BusinessRuleViolationError(
         "上位役割に指定できるのは、選択した役職の上位役職に属する役割のみです"
       );

--- a/src/server/subdomains/role/domain/services/__tests__/RoleCdDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/role/domain/services/__tests__/RoleCdDuplicationCheckDomainService.test.ts
@@ -2,6 +2,7 @@ import prisma from "@server/prisma";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RoleCdDuplicationCheckDomainService } from "../RoleCdDuplicationCheckDomainService";
@@ -42,7 +43,11 @@ describe("RoleCdDuplicationCheckDomainService", () => {
   });
 
   it("役割コードが既に存在する場合は true を返す", async () => {
-    const role = Role.create(new RoleCd(TEST_ROLE_CD), new RoleName("テスト役割"), positionId);
+    const role = Role.create(
+      new RoleCd(TEST_ROLE_CD),
+      new RoleName("テスト役割"),
+      new PositionId(positionId)
+    );
     await repository.save(role);
 
     const isDuplicated = await service.execute(new RoleCd(TEST_ROLE_CD));

--- a/src/server/subdomains/role/domain/services/__tests__/RoleNameDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/role/domain/services/__tests__/RoleNameDuplicationCheckDomainService.test.ts
@@ -2,6 +2,7 @@ import prisma from "@server/prisma";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RoleNameDuplicationCheckDomainService } from "../RoleNameDuplicationCheckDomainService";
@@ -42,7 +43,11 @@ describe("RoleNameDuplicationCheckDomainService", () => {
   });
 
   it("役割名が既に存在する場合は true を返す", async () => {
-    const role = Role.create(new RoleCd(TEST_ROLE_CD), new RoleName(TEST_ROLE_NAME), positionId);
+    const role = Role.create(
+      new RoleCd(TEST_ROLE_CD),
+      new RoleName(TEST_ROLE_NAME),
+      new PositionId(positionId)
+    );
     await repository.save(role);
 
     const isDuplicated = await service.execute(TEST_ROLE_NAME);
@@ -50,7 +55,11 @@ describe("RoleNameDuplicationCheckDomainService", () => {
   });
 
   it("excludeIdで自分自身を除外できる", async () => {
-    const role = Role.create(new RoleCd(TEST_ROLE_CD), new RoleName(TEST_ROLE_NAME), positionId);
+    const role = Role.create(
+      new RoleCd(TEST_ROLE_CD),
+      new RoleName(TEST_ROLE_NAME),
+      new PositionId(positionId)
+    );
     const savedRole = await repository.save(role);
 
     const isDuplicated = await service.execute(TEST_ROLE_NAME, savedRole.id);

--- a/src/server/subdomains/role/domain/services/__tests__/SuperiorRoleValidationDomainService.test.ts
+++ b/src/server/subdomains/role/domain/services/__tests__/SuperiorRoleValidationDomainService.test.ts
@@ -1,7 +1,9 @@
 import prisma from "@server/prisma";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleId } from "@subdomains/role/domain/values/RoleId";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PrismaRoleRepository } from "@subdomains/role/infrastructure/prisma/PrismaRoleRepository";
 import { PrismaPositionRepository } from "@subdomains/role/infrastructure/prisma/PrismaPositionRepository";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -49,27 +51,29 @@ describe("SuperiorRoleValidationDomainService", () => {
     const buchouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("テスト部長"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(buchouRole);
 
     // 課長ポジションから部長ポジションの役割を上位に指定 → OK
-    await expect(service.execute(kachouPositionId, buchouRole.id)).resolves.not.toThrow();
+    await expect(
+      service.execute(new PositionId(kachouPositionId), buchouRole.id)
+    ).resolves.not.toThrow();
   });
 
   it("最上位の役職には上位役割を設定できない", async () => {
     const someRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("テスト役割"),
-      buchouPositionId
+      new PositionId(buchouPositionId)
     );
     await roleRepository.save(someRole);
 
     // 社長ポジションから上位役割を指定 → エラー
-    await expect(service.execute(shachouPositionId, someRole.id)).rejects.toThrow(
+    await expect(service.execute(new PositionId(shachouPositionId), someRole.id)).rejects.toThrow(
       BusinessRuleViolationError
     );
-    await expect(service.execute(shachouPositionId, someRole.id)).rejects.toThrow(
+    await expect(service.execute(new PositionId(shachouPositionId), someRole.id)).rejects.toThrow(
       "最上位の役職には上位役割を設定できません"
     );
   });
@@ -79,26 +83,32 @@ describe("SuperiorRoleValidationDomainService", () => {
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[0]),
       new RoleName("テスト課長"),
-      kachouPositionId
+      new PositionId(kachouPositionId)
     );
     await roleRepository.save(kachouRole);
 
     // 課長ポジションから同じ課長ポジションの役割を上位に指定 → エラー
     // （課長の上位は部長でなければならない）
-    await expect(service.execute(kachouPositionId, kachouRole.id)).rejects.toThrow(
+    await expect(service.execute(new PositionId(kachouPositionId), kachouRole.id)).rejects.toThrow(
       BusinessRuleViolationError
     );
-    await expect(service.execute(kachouPositionId, kachouRole.id)).rejects.toThrow(
+    await expect(service.execute(new PositionId(kachouPositionId), kachouRole.id)).rejects.toThrow(
       "上位役割に指定できるのは、選択した役職の上位役職に属する役割のみです"
     );
   });
 
   it("存在しない上位役割を指定するとエラー", async () => {
     await expect(
-      service.execute(kachouPositionId, "00000000-0000-7000-8000-000000000000")
+      service.execute(
+        new PositionId(kachouPositionId),
+        new RoleId("00000000-0000-7000-8000-000000000000")
+      )
     ).rejects.toThrow(BusinessRuleViolationError);
     await expect(
-      service.execute(kachouPositionId, "00000000-0000-7000-8000-000000000000")
+      service.execute(
+        new PositionId(kachouPositionId),
+        new RoleId("00000000-0000-7000-8000-000000000000")
+      )
     ).rejects.toThrow("上位役割が存在しません");
   });
 });

--- a/src/server/subdomains/role/domain/values/RoleId.ts
+++ b/src/server/subdomains/role/domain/values/RoleId.ts
@@ -1,0 +1,10 @@
+import { EntityId } from "@server/shared/domain/values/EntityId";
+
+/**
+ * 役割ID値オブジェクト
+ */
+export class RoleId extends EntityId<"RoleId"> {
+  static generate(): RoleId {
+    return new RoleId(EntityId.generateValue());
+  }
+}

--- a/src/server/subdomains/role/infrastructure/mappers/RoleMapper.ts
+++ b/src/server/subdomains/role/infrastructure/mappers/RoleMapper.ts
@@ -1,5 +1,7 @@
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleId } from "@subdomains/role/domain/values/RoleId";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
 import { Role as PrismaRole } from "@generated/prisma/client";
 
@@ -17,11 +19,11 @@ export class RoleMapper {
     const name = new RoleName(prismaRole.name);
 
     return Role.reconstruct(
-      prismaRole.id,
+      new RoleId(prismaRole.id),
       roleCd,
       name,
-      prismaRole.positionId,
-      prismaRole.superiorRoleId,
+      new PositionId(prismaRole.positionId),
+      prismaRole.superiorRoleId ? new RoleId(prismaRole.superiorRoleId) : null,
       prismaRole.createdAt,
       prismaRole.updatedAt
     );
@@ -32,11 +34,11 @@ export class RoleMapper {
    */
   static toPrismaCreate(role: Role) {
     return {
-      id: role.id,
+      id: role.id.value,
       roleCd: role.roleCd.value,
       name: role.name.value,
-      positionId: role.positionId,
-      superiorRoleId: role.superiorRoleId,
+      positionId: role.positionId.value,
+      superiorRoleId: role.superiorRoleId?.value ?? null,
     };
   }
 
@@ -47,7 +49,7 @@ export class RoleMapper {
   static toPrismaUpdate(role: Role) {
     return {
       name: role.name.value,
-      superiorRoleId: role.superiorRoleId,
+      superiorRoleId: role.superiorRoleId?.value ?? null,
       updatedAt: role.updatedAt,
     };
   }

--- a/src/server/subdomains/role/infrastructure/prisma/PrismaPositionRepository.ts
+++ b/src/server/subdomains/role/infrastructure/prisma/PrismaPositionRepository.ts
@@ -1,3 +1,4 @@
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { PositionRepository } from "@subdomains/role/domain/repositories/PositionRepository";
 import prisma from "@server/prisma";
 
@@ -8,19 +9,20 @@ import prisma from "@server/prisma";
  * 上位役割バリデーションに必要な最小限のメソッドのみ提供。
  */
 export class PrismaPositionRepository implements PositionRepository {
-  async findSuperiorPositionId(positionId: string): Promise<string | null> {
+  async findSuperiorPositionId(positionId: PositionId): Promise<PositionId | null> {
     const position = await prisma.position.findUnique({
-      where: { id: positionId },
+      where: { id: positionId.value },
       select: { superiorPositionId: true },
     });
 
     // 役職が見つからない場合は null を返す
-    return position?.superiorPositionId ?? null;
+    const superiorId = position?.superiorPositionId ?? null;
+    return superiorId ? new PositionId(superiorId) : null;
   }
 
-  async exists(positionId: string): Promise<boolean> {
+  async exists(positionId: PositionId): Promise<boolean> {
     const position = await prisma.position.findUnique({
-      where: { id: positionId },
+      where: { id: positionId.value },
       select: { id: true },
     });
 

--- a/src/server/subdomains/role/infrastructure/prisma/PrismaRoleRepository.ts
+++ b/src/server/subdomains/role/infrastructure/prisma/PrismaRoleRepository.ts
@@ -1,13 +1,14 @@
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleRepository } from "@subdomains/role/domain/repositories/RoleRepository";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleId } from "@subdomains/role/domain/values/RoleId";
 import { RoleMapper } from "@subdomains/role/infrastructure/mappers/RoleMapper";
 import prisma from "@server/prisma";
 
 export class PrismaRoleRepository implements RoleRepository {
   async save(role: Role): Promise<Role> {
     const prismaRole = await prisma.role.upsert({
-      where: { id: role.id },
+      where: { id: role.id.value },
       create: RoleMapper.toPrismaCreate(role),
       update: RoleMapper.toPrismaUpdate(role),
     });
@@ -15,15 +16,15 @@ export class PrismaRoleRepository implements RoleRepository {
     return RoleMapper.toDomain(prismaRole);
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: RoleId): Promise<void> {
     await prisma.role.delete({
-      where: { id },
+      where: { id: id.value },
     });
   }
 
-  async findById(id: string): Promise<Role | null> {
+  async findById(id: RoleId): Promise<Role | null> {
     const prismaRole = await prisma.role.findUnique({
-      where: { id },
+      where: { id: id.value },
     });
 
     return prismaRole ? RoleMapper.toDomain(prismaRole) : null;
@@ -45,19 +46,19 @@ export class PrismaRoleRepository implements RoleRepository {
     return prismaRole ? RoleMapper.toDomain(prismaRole) : null;
   }
 
-  async findSubordinates(superiorRoleId: string): Promise<Role[]> {
+  async findSubordinates(superiorRoleId: RoleId): Promise<Role[]> {
     const prismaRoles = await prisma.role.findMany({
-      where: { superiorRoleId },
+      where: { superiorRoleId: superiorRoleId.value },
       orderBy: { roleCd: "asc" },
     });
 
     return prismaRoles.map(RoleMapper.toDomain);
   }
 
-  async isInUse(roleId: string): Promise<boolean> {
+  async isInUse(roleId: RoleId): Promise<boolean> {
     const [employeeRoleCount, employeeSuperiorCount] = await Promise.all([
-      prisma.employeeRole.count({ where: { roleId } }),
-      prisma.employee.count({ where: { superiorRoleId: roleId } }),
+      prisma.employeeRole.count({ where: { roleId: roleId.value } }),
+      prisma.employee.count({ where: { superiorRoleId: roleId.value } }),
     ]);
 
     return employeeRoleCount > 0 || employeeSuperiorCount > 0;


### PR DESCRIPTION
## Summary

全エンティティ（Employee, Customer, Department, DeliveryLocation, Position, Role）のIDを生の `string` 型から型付き Value Object に置き換え、型安全性を確保しました。`StringValueObject` を継承した `EntityId` 抽象基底クラスを作成し、UUIDv7フォーマットバリデーション付きのIDクラスを各サブドメインに導入しています。

これにより、異なるエンティティのID取り違え（例: `EmployeeId` と `CustomerId`）がコンパイル時に検出可能になり、不正なUUIDv7形式の文字列によるID生成時には `ValidationError` が発生するようになりました。

Closes #189

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

# Issue #189: UUIDv7 ID Value Object の導入による型安全なエンティティID — 実装計画

## 概要

全エンティティのIDを生の `string` 型から型付き Value Object（`EmployeeId`, `CustomerId`, `DepartmentId` 等）に置き換え、型安全性を確保する。既存の `StringValueObject` を継承した `EntityId` 基底クラスを作成し、UUIDv7フォーマットバリデーション付きのIDクラスを各サブドメインに導入する。

## 設計判断

### CompanyIdの配置場所
- A. customer サブドメインに配置
- B. shared/domain/values に配置（Customer と DeliveryLocation の両方が使用するため）
- 推奨: B（CompanyCode, CompanyName と同様に共有値オブジェクトとして扱う）

### CustomerIdの配置場所
- A. customer サブドメインのみに配置
- B. shared/domain/values に配置（DeliveryLocation が外部キーとして参照するため）
- 推奨: A（DDDではIDによるサブドメイン間参照は許容。DeliveryLocationからcustomerサブドメインのCustomerIdをimport）

### EntityId.generate() のUUIDv7生成方式
- A. EntityId内で直接 uuid ライブラリを使用
- B. 既存の generateId() を内部で呼び出す
- 推奨: B（既存パターンを踏襲し、変更箇所を最小化）

## ステップ

### Step 1: EntityId基底クラス + 全ID Value Object + テスト作成
- EntityId 抽象クラス（UUIDv7正規表現バリデーション）を作成
- 各サブドメインに具体的なID Value Objectを作成
- EntityId のユニットテスト作成

### Step 2: Employee サブドメインの全レイヤー更新

### Step 3: Department サブドメインの全レイヤー更新

### Step 4: Customer サブドメインの全レイヤー更新

### Step 5: DeliveryLocation サブドメインの全レイヤー更新

### Step 6: Position + Role サブドメインの全レイヤー更新

### Step 7: 最終検証（lint, test）

</details>

## 計画からの逸脱

### Customer + DeliveryLocation サブドメインの同時コミット

- **計画**: Step 4（Customer）と Step 5（DeliveryLocation）を個別にコミット
- **実際**: 2つのサブドメインを1つのコミットにまとめて実施
- **理由**: DeliveryLocation が Customer の `CustomerId` を外部キーとして参照しているため、Customer の ID を `string` → `CustomerId` に変更すると、DeliveryLocation 側の TypeScript コンパイルが失敗する。pre-commit フックで全体の型チェックが走るため、両サブドメインを同時に更新・コミットする必要があった。

## Test Plan

- [x] EntityId 基底クラスのユニットテスト（バリデーション、generate、equals）
- [x] 各サブドメインのエンティティテスト更新（EmployeeId, DepartmentId, CustomerId, DeliveryLocationId, PositionId, RoleId）
- [x] ドメインサービステスト更新（重複チェック、上位役割バリデーション等）
- [x] アプリケーション層テスト更新（Create/Update/Delete コマンド、クエリ）
- [x] インフラ層テスト更新（PrismaEmployeeRepository 等）
- [ ] `pnpm lint` 成功確認
- [ ] `pnpm test` 全件パス確認
- [ ] `pnpm build` 成功確認

---

Generated with [Claude Code](https://claude.ai/code)