### PR TITLE
test: E2Eテスト移行 employees-detail.e2e.ts - E2Eテスト専用DB対応

### DIFF
--- a/docs/claude-plans/issue-217/plan.md
+++ b/docs/claude-plans/issue-217/plan.md
@@ -1,0 +1,46 @@
+# Issue #217: test: E2Eテスト移行 employees-detail.e2e.ts - E2Eテスト専用DB対応 — 実装計画
+
+## 概要
+
+`employees-detail.e2e.ts` をE2Eテスト専用DB（seed-e2e.ts）に対応させる。主な変更点:
+1. EMP000050（シード範囲外）→ EMP000010（シード内の従業員）に変更
+2. `createTestEmployee`（UI経由）→ `e2e-helpers/prisma.ts` を使ったDB直接操作に置き換え
+3. 削除テストのクリーンアップ（afterEach）を追加
+
+## 設計判断
+
+### 更新テストの対象従業員の選択
+- EMP000010（中村直樹、営業部、一般従業員）を選択
+- 理由: 役割付き従業員（EMP000001〜005）を更新するとFK制約やテスト間干渉のリスクがある。一般従業員が安全
+- 注意: 更新テストで名前を変更するため、テスト後にシード値に戻す afterEach を追加してテスト間の独立性を確保
+
+### 削除テスト用従業員の作成方法
+- `e2e-helpers/prisma.ts` でDB直接作成（Employee + User + Account）
+- Employee単体ではなく User/Account も作成する理由: 従業員詳細画面のアクセスにはログイン認証が必要で、画面表示には User リレーションの存在が前提
+- `generateId` を使ってUUIDv7を生成（既存シードと同じパターン）
+
+## ステップ
+
+### Step 1: 更新テストをシード内従業員に変更 & 復元処理追加
+- 対象ファイル: `src/app/(features)/employees/employees-detail.e2e.ts`
+- 作業内容:
+  - EMP000050 → EMP000010 に変更
+  - `createTestEmployee` 関数を削除
+  - 更新テストの afterEach で名前をシード値「中村 直樹」に復元
+  - prisma ヘルパーを import
+- コミットメッセージ: test: 更新テストをE2Eシード内の従業員(EMP000010)に変更
+
+### Step 2: 削除テストをPrismaヘルパーに移行 & クリーンアップ追加
+- 対象ファイル: `src/app/(features)/employees/employees-detail.e2e.ts`
+- 作業内容:
+  - beforeEach で Prisma を使って削除テスト用従業員を直接作成（Employee + User + Account）
+  - afterEach で作成したテストデータをクリーンアップ（FK制約順にAccount → User → Employee）
+  - テスト定数を整理
+- コミットメッセージ: test: 削除テストをPrismaヘルパーに移行しクリーンアップ追加
+
+### Step 3: lint & テスト検証
+- 対象ファイル: `src/app/(features)/employees/employees-detail.e2e.ts`
+- 作業内容:
+  - `pnpm lint` で問題がないことを確認
+  - 全体の整合性を最終確認
+- コミットメッセージ: (必要に応じてlint修正をコミット)

--- a/e2e-helpers/prisma.ts
+++ b/e2e-helpers/prisma.ts
@@ -1,0 +1,24 @@
+/**
+ * E2Eテスト用 Prisma クライアント
+ *
+ * テスト内でDBを直接操作するためのクライアント。
+ * .env.test の DATABASE_URL に接続する。
+ *
+ * 使い方:
+ *   import { prisma } from "../../e2e-helpers/prisma";
+ *
+ *   test.afterEach(async () => {
+ *     await prisma.employee.deleteMany({ where: { employeeCd: "EMP099901" } });
+ *   });
+ */
+import { PrismaPg } from "@prisma/adapter-pg";
+import { config } from "dotenv";
+import { PrismaClient } from "../generated/prisma/client";
+
+config({ path: ".env.test" });
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export const prisma = new PrismaClient({ adapter });

--- a/src/app/(features)/employees/employees-detail.e2e.ts
+++ b/src/app/(features)/employees/employees-detail.e2e.ts
@@ -1,49 +1,43 @@
 import { expect, test } from "@playwright/test";
+import { prisma } from "../../../../e2e-helpers/prisma";
+import { generateId } from "../../../../src/server/shared/generateId";
 
