### PR TITLE
test: departments e2e の create-e2e-test スキル準拠（chain分離・ドメインエラーシード分離）

### DIFF
--- a/docs/claude-plans/issue-258/plan.md
+++ b/docs/claude-plans/issue-258/plan.md
@@ -1,0 +1,73 @@
+# Issue #258 実装計画
+
+## 背景
+
+`src/app/(features)/departments/departments-crud.e2e.ts` が create-e2e-test スキル（`.claude/skills/create-e2e-test/SKILL.md`）に準拠していない。Issue #257（roles）の対応と同様の構造的リファクタを実施する。
+
+違反箇所（Issue #258 本文より）:
+1. **§4 chain 粒度違反**: ライフサイクル chain 内に `isActive` ステータス変更が混在
+2. **§13 ドメインエラーの自前構築**: 子部署削除制約テストが serial 内で PARENT/CHILD を自前 create → delete
+3. **§11 簡易 chain の欠如確認**: 閲覧テストのみで簡易 chain がない
+
+## 仕様確認結果
+
+既存テスト（`departments-crud.e2e.ts:212-217`）で `一般ユーザーは /departments/new にアクセスできない（/signin?reason=forbidden にリダイレクト）` が確認されている → **権限差異あり機能**。
+
+SKILL §11「権限差異がある機能のみ両ユーザーでテスト」「権限差異なし → 管理者テストのみ + 一般ユーザー簡易 chain 1 つ」に照らすと、今回は**権限差異あり**なので**一般ユーザー簡易 chain は省略**する（Issue #257 roles と同判断）。
+
+## テストデータコード設計
+
+| cd | 区分 | 用途 |
+|---|---|---|
+| `DEPT901` | 共通シード（`seed-e2e.ts`） | E2E専用_子部署あり削除テスト親部署 |
+| `DEPT902` | 共通シード（`seed-e2e.ts`） | E2E専用_子部署あり削除テスト子部署（親=DEPT901） |
+| `DEPT903` | テスト内生成（ライフサイクル chain） | 作成 → 更新 → 削除 |
+| `DEPT904` | テスト内生成（ステータス chain） | 作成 → 無効化 → 有効化 → 削除 |
+
+**DEPT901 は従来テスト内での `TEST_DEPT_CD` 値だったが、シード予約のため番号を下げる**（Issue #257 の ROLE901 → ROLE904 と同じ判断）。
+
+## 実装ステップ
+
+### Step 1: `prisma/seed-e2e.ts` に `E2E_ONLY_DEPARTMENTS` を追加
+
+追加するデータ:
+
+| cd | name | abbreviation | parentDepartmentCd |
+|---|---|---|---|
+| `DEPT901` | `E2E専用_子部署あり削除テスト親部署` | `E2E親` | null |
+| `DEPT902` | `E2E専用_子部署あり削除テスト子部署` | `E2E子` | `DEPT901` |
+
+実装方針:
+- `DEPARTMENTS` 配列とは分離（`E2E_ONLY_DEPARTMENTS`）。理由: §13 の共通/E2E 専用境界を明確化
+- `name` に `E2E専用_` プレフィックス（§13 準拠）
+- 親子関係は既存 department スキーマの `parentDepartmentId` を使う
+- メイン処理で部署作成ブロックの後に E2E 専用部署を作成（親→子の順）
+
+### Step 2: `departments-crud.e2e.ts` を分離
+
+1. 定数を整理
+   ```ts
+   const TEST_DEPT_CD = "DEPT903";           // ライフサイクル chain
+   const STATUS_TEST_DEPT_CD = "DEPT904";    // ステータス管理 chain
+   const PARENT_WITH_CHILD = "DEPT901";      // seed-e2e.ts: 子部署あり削除テスト親
+   ```
+2. **ライフサイクル chain**（`test.describe.serial "作成・更新・削除"`）: 作成 → 更新 → 削除（isActive は含めない）
+3. **ステータス管理 chain**（`test.describe.serial "ステータス管理"`）: 作成 → 無効化 → 有効化 → 削除（DEPT904）
+4. **子部署あり削除不可**: serial 外の単体テストに切り出し、`PARENT_WITH_CHILD` を参照（テスト内 create/delete を排除）
+5. 既存の個別テスト（重複エラー / キャンセル / 削除ボタン表示 / 404）はそのまま
+6. 一般ユーザー簡易 chain は §11 準拠で省略
+
+### Step 3: 検証
+
+1. `pnpm lint`
+2. `pnpm e2e:seed` でシード再生成確認
+3. `pnpm e2e -- --grep "部署"` で該当テストのみ実行
+4. `pnpm e2e` でフル回帰
+
+## 完了条件
+
+- [ ] §4 準拠: ライフサイクル chain と ステータス管理 chain が独立
+- [ ] §13 準拠: 「子部署あり削除不可」が `DEPT901`/`DEPT902` を参照（テスト内 create/delete なし）
+- [ ] §11 準拠: 権限差異あり機能のため簡易 chain 省略（方針を明記）
+- [ ] `pnpm lint` 成功
+- [ ] `pnpm e2e` 成功

