### PR TITLE
test: 役割管理画面のE2Eテスト作成

### DIFF
--- a/docs/claude-plans/issue-187/drifting-moseying-rain.md
+++ b/docs/claude-plans/issue-187/drifting-moseying-rain.md
@@ -1,0 +1,119 @@
+# Issue #187: 役割管理画面のE2Eテスト作成 — 実装計画
+
+## 概要
+
+#175 で実装した役割管理画面（一覧・新規作成・編集・削除）のE2Eテストを Playwright で作成する。
+既存の従業員E2Eテスト（`employees-list.e2e.ts`, `employees-create.e2e.ts`, `employees-detail.e2e.ts`）のパターンに準拠し、動的上位役割フィルタリングのテストも含む。
+
+## 設計判断
+
+### テストファイル構成
+- 従業員テストと同じ3ファイル構成（list / create / detail）で統一
+- 動的フィルタリングテストは `roles-create.e2e.ts` に含める（クライアント側フィルタリングは新規作成フォームのみ）
+
+### テストデータ戦略
+- テスト用の役割コード: `ROLE901`（create用）、`ROLE902`（detail用）— シード範囲 ROLE001〜ROLE015 外
+- 削除エラーテストはシードデータを利用（ROLE001: 下位役割あり、ROLE009: 従業員割当あり）
+- 作成テストは `afterEach` でUI経由クリーンアップ（従業員テストと同パターン）
+- 削除テストは `beforeEach` で `createTestRole()` ヘルパーを使い一時データ作成
+
+### 非管理者アクセステスト
+- 従業員テストと同じく `/signin?reason=forbidden` リダイレクトを期待する
+- 前提: `src/proxy.ts` の `adminRoutes` に `/roles/new` を追加する修正が別ブランチで行われ、本ブランチに取り込まれていること
+
+## ステップ
+
+### Step 1: 役割一覧E2Eテスト作成
+
+- 対象ファイル: `src/app/(features)/roles/roles-list.e2e.ts`
+- 作業内容:
+  - `waitForListReady()` ヘルパー作成（heading「役割管理」+ テーブル行の表示を待機）
+  - 管理者テスト:
+    - `一覧が表示され、管理者には「新規登録」ボタンが見える` — ページ表示、heading、新規登録リンク、DataTable行
+    - `役割名で検索（部分一致）できる` — "営業" で検索、URL検証、結果に営業系役割表示
+    - `役割コードで検索（完全一致）できる` — "ROLE001" で検索、結果1行、リンク表示
+    - `役職で検索できる` — "課長" 選択、URL検証、表示される役職列がすべて "課長"
+    - `クリアボタンで検索条件がリセットされる` — `/roles?name=営業` → クリア → `/roles`
+    - `役割コードリンクから詳細画面に遷移できる` — ROLE001 リンククリック → `/roles/ROLE001`
+  - 一般ユーザーテスト:
+    - `一般ユーザーには「新規登録」ボタンが見えない` — storageState切替、テーブル行あり、新規登録リンクなし
+- 参考ファイル: `src/app/(features)/employees/employees-list.e2e.ts`
+- コミットメッセージ: `test(e2e): 役割一覧画面のE2Eテスト作成 (#187)`
+
+### Step 2: 役割新規作成・動的フィルタリングE2Eテスト作成
+
+- 対象ファイル: `src/app/(features)/roles/roles-create.e2e.ts`
+- 作業内容:
+  - テストデータ定数: `TEST_ROLE_CD = "ROLE901"`
+  - `afterEach` クリーンアップ: `/roles/ROLE901` に遷移して削除ボタンクリック
+  - 管理者テスト（作成）:
+    - `管理者が新規役割を作成できる` — 一覧→新規→フォーム入力（ROLE901、E2Eテスト役割、課長、上位役割選択）→登録→リダイレクト→トースト「役割を登録しました。」→検索確認
+    - `重複する役割コードでエラーが表示される` — ROLE001（既存）で登録→ `role="alert"` 表示、ページ遷移なし
+    - `役割名が未入力でバリデーションエラーが表示される` — 名前空のまま登録→エラー表示
+    - `キャンセルボタンで一覧に戻れる` — キャンセルクリック→ `/roles`
+  - 管理者テスト（動的上位役割フィルタリング）:
+    - `役職選択で上位役割候補がフィルタリングされる` — 課長選択→上位役割ドロップダウン表示→部長系役割がオプションに含まれる
+    - `役職変更で上位役割の選択がリセットされる` — 課長→上位役割選択→部長に変更→上位役割リセット、本部長系がオプションに
+    - `最上位役職では上位役割が表示されない` — 社長選択→上位役割ドロップダウン非表示→メッセージ「この役職には上位役職がないため、上位役割は設定できません。」表示
+    - `本部長選択で社長の役割が上位候補になる` — 本部長選択→上位役割表示→「社長」がオプションに
+  - 一般ユーザーテスト:
+    - `一般ユーザーは新規作成画面にアクセスできない` — `/roles/new` → `/signin?reason=forbidden` リダイレクト
+- 参考ファイル: `src/app/(features)/employees/employees-create.e2e.ts`, `src/app/(features)/roles/new/RoleCreateForm.tsx`
+- コミットメッセージ: `test(e2e): 役割新規作成・動的フィルタリングのE2Eテスト作成 (#187)`
+
+### Step 3: 役割詳細・編集・削除E2Eテスト作成
+
+- 対象ファイル: `src/app/(features)/roles/roles-detail.e2e.ts`
+- 作業内容:
+  - テストデータ定数: `TEST_ROLE_CD = "ROLE902"`
+  - `createTestRole()` ヘルパー: `/roles/new` からフォーム入力→登録→リダイレクト待ち
+  - 管理者テスト（更新・削除成功） — `test.describe` で囲み、共通の `beforeEach` で ROLE902 作成:
+    - `管理者が役割情報を更新できる` — `/roles/ROLE902` → 「役割変更」表示 → 役割コード/役職が disabled → 名前変更 → 更新ボタン → トースト「役割情報を更新しました。」→ 値反映確認 → afterEach で削除
+    - `管理者が未使用の役割を削除できる` — `/roles/ROLE902` → 削除ボタン → `/roles` リダイレクト → トースト「役割を削除しました。」→ 検索で見つからない
+  - 管理者テスト（削除エラー）:
+    - `使用中の役割は削除できない` — `/roles/ROLE009`（従業員割当あり）→ 削除 → `role="alert"` にエラーメッセージ表示 → ページ遷移なし
+    - `下位役割がある役割は削除できない` — `/roles/ROLE001`（下位役割あり）→ 削除 → `role="alert"` にエラーメッセージ表示 → ページ遷移なし
+  - 管理者テスト（404）:
+    - `存在しない役割コードで404が表示される` — `/roles/ROLE999` → 404 表示
+  - 一般ユーザーテスト:
+    - `一般ユーザーは閲覧のみ` — storageState切替 → `/roles/ROLE001` → 「役割詳細」表示（「役割変更」ではない）→ 名前フィールド disabled → 更新/削除ボタン非表示
+- 参考ファイル: `src/app/(features)/employees/employees-detail.e2e.ts`, `src/app/(features)/roles/[roleCd]/RoleUpdateForm.tsx`, `src/app/(features)/roles/[roleCd]/RoleDeleteForm.tsx`
+- コミットメッセージ: `test(e2e): 役割詳細・編集・削除のE2Eテスト作成 (#187)`
+
+## 実装上の注意点
+
+- 役職ドロップダウンは UUID を value に使用。テストでは `selectOption({ label: "課長" })` で選択
+- 上位役割ドロップダウンは条件付きレンダリング（`selectedPositionId && superiorRoleOptions.length > 0`）。Playwright の auto-wait で対応可能だが、タイミング問題があれば `waitFor` 追加
+- トーストメッセージは `redirect-reason-toast` コンポーネント経由。リダイレクト後にページロード完了を待つ必要がある
+- 削除エラーは `useActionState` で管理され、`role="alert"` の div に表示（リダイレクトなし）
+- 更新テストでシードデータの名前を変更する場合、他テストへの影響を避けるためテスト専用の ROLE902 を使用
+
+## 実装時の逸脱（Deviations）
+
+### Step 1: roles-list.e2e.ts
+
+- **URLアサーション変更**: `/name=営業/` → `/name=/` に変更。日本語がURLエンコード（`%E5%96%B6%E6%A5%AD`）されるため、パラメータの存在のみ検証する形に修正。
+- **検索結果の検証方法変更**: `getByText("営業本部長")` → 全行の役割名列（`td:nth-child(2)`）に対して `toContainText("営業")` で部分一致検証。「営業本部長」が複数セルにマッチし strict mode violation が発生したため。
+
+### Step 2: roles-create.e2e.ts
+
+- **afterEachのスコープ変更**: 計画では内側の「データ作成テスト」describe 内に配置する想定だったが、外側の「役割新規作成（管理者）」describe に移動し、内側の wrapper を削除。並列実行時にスコープが限定されすぎてテストが不安定になったため。
+
+### Step 3: roles-detail.e2e.ts
+
+- **beforeEach → beforeAll + serial に変更**: 計画では `test.describe` + `beforeEach`（毎回 ROLE902 作成）だったが、`test.describe.serial` + `beforeAll`（1回だけ作成）に変更。`fullyParallel: true` 環境で更新・削除テストが同時実行されフレーキーテストになったため、serial で順序保証する方式に。
+- **beforeAll内の認証方法**: `browser.newPage()` では project の storageState が継承されないため、`browser.newContext({ storageState: "playwright/.auth/admin.json" })` を使用して管理者認証を明示的に指定。
+- **afterEach削除**: serial 実行で更新→削除の順が保証されるため、削除テスト自体がクリーンアップを兼ねる。計画にあった afterEach での削除処理は不要に。
+
+## 検証方法
+
+```bash
+# 役割E2Eテストのみ実行
+pnpm exec playwright test src/app/\(features\)/roles/
+
+# 全E2Eテスト実行（既存テストとの干渉がないことを確認）
+pnpm e2e
+
+# UIモードで確認
+pnpm e2e:ui
+```

