### PR TITLE
ci: CIのpnpmをバージョン固定しonly-allow誤判定によるインストール失敗を解消

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,12 +49,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v5
         with:
           node-version: lts/*
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma Client
         run: pnpm db:generate

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.28.2",
   "scripts": {
     "preinstall": "npx -y only-allow pnpm",
     "dev": "next dev",


### PR DESCRIPTION
## Summary

PR 時に走る Playwright Tests ワークフローが `npm install -g pnpm`（バージョン非固定）に起因し、`only-allow` の `npm_config_user_agent` 誤判定で依存インストールに失敗していた問題を解消する。CI の pnpm を `package.json` の `packageManager`（pnpm@10.28.2）に固定し、`pnpm/action-setup@v4` + `--frozen-lockfile` でインストールを安定化させる。

Closes #268

## 計画からの逸脱

実装計画なしで実装を行いました。

本対応は CI 設定の局所的な修正（2 ファイル・差分 6 行）であり、issue 本文の「作業内容」チェックリストがそのまま実装手順として機能したため plan ファイルは作成していません。

## 変更内容

issue の作業内容に沿って以下を実施:

- `.github/workflows/playwright.yml`
  - `npm install -g pnpm` を `pnpm/action-setup@v4`（version 省略で `package.json` の `packageManager` を参照）に置換
  - `actions/setup-node` に `cache: pnpm` を追加し、`action-setup` を前段に配置
  - `pnpm install` を `pnpm install --frozen-lockfile` に変更
- `package.json`
  - `"packageManager": "pnpm@10.28.2"` を追加し、pnpm バージョン定義を集約

## Test Plan

CI 設定の変更のため、検証は GitHub Actions 上で行う。

- [ ] この PR 上で Playwright Tests ワークフローの `Install dependencies` が成功する
- [ ] CI で使用される pnpm バージョンが `package.json` の `packageManager`（10.28.2）に一致する
- [ ] `--frozen-lockfile` により lockfile 不整合時に CI がエラー検知できる（lockfile が最新であれば正常通過）

---

Generated with [Claude Code](https://claude.ai/code)
