### PR TITLE
test: delivery-locations e2e の create-e2e-test スキル準拠（chain分離）

### DIFF
--- a/docs/claude-plans/issue-262/deviations.md
+++ b/docs/claude-plans/issue-262/deviations.md
@@ -1,0 +1,55 @@
+# Issue #262 実装の逸脱記録
+
+## 1. スコープ外ファイル `delivery-locations-list.e2e.ts` の修正
+
+### 元の計画 / Issue 文言
+
+> ## 対象
+> - `src/app/(features)/delivery-locations/delivery-locations-crud.e2e.ts`
+
+Issue #262 の対象は crud e2e の 1 ファイルのみ。`delivery-locations-list.e2e.ts`
+は対象外。
+
+### 実際の実装
+
+ユーザー追加要望により `delivery-locations-list.e2e.ts` の 1 テストの件数
+アサーションを堅牢化:
+
+- `状態「有効」で検索できる`: `expect(count).toBe(6)` →
+  `expect(count).toBeGreaterThan(0)`
+
+「全表示行が絞り込み条件に一致する」不変条件のループ検証は維持。他の
+`toHaveCount`（名前=山田 / 得意先=山田 / 状態=無効 / 複合）は変更しない。
+
+### 逸脱の理由
+
+Issue #261（PR #270 で merge 済み）が skill §13 に従い独自シード `C901` と
+配下 `D901` を共通シードプールへ追加した。`D901` は **active な納品先**のため、
+共通シードの有効納品先数が 6 → 7 に増加し、`delivery-locations-list.e2e.ts`
+の **シード件数に結合した exact-count アサーション** `expect(count).toBe(6)`
+が必然的に破綻した（実際は 7 件）。検索ロジック自体は正常で、破綻したのは
+脆い件数アサーションのみ。
+
+ユーザーが当該アサーションを名指しで指摘し（「`expect(count).toBe(6)` という
+テストが脆弱」）、PR #270 に倣った修正を明示的に要望した。検索テストが本来
+検証すべき不変条件は「絞り込み結果の全行が条件に一致する」ことであり、総件数
+はシード基数への偶発的結合にすぎない。直接の前例である products リファクタ
+（commit `a415cb0`）/ customers リファクタ（commit `09d09bc` / PR #270）で
+`products-list.e2e.ts` / `customers-list.e2e.ts` は既に `toBeGreaterThan(0)`
++ 全行一致パターンへ移行済み。本変更はその確立済みパターンへ
+`delivery-locations-list.e2e.ts` を追従させるもので、skill の方向性と一致する。
+
+修正スコープは #261 で実際に破綻した 1 箇所のみに限定した。理由: PR #270 も
+`customers-list` で破綻した箇所のみ修正し健全な count アサーションには手を
+付けていない前例に従い、最小・原則的スコープを維持するため。他の
+`toHaveCount` は `D901`（C901 配下・名前非該当・active）の影響を受けず green。
+
+## 2. §13 独自シードを追加しなかった点（参考・逸脱ではない）
+
+customers（#261）は「納品先がある得意先は削除できない」ドメインエラー
+テストのため `C901`/`D901` を追加したが、`delivery-locations-crud.e2e.ts`
+にはドメインエラーテストが存在しない（`重複する取引先コード` は §3 簡易
+エラー・共通シード `D001`・DB 不変）。よって §13 に基づく `seed-e2e.ts` への
+独自シード追加は不要と判断し、`seed-e2e.ts` は無変更（Issue #250 既存構造
+不変原則とも整合）。これは計画どおりの判断であり逸脱ではないが、customers
+との対比で誤解を招きやすいため記録する。