-/** テストで使用する固定の従業員データ（seed範囲 EMP000001〜EMP002000 外） */
-const TEST_EMPLOYEE_CD = "EMP099902";
-const TEST_EMAIL = "e2e-detail-test@example.com";
-
-/**
- * テスト用従業員を新規作成画面から作成し、一覧にリダイレクトされるまで待つ。
- */
-async function createTestEmployee(
-  page: import("@playwright/test").Page,
-  data: { employeeCd: string; email: string; name: string }
-) {
-  await page.goto("/employees/new");
-  await expect(page.getByRole("heading", { name: "新規従業員登録" })).toBeVisible();
-  await page.getByLabel("名前").fill(data.name);
-  await page.getByLabel("メールアドレス").fill(data.email);
-  await page.getByLabel("従業員コード").fill(data.employeeCd);
-  await page.getByLabel("所属部署").selectOption({ index: 1 });
-  await page.getByLabel("パスワード").fill("testpass123");
-  await page.getByRole("button", { name: "登録" }).click();
-  await expect(page).toHaveURL(/\/employees/, { timeout: 10000 });
-}
+/** 削除テストで使用する固定の従業員データ（seed範囲外） */
+const DELETE_TEST_EMPLOYEE_CD = "EMP099902";
+const DELETE_TEST_EMAIL = "e2e-detail-delete@example.com";
 
 test.describe("従業員詳細・編集・削除（管理者）", () => {
-  test("管理者が従業員情報を更新できる", async ({ page }) => {
-    await page.goto("/employees/EMP000050");
+  test.describe("更新テスト", () => {
+    test.afterEach(async () => {
+      // シードデータの名前を復元（EMP000010: 中村 直樹）
+      await prisma.employee.update({
+        where: { employeeCd: "EMP000010" },
+        data: { name: "中村 直樹" },
+      });
+    });
 
-    // 編集モードで表示されること
-    await expect(page.getByRole("heading", { name: "従業員管理" })).toBeVisible();
-    await expect(page.getByText("従業員変更")).toBeVisible();
+    test("管理者が従業員情報を更新できる", async ({ page }) => {
+      await page.goto("/employees/EMP000010");
 
-    // 従業員コードが読み取り専用であること
-    await expect(page.locator("#employeeCd-display")).toBeDisabled();
+      // 編集モードで表示されること
+      await expect(page.getByRole("heading", { name: "従業員管理" })).toBeVisible();
+      await expect(page.getByText("従業員変更")).toBeVisible();
 
-    // 名前を変更して更新
-    const nameField = page.getByLabel("名前");
-    await nameField.clear();
-    await nameField.fill("E2E更新テスト");
-    await page.getByRole("button", { name: "更新" }).click();
+      // 従業員コードが読み取り専用であること
+      await expect(page.locator("#employeeCd-display")).toBeDisabled();
 
-    // 成功トーストが表示される
-    await expect(page.getByText("従業員情報を更新しました。")).toBeVisible({ timeout: 10000 });
+      // 名前を変更して更新
+      const nameField = page.getByLabel("名前");
+      await nameField.clear();
+      await nameField.fill("E2E更新テスト");
+      await page.getByRole("button", { name: "更新" }).click();
 
-    // 変更が反映されていること
-    await expect(nameField).toHaveValue("E2E更新テスト");
+      // 成功トーストが表示される
+      await expect(page.getByText("従業員情報を更新しました。")).toBeVisible({ timeout: 10000 });
+
+      // 変更が反映されていること
+      await expect(nameField).toHaveValue("E2E更新テスト");
+    });
   });
 
   test("管理者には削除ボタンが表示される", async ({ page }) => {
@@ -53,18 +47,58 @@ test.describe("従業員詳細・編集・削除（管理者）", () => {
   });
 
   test.describe("削除テスト", () => {
-    // 暫定対応: テスト用従業員をUIから作成する（#157 で改善予定）
-    test.beforeEach(async ({ page }) => {
-      await createTestEmployee(page, {
-        employeeCd: TEST_EMPLOYEE_CD,
-        email: TEST_EMAIL,
-        name: "削除テスト従業員",
+    test.beforeEach(async () => {
+      // Prismaで削除テスト用従業員をDB直接作成（Employee + User + Account）
+      const employeeId = generateId();
+      const userId = generateId();
+      const accountId = generateId();
+      // シードデータの部署（DEPT001: 営業部）のIDを取得
+      const department = await prisma.department.findFirstOrThrow({
+        where: { departmentCd: "DEPT001" },
       });
+
+      await prisma.$transaction(async (tx) => {
+        await tx.employee.create({
+          data: {
+            id: employeeId,
+            employeeCd: DELETE_TEST_EMPLOYEE_CD,
+            email: DELETE_TEST_EMAIL,
+            name: "削除テスト従業員",
+            departmentId: department.id,
+          },
+        });
+        await tx.user.create({
+          data: {
+            id: userId,
+            name: "削除テスト従業員",
+            email: DELETE_TEST_EMAIL,
+            emailVerified: true,
+            employeeId: employeeId,
+            role: "user",
+          },
+        });
+        await tx.account.create({
+          data: {
+            id: accountId,
+            accountId: userId,
+            providerId: "credential",
+            userId: userId,
+            password: "dummy-not-used-for-login",
+          },
+        });
+      });
+    });
+
+    test.afterEach(async () => {
+      // FK制約順にクリーンアップ: Account → User → Employee
+      await prisma.account.deleteMany({ where: { user: { email: DELETE_TEST_EMAIL } } });
+      await prisma.user.deleteMany({ where: { email: DELETE_TEST_EMAIL } });
+      await prisma.employee.deleteMany({ where: { employeeCd: DELETE_TEST_EMPLOYEE_CD } });
     });
 
     test("管理者が従業員を削除できる", async ({ page }) => {
       // 作成した従業員の詳細画面に遷移
-      await page.goto(`/employees/${TEST_EMPLOYEE_CD}`);
+      await page.goto(`/employees/${DELETE_TEST_EMPLOYEE_CD}`);
       await expect(page.getByText("従業員変更")).toBeVisible();
 
       // 削除実行
@@ -76,12 +110,12 @@ test.describe("従業員詳細・編集・削除（管理者）", () => {
 
       // 削除した従業員が検索で見つからない
       await expect(page.locator("table tbody tr").first()).toBeVisible();
-      await page.getByLabel("従業員コード").fill(TEST_EMPLOYEE_CD);
+      await page.getByLabel("従業員コード").fill(DELETE_TEST_EMPLOYEE_CD);
       await page.getByRole("button", { name: "検索" }).click();
-      await expect(page).toHaveURL(new RegExp(`employeeCd=${TEST_EMPLOYEE_CD}`), {
+      await expect(page).toHaveURL(new RegExp(`employeeCd=${DELETE_TEST_EMPLOYEE_CD}`), {
         timeout: 10000,
       });
-      await expect(page.getByRole("link", { name: TEST_EMPLOYEE_CD })).not.toBeVisible();
+      await expect(page.getByRole("link", { name: DELETE_TEST_EMPLOYEE_CD })).not.toBeVisible();
     });
   });
 


### PR DESCRIPTION
## Summary

`employees-detail.e2e.ts` をE2Eテスト専用DB（seed-e2e.ts）に対応させた。シード範囲外の従業員コード（EMP000050）をシード内（EMP000010）に変更し、UI経由のテスト従業員作成（`createTestEmployee`）を `e2e-helpers/prisma.ts` によるDB直接操作に置き換えた。削除テストではテストデータのクリーンアップ（afterEach）も追加。

Closes #217

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

# Issue #217: test: E2Eテスト移行 employees-detail.e2e.ts - E2Eテスト専用DB対応 — 実装計画

## 概要

`employees-detail.e2e.ts` をE2Eテスト専用DB（seed-e2e.ts）に対応させる。主な変更点:
1. EMP000050（シード範囲外）→ EMP000010（シード内の従業員）に変更
2. `createTestEmployee`（UI経由）→ `e2e-helpers/prisma.ts` を使ったDB直接操作に置き換え
3. 削除テストのクリーンアップ（afterEach）を追加

## 設計判断

### 更新テストの対象従業員の選択
- EMP000010（中村直樹、営業部、一般従業員）を選択
- 理由: 役割付き従業員（EMP000001〜005）を更新するとFK制約やテスト間干渉のリスクがある。一般従業員が安全
- 注意: 更新テストで名前を変更するため、テスト後にシード値に戻す afterEach を追加してテスト間の独立性を確保

### 削除テスト用従業員の作成方法
- `e2e-helpers/prisma.ts` でDB直接作成（Employee + User + Account）
- Employee単体ではなく User/Account も作成する理由: 従業員詳細画面のアクセスにはログイン認証が必要で、画面表示には User リレーションの存在が前提
- `generateId` を使ってUUIDv7を生成（既存シードと同じパターン）

## ステップ

### Step 1: 更新テストをシード内従業員に変更 & 復元処理追加
- EMP000050 → EMP000010 に変更
- `createTestEmployee` 関数を削除
- 更新テストの afterEach で名前をシード値「中村 直樹」に復元
- prisma ヘルパーを import

### Step 2: 削除テストをPrismaヘルパーに移行 & クリーンアップ追加
- beforeEach で Prisma を使って削除テスト用従業員を直接作成（Employee + User + Account）
- afterEach で作成したテストデータをクリーンアップ（FK制約順にAccount → User → Employee）
- テスト定数を整理

### Step 3: lint & テスト検証
- `pnpm lint` で問題がないことを確認
- 全体の整合性を最終確認

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

- [ ] `pnpm test:e2e` で `employees-detail.e2e.ts` の全テストケースが通ること
- [ ] 更新テスト: EMP000010 を使用し、テスト後に名前がシード値に復元されること
- [ ] 削除テスト: Prismaヘルパーで作成したテスト従業員が正しく削除されること
- [ ] 削除テスト: afterEach でテストデータ（Account → User → Employee）がクリーンアップされること
- [ ] シード範囲外の従業員コード（EMP000050）が使用されていないこと

---

Generated with [Claude Code](https://claude.ai/code)