### PR TITLE
refactor: E2Eテストのテーブルセル特定を nth-child ハードコードからヘッダー名ベースに統一する

### DIFF
--- a/docs/claude-plans/issue-242/plan.md
+++ b/docs/claude-plans/issue-242/plan.md
@@ -1,0 +1,45 @@
+# Issue #242: E2Eテストのテーブルセル特定を nth-child ハードコードからヘッダー名ベースに統一する — 実装計画
+
+## 概要
+
+ADR-0017 で採用された「ヘッダー名ベース」のカラム特定方式を、既存の一覧テスト3ファイルに適用する。
+`td:nth-child(N)` のハードコードを `getColumnIndex()` ヘルパーによる動的取得に置き換える。
+
+## 参考パターン
+
+`customers-list.e2e.ts` の `getColumnIndex()` ヘルパーを標準パターンとして採用:
+
+```typescript
+async function getColumnIndex(page: import("@playwright/test").Page, headerName: string) {
+  const headers = await page.locator("table thead th").allTextContents();
+  return headers.indexOf(headerName) + 1;
+}
+```
+
+## ステップ
+
+### Step 1: products-list.e2e.ts のリファクタリング
+
+- 対象ファイル: `src/app/(features)/products/products-list.e2e.ts`
+- 作業内容:
+  - `getColumnIndex()` ヘルパー関数を追加
+  - L58: `td:nth-child(3) span` → ヘッダー名「商品区分」で動的取得
+  - L75: `td:nth-child(5) span` → ヘッダー名「状態」で動的取得
+- コミットメッセージ: refactor: products-list.e2e.ts の nth-child をヘッダー名ベースに変更
+
+### Step 2: departments-list.e2e.ts のリファクタリング
+
+- 対象ファイル: `src/app/(features)/departments/departments-list.e2e.ts`
+- 作業内容:
+  - `getColumnIndex()` ヘルパー関数を追加
+  - L72: `td:nth-child(5) span` → ヘッダー名「状態」で動的取得
+- コミットメッセージ: refactor: departments-list.e2e.ts の nth-child をヘッダー名ベースに変更
+
+### Step 3: roles-list.e2e.ts のリファクタリング
+
+- 対象ファイル: `src/app/(features)/roles/roles-list.e2e.ts`
+- 作業内容:
+  - `getColumnIndex()` ヘルパー関数を追加
+  - L36: `td:nth-child(2)` → ヘッダー名「役割名」で動的取得
+  - L67: `td:nth-child(3)` → ヘッダー名「役職」で動的取得
+- コミットメッセージ: refactor: roles-list.e2e.ts の nth-child をヘッダー名ベースに変更

--- a/src/app/(features)/departments/departments-list.e2e.ts
+++ b/src/app/(features)/departments/departments-list.e2e.ts
@@ -10,6 +10,12 @@ async function waitForListReady(page: import("@playwright/test").Page) {
   await expect(page.locator("table tbody tr").first()).toBeVisible();
 }
 
