### PR TITLE
test: customers e2e の create-e2e-test スキル準拠（chain分離・ドメインエラーシード分離）

### DIFF
--- a/docs/claude-plans/issue-261/deviations.md
+++ b/docs/claude-plans/issue-261/deviations.md
@@ -1,0 +1,41 @@
+# Issue #261 実装の逸脱記録
+
+## 1. スコープ外ファイル `customers-list.e2e.ts` の修正
+
+### 元の計画 / Issue 文言
+
+> ## 対象
+> - `src/app/(features)/customers/customers-crud.e2e.ts`
+> - `prisma/seed-e2e.ts`
+
+Issue の対象は crud e2e と seed の 2 ファイルのみ。`customers-list.e2e.ts` は
+対象外。
+
+### 実際の実装
+
+`customers-list.e2e.ts` の 2 テストの件数アサーションを堅牢化:
+
+- `都道府県で検索できる`: `expect(count).toBe(2)` → `expect(count).toBeGreaterThan(0)`
+- `状態「有効」で検索できる`: `expect(count).toBe(4)` → `expect(count).toBeGreaterThan(0)`
+
+いずれも「全表示行が絞り込み条件に一致する」不変条件のループ検証は維持。
+
+### 逸脱の理由
+
+§13 に従い独自シード `C901`（prefecture=東京都・isActive=true）を共通シード
+プールに追加した結果、`customers-list.e2e.ts` の **シード件数に結合した
+exact-count アサーション**が必然的に破綻した:
+
+- 都道府県=東京都: 既存 C001/C002 の 2 件 → C901 追加で 3 件（`toBe(2)` 失敗）
+- 状態=有効: 既存 4 件 → C901 追加で 5 件（`toBe(4)` 失敗）
+
+`C901` の属性調整では回避不能（active なら有効件数、inactive なら無効件数の
+どちらかが必ずズレる）。Issue の完了条件「`pnpm e2e` がグリーン」を満たすには
+当該アサーションの堅牢化が必須。
+
+検索テストが本来検証すべき不変条件は「絞り込み結果の全行が条件に一致する」
+ことであり、総件数はシード基数への偶発的結合にすぎない。直接の前例である
+products リファクタ（commit `a415cb0` / 親 Issue #255 系列）で
+`products-list.e2e.ts` は既に `toBeGreaterThan(0)` + 全行一致パターンへ移行済み。
+本変更はその確立済みパターンへ `customers-list.e2e.ts` を追従させるもので、
+skill の方向性と一致する。ユーザー承認済み（products 前例に合わせ堅牢化）。