--- a/docs/claude-plans/issue-262/plan.md
+++ b/docs/claude-plans/issue-262/plan.md
@@ -1,0 +1,66 @@
+# Issue #262: delivery-locations e2e の create-e2e-test スキル準拠（chain分離） — 実装計画
+
+## 概要
+
+`delivery-locations-crud.e2e.ts` の単一 serial chain（作成→詳細→更新→無効化→
+有効化→削除の 6 ステップ）を create-e2e-test skill §4/§9 に準拠させ、
+「ライフサイクル chain」と「ステータス管理 chain」の 2 chain に分離する。
+
+加えてユーザー追加要望として、Issue #261（PR #270）の共通シード変更
+（`C901`/配下 `D901` 追加・`D901` は active）により破綻した
+`delivery-locations-list.e2e.ts` の `状態「有効」で検索できる` テストの
+脆い件数アサーション `expect(count).toBe(6)` を PR #270 と同一パターン
+（`toBeGreaterThan(0)` + 全行一致不変条件）へ堅牢化する。
+
+## 設計判断
+
+### list 修正のスコープ
+- A. list の全 `toHaveCount`/`toBe` を一括堅牢化
+- B. #261 で実際に壊れた `expect(count).toBe(6)`（line 91）のみを修正
+- 推奨: **B**。ユーザー指示が当該アサーションを明示。直接前例 PR #270 も
+  `customers-list` で壊れた箇所のみ修正（健全な count は不変）。他の
+  `toHaveCount` は D901 の影響を受けず green のため変更しない。
+
+### §13 独自シードの追加
+- 追加しない。delivery-locations-crud にドメインエラーテストが存在しない
+  （重複コードは §3 簡易エラー・共通シード D001・DB 不変）。customers
+  （#261）と異なり `seed-e2e.ts` は無変更（Issue #250 既存構造不変原則）。
+
+### ステータス管理 chain の作成ステップ
+- 最小フォーム入力（取引先コード・名前・得意先のみ）。フィールド網羅は
+  ライフサイクル chain の関心事であり §4「1 chain = 1 関心事」に従い重複を
+  避ける（`customers-crud.e2e.ts` PR #270 の前例に準拠）。
+
+## ステップ
+
+### Step 1: crud serial chain を §4/§9 準拠で分離
+- 対象ファイル: `src/app/(features)/delivery-locations/delivery-locations-crud.e2e.ts`
+- 作業内容:
+  - 定数追加 `TEST_STATUS_DL_CD = "DL903"` / `TEST_STATUS_DL_NAME`、既存
+    `TEST_DL_CD = "DL901"` を §9 chain1 用とコメント明示
+  - 単一 chain を `test.describe.serial("ライフサイクル")`（作成→詳細→更新→
+    削除・4 ステップ）と `test.describe.serial("ステータス管理")`（作成→無効化
+    →有効化→削除・DL903・4 ステップ）へ分離
+  - `重複する取引先コード`（§3 簡易エラー）と一般ユーザー簡易 chain は変更しない
+- コミットメッセージ: `test: delivery-locations crud e2e の serial chain を分離（§4/§9 準拠）`
+
+### Step 2: list の脆い件数アサーションを堅牢化（#261 seed 追従）
+- 対象ファイル: `src/app/(features)/delivery-locations/delivery-locations-list.e2e.ts`
+- 作業内容: line 91 の `expect(count).toBe(6);` を
+  `expect(count).toBeGreaterThan(0);` + 不変条件コメントへ。全行「有効」
+  ループ（line 92-94）は維持
+- コミットメッセージ: `test: delivery-locations-list の脆い件数アサーションを堅牢化（#261 seed 追従）`
+
+### Step 3: 逸脱を記録
+- 対象ファイル: `docs/claude-plans/issue-262/deviations.md`
+- 作業内容: Issue #262 文言は crud のみ対象。list 修正はユーザー追加要望に
+  よるスコープ拡大であることを PR #270 の `issue-261/deviations.md` に倣い記録
+- コミットメッセージ: `docs: Issue #262 の逸脱（list e2e スコープ拡大）を記録`
+
+## 完了条件
+
+- どの chain も §4 の最大 5 テスト以内
+- ステータス管理が独立 chain（§9）
+- `delivery-locations-list.e2e.ts` の脆い件数アサーションが堅牢化済み
+- `seed-e2e.ts` は無変更
+- `pnpm e2e` がグリーン

--- a/src/app/(features)/delivery-locations/delivery-locations-crud.e2e.ts
+++ b/src/app/(features)/delivery-locations/delivery-locations-crud.e2e.ts
@@ -1,17 +1,21 @@
 import { expect, test } from "@playwright/test";
 
-/** テストで使用する固定の納品先データ（seed範囲 D001〜D007 外） */
+/** §9 chain1（ライフサイクル）用: 作成→詳細→更新→削除（テスト内作成・seed範囲 D001〜D007 外） */
 const TEST_DL_CD = "DL901";
 const TEST_DL_NAME = "E2Eテスト納品先";
 const TEST_CUSTOMER_NAME = "株式会社山田製作所";