--- a/src/app/(features)/roles/roles-create.e2e.ts
+++ b/src/app/(features)/roles/roles-create.e2e.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "@playwright/test";
+
+/** テストで使用する固定の役割データ（seed範囲 ROLE001〜ROLE015 外） */
+const TEST_ROLE_CD = "ROLE901";
+
+test.describe("役割新規作成（管理者）", () => {
+  test.describe("データ作成テスト", () => {
+    // 暫定対応: テストで作成した役割をUIから削除する
+    test.afterEach(async ({ page }) => {
+      await page.goto(`/roles/${TEST_ROLE_CD}`);
+      const deleteButton = page.getByRole("button", { name: "削除" });
+      if (await deleteButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await deleteButton.click();
+        await expect(page).toHaveURL(/\/roles/, { timeout: 10000 });
+      }
+    });
+
+    test("管理者が新規役割を作成できる", async ({ page }) => {
+      // 一覧画面から新規登録画面に遷移
+      await page.goto("/roles");
+      await page.getByRole("link", { name: "新規登録" }).click();
+      await expect(page).toHaveURL("/roles/new", { timeout: 10000 });
+      await expect(page.getByRole("heading", { name: "新規役割登録" })).toBeVisible();
+
+      // フォーム入力
+      await page.getByLabel("役割コード").fill(TEST_ROLE_CD);
+      await page.getByLabel("役割名").fill("E2Eテスト役割");
+      await page.getByLabel("役職").selectOption({ label: "課長" });
+      // 上位役割ドロップダウンが表示されるのを待って選択
+      await expect(page.getByLabel("上位役割")).toBeVisible();
+      await page.getByLabel("上位役割").selectOption({ index: 1 }); // 最初の上位役割を選択
+
+      // 登録実行
+      await page.getByRole("button", { name: "登録" }).click();
+
+      // 一覧画面にリダイレクトされ、成功トーストが表示される
+      await expect(page).toHaveURL(/\/roles/, { timeout: 10000 });
+      await page.waitForLoadState("load");
+      await expect(page.getByText("役割を登録しました。")).toBeVisible({ timeout: 10000 });
+
+      // 作成した役割が検索で見つかる
+      await expect(page.locator("table tbody tr").first()).toBeVisible();
+      await page.getByLabel("役割コード").fill(TEST_ROLE_CD);
+      await page.getByRole("button", { name: "検索" }).click();
+      await expect(page).toHaveURL(new RegExp(`roleCd=${TEST_ROLE_CD}`), {
+        timeout: 10000,
+      });
+      await expect(page.getByRole("link", { name: TEST_ROLE_CD })).toBeVisible();
+    });
+  });
+
+  test("重複する役割コードでエラーが表示される", async ({ page }) => {
+    await page.goto("/roles/new");
+
+    await page.getByLabel("役割コード").fill("ROLE001"); // 既存の役割コード
+    await page.getByLabel("役割名").fill("重複テスト");
+    await page.getByLabel("役職").selectOption({ label: "課長" });
+
+    await page.getByRole("button", { name: "登録" }).click();
+
+    // エラーメッセージが表示される（ページは遷移しない）
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(/\/roles\/new/);
+  });
+
+  test("役割名が未入力でバリデーションエラーが表示される", async ({ page }) => {
+    await page.goto("/roles/new");
+
+    await page.getByLabel("役割コード").fill(TEST_ROLE_CD);
+    // 役割名は空のまま
+    await page.getByLabel("役職").selectOption({ label: "課長" });
+
+    await page.getByRole("button", { name: "登録" }).click();
+
+    // バリデーションエラーが表示される
+    await expect(page.getByText(/役割名/)).toBeVisible();
+  });
+
+  test("キャンセルボタンで一覧に戻れる", async ({ page }) => {
+    await page.goto("/roles/new");
+
+    await page.getByRole("link", { name: "キャンセル" }).click();
+
+    await expect(page).toHaveURL(/\/roles$/, { timeout: 10000 });
+  });
+});
+
+test.describe("動的上位役割フィルタリング（管理者）", () => {
+  test("役職選択で上位役割候補がフィルタリングされる", async ({ page }) => {
+    await page.goto("/roles/new");
+
+    // 課長を選択すると、上位役割に部長系の役割が表示される
+    await page.getByLabel("役職").selectOption({ label: "課長" });
+
+    await expect(page.getByLabel("上位役割")).toBeVisible();
+    // 部長系の役割がオプションに含まれること
+    const options = page.getByLabel("上位役割").locator("option");
+    await expect(options.filter({ hasText: "営業部長" })).toBeAttached();
+    await expect(options.filter({ hasText: "開発部長" })).toBeAttached();
+  });
+
+  test("役職変更で上位役割の選択がリセットされる", async ({ page }) => {
+    await page.goto("/roles/new");
+
+    // 課長を選択して上位役割を選ぶ
+    await page.getByLabel("役職").selectOption({ label: "課長" });
+    await expect(page.getByLabel("上位役割")).toBeVisible();
+    await page.getByLabel("上位役割").selectOption({ index: 1 });
+
+    // 部長に変更すると上位役割の選択肢が本部長系に変わる
+    await page.getByLabel("役職").selectOption({ label: "部長" });
+    await expect(page.getByLabel("上位役割")).toBeVisible();
+    // 本部長系がオプションに含まれること
+    const options = page.getByLabel("上位役割").locator("option");
+    await expect(options.filter({ hasText: "営業本部長" })).toBeAttached();
+    await expect(options.filter({ hasText: "管理本部長" })).toBeAttached();
+  });
+
+  test("最上位役職では上位役割が表示されない", async ({ page }) => {
+    await page.goto("/roles/new");
+
+    // 社長を選択すると上位役割ドロップダウンは非表示
+    await page.getByLabel("役職").selectOption({ label: "社長" });
+
+    await expect(page.getByLabel("上位役割")).not.toBeVisible();
+    await expect(
+      page.getByText("この役職には上位役職がないため、上位役割は設定できません。")
+    ).toBeVisible();
+  });
+
+  test("本部長選択で社長の役割が上位候補になる", async ({ page }) => {
+    await page.goto("/roles/new");
+
+    // 本部長を選択すると上位役割に社長が表示される
+    await page.getByLabel("役職").selectOption({ label: "本部長" });
+
+    await expect(page.getByLabel("上位役割")).toBeVisible();
+    const options = page.getByLabel("上位役割").locator("option");
+    await expect(options.filter({ hasText: "社長" })).toBeAttached();
+  });
+});
+
+test.describe("役割新規作成（一般ユーザー）", () => {
+  test.use({ storageState: "playwright/.auth/user.json" });
+
+  test("一般ユーザーは新規作成画面にアクセスできない", async ({ page }) => {
+    await page.goto("/roles/new");
+
+    // 権限がないため /signin にリダイレクトされる
+    await expect(page).toHaveURL(/\/signin\?reason=forbidden/, { timeout: 10000 });
+  });
+});