--- a/docs/claude-plans/issue-261/plan.md
+++ b/docs/claude-plans/issue-261/plan.md
@@ -1,0 +1,59 @@
+# Issue #261 実装計画
+
+## 目的
+
+`src/app/(features)/customers/customers-crud.e2e.ts` を `create-e2e-test` スキル
+（§4 / §9 / §13）に準拠させる。serial chain の粒度を再編し、ドメインエラー
+failure-only テスト用の独自シードを `prisma/seed-e2e.ts` に分離する。
+
+## 調査結果（前提となる事実）
+
+| 観点 | 事実 | 根拠 |
+|------|------|------|
+| 現状 chain | `作成・更新・ステータス変更・削除テスト` に 6 ステップ（作成→詳細→更新→無効化→有効化→削除） | `customers-crud.e2e.ts:13-168` |
+| skill §4 上限 | chain 最大 5 テスト・ステータス管理は独立 chain | SKILL.md §4 |
+| 既存テスト専用CD | 管理者 `CUST901` / 一般 `CUST902`（テスト内作成） | `customers-crud.e2e.ts:4,8` |
+| status chain CD 前例 | products は chain2 用に `PRD903` を別CDで採用 | `products-crud.e2e.ts:8` |
+| ドメインエラーテスト | `納品先がある得意先は削除できない` が共通シード `C001`（D001/D002 保有）を借用 | `customers-crud.e2e.ts:170-182` |
+| seed 構造 | `CUSTOMERS` 配列に `deliveryLocations[]` をネスト。`seedCustomersAndDeliveryLocations()` が Company+Customer / Company+DeliveryLocation を生成 | `seed-e2e.ts:172-306,472-544` |
+| skill §13 | 独自シード CD は `xxx9NN` 帯・`name`/`description` に `E2E専用_` プレフィックス・シナリオコメント・既存構造は不変 | SKILL.md §13 |
+
+## 変更後の構成
+
+### `prisma/seed-e2e.ts`
+
+`CUSTOMERS` 配列末尾（C005 の後）に追記（既存 C001〜C005 は不変）:
+
+- `C901`（`E2E専用_納品先あり削除テスト用得意先`）+ 配下 `D901`
+  （`E2E専用_納品先あり削除テスト用納品先`）
+- `// C901/D901: E2E専用_納品先あり削除テスト用（skill §13 / Issue #261）` コメント付与
+
+### `customers-crud.e2e.ts`
+
+定数追加:
+- `TEST_STATUS_CUSTOMER_CD = "CUST903"` / `TEST_STATUS_CUSTOMER_NAME`
+- `CUSTOMER_HAS_DELIVERY = "C901"`（seed 由来であることをコメント明示）
+
+`test.describe("得意先CRUD（管理者）")`:
+
+1. `test.describe.serial("ライフサイクル")` … §9 chain1（4 ステップ）
+   - 新規得意先を作成できる（`CUST901`）
+   - 得意先詳細を確認できる
+   - 得意先情報を更新できる
+   - 得意先を削除できる
+2. `test.describe.serial("ステータス管理")` … §9 chain2（4 ステップ・別CD `CUST903`）
+   - ステータス管理用の得意先を作成できる
+   - 得意先を無効化できる
+   - 得意先を有効化できる
+   - 得意先を削除できる
+3. `test("納品先がある得意先は削除できない")` … `C901` を参照（並列・DB 不変）
+4. `test("重複する取引先コードでエラーが表示される")` … 既存維持
+
+`test.describe("得意先CRUD（一般ユーザー）")`: 既存維持（変更なし）
+
+## 完了条件
+
+- 各 chain のステップ数 ≤ 5（§4）
+- ドメインエラー failure-only テストが独自シード `C901`/`D901` を使用（§13）
+- 共通シード `C001` を失敗系テストで借用しない
+- `pnpm e2e` グリーン

--- a/prisma/seed-e2e.ts
+++ b/prisma/seed-e2e.ts
@@ -303,6 +303,30 @@ const CUSTOMERS = [
       },
     ],
   },
+  // C901/D901: E2E専用_納品先あり削除テスト用（skill §13 / Issue #261・failure-only・DB 不変）
+  {
+    code: "C901",
+    name: "E2E専用_納品先あり削除テスト用得意先",
+    postalCode: "1000005",
+    prefecture: "東京都",
+    address: "千代田区丸の内1-9-1",
+    phoneNumber: "0399990901",
+    faxNumber: null,
+    contactPerson: null,
+    marginRate: 10,
+    isActive: true,
+    deliveryLocations: [
+      {
+        code: "D901",
+        name: "E2E専用_納品先あり削除テスト用納品先",
+        postalCode: "1000005",
+        prefecture: "東京都",
+        address: "千代田区丸の内1-9-1 1F",
+        phoneNumber: "0399990902",
+        deliveryNotes: "E2E専用_削除不可検証用",
+      },
+    ],
+  },
 ];
 
 // 商品データ（各区分 + 有効/無効を含む）

--- a/src/app/(features)/customers/customers-crud.e2e.ts
+++ b/src/app/(features)/customers/customers-crud.e2e.ts
@@ -1,16 +1,23 @@
 import { expect, test } from "@playwright/test";
 