+/** ヘッダー名からカラム位置（1始まり）を取得する */
+async function getColumnIndex(page: import("@playwright/test").Page, headerName: string) {
+  const headers = await page.locator("table thead th").allTextContents();
+  return headers.indexOf(headerName) + 1;
+}
+
 test.describe("部署一覧（管理者）", () => {
   test("一覧が表示され、管理者には「新規登録」ボタンが見える", async ({ page }) => {
     await page.goto("/departments");
@@ -69,7 +75,8 @@ test.describe("部署一覧（管理者）", () => {
 
     await expect(page).toHaveURL(/isActive=true/, { timeout: 10000 });
     // 表示されている状態バッジがすべて「有効」であること
-    const statusCells = page.locator("table tbody tr td:nth-child(5) span");
+    const statusCol = await getColumnIndex(page, "状態");
+    const statusCells = page.locator(`table tbody tr td:nth-child(${statusCol}) span`);
     const count = await statusCells.count();
     expect(count).toBeGreaterThan(0);
     for (let i = 0; i < count; i++) {

--- a/src/app/(features)/products/products-list.e2e.ts
+++ b/src/app/(features)/products/products-list.e2e.ts
@@ -10,6 +10,12 @@ async function waitForListReady(page: import("@playwright/test").Page) {
   await expect(page.locator("table tbody tr").first()).toBeVisible();
 }
 
+/** ヘッダー名からカラム位置（1始まり）を取得する */
+async function getColumnIndex(page: import("@playwright/test").Page, headerName: string) {
+  const headers = await page.locator("table thead th").allTextContents();
+  return headers.indexOf(headerName) + 1;
+}
+
 test.describe("商品一覧（管理者）", () => {
   test("一覧が表示され、管理者には「新規登録」ボタンが見える", async ({ page }) => {
     await page.goto("/products");
@@ -55,7 +61,8 @@ test.describe("商品一覧（管理者）", () => {
 
     await expect(page).toHaveURL(/category=CONSUMABLE/, { timeout: 10000 });
     // 表示されている商品区分がすべて「消耗品」であること
-    const categoryBadges = page.locator("table tbody tr td:nth-child(3) span");
+    const categoryCol = await getColumnIndex(page, "商品区分");
+    const categoryBadges = page.locator(`table tbody tr td:nth-child(${categoryCol}) span`);
     const count = await categoryBadges.count();
     expect(count).toBeGreaterThan(0);
     for (let i = 0; i < count; i++) {
@@ -72,7 +79,8 @@ test.describe("商品一覧（管理者）", () => {
 
     await expect(page).toHaveURL(/isActive=true/, { timeout: 10000 });
     // 表示されている状態バッジがすべて「有効」であること
-    const statusCells = page.locator("table tbody tr td:nth-child(5) span");
+    const statusCol = await getColumnIndex(page, "状態");
+    const statusCells = page.locator(`table tbody tr td:nth-child(${statusCol}) span`);
     const count = await statusCells.count();
     expect(count).toBeGreaterThan(0);
     for (let i = 0; i < count; i++) {

--- a/src/app/(features)/roles/roles-list.e2e.ts
+++ b/src/app/(features)/roles/roles-list.e2e.ts
@@ -10,6 +10,12 @@ async function waitForListReady(page: import("@playwright/test").Page) {
   await expect(page.locator("table tbody tr").first()).toBeVisible();
 }
 
+/** ヘッダー名からカラム位置（1始まり）を取得する */
+async function getColumnIndex(page: import("@playwright/test").Page, headerName: string) {
+  const headers = await page.locator("table thead th").allTextContents();
+  return headers.indexOf(headerName) + 1;
+}
+
 test.describe("役割一覧（管理者）", () => {
   test("一覧が表示され、管理者には「新規登録」ボタンが見える", async ({ page }) => {
     await page.goto("/roles");
@@ -33,7 +39,8 @@ test.describe("役割一覧（管理者）", () => {
 
     await expect(page).toHaveURL(/name=/, { timeout: 10000 });
     // 表示されている役割名列がすべて「営業」を含むこと
-    const nameCells = page.locator("table tbody tr td:nth-child(2)");
+    const nameCol = await getColumnIndex(page, "役割名");
+    const nameCells = page.locator(`table tbody tr td:nth-child(${nameCol})`);
     const count = await nameCells.count();
     expect(count).toBeGreaterThan(0);
     for (let i = 0; i < count; i++) {
@@ -64,7 +71,8 @@ test.describe("役割一覧（管理者）", () => {
 
     await expect(page).toHaveURL(/positionId=/, { timeout: 10000 });
     // 表示されている役職列がすべて「課長」であること
-    const positionCells = page.locator("table tbody tr td:nth-child(3)");
+    const positionCol = await getColumnIndex(page, "役職");
+    const positionCells = page.locator(`table tbody tr td:nth-child(${positionCol})`);
     const count = await positionCells.count();
     expect(count).toBeGreaterThan(0);
     for (let i = 0; i < count; i++) {


### PR DESCRIPTION
## Summary

E2Eテストの一覧画面3ファイル（products, departments, roles）で `td:nth-child(N)` でハードコードされていたテーブルセル特定を、ADR-0017 で採用されたヘッダー名ベースの `getColumnIndex()` パターンに統一した。これにより、列の追加・並び替え時の偽陽性テスト失敗を防止する。

Closes #242

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

# Issue #242: E2Eテストのテーブルセル特定を nth-child ハードコードからヘッダー名ベースに統一する — 実装計画

## 概要

ADR-0017 で採用された「ヘッダー名ベース」のカラム特定方式を、既存の一覧テスト3ファイルに適用する。
`td:nth-child(N)` のハードコードを `getColumnIndex()` ヘルパーによる動的取得に置き換える。

## 参考パターン

`customers-list.e2e.ts` の `getColumnIndex()` ヘルパーを標準パターンとして採用:

```typescript
async function getColumnIndex(page: import("@playwright/test").Page, headerName: string) {
  const headers = await page.locator("table thead th").allTextContents();
  return headers.indexOf(headerName) + 1;
}
```

## ステップ

### Step 1: products-list.e2e.ts のリファクタリング

- 対象ファイル: `src/app/(features)/products/products-list.e2e.ts`
- 作業内容:
  - `getColumnIndex()` ヘルパー関数を追加
  - L58: `td:nth-child(3) span` → ヘッダー名「商品区分」で動的取得
  - L75: `td:nth-child(5) span` → ヘッダー名「状態」で動的取得
- コミットメッセージ: refactor: products-list.e2e.ts の nth-child をヘッダー名ベースに変更

### Step 2: departments-list.e2e.ts のリファクタリング

- 対象ファイル: `src/app/(features)/departments/departments-list.e2e.ts`
- 作業内容:
  - `getColumnIndex()` ヘルパー関数を追加
  - L72: `td:nth-child(5) span` → ヘッダー名「状態」で動的取得
- コミットメッセージ: refactor: departments-list.e2e.ts の nth-child をヘッダー名ベースに変更

### Step 3: roles-list.e2e.ts のリファクタリング

- 対象ファイル: `src/app/(features)/roles/roles-list.e2e.ts`
- 作業内容:
  - `getColumnIndex()` ヘルパー関数を追加
  - L36: `td:nth-child(2)` → ヘッダー名「役割名」で動的取得
  - L67: `td:nth-child(3)` → ヘッダー名「役職」で動的取得
- コミットメッセージ: refactor: roles-list.e2e.ts の nth-child をヘッダー名ベースに変更

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

- [ ] `pnpm e2e` で E2E テスト全体がパスすることを確認
- [ ] `products-list.e2e.ts` で商品区分バッジ・状態バッジの検証が正常動作すること
- [ ] `departments-list.e2e.ts` で状態バッジの検証が正常動作すること
- [ ] `roles-list.e2e.ts` で役割名・役職の検証が正常動作すること
- [ ] 各ファイルで `td:nth-child(N)` のハードコードが完全に排除されていること

---

Generated with [Claude Code](https://claude.ai/code)