### PR TITLE
test: 全 list e2e で Page 型 import を named import に統一

### DIFF
--- a/src/app/(features)/customers/customers-list.e2e.ts
+++ b/src/app/(features)/customers/customers-list.e2e.ts
@@ -1,17 +1,17 @@
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 /**
  * 一覧画面のハイドレーション完了を待つ。
  * SearchForm（"use client"）の onSubmit が機能するには React のハイドレーションが必要。
  * DataTable の行が表示された時点で、ページ全体がインタラクティブになっていると判断する。
  */
-async function waitForListReady(page: import("@playwright/test").Page) {
+async function waitForListReady(page: Page) {
   await expect(page.getByRole("heading", { name: "得意先一覧" })).toBeVisible();
   await expect(page.locator("table tbody tr").first()).toBeVisible();
 }
 
 /** ヘッダー名からカラム位置（1始まり）を取得する */
-async function getColumnIndex(page: import("@playwright/test").Page, headerName: string) {
+async function getColumnIndex(page: Page, headerName: string) {
   const headers = await page.locator("table thead th").allTextContents();
   return headers.indexOf(headerName) + 1;
 }

--- a/src/app/(features)/delivery-locations/delivery-locations-list.e2e.ts
+++ b/src/app/(features)/delivery-locations/delivery-locations-list.e2e.ts
@@ -1,17 +1,17 @@
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 /**
  * 一覧画面のハイドレーション完了を待つ。
  * SearchForm（"use client"）の onSubmit が機能するには React のハイドレーションが必要。
  * DataTable の行が表示された時点で、ページ全体がインタラクティブになっていると判断する。
  */
-async function waitForListReady(page: import("@playwright/test").Page) {
+async function waitForListReady(page: Page) {
   await expect(page.getByRole("heading", { name: "納品先一覧" })).toBeVisible();
   await expect(page.locator("table tbody tr").first()).toBeVisible();
 }
 
 /** ヘッダー名からカラム位置（1始まり）を取得する */
-async function getColumnIndex(page: import("@playwright/test").Page, headerName: string) {
+async function getColumnIndex(page: Page, headerName: string) {
   const headers = await page.locator("table thead th").allTextContents();
   return headers.indexOf(headerName) + 1;
 }

--- a/src/app/(features)/departments/departments-list.e2e.ts
+++ b/src/app/(features)/departments/departments-list.e2e.ts
@@ -1,17 +1,17 @@
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 /**
  * 一覧画面のハイドレーション完了を待つ。
  * SearchForm（"use client"）の onSubmit が機能するには React のハイドレーションが必要。
  * DataTable の行が表示された時点で、ページ全体がインタラクティブになっていると判断する。
  */
-async function waitForListReady(page: import("@playwright/test").Page) {
+async function waitForListReady(page: Page) {
   await expect(page.getByRole("heading", { name: "部署管理" })).toBeVisible();
   await expect(page.locator("table tbody tr").first()).toBeVisible();
 }
 
 /** ヘッダー名からカラム位置（1始まり）を取得する */
-async function getColumnIndex(page: import("@playwright/test").Page, headerName: string) {
+async function getColumnIndex(page: Page, headerName: string) {
   const headers = await page.locator("table thead th").allTextContents();
   return headers.indexOf(headerName) + 1;
 }

--- a/src/app/(features)/employees/employees-list.e2e.ts
+++ b/src/app/(features)/employees/employees-list.e2e.ts
@@ -1,11 +1,11 @@
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 /**
  * 一覧画面のハイドレーション完了を待つ。
  * SearchForm（"use client"）の onSubmit が機能するには React のハイドレーションが必要。
  * DataTable の行が表示された時点で、ページ全体がインタラクティブになっていると判断する。
  */
-async function waitForListReady(page: import("@playwright/test").Page) {
+async function waitForListReady(page: Page) {
   await expect(page.getByRole("heading", { name: "従業員管理" })).toBeVisible();
   await expect(page.locator("table tbody tr").first()).toBeVisible();
 }

--- a/src/app/(features)/products/products-list.e2e.ts
+++ b/src/app/(features)/products/products-list.e2e.ts
@@ -1,17 +1,17 @@
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 /**
  * 一覧画面のハイドレーション完了を待つ。
  * SearchForm（"use client"）の onSubmit が機能するには React のハイドレーションが必要。
  * DataTable の行が表示された時点で、ページ全体がインタラクティブになっていると判断する。
  */
-async function waitForListReady(page: import("@playwright/test").Page) {
+async function waitForListReady(page: Page) {
   await expect(page.getByRole("heading", { name: "商品管理" })).toBeVisible();
   await expect(page.locator("table tbody tr").first()).toBeVisible();
 }
 
 /** ヘッダー名からカラム位置（1始まり）を取得する */
-async function getColumnIndex(page: import("@playwright/test").Page, headerName: string) {
+async function getColumnIndex(page: Page, headerName: string) {
   const headers = await page.locator("table thead th").allTextContents();
   return headers.indexOf(headerName) + 1;
 }

--- a/src/app/(features)/roles/roles-list.e2e.ts
+++ b/src/app/(features)/roles/roles-list.e2e.ts
@@ -1,17 +1,17 @@
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 /**
  * 一覧画面のハイドレーション完了を待つ。
  * SearchForm（"use client"）の onSubmit が機能するには React のハイドレーションが必要。
  * DataTable の行が表示された時点で、ページ全体がインタラクティブになっていると判断する。
  */
-async function waitForListReady(page: import("@playwright/test").Page) {
+async function waitForListReady(page: Page) {
   await expect(page.getByRole("heading", { name: "役割管理" })).toBeVisible();
   await expect(page.locator("table tbody tr").first()).toBeVisible();
 }
 
 /** ヘッダー名からカラム位置（1始まり）を取得する */
-async function getColumnIndex(page: import("@playwright/test").Page, headerName: string) {
+async function getColumnIndex(page: Page, headerName: string) {
   const headers = await page.locator("table thead th").allTextContents();
   return headers.indexOf(headerName) + 1;
 }


### PR DESCRIPTION
## Summary

一覧系 e2e ファイル（employees / departments / roles / products / customers / delivery-locations）で残存していた `import("@playwright/test").Page` インライン型を、create-e2e-test スキル §6 標準の named import 形式（`import { type Page, expect, test } from "@playwright/test"`）に統一するリファクタリング。`waitForListReady` / `getColumnIndex` などヘルパー関数の引数型注釈も named import の `Page` 型へ変更した。

Closes #256

## 計画からの逸脱

実装計画なしで実装を行いました。

## Test Plan

import 形式・型注釈のみの変更で挙動変更はないため、既存E2Eの通過確認が完了条件。

- [ ] `pnpm e2e` で全E2Eテストがパスする
- [ ] 対象6ファイル全てで `import { type Page, expect, test } from "@playwright/test"` の named import になっている
- [ ] 対象ファイル内に `import("@playwright/test").Page` インライン型が残っていない
- [ ] `waitForListReady` / `getColumnIndex` の引数型が named import の `Page` 型になっている

---

Generated with [Claude Code](https://claude.ai/code)