--- a/prisma/seed-e2e.ts
+++ b/prisma/seed-e2e.ts
@@ -30,6 +30,23 @@ const DEPARTMENTS = [
   { departmentCd: "DEPT003", name: "総務部", abbreviation: "総務" },
 ];
 
+// E2E専用シード（DEPT9NN 帯）: ドメインエラーテスト用。DB 不変が前提。
+// DEPT901/902: 子部署あり削除テスト用（DEPT901 が親、DEPT902 が子）
+const E2E_ONLY_DEPARTMENTS = [
+  {
+    departmentCd: "DEPT901",
+    name: "E2E専用_子部署あり削除テスト親部署",
+    abbreviation: "E2E親",
+    parentDepartmentCd: null as string | null,
+  },
+  {
+    departmentCd: "DEPT902",
+    name: "E2E専用_子部署あり削除テスト子部署",
+    abbreviation: "E2E子",
+    parentDepartmentCd: "DEPT901" as string | null,
+  },
+];
+
 const POSITIONS = [
   { cd: "POS001", name: "課長", superiorCd: "POS002" as string | null },
   { cd: "POS002", name: "部長", superiorCd: "POS003" as string | null },
@@ -566,6 +583,25 @@ async function main() {
   }
   console.log(`Created ${DEPARTMENTS.length} departments`);
 
+  // E2E専用部署を作成（DEPT9NN 帯）
+  for (const dept of E2E_ONLY_DEPARTMENTS) {
+    const id = generateId();
+    departmentIdMap.set(dept.departmentCd, id);
+    await prisma.department.create({
+      data: {
+        id,
+        departmentCd: dept.departmentCd,
+        name: dept.name,
+        abbreviation: dept.abbreviation,
+        isActive: true,
+        parentId: dept.parentDepartmentCd
+          ? (departmentIdMap.get(dept.parentDepartmentCd) ?? null)
+          : null,
+      },
+    });
+  }
+  console.log(`Created ${E2E_ONLY_DEPARTMENTS.length} E2E-only departments`);
+
   // 役職を作成（上位から作成でFK制約を満たす）
   const positionIdMap = new Map<string, string>();
   const positionsOrdered = [...POSITIONS].reverse();
@@ -680,7 +716,9 @@ async function main() {
   console.log("");
   console.log("=".repeat(50));
   console.log("E2E seed finished.");
-  console.log(`  Departments: ${DEPARTMENTS.length}`);
+  console.log(
+    `  Departments: ${DEPARTMENTS.length + E2E_ONLY_DEPARTMENTS.length} (incl. ${E2E_ONLY_DEPARTMENTS.length} E2E-only)`
+  );
   console.log(`  Positions: ${POSITIONS.length}`);
   console.log(
     `  Roles: ${ROLES.length + E2E_ONLY_ROLES.length} (incl. ${E2E_ONLY_ROLES.length} E2E-only)`

--- a/src/app/(features)/departments/departments-crud.e2e.ts
+++ b/src/app/(features)/departments/departments-crud.e2e.ts
@@ -1,16 +1,18 @@
 import { expect, test } from "@playwright/test";
 
-/** テストで使用する固定の部署データ（seed範囲 DEPT001〜DEPT003 外） */
-const TEST_DEPT_CD = "DEPT901";
+/** 成功系CRUD用: ライフサイクル chain（作成→更新→削除） */
+const TEST_DEPT_CD = "DEPT903";
 const TEST_DEPT_NAME = "E2Eテスト部署";
 const TEST_DEPT_ABBR = "E2Eテスト";
 
-/** 子部署削除制約テスト用 */
-const PARENT_DEPT_CD = "DEPT902";
-const CHILD_DEPT_CD = "DEPT903";
+/** 成功系CRUD用: ステータス管理 chain（作成→無効化→有効化→削除） */
+const STATUS_TEST_DEPT_CD = "DEPT904";
+
+/** seed-e2e.ts: E2E専用_子部署あり削除テスト親部署（DEPT902 が子部署） */
+const PARENT_WITH_CHILD = "DEPT901";
 
 test.describe("部署CRUD（管理者）", () => {
-  // 作成→更新→isActive変更→削除の順で実行（同一テストデータを使い回すため serial で順序保証）
+  // 作成→更新→削除の順で実行（同一テストデータを使い回すため serial で順序保証）
   test.describe.serial("作成・更新・削除テスト", () => {
     test("管理者が新規部署を作成できる", async ({ page }) => {
       // 一覧画面から新規登録画面に遷移
@@ -65,25 +67,6 @@ test.describe("部署CRUD（管理者）", () => {
       await expect(nameField).toHaveValue("E2E更新テスト");
     });
 
-    test("管理者がisActiveを変更できる", async ({ page }) => {
-      await page.goto(`/departments/${TEST_DEPT_CD}`);
-      await expect(page.getByText("部署変更")).toBeVisible();
-
-      // デフォルトで「有効」チェックボックスがONであること
-      const isActiveCheckbox = page.getByLabel("有効");
-      await expect(isActiveCheckbox).toBeChecked();
-
-      // チェックをOFFにして更新
-      await isActiveCheckbox.uncheck();
-      await page.getByRole("button", { name: "更新" }).click();
-
-      // 成功トーストが表示される
-      await expect(page.getByText("部署情報を更新しました。")).toBeVisible({ timeout: 10000 });
-
-      // チェックボックスがOFFになっていること
-      await expect(isActiveCheckbox).not.toBeChecked();
-    });
-
     test("管理者が部署を削除できる", async ({ page }) => {
       await page.goto(`/departments/${TEST_DEPT_CD}`);
       await expect(page.getByText("部署変更")).toBeVisible();
@@ -106,51 +89,55 @@ test.describe("部署CRUD（管理者）", () => {
     });
   });
 
-  // 親部署→子部署の作成・制約テスト・削除を直列実行
-  test.describe.serial("子部署削除制約テスト", () => {
-    test("親部署を作成できる", async ({ page }) => {
+  // 作成→無効化→有効化→削除を直列実行（別データ区分のため独立 chain）
+  test.describe.serial("ステータス管理テスト", () => {
+    test("管理者がステータス管理用の部署を作成できる", async ({ page }) => {
       await page.goto("/departments/new");
       await expect(page.getByRole("heading", { name: "新規部署登録" })).toBeVisible();
 
-      await page.getByLabel("部署コード").fill(PARENT_DEPT_CD);
-      await page.getByLabel("部署名").fill("親部署テスト");
-      await page.getByLabel("略称").fill("親テスト");
+      await page.getByLabel("部署コード").fill(STATUS_TEST_DEPT_CD);
+      await page.getByLabel("部署名").fill("E2Eステータス管理");
+      await page.getByLabel("略称").fill("E2E状態");
+
       await page.getByRole("button", { name: "登録" }).click();
 
       await expect(page).toHaveURL(/\/departments/, { timeout: 10000 });
       await expect(page.getByText("部署を登録しました。")).toBeVisible({ timeout: 10000 });
     });
 
-    test("子部署を作成できる", async ({ page }) => {
-      await page.goto("/departments/new");
-      await expect(page.getByRole("heading", { name: "新規部署登録" })).toBeVisible();
-
-      await page.getByLabel("部署コード").fill(CHILD_DEPT_CD);
-      await page.getByLabel("部署名").fill("子部署テスト");
-      await page.getByLabel("略称").fill("子テスト");
-      await page.getByLabel("親部署").selectOption({ label: "親部署テスト" });
-      await page.getByRole("button", { name: "登録" }).click();
-
-      await expect(page).toHaveURL(/\/departments/, { timeout: 10000 });
-      await expect(page.getByText("部署を登録しました。")).toBeVisible({ timeout: 10000 });
-    });
-
-    test("子部署がある場合は削除できない", async ({ page }) => {
-      // 親部署の詳細画面に遷移
-      await page.goto(`/departments/${PARENT_DEPT_CD}`);
+    test("管理者が部署を無効化できる", async ({ page }) => {
+      await page.goto(`/departments/${STATUS_TEST_DEPT_CD}`);
       await expect(page.getByText("部署変更")).toBeVisible();
 
-      // 削除実行
-      await page.getByRole("button", { name: "削除" }).click();
+      // デフォルトで「有効」チェックボックスがONであること
+      const isActiveCheckbox = page.getByLabel("有効");
+      await expect(isActiveCheckbox).toBeChecked();
 
-      // エラーメッセージが表示される（ページは遷移しない）
-      await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
-      // 詳細画面に留まっていること
-      await expect(page.getByText("部署変更")).toBeVisible();
+      // チェックをOFFにして更新
+      await isActiveCheckbox.uncheck();
+      await page.getByRole("button", { name: "更新" }).click();
+
+      await expect(page.getByText("部署情報を更新しました。")).toBeVisible({ timeout: 10000 });
+      await expect(isActiveCheckbox).not.toBeChecked();
     });
 
-    test("子部署を削除できる", async ({ page }) => {
-      await page.goto(`/departments/${CHILD_DEPT_CD}`);
+    test("管理者が部署を有効化できる", async ({ page }) => {
+      await page.goto(`/departments/${STATUS_TEST_DEPT_CD}`);
+      await expect(page.getByText("部署変更")).toBeVisible();
+
+      // 現在「無効」のはずなので ON にする
+      const isActiveCheckbox = page.getByLabel("有効");
+      await expect(isActiveCheckbox).not.toBeChecked();
+
+      await isActiveCheckbox.check();
+      await page.getByRole("button", { name: "更新" }).click();
+
+      await expect(page.getByText("部署情報を更新しました。")).toBeVisible({ timeout: 10000 });
+      await expect(isActiveCheckbox).toBeChecked();
+    });
+
+    test("管理者がステータス管理用の部署を削除できる", async ({ page }) => {
+      await page.goto(`/departments/${STATUS_TEST_DEPT_CD}`);
       await expect(page.getByText("部署変更")).toBeVisible();
 
       await page.getByRole("button", { name: "削除" }).click();
@@ -158,16 +145,18 @@ test.describe("部署CRUD（管理者）", () => {
       await expect(page).toHaveURL(/\/departments/, { timeout: 10000 });
       await expect(page.getByText("部署を削除しました。")).toBeVisible({ timeout: 10000 });
     });
+  });
 
-    test("親部署を削除できる", async ({ page }) => {
-      await page.goto(`/departments/${PARENT_DEPT_CD}`);
-      await expect(page.getByText("部署変更")).toBeVisible();
+  test("子部署がある部署は削除できない", async ({ page }) => {
+    // PARENT_WITH_CHILD は DEPT902 を子部署として持つ（seed-e2e.ts）
+    await page.goto(`/departments/${PARENT_WITH_CHILD}`);
+    await expect(page.getByText("部署変更")).toBeVisible();
 
-      await page.getByRole("button", { name: "削除" }).click();
+    await page.getByRole("button", { name: "削除" }).click();
 
-      await expect(page).toHaveURL(/\/departments/, { timeout: 10000 });
-      await expect(page.getByText("部署を削除しました。")).toBeVisible({ timeout: 10000 });
-    });
+    // エラーメッセージが表示される（ページは遷移しない）
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(new RegExp(`/departments/${PARENT_WITH_CHILD}`));
   });
 
   test("重複する部署コードでエラーが表示される", async ({ page }) => {


### PR DESCRIPTION
## Summary

`departments-crud.e2e.ts` を create-e2e-test スキルに準拠するようリファクタ。ライフサイクル chain とステータス管理 chain を分離し、「子部署あり削除不可」の失敗系テストを `seed-e2e.ts` に追加した E2E 専用シード（`DEPT901`/`DEPT902`）参照に切替。Issue #257 (roles) と同様の構造的リファクタ。

Closes #258

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### plan.md

# Issue #258 実装計画

## 背景

`src/app/(features)/departments/departments-crud.e2e.ts` が create-e2e-test スキル（`.claude/skills/create-e2e-test/SKILL.md`）に準拠していない。Issue #257（roles）の対応と同様の構造的リファクタを実施する。

違反箇所（Issue #258 本文より）:
1. **§4 chain 粒度違反**: ライフサイクル chain 内に `isActive` ステータス変更が混在
2. **§13 ドメインエラーの自前構築**: 子部署削除制約テストが serial 内で PARENT/CHILD を自前 create → delete
3. **§11 簡易 chain の欠如確認**: 閲覧テストのみで簡易 chain がない

## 仕様確認結果

既存テスト（`departments-crud.e2e.ts:212-217`）で `一般ユーザーは /departments/new にアクセスできない（/signin?reason=forbidden にリダイレクト）` が確認されている → **権限差異あり機能**。

SKILL §11「権限差異がある機能のみ両ユーザーでテスト」「権限差異なし → 管理者テストのみ + 一般ユーザー簡易 chain 1 つ」に照らすと、今回は**権限差異あり**なので**一般ユーザー簡易 chain は省略**する（Issue #257 roles と同判断）。

## テストデータコード設計

| cd | 区分 | 用途 |
|---|---|---|
| `DEPT901` | 共通シード（`seed-e2e.ts`） | E2E専用_子部署あり削除テスト親部署 |
| `DEPT902` | 共通シード（`seed-e2e.ts`） | E2E専用_子部署あり削除テスト子部署（親=DEPT901） |
| `DEPT903` | テスト内生成（ライフサイクル chain） | 作成 → 更新 → 削除 |
| `DEPT904` | テスト内生成（ステータス chain） | 作成 → 無効化 → 有効化 → 削除 |

**DEPT901 は従来テスト内での `TEST_DEPT_CD` 値だったが、シード予約のため番号を下げる**（Issue #257 の ROLE901 → ROLE904 と同じ判断）。

## 実装ステップ

### Step 1: `prisma/seed-e2e.ts` に `E2E_ONLY_DEPARTMENTS` を追加

追加するデータ:

| cd | name | abbreviation | parentDepartmentCd |
|---|---|---|---|
| `DEPT901` | `E2E専用_子部署あり削除テスト親部署` | `E2E親` | null |
| `DEPT902` | `E2E専用_子部署あり削除テスト子部署` | `E2E子` | `DEPT901` |

実装方針:
- `DEPARTMENTS` 配列とは分離（`E2E_ONLY_DEPARTMENTS`）。理由: §13 の共通/E2E 専用境界を明確化
- `name` に `E2E専用_` プレフィックス（§13 準拠）
- 親子関係は既存 department スキーマの `parentDepartmentId` を使う
- メイン処理で部署作成ブロックの後に E2E 専用部署を作成（親→子の順）

### Step 2: `departments-crud.e2e.ts` を分離

1. 定数を整理
   ```ts
   const TEST_DEPT_CD = "DEPT903";           // ライフサイクル chain
   const STATUS_TEST_DEPT_CD = "DEPT904";    // ステータス管理 chain
   const PARENT_WITH_CHILD = "DEPT901";      // seed-e2e.ts: 子部署あり削除テスト親
   ```
2. **ライフサイクル chain**（`test.describe.serial "作成・更新・削除"`）: 作成 → 更新 → 削除（isActive は含めない）
3. **ステータス管理 chain**（`test.describe.serial "ステータス管理"`）: 作成 → 無効化 → 有効化 → 削除（DEPT904）
4. **子部署あり削除不可**: serial 外の単体テストに切り出し、`PARENT_WITH_CHILD` を参照（テスト内 create/delete を排除）
5. 既存の個別テスト（重複エラー / キャンセル / 削除ボタン表示 / 404）はそのまま
6. 一般ユーザー簡易 chain は §11 準拠で省略

### Step 3: 検証

1. `pnpm lint`
2. `pnpm e2e:seed` でシード再生成確認
3. `pnpm e2e -- --grep "部署"` で該当テストのみ実行
4. `pnpm e2e` でフル回帰

## 完了条件

- [ ] §4 準拠: ライフサイクル chain と ステータス管理 chain が独立
- [ ] §13 準拠: 「子部署あり削除不可」が `DEPT901`/`DEPT902` を参照（テスト内 create/delete なし）
- [ ] §11 準拠: 権限差異あり機能のため簡易 chain 省略（方針を明記）
- [ ] `pnpm lint` 成功
- [ ] `pnpm e2e` 成功

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

- [ ] `pnpm e2e:seed` で `DEPT901`/`DEPT902`（E2E 専用シード）が作成されることを確認
- [ ] `pnpm e2e -- --grep "部署"` で departments 関連 E2E テストがすべてパスすること
- [ ] ライフサイクル chain（作成→更新→削除）が独立して完走すること
- [ ] ステータス管理 chain（作成→無効化→有効化→削除）が独立して完走すること
- [ ] 「子部署あり削除不可」テストが `DEPT901`/`DEPT902` を参照しテスト内で create/delete していないこと
- [ ] `pnpm e2e` でフル回帰が成功すること

---

Generated with [Claude Code](https://claude.ai/code)