-/** テストで使用する固定の得意先データ（seed範囲 C001〜C005 外） */
+/** §9 chain1（ライフサイクル）用: 作成→詳細→更新→削除（テスト内作成・seed範囲外） */
 const TEST_CUSTOMER_CD = "CUST901";
 const TEST_CUSTOMER_NAME = "E2Eテスト得意先";
+
+/** §9 chain2（ステータス管理）用: ライフサイクルとは別データコード */
+const TEST_STATUS_CUSTOMER_CD = "CUST903";
+const TEST_STATUS_CUSTOMER_NAME = "E2Eステータス管理得意先";
 
 /** 一般ユーザー作成・削除テスト用 */
 const TEST_USER_CUSTOMER_CD = "CUST902";
 const TEST_USER_CUSTOMER_NAME = "E2E一般テスト得意先";
 
+/** §13 ドメインエラー用独自シード（seed-e2e.ts に事前定義・配下に D901 を持つ） */
+const CUSTOMER_HAS_DELIVERY = "C901";
+
 test.describe("得意先CRUD（管理者）", () => {
-  // 作成→詳細確認→更新→無効化→有効化→削除の順で実行（同一テストデータを使い回すため serial で順序保証）
-  test.describe.serial("作成・更新・ステータス変更・削除テスト", () => {
+  // §9 chain1: 作成 → 詳細確認 → 更新 → 削除（1 ライフサイクル × 1 関心事・§4 ステップ数 4）
+  test.describe.serial("ライフサイクル", () => {
     test("新規得意先を作成できる", async ({ page }) => {
       // 一覧画面から新規登録画面に遷移
       await page.goto("/customers");
@@ -111,40 +118,6 @@ test.describe("得意先CRUD（管理者）", () => {
       await expect(contactField).toHaveValue("更新担当");
     });
 
-    test("得意先を無効化できる", async ({ page }) => {
-      await page.goto(`/customers/${TEST_CUSTOMER_CD}`);
-      await expect(page.getByRole("heading", { name: "得意先編集" })).toBeVisible();
-
-      // 「無効化」ボタンが表示されること（有効状態）
-      await expect(page.getByRole("button", { name: "無効化" })).toBeVisible();
-
-      // 無効化実行
-      await page.getByRole("button", { name: "無効化" }).click();
-
-      // 成功トーストが表示される
-      await expect(page.getByText("得意先を無効化しました。")).toBeVisible({ timeout: 10000 });
-
-      // 「有効化」ボタンに切り替わること（無効状態）
-      await expect(page.getByRole("button", { name: "有効化" })).toBeVisible();
-    });
-
-    test("得意先を有効化できる", async ({ page }) => {
-      await page.goto(`/customers/${TEST_CUSTOMER_CD}`);
-      await expect(page.getByRole("heading", { name: "得意先編集" })).toBeVisible();
-
-      // 「有効化」ボタンが表示されること（無効状態）
-      await expect(page.getByRole("button", { name: "有効化" })).toBeVisible();
-
-      // 有効化実行
-      await page.getByRole("button", { name: "有効化" }).click();
-
-      // 成功トーストが表示される
-      await expect(page.getByText("得意先を有効化しました。")).toBeVisible({ timeout: 10000 });
-
-      // 「無効化」ボタンに切り替わること（有効状態）
-      await expect(page.getByRole("button", { name: "無効化" })).toBeVisible();
-    });
-
     test("得意先を削除できる", async ({ page }) => {
       await page.goto(`/customers/${TEST_CUSTOMER_CD}`);
       await expect(page.getByRole("heading", { name: "得意先編集" })).toBeVisible();
@@ -167,9 +140,82 @@ test.describe("得意先CRUD（管理者）", () => {
     });
   });
 
+  // §9 chain2: 作成 → 無効化 → 有効化 → 削除（ステータス管理は独立 chain・§4・別データコード CUST903）
+  test.describe.serial("ステータス管理", () => {
+    test("ステータス管理用の得意先を作成できる", async ({ page }) => {
+      // 最小フォーム入力で作成（フィールド網羅はライフサイクル chain の関心事）
+      await page.goto("/customers/new");
+      await expect(page.getByRole("heading", { name: "得意先登録" })).toBeVisible();
+
+      await page.getByLabel("取引先コード").fill(TEST_STATUS_CUSTOMER_CD);
+      await page.getByLabel("名前").fill(TEST_STATUS_CUSTOMER_NAME);
+
+      await page.getByRole("button", { name: "登録" }).click();
+
+      await expect(page).toHaveURL(/\/customers/, { timeout: 10000 });
+      await page.waitForLoadState("load");
+      await expect(page.getByText("得意先を登録しました。")).toBeVisible({ timeout: 10000 });
+    });
+
+    test("得意先を無効化できる", async ({ page }) => {
+      await page.goto(`/customers/${TEST_STATUS_CUSTOMER_CD}`);
+      await expect(page.getByRole("heading", { name: "得意先編集" })).toBeVisible();
+
+      // 「無効化」ボタンが表示されること（有効状態）
+      await expect(page.getByRole("button", { name: "無効化" })).toBeVisible();
+
+      // 無効化実行
+      await page.getByRole("button", { name: "無効化" }).click();
+
+      // 成功トーストが表示される
+      await expect(page.getByText("得意先を無効化しました。")).toBeVisible({ timeout: 10000 });
+
+      // 「有効化」ボタンに切り替わること（無効状態）
+      await expect(page.getByRole("button", { name: "有効化" })).toBeVisible();
+    });
+
+    test("得意先を有効化できる", async ({ page }) => {
+      await page.goto(`/customers/${TEST_STATUS_CUSTOMER_CD}`);
+      await expect(page.getByRole("heading", { name: "得意先編集" })).toBeVisible();
+
+      // 「有効化」ボタンが表示されること（無効状態）
+      await expect(page.getByRole("button", { name: "有効化" })).toBeVisible();
+
+      // 有効化実行
+      await page.getByRole("button", { name: "有効化" }).click();
+
+      // 成功トーストが表示される
+      await expect(page.getByText("得意先を有効化しました。")).toBeVisible({ timeout: 10000 });
+
+      // 「無効化」ボタンに切り替わること（有効状態）
+      await expect(page.getByRole("button", { name: "無効化" })).toBeVisible();
+    });
+
+    test("得意先を削除できる", async ({ page }) => {
+      await page.goto(`/customers/${TEST_STATUS_CUSTOMER_CD}`);
+      await expect(page.getByRole("heading", { name: "得意先編集" })).toBeVisible();
+
+      // 削除実行
+      await page.getByRole("button", { name: "削除" }).click();
+
+      // 一覧画面にリダイレクトされ、成功トーストが表示される
+      await expect(page).toHaveURL(/\/customers/, { timeout: 10000 });
+      await expect(page.getByText("得意先を削除しました。")).toBeVisible({ timeout: 10000 });
+
+      // 削除した得意先が検索で見つからない
+      await expect(page.locator("table tbody tr").first()).toBeVisible();
+      await page.getByLabel("コード").fill(TEST_STATUS_CUSTOMER_CD);
+      await page.getByRole("button", { name: "検索" }).click();
+      await expect(page).toHaveURL(new RegExp(`code=${TEST_STATUS_CUSTOMER_CD}`), {
+        timeout: 10000,
+      });
+      await expect(page.getByRole("link", { name: TEST_STATUS_CUSTOMER_CD })).not.toBeVisible();
+    });
+  });
+
   test("納品先がある得意先は削除できない", async ({ page }) => {
-    // C001は納品先（D001, D002）を持つシードデータ
-    await page.goto("/customers/C001");
+    // C901 は配下に納品先 D901 を持つ E2E 専用シード（skill §13・seed-e2e.ts・DB 不変）
+    await page.goto(`/customers/${CUSTOMER_HAS_DELIVERY}`);
     await expect(page.getByRole("heading", { name: "得意先編集" })).toBeVisible();
 
     // 削除実行
@@ -184,7 +230,7 @@ test.describe("得意先CRUD（管理者）", () => {
   test("重複する取引先コードでエラーが表示される", async ({ page }) => {
     await page.goto("/customers/new");
 
-    await page.getByLabel("取引先コード").fill("C001"); // 既存の得意先コード
+    await page.getByLabel("取引先コード").fill("C001"); // 既存の得意先コード（共通シード・簡易エラー §3）
     await page.getByLabel("名前").fill("重複テスト得意先");
 
     await page.getByRole("button", { name: "登録" }).click();

--- a/src/app/(features)/customers/customers-list.e2e.ts
+++ b/src/app/(features)/customers/customers-list.e2e.ts
@@ -86,7 +86,8 @@ test.describe("得意先一覧（管理者）", () => {
     const prefectureCol = await getColumnIndex(page, "都道府県");
     const prefectureCells = page.locator(`table tbody tr td:nth-child(${prefectureCol})`);
     const count = await prefectureCells.count();
-    expect(count).toBe(2);
+    // 件数はシード件数に結合させず、絞り込み不変条件（全行が条件一致）を検証する
+    expect(count).toBeGreaterThan(0);
     for (let i = 0; i < count; i++) {
       await expect(prefectureCells.nth(i)).toHaveText("東京都");
     }
@@ -161,7 +162,8 @@ test.describe("得意先一覧（管理者）", () => {
     const statusCol = await getColumnIndex(page, "状態");
     const statusBadges = page.locator(`table tbody tr td:nth-child(${statusCol}) span`);
     const count = await statusBadges.count();
-    expect(count).toBe(4);
+    // 件数はシード件数に結合させず、絞り込み不変条件（全行が条件一致）を検証する
+    expect(count).toBeGreaterThan(0);
     for (let i = 0; i < count; i++) {
       await expect(statusBadges.nth(i)).toHaveText("有効");
     }


### PR DESCRIPTION
## Summary

`customers-crud.e2e.ts` を `create-e2e-test` スキル（§4 / §9 / §13）に準拠させた。6 ステップの単一 serial chain を「ライフサイクル chain」と「ステータス管理 chain」の 2 chain に分離し、ドメインエラー failure-only テスト用の独自シード `C901`/`D901` を `prisma/seed-e2e.ts` に追加。共通シード `C001` の借用を解消した。

Closes #261

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### 目的

`src/app/(features)/customers/customers-crud.e2e.ts` を `create-e2e-test` スキル（§4 / §9 / §13）に準拠させる。serial chain の粒度を再編し、ドメインエラー failure-only テスト用の独自シードを `prisma/seed-e2e.ts` に分離する。

### 調査結果（前提となる事実）

| 観点 | 事実 | 根拠 |
|------|------|------|
| 現状 chain | `作成・更新・ステータス変更・削除テスト` に 6 ステップ（作成→詳細→更新→無効化→有効化→削除） | `customers-crud.e2e.ts:13-168` |
| skill §4 上限 | chain 最大 5 テスト・ステータス管理は独立 chain | SKILL.md §4 |
| 既存テスト専用CD | 管理者 `CUST901` / 一般 `CUST902`（テスト内作成） | `customers-crud.e2e.ts:4,8` |
| status chain CD 前例 | products は chain2 用に `PRD903` を別CDで採用 | `products-crud.e2e.ts:8` |
| ドメインエラーテスト | `納品先がある得意先は削除できない` が共通シード `C001`（D001/D002 保有）を借用 | `customers-crud.e2e.ts:170-182` |
| seed 構造 | `CUSTOMERS` 配列に `deliveryLocations[]` をネスト。`seedCustomersAndDeliveryLocations()` が Company+Customer / Company+DeliveryLocation を生成 | `seed-e2e.ts:172-306,472-544` |
| skill §13 | 独自シード CD は `xxx9NN` 帯・`name`/`description` に `E2E専用_` プレフィックス・シナリオコメント・既存構造は不変 | SKILL.md §13 |

### 変更後の構成

#### `prisma/seed-e2e.ts`

`CUSTOMERS` 配列末尾（C005 の後）に追記（既存 C001〜C005 は不変）:

- `C901`（`E2E専用_納品先あり削除テスト用得意先`）+ 配下 `D901`（`E2E専用_納品先あり削除テスト用納品先`）
- `// C901/D901: E2E専用_納品先あり削除テスト用（skill §13 / Issue #261）` コメント付与

#### `customers-crud.e2e.ts`

定数追加:
- `TEST_STATUS_CUSTOMER_CD = "CUST903"` / `TEST_STATUS_CUSTOMER_NAME`
- `CUSTOMER_HAS_DELIVERY = "C901"`（seed 由来であることをコメント明示）

`test.describe("得意先CRUD（管理者）")`:

1. `test.describe.serial("ライフサイクル")` … §9 chain1（4 ステップ）: 作成（`CUST901`）→ 詳細 → 更新 → 削除
2. `test.describe.serial("ステータス管理")` … §9 chain2（4 ステップ・別CD `CUST903`）: 作成 → 無効化 → 有効化 → 削除
3. `test("納品先がある得意先は削除できない")` … `C901` を参照（並列・DB 不変）
4. `test("重複する取引先コードでエラーが表示される")` … 既存維持

`test.describe("得意先CRUD（一般ユーザー）")`: 既存維持（変更なし）

### 完了条件

- 各 chain のステップ数 ≤ 5（§4）
- ドメインエラー failure-only テストが独自シード `C901`/`D901` を使用（§13）
- 共通シード `C001` を失敗系テストで借用しない
- `pnpm e2e` グリーン

</details>

## 計画からの逸脱

### スコープ外ファイル `customers-list.e2e.ts` の修正

- **元の計画**: Issue 対象は `customers-crud.e2e.ts` と `prisma/seed-e2e.ts` の 2 ファイルのみ。`customers-list.e2e.ts` は対象外。
- **実際の実装**: `customers-list.e2e.ts` の 2 テストの件数アサーションを堅牢化（`都道府県で検索できる`: `toBe(2)` → `toBeGreaterThan(0)`、`状態「有効」で検索できる`: `toBe(4)` → `toBeGreaterThan(0)`）。全表示行が絞り込み条件に一致する不変条件のループ検証は維持。
- **逸脱の理由**: §13 に従い独自シード `C901`（prefecture=東京都・isActive=true）を共通シードプールに追加した結果、`customers-list.e2e.ts` のシード件数に結合した exact-count アサーションが必然的に破綻（東京都 2→3 件、有効 4→5 件）。`C901` の属性調整では回避不能。Issue の完了条件「`pnpm e2e` がグリーン」を満たすには当該アサーションの堅牢化が必須。検索テストが本来検証すべき不変条件は「絞り込み結果の全行が条件に一致する」ことであり、総件数はシード基数への偶発的結合にすぎない。直接の前例である products リファクタ（commit `a415cb0` / 親 Issue #255 系列）で `products-list.e2e.ts` は既に同パターンへ移行済みであり、確立済みパターンへの追従。ユーザー承認済み。

## Test Plan

- [ ] `pnpm e2e` がグリーン（テストデータ再シード + E2E 全実行）
- [ ] ライフサイクル chain（作成→詳細→更新→削除）が直列で通る
- [ ] ステータス管理 chain（作成→無効化→有効化→削除）が直列で通る
- [ ] 「納品先がある得意先は削除できない」テストが独自シード `C901`/`D901` を参照して通る
- [ ] 各 chain のステップ数が 5 以下（skill §4 準拠）
- [ ] 共通シード `C001` が失敗系テストで借用されていない（skill §13 準拠）
- [ ] `customers-list.e2e.ts` の検索テストが `C901` シード追加後もグリーン

---

Generated with [Claude Code](https://claude.ai/code)