+
+/** §9 chain2（ステータス管理）用: ライフサイクルとは別データコード */
+const TEST_STATUS_DL_CD = "DL903";
+const TEST_STATUS_DL_NAME = "E2Eステータス管理納品先";
 
 /** 一般ユーザー作成・削除テスト用 */
 const TEST_USER_DL_CD = "DL902";
 const TEST_USER_DL_NAME = "E2E一般テスト納品先";
 
 test.describe("納品先CRUD（管理者）", () => {
-  // 作成→詳細確認→更新→無効化→有効化→削除の順で実行（同一テストデータを使い回すため serial で順序保証）
-  test.describe.serial("作成・更新・ステータス変更・削除テスト", () => {
+  // §9 chain1: 作成 → 詳細確認 → 更新 → 削除（1 ライフサイクル × 1 関心事・§4 ステップ数 4）
+  test.describe.serial("ライフサイクル", () => {
     test("新規納品先を作成できる", async ({ page }) => {
       // 一覧画面から新規登録画面に遷移
       await page.goto("/delivery-locations");
@@ -110,40 +114,6 @@ test.describe("納品先CRUD（管理者）", () => {
       await expect(contactField).toHaveValue("更新担当");
     });
 
-    test("納品先を無効化できる", async ({ page }) => {
-      await page.goto(`/delivery-locations/${TEST_DL_CD}`);
-      await expect(page.getByRole("heading", { name: "納品先編集" })).toBeVisible();
-
-      // 「無効化」ボタンが表示されること（有効状態）
-      await expect(page.getByRole("button", { name: "無効化" })).toBeVisible();
-
-      // 無効化実行
-      await page.getByRole("button", { name: "無効化" }).click();
-
-      // 成功トーストが表示される
-      await expect(page.getByText("納品先を無効化しました。")).toBeVisible({ timeout: 10000 });
-
-      // 「有効化」ボタンに切り替わること（無効状態）
-      await expect(page.getByRole("button", { name: "有効化" })).toBeVisible();
-    });
-
-    test("納品先を有効化できる", async ({ page }) => {
-      await page.goto(`/delivery-locations/${TEST_DL_CD}`);
-      await expect(page.getByRole("heading", { name: "納品先編集" })).toBeVisible();
-
-      // 「有効化」ボタンが表示されること（無効状態）
-      await expect(page.getByRole("button", { name: "有効化" })).toBeVisible();
-
-      // 有効化実行
-      await page.getByRole("button", { name: "有効化" }).click();
-
-      // 成功トーストが表示される
-      await expect(page.getByText("納品先を有効化しました。")).toBeVisible({ timeout: 10000 });
-
-      // 「無効化」ボタンに切り替わること（有効状態）
-      await expect(page.getByRole("button", { name: "無効化" })).toBeVisible();
-    });
-
     test("納品先を削除できる", async ({ page }) => {
       await page.goto(`/delivery-locations/${TEST_DL_CD}`);
       await expect(page.getByRole("heading", { name: "納品先編集" })).toBeVisible();
@@ -166,10 +136,84 @@ test.describe("納品先CRUD（管理者）", () => {
     });
   });
 
+  // §9 chain2: 作成 → 無効化 → 有効化 → 削除（ステータス管理は独立 chain・§4・別データコード DL903）
+  test.describe.serial("ステータス管理", () => {
+    test("ステータス管理用の納品先を作成できる", async ({ page }) => {
+      // 最小フォーム入力で作成（フィールド網羅はライフサイクル chain の関心事）
+      await page.goto("/delivery-locations/new");
+      await expect(page.getByRole("heading", { name: "納品先登録" })).toBeVisible();
+
+      await page.getByLabel("取引先コード").fill(TEST_STATUS_DL_CD);
+      await page.getByLabel("名前").fill(TEST_STATUS_DL_NAME);
+      await page.getByLabel("得意先").selectOption({ label: TEST_CUSTOMER_NAME });
+
+      await page.getByRole("button", { name: "登録" }).click();
+
+      await expect(page).toHaveURL(/\/delivery-locations/, { timeout: 10000 });
+      await page.waitForLoadState("load");
+      await expect(page.getByText("納品先を登録しました。")).toBeVisible({ timeout: 10000 });
+    });
+
+    test("納品先を無効化できる", async ({ page }) => {
+      await page.goto(`/delivery-locations/${TEST_STATUS_DL_CD}`);
+      await expect(page.getByRole("heading", { name: "納品先編集" })).toBeVisible();
+
+      // 「無効化」ボタンが表示されること（有効状態）
+      await expect(page.getByRole("button", { name: "無効化" })).toBeVisible();
+
+      // 無効化実行
+      await page.getByRole("button", { name: "無効化" }).click();
+
+      // 成功トーストが表示される
+      await expect(page.getByText("納品先を無効化しました。")).toBeVisible({ timeout: 10000 });
+
+      // 「有効化」ボタンに切り替わること（無効状態）
+      await expect(page.getByRole("button", { name: "有効化" })).toBeVisible();
+    });
+
+    test("納品先を有効化できる", async ({ page }) => {
+      await page.goto(`/delivery-locations/${TEST_STATUS_DL_CD}`);
+      await expect(page.getByRole("heading", { name: "納品先編集" })).toBeVisible();
+
+      // 「有効化」ボタンが表示されること（無効状態）
+      await expect(page.getByRole("button", { name: "有効化" })).toBeVisible();
+
+      // 有効化実行
+      await page.getByRole("button", { name: "有効化" }).click();
+
+      // 成功トーストが表示される
+      await expect(page.getByText("納品先を有効化しました。")).toBeVisible({ timeout: 10000 });
+
+      // 「無効化」ボタンに切り替わること（有効状態）
+      await expect(page.getByRole("button", { name: "無効化" })).toBeVisible();
+    });
+
+    test("納品先を削除できる", async ({ page }) => {
+      await page.goto(`/delivery-locations/${TEST_STATUS_DL_CD}`);
+      await expect(page.getByRole("heading", { name: "納品先編集" })).toBeVisible();
+
+      // 削除実行
+      await page.getByRole("button", { name: "削除" }).click();
+
+      // 一覧画面にリダイレクトされ、成功トーストが表示される
+      await expect(page).toHaveURL(/\/delivery-locations/, { timeout: 10000 });
+      await expect(page.getByText("納品先を削除しました。")).toBeVisible({ timeout: 10000 });
+
+      // 削除した納品先が検索で見つからない
+      await expect(page.locator("table tbody tr").first()).toBeVisible();
+      await page.getByLabel("コード").fill(TEST_STATUS_DL_CD);
+      await page.getByRole("button", { name: "検索" }).click();
+      await expect(page).toHaveURL(new RegExp(`code=${TEST_STATUS_DL_CD}`), {
+        timeout: 10000,
+      });
+      await expect(page.getByRole("link", { name: TEST_STATUS_DL_CD })).not.toBeVisible();
+    });
+  });
+
   test("重複する取引先コードでエラーが表示される", async ({ page }) => {
     await page.goto("/delivery-locations/new");
 
-    await page.getByLabel("取引先コード").fill("D001"); // 既存の納品先コード
+    await page.getByLabel("取引先コード").fill("D001"); // 既存の納品先コード（共通シード・簡易エラー §3）
     await page.getByLabel("名前").fill("重複テスト納品先");
     await page.getByLabel("得意先").selectOption({ label: TEST_CUSTOMER_NAME });
 

--- a/src/app/(features)/delivery-locations/delivery-locations-list.e2e.ts
+++ b/src/app/(features)/delivery-locations/delivery-locations-list.e2e.ts
@@ -88,7 +88,8 @@ test.describe("納品先一覧（管理者）", () => {
     const statusCol = await getColumnIndex(page, "状態");
     const statusBadges = page.locator(`table tbody tr td:nth-child(${statusCol}) span`);
     const count = await statusBadges.count();
-    expect(count).toBe(6);
+    // 件数はシード件数に結合させず、絞り込み不変条件（全行が条件一致）を検証する
+    expect(count).toBeGreaterThan(0);
     for (let i = 0; i < count; i++) {
       await expect(statusBadges.nth(i)).toHaveText("有効");
     }


### PR DESCRIPTION
## Summary

`delivery-locations-crud.e2e.ts` の単一 serial chain（作成→詳細→更新→無効化→有効化→削除の 6 ステップ）を create-e2e-test skill §4/§9 に準拠させ、「ライフサイクル chain」（4 ステップ）と「ステータス管理 chain」（DL903 でデータ分離・4 ステップ）の 2 chain に分離した。あわせて #261（PR #270）の共通シード変更で破綻した `delivery-locations-list.e2e.ts` の脆い件数アサーションを堅牢化した。

Closes #262

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### 概要

`delivery-locations-crud.e2e.ts` の単一 serial chain（作成→詳細→更新→無効化→有効化→削除の 6 ステップ）を create-e2e-test skill §4/§9 に準拠させ、「ライフサイクル chain」と「ステータス管理 chain」の 2 chain に分離する。

加えてユーザー追加要望として、Issue #261（PR #270）の共通シード変更（`C901`/配下 `D901` 追加・`D901` は active）により破綻した `delivery-locations-list.e2e.ts` の `状態「有効」で検索できる` テストの脆い件数アサーション `expect(count).toBe(6)` を PR #270 と同一パターン（`toBeGreaterThan(0)` + 全行一致不変条件）へ堅牢化する。

### 設計判断

**list 修正のスコープ**
- B を採用: #261 で実際に壊れた `expect(count).toBe(6)`（line 91）のみを修正。ユーザー指示が当該アサーションを明示し、前例 PR #270 も `customers-list` で壊れた箇所のみ修正している（健全な count は不変）。他の `toHaveCount` は D901 の影響を受けず green のため変更しない。

**§13 独自シードの追加**
- 追加しない。delivery-locations-crud にドメインエラーテストが存在しない（重複コードは §3 簡易エラー・共通シード D001・DB 不変）。customers（#261）と異なり `seed-e2e.ts` は無変更（Issue #250 既存構造不変原則）。

**ステータス管理 chain の作成ステップ**
- 最小フォーム入力（取引先コード・名前・得意先のみ）。フィールド網羅はライフサイクル chain の関心事であり §4「1 chain = 1 関心事」に従い重複を避ける（`customers-crud.e2e.ts` PR #270 の前例に準拠）。

### ステップ

- **Step 1**: crud serial chain を §4/§9 準拠で分離（定数 `TEST_STATUS_DL_CD = "DL903"` 追加、ライフサイクル chain と ステータス管理 chain に分離。`重複する取引先コード` と一般ユーザー簡易 chain は変更しない）
- **Step 2**: list の脆い件数アサーションを堅牢化（line 91 を `toBeGreaterThan(0)` + 不変条件コメントへ。全行「有効」ループは維持）
- **Step 3**: 逸脱を記録（list 修正がユーザー追加要望によるスコープ拡大であることを記録）

### 完了条件

- どの chain も §4 の最大 5 テスト以内
- ステータス管理が独立 chain（§9）
- `delivery-locations-list.e2e.ts` の脆い件数アサーションが堅牢化済み
- `seed-e2e.ts` は無変更
- `pnpm e2e` がグリーン

</details>

## 計画からの逸脱

### 1. スコープ外ファイル `delivery-locations-list.e2e.ts` の修正

Issue #262 の対象は crud e2e の 1 ファイルのみで `delivery-locations-list.e2e.ts` は対象外だったが、ユーザー追加要望により 1 テストの件数アサーションを堅牢化した。

- `状態「有効」で検索できる`: `expect(count).toBe(6)` → `expect(count).toBeGreaterThan(0)`
- 「全表示行が絞り込み条件に一致する」不変条件のループ検証は維持。他の `toHaveCount`（名前=山田 / 得意先=山田 / 状態=無効 / 複合）は変更しない。

**理由**: Issue #261（PR #270 で merge 済み）が skill §13 に従い独自シード `C901` と配下 `D901`（active な納品先）を共通シードプールへ追加した結果、有効納品先数が 6 → 7 に増加し、シード件数に結合した exact-count アサーション `expect(count).toBe(6)` が必然的に破綻した。検索ロジック自体は正常で、破綻したのは脆い件数アサーションのみ。ユーザーが当該アサーションを名指しで指摘し、PR #270 に倣った修正を明示的に要望した。products（commit a415cb0）/ customers（PR #270）で確立済みの `toBeGreaterThan(0)` + 全行一致パターンへ追従させるもので、skill の方向性と一致する。修正スコープは #261 で実際に破綻した 1 箇所のみに限定（PR #270 の最小・原則的スコープ前例に従う）。

### 2. §13 独自シードを追加しなかった点（参考・逸脱ではない）

customers（#261）は「納品先がある得意先は削除できない」ドメインエラーテストのため `C901`/`D901` を追加したが、`delivery-locations-crud.e2e.ts` にはドメインエラーテストが存在しない（`重複する取引先コード` は §3 簡易エラー・共通シード `D001`・DB 不変）。よって §13 に基づく `seed-e2e.ts` への独自シード追加は不要と判断し `seed-e2e.ts` は無変更（Issue #250 既存構造不変原則とも整合）。計画どおりの判断であり逸脱ではないが、customers との対比で誤解を招きやすいため記録。

## Test Plan

- [ ] `pnpm e2e` がローカルで成功する（全 chain が green）
- [ ] ライフサイクル chain（作成→詳細→更新→削除・4 ステップ）が §4 の最大 5 テスト以内
- [ ] ステータス管理 chain（作成→無効化→有効化→削除・DL903・4 ステップ）が独立 chain として分離されている（§9 準拠）
- [ ] テストデータコード（`DL901` ライフサイクル / `DL903` ステータス管理）が chain 間で衝突していない
- [ ] `delivery-locations-list.e2e.ts` の `状態「有効」で検索できる` が #261 のシード変更後も green
- [ ] `重複する取引先コード`（§3 簡易エラー）と一般ユーザー簡易 chain は未変更で green
- [ ] `seed-e2e.ts` が無変更であること

---

Generated with [Claude Code](https://claude.ai/code)