--- a/src/app/(features)/roles/roles-create.e2e.ts
+++ b/src/app/(features)/roles/roles-create.e2e.ts
@@ -4,49 +4,47 @@ import { expect, test } from "@playwright/test";
 const TEST_ROLE_CD = "ROLE901";
 
 test.describe("役割新規作成（管理者）", () => {
-  test.describe("データ作成テスト", () => {
-    // 暫定対応: テストで作成した役割をUIから削除する
-    test.afterEach(async ({ page }) => {
-      await page.goto(`/roles/${TEST_ROLE_CD}`);
-      const deleteButton = page.getByRole("button", { name: "削除" });
-      if (await deleteButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-        await deleteButton.click();
-        await expect(page).toHaveURL(/\/roles/, { timeout: 10000 });
-      }
-    });
-
-    test("管理者が新規役割を作成できる", async ({ page }) => {
-      // 一覧画面から新規登録画面に遷移
-      await page.goto("/roles");
-      await page.getByRole("link", { name: "新規登録" }).click();
-      await expect(page).toHaveURL("/roles/new", { timeout: 10000 });
-      await expect(page.getByRole("heading", { name: "新規役割登録" })).toBeVisible();
-
-      // フォーム入力
-      await page.getByLabel("役割コード").fill(TEST_ROLE_CD);
-      await page.getByLabel("役割名").fill("E2Eテスト役割");
-      await page.getByLabel("役職").selectOption({ label: "課長" });
-      // 上位役割ドロップダウンが表示されるのを待って選択
-      await expect(page.getByLabel("上位役割")).toBeVisible();
-      await page.getByLabel("上位役割").selectOption({ index: 1 }); // 最初の上位役割を選択
-
-      // 登録実行
-      await page.getByRole("button", { name: "登録" }).click();
-
-      // 一覧画面にリダイレクトされ、成功トーストが表示される
+  // 暫定対応: テストで作成した役割をUIから削除する
+  test.afterEach(async ({ page }) => {
+    await page.goto(`/roles/${TEST_ROLE_CD}`);
+    const deleteButton = page.getByRole("button", { name: "削除" });
+    if (await deleteButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await deleteButton.click();
       await expect(page).toHaveURL(/\/roles/, { timeout: 10000 });
-      await page.waitForLoadState("load");
-      await expect(page.getByText("役割を登録しました。")).toBeVisible({ timeout: 10000 });
+    }
+  });
 
-      // 作成した役割が検索で見つかる
-      await expect(page.locator("table tbody tr").first()).toBeVisible();
-      await page.getByLabel("役割コード").fill(TEST_ROLE_CD);
-      await page.getByRole("button", { name: "検索" }).click();
-      await expect(page).toHaveURL(new RegExp(`roleCd=${TEST_ROLE_CD}`), {
-        timeout: 10000,
-      });
-      await expect(page.getByRole("link", { name: TEST_ROLE_CD })).toBeVisible();
+  test("管理者が新規役割を作成できる", async ({ page }) => {
+    // 一覧画面から新規登録画面に遷移
+    await page.goto("/roles");
+    await page.getByRole("link", { name: "新規登録" }).click();
+    await expect(page).toHaveURL("/roles/new", { timeout: 10000 });
+    await expect(page.getByRole("heading", { name: "新規役割登録" })).toBeVisible();
+
+    // フォーム入力
+    await page.getByLabel("役割コード").fill(TEST_ROLE_CD);
+    await page.getByLabel("役割名").fill("E2Eテスト役割");
+    await page.getByLabel("役職").selectOption({ label: "課長" });
+    // 上位役割ドロップダウンが表示されるのを待って選択
+    await expect(page.getByLabel("上位役割")).toBeVisible();
+    await page.getByLabel("上位役割").selectOption({ index: 1 }); // 最初の上位役割を選択
+
+    // 登録実行
+    await page.getByRole("button", { name: "登録" }).click();
+
+    // 一覧画面にリダイレクトされ、成功トーストが表示される
+    await expect(page).toHaveURL(/\/roles/, { timeout: 10000 });
+    await page.waitForLoadState("load");
+    await expect(page.getByText("役割を登録しました。")).toBeVisible({ timeout: 10000 });
+
+    // 作成した役割が検索で見つかる
+    await expect(page.locator("table tbody tr").first()).toBeVisible();
+    await page.getByLabel("役割コード").fill(TEST_ROLE_CD);
+    await page.getByRole("button", { name: "検索" }).click();
+    await expect(page).toHaveURL(new RegExp(`roleCd=${TEST_ROLE_CD}`), {
+      timeout: 10000,
     });
+    await expect(page.getByRole("link", { name: TEST_ROLE_CD })).toBeVisible();
   });
 
   test("重複する役割コードでエラーが表示される", async ({ page }) => {

--- a/src/app/(features)/roles/roles-detail.e2e.ts
+++ b/src/app/(features)/roles/roles-detail.e2e.ts
@@ -25,12 +25,16 @@ test.describe("役割詳細・編集・削除（管理者）", () => {
   // 更新→削除の順で実行（同一テストデータを使い回すため serial で順序保証）
   test.describe.serial("更新・削除テスト", () => {
     test.beforeAll(async ({ browser }) => {
-      const page = await browser.newPage();
+      const context = await browser.newContext({
+        storageState: "playwright/.auth/admin.json",
+      });
+      const page = await context.newPage();
       await createTestRole(page, {
         roleCd: TEST_ROLE_CD,
         name: "E2E詳細テスト役割",
       });
       await page.close();
+      await context.close();
     });
 
     test("管理者が役割情報を更新できる", async ({ page }) => {

--- a/src/app/(features)/roles/roles-detail.e2e.ts
+++ b/src/app/(features)/roles/roles-detail.e2e.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+
+/** テストで使用する固定の役割データ（seed範囲 ROLE001〜ROLE015 外） */
+const TEST_ROLE_CD = "ROLE902";
+
+/**
+ * テスト用役割を新規作成画面から作成し、一覧にリダイレクトされるまで待つ。
+ */
+async function createTestRole(
+  page: import("@playwright/test").Page,
+  data: { roleCd: string; name: string }
+) {
+  await page.goto("/roles/new");
+  await expect(page.getByRole("heading", { name: "新規役割登録" })).toBeVisible();
+  await page.getByLabel("役割コード").fill(data.roleCd);
+  await page.getByLabel("役割名").fill(data.name);
+  await page.getByLabel("役職").selectOption({ label: "課長" });
+  await expect(page.getByLabel("上位役割")).toBeVisible();
+  await page.getByLabel("上位役割").selectOption({ index: 1 });
+  await page.getByRole("button", { name: "登録" }).click();
+  await expect(page).toHaveURL(/\/roles/, { timeout: 10000 });
+}
+
+test.describe("役割詳細・編集・削除（管理者）", () => {
+  test.describe("更新・削除テスト", () => {
+    test.beforeEach(async ({ page }) => {
+      await createTestRole(page, {
+        roleCd: TEST_ROLE_CD,
+        name: "E2E詳細テスト役割",
+      });
+    });
+
+    // テストで作成した役割をUIから削除（削除テスト後は既に消えているため catch で吸収）
+    test.afterEach(async ({ page }) => {
+      await page.goto(`/roles/${TEST_ROLE_CD}`);
+      const deleteButton = page.getByRole("button", { name: "削除" });
+      if (await deleteButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await deleteButton.click();
+        await expect(page).toHaveURL(/\/roles/, { timeout: 10000 });
+      }
+    });
+
+    test("管理者が役割情報を更新できる", async ({ page }) => {
+      await page.goto(`/roles/${TEST_ROLE_CD}`);
+
+      // 編集モードで表示されること
+      await expect(page.getByRole("heading", { name: "役割管理" })).toBeVisible();
+      await expect(page.getByText("役割変更")).toBeVisible();
+
+      // 役割コードと役職が読み取り専用であること
+      await expect(page.locator("#roleCd-display")).toBeDisabled();
+      await expect(page.locator("#positionName-display")).toBeDisabled();
+
+      // 名前を変更して更新
+      const nameField = page.getByLabel("役割名");
+      await nameField.clear();
+      await nameField.fill("E2E更新テスト役割");
+      await page.getByRole("button", { name: "更新" }).click();
+
+      // 成功トーストが表示される
+      await expect(page.getByText("役割情報を更新しました。")).toBeVisible({ timeout: 10000 });
+
+      // 変更が反映されていること
+      await expect(nameField).toHaveValue("E2E更新テスト役割");
+    });
+
+    test("管理者が未使用の役割を削除できる", async ({ page }) => {
+      // 作成した役割の詳細画面に遷移
+      await page.goto(`/roles/${TEST_ROLE_CD}`);
+      await expect(page.getByText("役割変更")).toBeVisible();
+
+      // 削除実行
+      await page.getByRole("button", { name: "削除" }).click();
+
+      // 一覧画面にリダイレクトされ、成功トーストが表示される
+      await expect(page).toHaveURL(/\/roles/, { timeout: 10000 });
+      await expect(page.getByText("役割を削除しました。")).toBeVisible({ timeout: 10000 });
+
+      // 削除した役割が検索で見つからない
+      await expect(page.locator("table tbody tr").first()).toBeVisible();
+      await page.getByLabel("役割コード").fill(TEST_ROLE_CD);
+      await page.getByRole("button", { name: "検索" }).click();
+      await expect(page).toHaveURL(new RegExp(`roleCd=${TEST_ROLE_CD}`), {
+        timeout: 10000,
+      });
+      await expect(page.getByRole("link", { name: TEST_ROLE_CD })).not.toBeVisible();
+    });
+  });
+
+  test("使用中の役割は削除できない", async ({ page }) => {
+    // ROLE009（営業一課長）は従業員に割り当てられている
+    await page.goto("/roles/ROLE009");
+    await expect(page.getByText("役割変更")).toBeVisible();
+
+    await page.getByRole("button", { name: "削除" }).click();
+
+    // エラーメッセージが表示される（ページは遷移しない）
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(/\/roles\/ROLE009/);
+  });
+
+  test("下位役割がある役割は削除できない", async ({ page }) => {
+    // ROLE001（社長）は下位役割（ROLE002, ROLE003）を持つ
+    await page.goto("/roles/ROLE001");
+    await expect(page.getByText("役割変更")).toBeVisible();
+
+    await page.getByRole("button", { name: "削除" }).click();
+
+    // エラーメッセージが表示される（ページは遷移しない）
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(/\/roles\/ROLE001/);
+  });
+
+  test("存在しない役割コードで404が表示される", async ({ page }) => {
+    await page.goto("/roles/ROLE999");
+
+    // 404ページが表示されること
+    await expect(page.getByText("404")).toBeVisible({ timeout: 10000 });
+  });
+});
+
+test.describe("役割詳細（一般ユーザー）", () => {
+  test.use({ storageState: "playwright/.auth/user.json" });
+
+  test("一般ユーザーは閲覧のみ", async ({ page }) => {
+    await page.goto("/roles/ROLE001");
+
+    // 閲覧モードで表示されること
+    await expect(page.getByText("役割詳細")).toBeVisible();
+    // フィールドが無効（disabled）
+    await expect(page.getByLabel("役割名")).toBeDisabled();
+    // 更新ボタンが表示されない
+    await expect(page.getByRole("button", { name: "更新" })).not.toBeVisible();
+    // 削除ボタンが表示されない
+    await expect(page.getByRole("button", { name: "削除" })).not.toBeVisible();
+  });
+});

--- a/src/app/(features)/roles/roles-detail.e2e.ts
+++ b/src/app/(features)/roles/roles-detail.e2e.ts
@@ -22,22 +22,15 @@ async function createTestRole(
 }
 
 test.describe("役割詳細・編集・削除（管理者）", () => {
-  test.describe("更新・削除テスト", () => {
-    test.beforeEach(async ({ page }) => {
+  // 更新→削除の順で実行（同一テストデータを使い回すため serial で順序保証）
+  test.describe.serial("更新・削除テスト", () => {
+    test.beforeAll(async ({ browser }) => {
+      const page = await browser.newPage();
       await createTestRole(page, {
         roleCd: TEST_ROLE_CD,
         name: "E2E詳細テスト役割",
       });
-    });
-
-    // テストで作成した役割をUIから削除（削除テスト後は既に消えているため catch で吸収）
-    test.afterEach(async ({ page }) => {
-      await page.goto(`/roles/${TEST_ROLE_CD}`);
-      const deleteButton = page.getByRole("button", { name: "削除" });
-      if (await deleteButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-        await deleteButton.click();
-        await expect(page).toHaveURL(/\/roles/, { timeout: 10000 });
-      }
+      await page.close();
     });
 
     test("管理者が役割情報を更新できる", async ({ page }) => {
@@ -65,7 +58,7 @@ test.describe("役割詳細・編集・削除（管理者）", () => {
     });
 
     test("管理者が未使用の役割を削除できる", async ({ page }) => {
-      // 作成した役割の詳細画面に遷移
+      // 更新テストで作成済みの役割の詳細画面に遷移
       await page.goto(`/roles/${TEST_ROLE_CD}`);
       await expect(page.getByText("役割変更")).toBeVisible();
 

--- a/src/app/(features)/roles/roles-list.e2e.ts
+++ b/src/app/(features)/roles/roles-list.e2e.ts
@@ -32,7 +32,13 @@ test.describe("役割一覧（管理者）", () => {
     await page.getByRole("button", { name: "検索" }).click();
 
     await expect(page).toHaveURL(/name=/, { timeout: 10000 });
-    await expect(page.getByText("営業本部長")).toBeVisible();
+    // 表示されている役割名列がすべて「営業」を含むこと
+    const nameCells = page.locator("table tbody tr td:nth-child(2)");
+    const count = await nameCells.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(nameCells.nth(i)).toContainText("営業");
+    }
   });
 
   test("役割コードで検索（完全一致）できる", async ({ page }) => {

--- a/src/app/(features)/roles/roles-list.e2e.ts
+++ b/src/app/(features)/roles/roles-list.e2e.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * 一覧画面のハイドレーション完了を待つ。
+ * SearchForm（"use client"）の onSubmit が機能するには React のハイドレーションが必要。
+ * DataTable の行が表示された時点で、ページ全体がインタラクティブになっていると判断する。
+ */
+async function waitForListReady(page: import("@playwright/test").Page) {
+  await expect(page.getByRole("heading", { name: "役割管理" })).toBeVisible();
+  await expect(page.locator("table tbody tr").first()).toBeVisible();
+}
+
+test.describe("役割一覧（管理者）", () => {
+  test("一覧が表示され、管理者には「新規登録」ボタンが見える", async ({ page }) => {
+    await page.goto("/roles");
+    await waitForListReady(page);
+
+    await expect(page.getByRole("heading", { name: "役割管理" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "新規登録" })).toBeVisible();
+
+    // DataTableに行が表示されていること
+    await expect(page.getByRole("heading", { name: "役割一覧" })).toBeVisible();
+    const rows = page.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible();
+  });
+
+  test("役割名で検索（部分一致）できる", async ({ page }) => {
+    await page.goto("/roles");
+    await waitForListReady(page);
+
+    await page.getByLabel("役割名").fill("営業");
+    await page.getByRole("button", { name: "検索" }).click();
+
+    await expect(page).toHaveURL(/name=営業/, { timeout: 10000 });
+    await expect(page.getByText("営業本部長")).toBeVisible();
+  });
+
+  test("役割コードで検索（完全一致）できる", async ({ page }) => {
+    await page.goto("/roles");
+    await waitForListReady(page);
+
+    await page.getByLabel("役割コード").fill("ROLE001");
+    await page.getByRole("button", { name: "検索" }).click();
+
+    await expect(page).toHaveURL(/roleCd=ROLE001/, { timeout: 10000 });
+    // 検索結果が1行のみ表示されること
+    const rows = page.locator("table tbody tr");
+    await expect(rows).toHaveCount(1);
+    await expect(page.getByRole("link", { name: "ROLE001" })).toBeVisible();
+  });
+
+  test("役職で検索できる", async ({ page }) => {
+    await page.goto("/roles");
+    await waitForListReady(page);
+
+    await page.getByLabel("役職").selectOption({ label: "課長" });
+    await page.getByRole("button", { name: "検索" }).click();
+
+    await expect(page).toHaveURL(/positionId=/, { timeout: 10000 });
+    // 表示されている役職列がすべて「課長」であること
+    const positionCells = page.locator("table tbody tr td:nth-child(3)");
+    const count = await positionCells.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(positionCells.nth(i)).toHaveText("課長");
+    }
+  });
+
+  test("クリアボタンで検索条件がリセットされる", async ({ page }) => {
+    await page.goto("/roles?name=営業");
+    await waitForListReady(page);
+
+    // 検索フィールドにデフォルト値が入っていること
+    await expect(page.getByLabel("役割名")).toHaveValue("営業");
+
+    await page.getByRole("button", { name: "クリア" }).click();
+
+    await expect(page).toHaveURL(/\/roles$/, { timeout: 10000 });
+    await expect(page.getByLabel("役割名")).toHaveValue("");
+  });
+
+  test("役割コードリンクから詳細画面に遷移できる", async ({ page }) => {
+    await page.goto("/roles?roleCd=ROLE001");
+    await waitForListReady(page);
+
+    await page.getByRole("link", { name: "ROLE001" }).click();
+
+    await expect(page).toHaveURL(/\/roles\/ROLE001/, { timeout: 10000 });
+    await expect(page.getByRole("heading", { name: "役割管理" })).toBeVisible();
+  });
+});
+
+test.describe("役割一覧（一般ユーザー）", () => {
+  test.use({ storageState: "playwright/.auth/user.json" });
+
+  test("一般ユーザーには「新規登録」ボタンが見えない", async ({ page }) => {
+    await page.goto("/roles");
+
+    await expect(page.getByRole("heading", { name: "役割管理" })).toBeVisible();
+    // DataTableの行は表示される
+    const rows = page.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible();
+    // 「新規登録」リンクは表示されない
+    await expect(page.getByRole("link", { name: "新規登録" })).not.toBeVisible();
+  });
+});

--- a/src/app/(features)/roles/roles-list.e2e.ts
+++ b/src/app/(features)/roles/roles-list.e2e.ts
@@ -31,7 +31,7 @@ test.describe("役割一覧（管理者）", () => {
     await page.getByLabel("役割名").fill("営業");
     await page.getByRole("button", { name: "検索" }).click();
 
-    await expect(page).toHaveURL(/name=営業/, { timeout: 10000 });
+    await expect(page).toHaveURL(/name=/, { timeout: 10000 });
     await expect(page.getByText("営業本部長")).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

#175 で実装した役割管理画面（一覧・新規作成・編集・削除）のE2Eテストを Playwright で作成した。既存の従業員E2Eテストパターンに準拠し、3ファイル構成（list / create / detail）で統一。動的上位役割フィルタリングのテストも含む。

Closes #187

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### 概要

#175 で実装した役割管理画面（一覧・新規作成・編集・削除）のE2Eテストを Playwright で作成する。
既存の従業員E2Eテスト（`employees-list.e2e.ts`, `employees-create.e2e.ts`, `employees-detail.e2e.ts`）のパターンに準拠し、動的上位役割フィルタリングのテストも含む。

### 設計判断

- **テストファイル構成**: 従業員テストと同じ3ファイル構成（list / create / detail）で統一。動的フィルタリングテストは `roles-create.e2e.ts` に含める
- **テストデータ戦略**: テスト用の役割コード `ROLE901`（create用）、`ROLE902`（detail用）。削除エラーテストはシードデータを利用（ROLE001: 下位役割あり、ROLE009: 従業員割当あり）
- **非管理者アクセステスト**: 従業員テストと同じく `/signin?reason=forbidden` リダイレクトを期待

### ステップ

1. **Step 1**: 役割一覧E2Eテスト作成（`roles-list.e2e.ts`）— 管理者・一般ユーザーの一覧表示、検索、遷移テスト
2. **Step 2**: 役割新規作成・動的フィルタリングE2Eテスト作成（`roles-create.e2e.ts`）— CRUD作成、バリデーション、動的上位役割フィルタリングテスト
3. **Step 3**: 役割詳細・編集・削除E2Eテスト作成（`roles-detail.e2e.ts`）— 更新、削除成功/エラー、404、一般ユーザー閲覧のみ

</details>

## 計画からの逸脱

### Step 1: roles-list.e2e.ts

- **URLアサーション変更**: 日本語がURLエンコードされるため、`/name=営業/` → `/name=/` に変更しパラメータの存在のみ検証する形に修正
- **検索結果の検証方法変更**: strict mode violation 回避のため、`getByText("営業本部長")` → 全行の役割名列に対して `toContainText("営業")` で部分一致検証に変更

### Step 2: roles-create.e2e.ts

- **afterEachのスコープ変更**: 並列実行時の不安定性を解消するため、afterEach を外側の describe に移動し内側のラッパーを削除

### Step 3: roles-detail.e2e.ts

- **beforeEach → beforeAll + serial に変更**: `fullyParallel: true` 環境でのフレーキーテスト対策として、`test.describe.serial` + `beforeAll` に変更し順序保証
- **beforeAll内の認証方法**: `browser.newContext({ storageState: "playwright/.auth/admin.json" })` で管理者認証を明示的に指定
- **afterEach削除**: serial 実行で削除テスト自体がクリーンアップを兼ねるため不要に

## Test Plan

- [ ] `pnpm exec playwright test src/app/\(features\)/roles/roles-list.e2e.ts` — 役割一覧の表示・検索・遷移テスト
- [ ] `pnpm exec playwright test src/app/\(features\)/roles/roles-create.e2e.ts` — 新規作成・バリデーション・動的フィルタリングテスト
- [ ] `pnpm exec playwright test src/app/\(features\)/roles/roles-detail.e2e.ts` — 編集・削除・エラー・権限テスト
- [ ] `pnpm e2e` — 全E2Eテスト実行（既存テストとの干渉がないことを確認）

---

Generated with [Claude Code](https://claude.ai/code)