### PR TITLE
feat: 見積コア Prisma スキーマ追加（見積本体＋サブタイプ＋税率マスタ）

### DIFF
--- a/docs/adr/0021-use-check-constraints-not-create-domain.md
+++ b/docs/adr/0021-use-check-constraints-not-create-domain.md
@@ -1,0 +1,64 @@
+# ADR-0021: 数値・文字列の制約にCREATE DOMAINを使わずCHECK制約を継続する
+
+| 項目 | 値 |
+|---|---|
+| ステータス | 採用 |
+| 起票日 | 2026-05-20 |
+| 最終更新日 | 2026-05-20 |
+
+## コンテキスト
+
+ADR-0019 で数値カラムの範囲制約を「マイグレーションSQLへの手動追記による`ALTER TABLE ... ADD CONSTRAINT ..._check`」で実装する方針を採用した。
+
+見積スキーマ実装（Issue #272）のレビューで、生成された`CREATE TABLE`の列定義が`fiscal_year INTEGER`のように素の型しか示さず、別オブジェクトとして付与したCHECK制約の存在が列定義から読み取れない、という指摘があった。PostgreSQLの`CREATE DOMAIN`を使えば`fiscal_year fiscal_year_t`のように制約を型レベルに埋め込め、自己文書化できるのではないかという提案である。
+
+このプロジェクトはPrismaを採用しており、`schema.prisma`をスキーマの単一の真実の源（single source of truth）としている。この前提のもとでCREATE DOMAINが採用可能かを判断する必要がある。
+
+## 検討した選択肢
+
+### A. CHECK制約を継続する（採用）
+
+ADR-0019 の方針を維持し、範囲制約はマイグレーションSQLへの手動追記で別オブジェクトとして付与する。列の型は`INTEGER` / `DECIMAL` のまま。
+
+```sql
+CREATE TABLE "estimates" (
+  "fiscal_year" INTEGER NOT NULL
+);
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_fiscal_year_check"
+  CHECK ("fiscal_year" >= 2000 AND "fiscal_year" <= 9999);
+```
+
+### B. CREATE DOMAINで型レベルに制約を埋め込む（不採用）
+
+```sql
+CREATE DOMAIN fiscal_year_t AS integer
+  CHECK (VALUE >= 2000 AND VALUE <= 9999);
+
+CREATE TABLE "estimates" (
+  "fiscal_year" fiscal_year_t NOT NULL
+);
+```
+
+PostgreSQL単体ではこの構文は有効で、制約が型として自己文書化される利点がある。
+
+## 決定
+
+CREATE DOMAINは採用せず、ADR-0019 のCHECK制約方式を継続する。
+
+## 根拠
+
+**PostgreSQL単体ではBが成立することは確認済み**（[公式ドキュメント](https://www.postgresql.jp/document/18/html/sql-createdomain.html)）。提案の「型レベルでの自己文書化」という利点も事実である。それでもBを不採用としたのは、Prismaとの組み合わせで以下の問題が生じるため:
+
+- **恒常的なdrift**: `schema.prisma`のDSLにはドメイン型を表現する構文がなく、フィールドは`Int` / `Decimal`としか書けない。マイグレーションSQLを手でドメイン型に書き換えると、Prismaのshadow DB比較で「DB＝独自ドメイン型／スキーマ＝integer」と毎回driftとして検出され、`prisma migrate dev`のたびに手当てが必要になる。
+- **Unsupported型化**: Prismaがドメイン列をintrospectすると`Unsupported("fiscal_year_t")`にマッピングする。`Unsupported`フィールドはPrisma Clientの型付きcreate/updateから除外されるため、`prisma.estimate.create({ data: { fiscalYear } })`が書けなくなる。
+- **DDDレイヤーへの波及**: Infrastructure層のPrisma↔Domainマッピングが、Unsupported列のためにraw SQL併用を強いられ、ADR-0009/0010で整えたマッピング規約と整合しなくなる。
+
+対して**CHECK制約方式（A）はPrismaから見て列型が素の`INTEGER` / `DECIMAL`のまま・制約は別オブジェクト**であるため、Prismaがこれを無視でき、driftを起こさない。ADR-0019 で手動追記を採用したのと同じ「DSLで表現できない制約を、ORMが無視できる形で足す」という回避策が、ドメイン型では型そのものを置換するために機能しない点が決定的である。
+
+自己文書化の欠如は、`estimates_fiscal_year_check`のような制約名で補う。
+
+## 影響
+
+- ADR-0019 の運用（数値制約はマイグレーションSQL手動追記）を引き続き踏襲する。新規テーブル・カラム追加時も同方式で範囲制約を付与する。
+- 列定義から制約の存在を読み取れない点はトレードオフとして受容する。制約の一覧性が必要な場合はマイグレーションSQLまたは`information_schema.check_constraints`を参照する。
+- 将来Prismaを脱却しraw SQLマイグレーション運用へ移行する場合は、CREATE DOMAINが有力な選択肢として再検討に値する。本決定は「現スタック（Prisma前提）では」という条件付きである。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -23,6 +23,7 @@
 | [0009](0009-migrate-id-generation-from-cuid2-to-uuidv7.md) | ID生成方式をCUID2からUUIDv7に移行する | 採用 | 2026-04-04 |
 | [0010](0010-migrate-datetime-to-timestamptz.md) | 全テーブルのDateTimeカラムをtimestamptzに移行する | 採用 | 2026-04-04 |
 | [0019](0019-add-varchar-and-check-constraints.md) | Stringカラムに@db.VarChar(N)、数値カラムにCHECK制約を追加する | 採用 | 2026-04-15 |
+| [0021](0021-use-check-constraints-not-create-domain.md) | 数値・文字列の制約にCREATE DOMAINを使わずCHECK制約を継続する | 採用 | 2026-05-20 |
 
 ## アプリケーション（フロントエンド・認可）
 

--- a/docs/claude-plans/issue-272/plan.md
+++ b/docs/claude-plans/issue-272/plan.md
@@ -1,0 +1,417 @@
+# Issue #272: 見積コア Prisma スキーマ追加（見積本体＋サブタイプ＋税率マスタ） — 実装計画
+
+## 概要
+
+`docs/business/estimate/システム設計書(見積).md` §11 の概念設計を Prisma スキーマとして実装する。本 issue では「見積本体＋サブタイプ＋税率マスタ」の **7 モデル**に絞り、Order 系・系譜（複製/改訂）・共通申請テーブル（ADR-0001）は別 issue で段階的に追加する。
+
+対象モデル:
+
+1. `TaxRate` (§11.5) — 消費税率マスタ
+2. `Estimate` (§11.1) — 見積本体
+3. `RepairEstimateDetail` (§11.1.1) — 修理見積サブタイプ
+4. `AfterRepairEstimateDetail` (§11.1.1) — 事後修理サブタイプ
+5. `EstimateVariation` (§11.2) — バリエーション
+6. `EstimateItem` (§11.3) — 明細
+7. `RevisedEstimateItemDetail` (§11.3.1) — 改訂明細サブタイプ
+
+スコープ外（別 issue）: `EstimateVariationCopy` / `EstimateVariationRevision` / `Order` / `OrderConfirmation` / `OrderCancellation` / 共通申請テーブル。
+
+## 設計判断
+
+### メモ系の型: 設計書 `@db.Text` → 実装 `@db.VarChar(2000)`
+- A. 設計書通り `@db.Text` を採用
+- B. **`@db.VarChar(2000)` で統一**（ユーザー確定）
+- 推奨: **B**。ADR-0019「全 String カラムに上限を持たせる」と整合。設計書 §11 冒頭「実装規約が別途優先」注記の範疇。対象: `customerMemo` / `internalMemo` / `faultDescription` / `emergencyReason`
+
+### `Estimate.createdBy` の参照先: `User` → `Employee`
+- A. 設計書通り `User` を参照
+- B. **`Employee` を参照**
+- 推奨: **B**。既存マスタの参照規約（業務エンティティは `Employee.id` を参照）に整合。§9 の部署権限チェックで `Employee.departmentId` が必要。`User` は better-auth 用テーブルで業務エンティティから直接参照しない（`Employee` ↔ `User` の 1:1 経由で必要時に解決）
+
+### 税率／掛率の Decimal 精度
+- 税率 `taxRate`: **`@db.Decimal(4, 3)`**（0.000〜0.999、例: 0.100）
+- 掛率 `discountRate`: **`@db.Decimal(5, 4)`**（0.0000〜1.0000、デフォルト 1.0000 を含めるため整数部 1 桁が必要）
+- 金額系: **`@db.Decimal(12, 2)`**（既存 `Product.costPrice` と整合）
+
+### CHECK 制約の上限値（業務意味で表現）
+- `tax_rate >= 0 AND tax_rate < 1` — 税率は元金額未満（業務制度上 100% 以上は想定外）
+- `discount_rate >= 0 AND discount_rate <= 1` — 掛率は 0〜1。デフォルト 1.0 を有効にするため `<=` を採用
+- Decimal 精度の上限（例: 9.9999）をそのまま CHECK 上限にしない（業務的意味と乖離するため）
+
+### マイグレーション分割: 論理単位で 3 つに分割
+- A. 1 マイグレーションで一括作成
+- B. **論理単位で 3 マイグレーション**
+- 推奨: **B**。CLAUDE.md「Commit at each meaningful change」と整合。Phase 順序は依存関係で固定（Phase 1 独立 → Phase 2 → Phase 3）
+
+### スコープ外モデルへの逆リレーションを今回は書かない
+- `Estimate.orders` / `EstimateVariation.copies` / `EstimateVariation.revisions` / `EstimateVariation.order` 等は今回追加しない
+- 理由: Order / 系譜モデル本体が未実装のため Prisma クライアント生成が失敗する。別 issue で本体モデル追加時に同 PR で逆リレーションも追加する方が安全
+
+## ステップ
+
+### Step 1: 計画ファイルをコミット
+- 対象ファイル: `docs/claude-plans/issue-272/plan.md`
+- 作業内容:
+  - 本ファイルを作成
+- コミットメッセージ: `docs: Issue #272 の実装計画を追加`
+
+### Step 2: Phase 1 — TaxRate モデル + マイグレーション + シード
+- 対象ファイル:
+  - `prisma/schema.prisma`
+  - `prisma/seed.ts`
+  - `prisma/migrations/<timestamp>_add_tax_rate_master/migration.sql`
+- 作業内容:
+  - schema.prisma 末尾に「消費税率関連」セクションを追加し `TaxRate` モデルを定義
+  - `pnpm db:migrate` で `add_tax_rate_master` マイグレーション生成
+  - 生成された migration.sql に CHECK 制約 `rate >= 0 AND rate < 1` を手書き追記
+  - `pnpm prisma migrate reset` で drift 解消
+  - seed.ts に税率 2 件（2014/4 から 0.080、2019/10 から 0.100）を JST で投入
+  - `pnpm prisma db seed` で投入確認、`pnpm prisma studio` で 2 行存在確認
+  - 税率取得クエリ（`findFirst({ where: { effectiveFrom: { lte: now } }, orderBy: { effectiveFrom: 'desc' } })`）が `0.100` を返すこと確認
+- コミットメッセージ: `feat: 消費税率マスタ (TaxRate) を追加`
+
+### Step 3: Phase 2 — Estimate + 修理サブタイプ
+- 対象ファイル:
+  - `prisma/schema.prisma`
+  - `prisma/migrations/<timestamp>_add_estimate_with_repair_subtypes/migration.sql`
+- 作業内容:
+  - 3 つの enum（`EstimateType`, `SubmissionType`, `TaxRoundingType`）を追加
+  - `Estimate` / `RepairEstimateDetail` / `AfterRepairEstimateDetail` モデルを追加
+  - 既存マスタに逆リレーション追加:
+    - `Customer.estimates Estimate[] @relation("CustomerEstimates")`
+    - `DeliveryLocation.estimates Estimate[] @relation("DeliveryLocationEstimates")`
+    - `Department.estimates Estimate[] @relation("EstimateDepartment")`
+    - `Employee.createdEstimates Estimate[] @relation("EstimateCreator")`
+    - `Product.repairTargetDetails RepairEstimateDetail[] @relation("RepairTargetProduct")`
+    - `Product.afterRepairTargetDetails AfterRepairEstimateDetail[] @relation("AfterRepairTargetProduct")`
+  - `pnpm db:migrate` で `add_estimate_with_repair_subtypes` マイグレーション生成
+  - 生成された migration.sql に CHECK 制約手書き追記:
+    - `fiscal_year >= 2000 AND fiscal_year <= 9999`
+    - `sequence >= 1 AND sequence <= 99999`
+    - `tax_rate >= 0 AND tax_rate < 1`
+  - `pnpm prisma migrate reset` で drift 解消
+  - `pnpm build` / `pnpm test` / `pnpm lint` で既存機能が壊れていないか確認
+- コミットメッセージ: `feat: 見積本体 (Estimate) と修理サブタイプ (Repair/AfterRepairEstimateDetail) を追加`
+
+### Step 4: Phase 3 — EstimateVariation + EstimateItem + RevisedEstimateItemDetail
+- 対象ファイル:
+  - `prisma/schema.prisma`
+  - `prisma/migrations/<timestamp>_add_estimate_variation_items/migration.sql`
+- 作業内容:
+  - `VariationStatus` enum を追加
+  - `EstimateVariation` / `EstimateItem` / `RevisedEstimateItemDetail` モデルを追加
+  - 既存マスタに逆リレーション追加:
+    - `Product.estimateItems EstimateItem[] @relation("EstimateItemProduct")`
+  - `pnpm db:migrate` で `add_estimate_variation_items` マイグレーション生成
+  - 生成された migration.sql に CHECK 制約手書き追記:
+    - バリエーション: `variation_number 1〜99`, 各種金額 `>= 0`
+    - 明細: `sort_order >= 0`, `quantity >= 1`, `unit_price >= 0`, `discount_rate 0〜1`, `item_discount >= 0`, 計算結果 `>= 0`
+    - 改訂明細: `delivery_price >= 0`
+  - `pnpm prisma migrate reset` で drift 解消
+  - `pnpm build` / `pnpm test` / `pnpm lint` で確認
+  - `pnpm prisma studio` で 7 テーブル全てが見えること確認
+- コミットメッセージ: `feat: バリエーション (EstimateVariation) と明細 (EstimateItem/RevisedEstimateItemDetail) を追加`
+
+## スキーマ DSL（完成形）
+
+### TaxRate (Phase 1)
+
+```prisma
+model TaxRate {
+  id   String  @id @db.Uuid
+  rate Decimal @db.Decimal(4, 3)
+
+  effectiveFrom DateTime @unique @map("effective_from") @db.Timestamptz(3)
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@map("tax_rates")
+}
+```
+
+### Estimate + 修理サブタイプ (Phase 2)
+
+```prisma
+enum EstimateType {
+  NEW
+  REPAIR
+  AFTER_REPAIR
+}
+
+enum SubmissionType {
+  CUSTOMER
+  DELIVERY_LOCATION
+}
+
+enum TaxRoundingType {
+  ROUND_DOWN
+  ROUND_UP
+  ROUND
+}
+
+model Estimate {
+  id             String @id @db.Uuid
+  estimateNumber String @unique @map("estimate_number") @db.VarChar(8)
+
+  estimateType EstimateType @map("estimate_type")
+
+  fiscalYear Int @map("fiscal_year")
+  sequence   Int
+
+  estimateDate DateTime @map("estimate_date") @db.Timestamptz(3)
+  deadline     DateTime @db.Timestamptz(3)
+
+  submissionType SubmissionType @map("submission_type")
+
+  customerId         String           @map("customer_id") @db.Uuid
+  customer           Customer         @relation("CustomerEstimates", fields: [customerId], references: [id])
+  deliveryLocationId String           @map("delivery_location_id") @db.Uuid
+  deliveryLocation   DeliveryLocation @relation("DeliveryLocationEstimates", fields: [deliveryLocationId], references: [id])
+
+  repairDetail      RepairEstimateDetail?
+  afterRepairDetail AfterRepairEstimateDetail?
+
+  taxRate         Decimal         @map("tax_rate") @db.Decimal(4, 3)
+  taxRoundingType TaxRoundingType @map("tax_rounding_type")
+
+  createdBy    String     @map("created_by") @db.Uuid
+  creator      Employee   @relation("EstimateCreator", fields: [createdBy], references: [id])
+  departmentId String     @map("department_id") @db.Uuid
+  department   Department @relation("EstimateDepartment", fields: [departmentId], references: [id])
+
+  variations EstimateVariation[]
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([estimateNumber])
+  @@index([fiscalYear, estimateType, sequence])
+  @@index([createdBy])
+  @@index([departmentId])
+  @@index([customerId])
+  @@index([deliveryLocationId])
+  @@index([submissionType])
+  @@map("estimates")
+}
+
+model RepairEstimateDetail {
+  id         String   @id @db.Uuid
+  estimateId String   @unique @map("estimate_id") @db.Uuid
+  estimate   Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)
+
+  targetProductId String  @map("target_product_id") @db.Uuid
+  targetProduct   Product @relation("RepairTargetProduct", fields: [targetProductId], references: [id])
+
+  faultDescription    String   @map("fault_description") @db.VarChar(2000)
+  scheduledRepairDate DateTime @map("scheduled_repair_date") @db.Timestamptz(3)
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([targetProductId])
+  @@map("repair_estimate_details")
+}
+
+model AfterRepairEstimateDetail {
+  id         String   @id @db.Uuid
+  estimateId String   @unique @map("estimate_id") @db.Uuid
+  estimate   Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)
+
+  targetProductId String  @map("target_product_id") @db.Uuid
+  targetProduct   Product @relation("AfterRepairTargetProduct", fields: [targetProductId], references: [id])
+
+  faultDescription String   @map("fault_description") @db.VarChar(2000)
+  actualRepairDate DateTime @map("actual_repair_date") @db.Timestamptz(3)
+  emergencyReason  String   @map("emergency_reason") @db.VarChar(2000)
+
+  afterServiceWarningAcknowledged Boolean @default(false) @map("after_service_warning_acknowledged")
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([targetProductId])
+  @@map("after_repair_estimate_details")
+}
+```
+
+### バリエーション + 明細 + 改訂明細 (Phase 3)
+
+```prisma
+enum VariationStatus {
+  ACTIVE
+  INACTIVE
+}
+
+model EstimateVariation {
+  id         String   @id @db.Uuid
+  estimateId String   @map("estimate_id") @db.Uuid
+  estimate   Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)
+
+  variationNumber Int             @map("variation_number")
+  status          VariationStatus @default(ACTIVE)
+
+  customerMemo String? @map("customer_memo") @db.VarChar(2000)
+  internalMemo String? @map("internal_memo") @db.VarChar(2000)
+
+  overallDiscount Decimal @default(0) @map("overall_discount") @db.Decimal(12, 2)
+
+  subtotal         Decimal @db.Decimal(12, 2)
+  discountSubtotal Decimal @map("discount_subtotal") @db.Decimal(12, 2)
+  finalSubtotal    Decimal @map("final_subtotal") @db.Decimal(12, 2)
+  taxAmount        Decimal @map("tax_amount") @db.Decimal(12, 2)
+  finalTotal       Decimal @map("final_total") @db.Decimal(12, 2)
+
+  items EstimateItem[]
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@unique([estimateId, variationNumber])
+  @@index([estimateId, status])
+  @@index([status])
+  @@map("estimate_variations")
+}
+
+model EstimateItem {
+  id          String            @id @db.Uuid
+  variationId String            @map("variation_id") @db.Uuid
+  variation   EstimateVariation @relation(fields: [variationId], references: [id], onDelete: Cascade)
+
+  sortOrder Int @map("sort_order")
+
+  productId String  @map("product_id") @db.Uuid
+  product   Product @relation("EstimateItemProduct", fields: [productId], references: [id])
+
+  itemName  String  @map("item_name") @db.VarChar(100)
+  quantity  Int
+  unit      String  @db.VarChar(20)
+  unitPrice Decimal @map("unit_price") @db.Decimal(12, 2)
+
+  customerMemo String? @map("customer_memo") @db.VarChar(2000)
+  internalMemo String? @map("internal_memo") @db.VarChar(2000)
+
+  discountRate Decimal @default(1.0) @map("discount_rate") @db.Decimal(5, 4)
+  itemDiscount Decimal @default(0) @map("item_discount") @db.Decimal(12, 2)
+
+  baseAmount       Decimal @map("base_amount") @db.Decimal(12, 2)
+  discountedAmount Decimal @map("discounted_amount") @db.Decimal(12, 2)
+  finalAmount      Decimal @map("final_amount") @db.Decimal(12, 2)
+
+  revisedDetail RevisedEstimateItemDetail?
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([variationId, sortOrder])
+  @@index([productId])
+  @@map("estimate_items")
+}
+
+model RevisedEstimateItemDetail {
+  id             String       @id @db.Uuid
+  estimateItemId String       @unique @map("estimate_item_id") @db.Uuid
+  estimateItem   EstimateItem @relation(fields: [estimateItemId], references: [id], onDelete: Cascade)
+
+  deliveryPrice Decimal @map("delivery_price") @db.Decimal(12, 2)
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@map("revised_estimate_item_details")
+}
+```
+
+## CHECK 制約 SQL（完成形）
+
+### Phase 1: TaxRate
+
+```sql
+ALTER TABLE "tax_rates" ADD CONSTRAINT "tax_rates_rate_check"
+  CHECK ("rate" >= 0 AND "rate" < 1);
+```
+
+### Phase 2: Estimate
+
+```sql
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_fiscal_year_check"
+  CHECK ("fiscal_year" >= 2000 AND "fiscal_year" <= 9999);
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_sequence_check"
+  CHECK ("sequence" >= 1 AND "sequence" <= 99999);
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_tax_rate_check"
+  CHECK ("tax_rate" >= 0 AND "tax_rate" < 1);
+```
+
+### Phase 3: バリエーション + 明細 + 改訂明細
+
+```sql
+-- バリエーション
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_variation_number_check"
+  CHECK ("variation_number" >= 1 AND "variation_number" <= 99);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_overall_discount_check"
+  CHECK ("overall_discount" >= 0);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_subtotal_check"
+  CHECK ("subtotal" >= 0);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_discount_subtotal_check"
+  CHECK ("discount_subtotal" >= 0);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_final_subtotal_check"
+  CHECK ("final_subtotal" >= 0);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_tax_amount_check"
+  CHECK ("tax_amount" >= 0);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_final_total_check"
+  CHECK ("final_total" >= 0);
+
+-- 明細
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_sort_order_check"
+  CHECK ("sort_order" >= 0);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_quantity_check"
+  CHECK ("quantity" >= 1);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_unit_price_check"
+  CHECK ("unit_price" >= 0);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_discount_rate_check"
+  CHECK ("discount_rate" >= 0 AND "discount_rate" <= 1);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_item_discount_check"
+  CHECK ("item_discount" >= 0);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_base_amount_check"
+  CHECK ("base_amount" >= 0);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_discounted_amount_check"
+  CHECK ("discounted_amount" >= 0);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_final_amount_check"
+  CHECK ("final_amount" >= 0);
+
+-- 改訂明細詳細
+ALTER TABLE "revised_estimate_item_details" ADD CONSTRAINT "revised_estimate_item_details_delivery_price_check"
+  CHECK ("delivery_price" >= 0);
+```
+
+## シードデータ (Phase 1)
+
+`prisma/seed.ts` に追記:
+
+```ts
+// 削除ブロックに追加
+await prisma.taxRate.deleteMany();
+
+// 作成ブロック（商品作成の後）
+console.log("Creating tax rates...");
+const TAX_RATES = [
+  { rate: "0.080", effectiveFrom: new Date("2014-04-01T00:00:00+09:00") },
+  { rate: "0.100", effectiveFrom: new Date("2019-10-01T00:00:00+09:00") },
+];
+for (const tr of TAX_RATES) {
+  await prisma.taxRate.create({
+    data: { id: generateId(), rate: tr.rate, effectiveFrom: tr.effectiveFrom },
+  });
+}
+console.log(`Created ${TAX_RATES.length} tax rates`);
+```
+
+## 完了条件
+
+- `prisma/schema.prisma` に 7 モデル + 4 enum が追加されている
+- 3 つのマイグレーションが生成され、それぞれ手書きの CHECK 制約が追記されている
+- `pnpm prisma migrate reset` が成功する（drift なし）
+- `pnpm build` / `pnpm test` / `pnpm lint` がオールグリーン
+- `pnpm db:studio` で 7 テーブル（`tax_rates`, `estimates`, `repair_estimate_details`, `after_repair_estimate_details`, `estimate_variations`, `estimate_items`, `revised_estimate_item_details`）が確認できる
+- `pnpm prisma db seed` で税率 2 件が投入されている
+- 各 Phase が独立したコミットとしてリポジトリに記録されている

--- a/prisma/migrations/20260520011920_add_tax_rate_master/migration.sql
+++ b/prisma/migrations/20260520011920_add_tax_rate_master/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "tax_rates" (
+    "id" UUID NOT NULL,
+    "rate" DECIMAL(4,3) NOT NULL,
+    "effective_from" TIMESTAMPTZ(3) NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "tax_rates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tax_rates_effective_from_key" ON "tax_rates"("effective_from");
+
+-- CheckConstraint: 税率は元金額未満（業務制度上 100% 以上は想定外）
+ALTER TABLE "tax_rates" ADD CONSTRAINT "tax_rates_rate_check"
+  CHECK ("rate" >= 0 AND "rate" < 1);

--- a/prisma/migrations/20260520012727_add_estimate_with_repair_subtypes/migration.sql
+++ b/prisma/migrations/20260520012727_add_estimate_with_repair_subtypes/migration.sql
@@ -1,0 +1,128 @@
+-- CreateEnum
+CREATE TYPE "EstimateType" AS ENUM ('NEW', 'REPAIR', 'AFTER_REPAIR');
+
+-- CreateEnum
+CREATE TYPE "SubmissionType" AS ENUM ('CUSTOMER', 'DELIVERY_LOCATION');
+
+-- CreateEnum
+CREATE TYPE "TaxRoundingType" AS ENUM ('ROUND_DOWN', 'ROUND_UP', 'ROUND');
+
+-- CreateTable
+CREATE TABLE "estimates" (
+    "id" UUID NOT NULL,
+    "estimate_number" VARCHAR(8) NOT NULL,
+    "estimate_type" "EstimateType" NOT NULL,
+    "fiscal_year" INTEGER NOT NULL,
+    "sequence" INTEGER NOT NULL,
+    "estimate_date" TIMESTAMPTZ(3) NOT NULL,
+    "deadline" TIMESTAMPTZ(3) NOT NULL,
+    "submission_type" "SubmissionType" NOT NULL,
+    "customer_id" UUID NOT NULL,
+    "delivery_location_id" UUID NOT NULL,
+    "tax_rate" DECIMAL(4,3) NOT NULL,
+    "tax_rounding_type" "TaxRoundingType" NOT NULL,
+    "created_by" UUID NOT NULL,
+    "department_id" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "estimates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "repair_estimate_details" (
+    "id" UUID NOT NULL,
+    "estimate_id" UUID NOT NULL,
+    "target_product_id" UUID NOT NULL,
+    "fault_description" VARCHAR(2000) NOT NULL,
+    "scheduled_repair_date" TIMESTAMPTZ(3) NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "repair_estimate_details_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "after_repair_estimate_details" (
+    "id" UUID NOT NULL,
+    "estimate_id" UUID NOT NULL,
+    "target_product_id" UUID NOT NULL,
+    "fault_description" VARCHAR(2000) NOT NULL,
+    "actual_repair_date" TIMESTAMPTZ(3) NOT NULL,
+    "emergency_reason" VARCHAR(2000) NOT NULL,
+    "after_service_warning_acknowledged" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "after_repair_estimate_details_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "estimates_estimate_number_key" ON "estimates"("estimate_number");
+
+-- CreateIndex
+CREATE INDEX "estimates_estimate_number_idx" ON "estimates"("estimate_number");
+
+-- CreateIndex
+CREATE INDEX "estimates_fiscal_year_estimate_type_sequence_idx" ON "estimates"("fiscal_year", "estimate_type", "sequence");
+
+-- CreateIndex
+CREATE INDEX "estimates_created_by_idx" ON "estimates"("created_by");
+
+-- CreateIndex
+CREATE INDEX "estimates_department_id_idx" ON "estimates"("department_id");
+
+-- CreateIndex
+CREATE INDEX "estimates_customer_id_idx" ON "estimates"("customer_id");
+
+-- CreateIndex
+CREATE INDEX "estimates_delivery_location_id_idx" ON "estimates"("delivery_location_id");
+
+-- CreateIndex
+CREATE INDEX "estimates_submission_type_idx" ON "estimates"("submission_type");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "repair_estimate_details_estimate_id_key" ON "repair_estimate_details"("estimate_id");
+
+-- CreateIndex
+CREATE INDEX "repair_estimate_details_target_product_id_idx" ON "repair_estimate_details"("target_product_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "after_repair_estimate_details_estimate_id_key" ON "after_repair_estimate_details"("estimate_id");
+
+-- CreateIndex
+CREATE INDEX "after_repair_estimate_details_target_product_id_idx" ON "after_repair_estimate_details"("target_product_id");
+
+-- AddForeignKey
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_delivery_location_id_fkey" FOREIGN KEY ("delivery_location_id") REFERENCES "delivery_locations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "employees"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_department_id_fkey" FOREIGN KEY ("department_id") REFERENCES "departments"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "repair_estimate_details" ADD CONSTRAINT "repair_estimate_details_estimate_id_fkey" FOREIGN KEY ("estimate_id") REFERENCES "estimates"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "repair_estimate_details" ADD CONSTRAINT "repair_estimate_details_target_product_id_fkey" FOREIGN KEY ("target_product_id") REFERENCES "products"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "after_repair_estimate_details" ADD CONSTRAINT "after_repair_estimate_details_estimate_id_fkey" FOREIGN KEY ("estimate_id") REFERENCES "estimates"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "after_repair_estimate_details" ADD CONSTRAINT "after_repair_estimate_details_target_product_id_fkey" FOREIGN KEY ("target_product_id") REFERENCES "products"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- CheckConstraint: 採番関連の範囲
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_fiscal_year_check"
+  CHECK ("fiscal_year" >= 2000 AND "fiscal_year" <= 9999);
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_sequence_check"
+  CHECK ("sequence" >= 1 AND "sequence" <= 99999);
+
+-- CheckConstraint: 税率は元金額未満
+ALTER TABLE "estimates" ADD CONSTRAINT "estimates_tax_rate_check"
+  CHECK ("tax_rate" >= 0 AND "tax_rate" < 1);

--- a/prisma/migrations/20260520013104_add_estimate_variation_items/migration.sql
+++ b/prisma/migrations/20260520013104_add_estimate_variation_items/migration.sql
@@ -1,0 +1,124 @@
+-- CreateEnum
+CREATE TYPE "VariationStatus" AS ENUM ('ACTIVE', 'INACTIVE');
+
+-- CreateTable
+CREATE TABLE "estimate_variations" (
+    "id" UUID NOT NULL,
+    "estimate_id" UUID NOT NULL,
+    "variation_number" INTEGER NOT NULL,
+    "status" "VariationStatus" NOT NULL DEFAULT 'ACTIVE',
+    "customer_memo" VARCHAR(2000),
+    "internal_memo" VARCHAR(2000),
+    "overall_discount" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "subtotal" DECIMAL(12,2) NOT NULL,
+    "discount_subtotal" DECIMAL(12,2) NOT NULL,
+    "final_subtotal" DECIMAL(12,2) NOT NULL,
+    "tax_amount" DECIMAL(12,2) NOT NULL,
+    "final_total" DECIMAL(12,2) NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "estimate_variations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "estimate_items" (
+    "id" UUID NOT NULL,
+    "variation_id" UUID NOT NULL,
+    "sort_order" INTEGER NOT NULL,
+    "product_id" UUID NOT NULL,
+    "item_name" VARCHAR(100) NOT NULL,
+    "quantity" INTEGER NOT NULL,
+    "unit" VARCHAR(20) NOT NULL,
+    "unit_price" DECIMAL(12,2) NOT NULL,
+    "customer_memo" VARCHAR(2000),
+    "internal_memo" VARCHAR(2000),
+    "discount_rate" DECIMAL(5,4) NOT NULL DEFAULT 1.0,
+    "item_discount" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "base_amount" DECIMAL(12,2) NOT NULL,
+    "discounted_amount" DECIMAL(12,2) NOT NULL,
+    "final_amount" DECIMAL(12,2) NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "estimate_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "revised_estimate_item_details" (
+    "id" UUID NOT NULL,
+    "estimate_item_id" UUID NOT NULL,
+    "delivery_price" DECIMAL(12,2) NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "revised_estimate_item_details_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "estimate_variations_estimate_id_status_idx" ON "estimate_variations"("estimate_id", "status");
+
+-- CreateIndex
+CREATE INDEX "estimate_variations_status_idx" ON "estimate_variations"("status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "estimate_variations_estimate_id_variation_number_key" ON "estimate_variations"("estimate_id", "variation_number");
+
+-- CreateIndex
+CREATE INDEX "estimate_items_variation_id_sort_order_idx" ON "estimate_items"("variation_id", "sort_order");
+
+-- CreateIndex
+CREATE INDEX "estimate_items_product_id_idx" ON "estimate_items"("product_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "revised_estimate_item_details_estimate_item_id_key" ON "revised_estimate_item_details"("estimate_item_id");
+
+-- AddForeignKey
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_estimate_id_fkey" FOREIGN KEY ("estimate_id") REFERENCES "estimates"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_variation_id_fkey" FOREIGN KEY ("variation_id") REFERENCES "estimate_variations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_product_id_fkey" FOREIGN KEY ("product_id") REFERENCES "products"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "revised_estimate_item_details" ADD CONSTRAINT "revised_estimate_item_details_estimate_item_id_fkey" FOREIGN KEY ("estimate_item_id") REFERENCES "estimate_items"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CheckConstraint: バリエーション
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_variation_number_check"
+  CHECK ("variation_number" >= 1 AND "variation_number" <= 99);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_overall_discount_check"
+  CHECK ("overall_discount" >= 0);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_subtotal_check"
+  CHECK ("subtotal" >= 0);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_discount_subtotal_check"
+  CHECK ("discount_subtotal" >= 0);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_final_subtotal_check"
+  CHECK ("final_subtotal" >= 0);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_tax_amount_check"
+  CHECK ("tax_amount" >= 0);
+ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_final_total_check"
+  CHECK ("final_total" >= 0);
+
+-- CheckConstraint: 明細
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_sort_order_check"
+  CHECK ("sort_order" >= 0);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_quantity_check"
+  CHECK ("quantity" >= 1);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_unit_price_check"
+  CHECK ("unit_price" >= 0);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_discount_rate_check"
+  CHECK ("discount_rate" >= 0 AND "discount_rate" <= 1);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_item_discount_check"
+  CHECK ("item_discount" >= 0);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_base_amount_check"
+  CHECK ("base_amount" >= 0);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_discounted_amount_check"
+  CHECK ("discounted_amount" >= 0);
+ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_final_amount_check"
+  CHECK ("final_amount" >= 0);
+
+-- CheckConstraint: 改訂明細詳細
+ALTER TABLE "revised_estimate_item_details" ADD CONSTRAINT "revised_estimate_item_details_delivery_price_check"
+  CHECK ("delivery_price" >= 0);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -356,6 +356,9 @@ model Product {
   repairTargetDetails      RepairEstimateDetail[]      @relation("RepairTargetProduct")
   afterRepairTargetDetails AfterRepairEstimateDetail[] @relation("AfterRepairTargetProduct")
 
+  // 見積明細の品目スナップショット参照
+  estimateItems EstimateItem[] @relation("EstimateItemProduct")
+
   // タイムスタンプ
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
@@ -473,7 +476,8 @@ model Estimate {
   // 複製元・改訂元・申請関連は本モデルに持たない（複製/改訂は別 issue の系譜テーブルへ）
   // Order との逆リレーション（orders Order[]）も別 issue で追加する
 
-  // バリエーション（別 issue の Phase 3 で追加されるまで参照されない）
+  // バリエーション
+  variations EstimateVariation[]
 
   // タイムスタンプ
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
@@ -541,6 +545,108 @@ model AfterRepairEstimateDetail {
 
   @@index([targetProductId])
   @@map("after_repair_estimate_details")
+}
+
+// バリエーション状態
+enum VariationStatus {
+  ACTIVE   // 有効
+  INACTIVE // 無効
+}
+
+model EstimateVariation {
+  id         String   @id @db.Uuid // ドメイン層でUUIDv7生成
+  estimateId String   @map("estimate_id") @db.Uuid
+  estimate   Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)
+
+  variationNumber Int             @map("variation_number") // 1〜99
+  status          VariationStatus @default(ACTIVE)
+
+  // メモ
+  customerMemo String? @map("customer_memo") @db.VarChar(2000)
+  internalMemo String? @map("internal_memo") @db.VarChar(2000)
+
+  // 全体値引
+  overallDiscount Decimal @default(0) @map("overall_discount") @db.Decimal(12, 2)
+
+  // 集計金額（計算結果を保存）
+  subtotal         Decimal @db.Decimal(12, 2)                              // 明細金額小計
+  discountSubtotal Decimal @map("discount_subtotal") @db.Decimal(12, 2)    // 明細値引金額小計
+  finalSubtotal    Decimal @map("final_subtotal") @db.Decimal(12, 2)       // 最終明細金額小計
+  taxAmount        Decimal @map("tax_amount") @db.Decimal(12, 2)           // 消費税額
+  finalTotal       Decimal @map("final_total") @db.Decimal(12, 2)          // 最終合計金額
+
+  // 申請・承認情報は本モデルに持たない（共通申請テーブル ADR-0001 が別 issue で参照）
+  // 複製元・改訂元・Order との逆リレーションは別 issue で追加する
+
+  items EstimateItem[]
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@unique([estimateId, variationNumber])
+  @@index([estimateId, status])
+  @@index([status])
+  @@map("estimate_variations")
+}
+
+model EstimateItem {
+  id          String            @id @db.Uuid // ドメイン層でUUIDv7生成
+  variationId String            @map("variation_id") @db.Uuid
+  variation   EstimateVariation @relation(fields: [variationId], references: [id], onDelete: Cascade)
+
+  sortOrder Int @map("sort_order")
+
+  // 商品マスタへの参照（必須）。フリーテキスト明細は許可しない
+  productId String  @map("product_id") @db.Uuid
+  product   Product @relation("EstimateItemProduct", fields: [productId], references: [id])
+
+  // 明細情報（商品マスタからのスナップショット）
+  // マスタ改訂後も見積時点の名称・単価を保持する（§8 金額の保存形式と整合）
+  itemName  String  @map("item_name") @db.VarChar(100)
+  quantity  Int
+  unit      String  @db.VarChar(20) // 単位（個・枚・台等。Product.unit enum のスナップショット文字列）
+  unitPrice Decimal @map("unit_price") @db.Decimal(12, 2)
+
+  // メモ
+  customerMemo String? @map("customer_memo") @db.VarChar(2000)
+  internalMemo String? @map("internal_memo") @db.VarChar(2000)
+
+  // 値引き
+  discountRate Decimal @default(1.0) @map("discount_rate") @db.Decimal(5, 4) // 掛率（1.0 = 値引なし）
+  itemDiscount Decimal @default(0) @map("item_discount") @db.Decimal(12, 2)  // 明細値引金額
+
+  // 計算結果（保存）
+  baseAmount       Decimal @map("base_amount") @db.Decimal(12, 2)       // 基本金額（数量×単価）
+  discountedAmount Decimal @map("discounted_amount") @db.Decimal(12, 2) // 掛率適用後金額
+  finalAmount      Decimal @map("final_amount") @db.Decimal(12, 2)      // 最終明細金額
+
+  // 得意先改訂で生まれた明細だけが持つ固有属性は別サブタイプ表に分離（§11.3.1）
+  revisedDetail RevisedEstimateItemDetail?
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([variationId, sortOrder])
+  @@index([productId])
+  @@map("estimate_items")
+}
+
+// 得意先改訂で生まれた明細だけが持つ固有属性。行の存在 ⟺ 改訂明細（1:1）
+model RevisedEstimateItemDetail {
+  id             String       @id @db.Uuid // ドメイン層でUUIDv7生成
+  estimateItemId String       @unique @map("estimate_item_id") @db.Uuid
+  estimateItem   EstimateItem @relation(fields: [estimateItemId], references: [id], onDelete: Cascade)
+
+  // 改訂元の納品先明細価格のスナップショット（粗利の真実の源・§8.4）
+  deliveryPrice Decimal @map("delivery_price") @db.Decimal(12, 2)
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@map("revised_estimate_item_details")
 }
 
 // ========================================

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -389,3 +389,24 @@ model SetProductComponent {
   @@id([setProductId, componentProductId])
   @@map("set_product_components")
 }
+
+// ========================================
+// 消費税率関連
+// ========================================
+
+// 消費税率マスタ
+// タイムラインの単調性（制度上ギャップなし）を利用し、effectiveFrom 1 カラムのみで表現する。
+// 前期間の終わり = 次の行の effectiveFrom（暗黙）。「行の存在＝そこから新税率が有効」パターン。
+model TaxRate {
+  id   String  @id @db.Uuid // ドメイン層でUUIDv7生成
+  rate Decimal @db.Decimal(4, 3) // 例: 0.080 (8%), 0.100 (10%)
+
+  // この日時から有効な税率。@unique で同時刻重複を禁止し B-tree 索引も提供
+  effectiveFrom DateTime @unique @map("effective_from") @db.Timestamptz(3)
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@map("tax_rates")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,9 @@ model Employee {
   // 従業員役割（逆参照）
   employeeRoles EmployeeRole[]
 
+  // 見積作成者としての逆参照
+  createdEstimates Estimate[] @relation("EstimateCreator")
+
   // タイムスタンプ
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
@@ -131,6 +134,9 @@ model Department {
 
   // 所属従業員（逆参照）
   employees Employee[]
+
+  // 部署紐付け見積（逆参照）
+  estimates Estimate[] @relation("EstimateDepartment")
 
   // タイムスタンプ
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
@@ -271,6 +277,9 @@ model Customer {
   // 配下の納品先
   deliveryLocations DeliveryLocation[]
 
+  // 得意先紐付け見積（逆参照）
+  estimates Estimate[] @relation("CustomerEstimates")
+
   // タイムスタンプ
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
@@ -289,6 +298,9 @@ model DeliveryLocation {
 
   // 納品先固有の属性
   deliveryNotes String? @map("delivery_notes") @db.VarChar(500) // 配送時の注意事項
+
+  // 納品先紐付け見積（逆参照）
+  estimates Estimate[] @relation("DeliveryLocationEstimates")
 
   // タイムスタンプ
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
@@ -340,6 +352,10 @@ model Product {
   // セット商品構成 (この商品が構成商品)
   componentOfSets SetProductComponent[] @relation("ComponentProduct")
 
+  // 修理対象機器としての逆参照
+  repairTargetDetails      RepairEstimateDetail[]      @relation("RepairTargetProduct")
+  afterRepairTargetDetails AfterRepairEstimateDetail[] @relation("AfterRepairTargetProduct")
+
   // タイムスタンプ
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
@@ -388,6 +404,143 @@ model SetProductComponent {
 
   @@id([setProductId, componentProductId])
   @@map("set_product_components")
+}
+
+// ========================================
+// 見積関連
+// ========================================
+
+// 見積区分
+enum EstimateType {
+  NEW          // 新規
+  REPAIR       // 修理（事前）
+  AFTER_REPAIR // 事後修理
+}
+
+// 提出区分
+enum SubmissionType {
+  CUSTOMER          // 得意先向け
+  DELIVERY_LOCATION // 納品先向け
+}
+
+// 消費税の端数処理
+enum TaxRoundingType {
+  ROUND_DOWN // 切捨
+  ROUND_UP   // 切上
+  ROUND      // 四捨五入
+}
+
+model Estimate {
+  id             String @id @db.Uuid // ドメイン層でUUIDv7生成
+  estimateNumber String @unique @map("estimate_number") @db.VarChar(8) // 例: N2500001（接頭辞1文字＋年度2桁＋連番5桁）
+
+  // 見積区分（NEW / REPAIR / AFTER_REPAIR）
+  estimateType EstimateType @map("estimate_type")
+
+  fiscalYear Int @map("fiscal_year") // 西暦4桁（採番用）
+  sequence   Int                       // 区分内連番（最大99999）
+
+  estimateDate DateTime @map("estimate_date") @db.Timestamptz(3) // 見積年月日
+  deadline     DateTime @db.Timestamptz(3)                       // 締切年月日
+
+  // 提出区分
+  submissionType SubmissionType @map("submission_type")
+
+  // 得意先・納品先（常に両方設定）
+  customerId         String           @map("customer_id") @db.Uuid
+  customer           Customer         @relation("CustomerEstimates", fields: [customerId], references: [id])
+  deliveryLocationId String           @map("delivery_location_id") @db.Uuid
+  deliveryLocation   DeliveryLocation @relation("DeliveryLocationEstimates", fields: [deliveryLocationId], references: [id])
+
+  // 修理関連は本モデルに持たない（NULL を排除するためサブタイプテーブルに分割）
+  //   estimateType = NEW          : どちらの詳細も持たない
+  //   estimateType = REPAIR       : RepairEstimateDetail (1:1) を持つ
+  //   estimateType = AFTER_REPAIR : AfterRepairEstimateDetail (1:1) を持つ
+  // estimateType と詳細テーブルの整合（排他的サブタイプ）はドメイン層で担保
+  repairDetail      RepairEstimateDetail?
+  afterRepairDetail AfterRepairEstimateDetail?
+
+  // 消費税（見積時点でスナップショット）
+  taxRate         Decimal         @map("tax_rate") @db.Decimal(4, 3)
+  taxRoundingType TaxRoundingType @map("tax_rounding_type")
+
+  // 作成者（Employee を参照。User は better-auth 用なので業務エンティティから直接参照しない）
+  createdBy    String     @map("created_by") @db.Uuid
+  creator      Employee   @relation("EstimateCreator", fields: [createdBy], references: [id])
+  departmentId String     @map("department_id") @db.Uuid
+  department   Department @relation("EstimateDepartment", fields: [departmentId], references: [id])
+
+  // 複製元・改訂元・申請関連は本モデルに持たない（複製/改訂は別 issue の系譜テーブルへ）
+  // Order との逆リレーション（orders Order[]）も別 issue で追加する
+
+  // バリエーション（別 issue の Phase 3 で追加されるまで参照されない）
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([estimateNumber])
+  @@index([fiscalYear, estimateType, sequence])
+  @@index([createdBy])
+  @@index([departmentId])
+  @@index([customerId])
+  @@index([deliveryLocationId])
+  @@index([submissionType])
+  @@map("estimates")
+}
+
+// REPAIR（事前修理）専用。estimateType = REPAIR のときのみ 1:1 で存在
+model RepairEstimateDetail {
+  id         String   @id @db.Uuid // ドメイン層でUUIDv7生成
+  estimateId String   @unique @map("estimate_id") @db.Uuid
+  estimate   Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)
+
+  // 修理対象機器（必須）
+  targetProductId String  @map("target_product_id") @db.Uuid
+  targetProduct   Product @relation("RepairTargetProduct", fields: [targetProductId], references: [id])
+
+  // 故障内容（必須）
+  faultDescription String @map("fault_description") @db.VarChar(2000)
+
+  // 修理予定日（必須）
+  scheduledRepairDate DateTime @map("scheduled_repair_date") @db.Timestamptz(3)
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([targetProductId])
+  @@map("repair_estimate_details")
+}
+
+// AFTER_REPAIR（事後修理）専用。estimateType = AFTER_REPAIR のときのみ 1:1 で存在
+model AfterRepairEstimateDetail {
+  id         String   @id @db.Uuid // ドメイン層でUUIDv7生成
+  estimateId String   @unique @map("estimate_id") @db.Uuid
+  estimate   Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)
+
+  // 修理対象機器（必須）
+  targetProductId String  @map("target_product_id") @db.Uuid
+  targetProduct   Product @relation("AfterRepairTargetProduct", fields: [targetProductId], references: [id])
+
+  // 故障内容（必須）
+  faultDescription String @map("fault_description") @db.VarChar(2000)
+
+  // 修理実施日（過去日付・必須）
+  actualRepairDate DateTime @map("actual_repair_date") @db.Timestamptz(3)
+
+  // 緊急対応理由（必須）
+  emergencyReason String @map("emergency_reason") @db.VarChar(2000)
+
+  // 10万円超警告の確認済フラグ
+  afterServiceWarningAcknowledged Boolean @default(false) @map("after_service_warning_acknowledged")
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([targetProductId])
+  @@map("after_repair_estimate_details")
 }
 
 // ========================================

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -932,6 +932,12 @@ const PRODUCTS = [
   },
 ];
 
+// 消費税率データ（昇順）
+const TAX_RATES = [
+  { rate: "0.080", effectiveFrom: new Date("2014-04-01T00:00:00+09:00") },
+  { rate: "0.100", effectiveFrom: new Date("2019-10-01T00:00:00+09:00") },
+];
+
 // ランダムな要素を取得
 function randomChoice<T>(array: T[]): T {
   return array[Math.floor(Math.random() * array.length)];
@@ -1167,6 +1173,7 @@ async function main() {
   console.log("");
 
   // 既存データを削除（外部キー制約を考慮した順序）
+  await prisma.taxRate.deleteMany();
   await prisma.setProductComponent.deleteMany();
   await prisma.productRelation.deleteMany();
   await prisma.product.deleteMany();
@@ -1260,6 +1267,16 @@ async function main() {
   console.log(`Created ${PRODUCTS.length} products`);
   console.log("");
 
+  // 消費税率を作成（昇順で投入。前期間の終わり = 次の行の effectiveFrom の暗黙）
+  console.log("Creating tax rates...");
+  for (const tr of TAX_RATES) {
+    await prisma.taxRate.create({
+      data: { id: generateId(), rate: tr.rate, effectiveFrom: tr.effectiveFrom },
+    });
+  }
+  console.log(`Created ${TAX_RATES.length} tax rates`);
+  console.log("");
+
   // 得意先・納品先を作成
   const { customerCount, deliveryLocationCount } = await seedCustomersAndDeliveryLocations();
 
@@ -1325,6 +1342,7 @@ async function main() {
   console.log(`Created ${ROLES.length} roles`);
   console.log(`Created ${employeeRoleData.length} employee role assignments`);
   console.log(`Created ${PRODUCTS.length} products`);
+  console.log(`Created ${TAX_RATES.length} tax rates`);
   console.log(`Created ${customerCount} customers`);
   console.log(`Created ${deliveryLocationCount} delivery locations`);
   console.log(`Default password for all users: ${DEFAULT_PASSWORD}`);


### PR DESCRIPTION
## Summary

`docs/business/estimate/システム設計書(見積).md` §11 の概念設計をもとに、見積コアの Prisma スキーマを追加。見積本体（Estimate）＋修理/事後修理サブタイプ、バリエーション・明細・改訂明細、消費税率マスタ（TaxRate）の **7 モデル + 4 enum** を、論理単位の 3 マイグレーションに分割して実装した。各テーブルには手書きの CHECK 制約を付与し、CREATE DOMAIN を使わず CHECK 制約を継続する判断を ADR-0021 として起票した。

Closes #272

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

# Issue #272: 見積コア Prisma スキーマ追加（見積本体＋サブタイプ＋税率マスタ） — 実装計画

## 概要

`docs/business/estimate/システム設計書(見積).md` §11 の概念設計を Prisma スキーマとして実装する。本 issue では「見積本体＋サブタイプ＋税率マスタ」の **7 モデル**に絞り、Order 系・系譜（複製/改訂）・共通申請テーブル（ADR-0001）は別 issue で段階的に追加する。

対象モデル:

1. `TaxRate` (§11.5) — 消費税率マスタ
2. `Estimate` (§11.1) — 見積本体
3. `RepairEstimateDetail` (§11.1.1) — 修理見積サブタイプ
4. `AfterRepairEstimateDetail` (§11.1.1) — 事後修理サブタイプ
5. `EstimateVariation` (§11.2) — バリエーション
6. `EstimateItem` (§11.3) — 明細
7. `RevisedEstimateItemDetail` (§11.3.1) — 改訂明細サブタイプ

スコープ外（別 issue）: `EstimateVariationCopy` / `EstimateVariationRevision` / `Order` / `OrderConfirmation` / `OrderCancellation` / 共通申請テーブル。

## 設計判断

### メモ系の型: 設計書 `@db.Text` → 実装 `@db.VarChar(2000)`
- A. 設計書通り `@db.Text` を採用
- B. **`@db.VarChar(2000)` で統一**（ユーザー確定）
- 推奨: **B**。ADR-0019「全 String カラムに上限を持たせる」と整合。設計書 §11 冒頭「実装規約が別途優先」注記の範疇。対象: `customerMemo` / `internalMemo` / `faultDescription` / `emergencyReason`

### `Estimate.createdBy` の参照先: `User` → `Employee`
- A. 設計書通り `User` を参照
- B. **`Employee` を参照**
- 推奨: **B**。既存マスタの参照規約（業務エンティティは `Employee.id` を参照）に整合。§9 の部署権限チェックで `Employee.departmentId` が必要。`User` は better-auth 用テーブルで業務エンティティから直接参照しない（`Employee` ↔ `User` の 1:1 経由で必要時に解決）

### 税率／掛率の Decimal 精度
- 税率 `taxRate`: **`@db.Decimal(4, 3)`**（0.000〜0.999、例: 0.100）
- 掛率 `discountRate`: **`@db.Decimal(5, 4)`**（0.0000〜1.0000、デフォルト 1.0000 を含めるため整数部 1 桁が必要）
- 金額系: **`@db.Decimal(12, 2)`**（既存 `Product.costPrice` と整合）

### CHECK 制約の上限値（業務意味で表現）
- `tax_rate >= 0 AND tax_rate < 1` — 税率は元金額未満（業務制度上 100% 以上は想定外）
- `discount_rate >= 0 AND discount_rate <= 1` — 掛率は 0〜1。デフォルト 1.0 を有効にするため `<=` を採用
- Decimal 精度の上限（例: 9.9999）をそのまま CHECK 上限にしない（業務的意味と乖離するため）

### マイグレーション分割: 論理単位で 3 つに分割
- A. 1 マイグレーションで一括作成
- B. **論理単位で 3 マイグレーション**
- 推奨: **B**。CLAUDE.md「Commit at each meaningful change」と整合。Phase 順序は依存関係で固定（Phase 1 独立 → Phase 2 → Phase 3）

### スコープ外モデルへの逆リレーションを今回は書かない
- `Estimate.orders` / `EstimateVariation.copies` / `EstimateVariation.revisions` / `EstimateVariation.order` 等は今回追加しない
- 理由: Order / 系譜モデル本体が未実装のため Prisma クライアント生成が失敗する。別 issue で本体モデル追加時に同 PR で逆リレーションも追加する方が安全

## ステップ

### Step 1: 計画ファイルをコミット
- 対象ファイル: `docs/claude-plans/issue-272/plan.md`
- 作業内容:
  - 本ファイルを作成
- コミットメッセージ: `docs: Issue #272 の実装計画を追加`

### Step 2: Phase 1 — TaxRate モデル + マイグレーション + シード
- 対象ファイル:
  - `prisma/schema.prisma`
  - `prisma/seed.ts`
  - `prisma/migrations/<timestamp>_add_tax_rate_master/migration.sql`
- 作業内容:
  - schema.prisma 末尾に「消費税率関連」セクションを追加し `TaxRate` モデルを定義
  - `pnpm db:migrate` で `add_tax_rate_master` マイグレーション生成
  - 生成された migration.sql に CHECK 制約 `rate >= 0 AND rate < 1` を手書き追記
  - `pnpm prisma migrate reset` で drift 解消
  - seed.ts に税率 2 件（2014/4 から 0.080、2019/10 から 0.100）を JST で投入
  - `pnpm prisma db seed` で投入確認、`pnpm prisma studio` で 2 行存在確認
  - 税率取得クエリ（`findFirst({ where: { effectiveFrom: { lte: now } }, orderBy: { effectiveFrom: 'desc' } })`）が `0.100` を返すこと確認
- コミットメッセージ: `feat: 消費税率マスタ (TaxRate) を追加`

### Step 3: Phase 2 — Estimate + 修理サブタイプ
- 対象ファイル:
  - `prisma/schema.prisma`
  - `prisma/migrations/<timestamp>_add_estimate_with_repair_subtypes/migration.sql`
- 作業内容:
  - 3 つの enum（`EstimateType`, `SubmissionType`, `TaxRoundingType`）を追加
  - `Estimate` / `RepairEstimateDetail` / `AfterRepairEstimateDetail` モデルを追加
  - 既存マスタに逆リレーション追加:
    - `Customer.estimates Estimate[] @relation("CustomerEstimates")`
    - `DeliveryLocation.estimates Estimate[] @relation("DeliveryLocationEstimates")`
    - `Department.estimates Estimate[] @relation("EstimateDepartment")`
    - `Employee.createdEstimates Estimate[] @relation("EstimateCreator")`
    - `Product.repairTargetDetails RepairEstimateDetail[] @relation("RepairTargetProduct")`
    - `Product.afterRepairTargetDetails AfterRepairEstimateDetail[] @relation("AfterRepairTargetProduct")`
  - `pnpm db:migrate` で `add_estimate_with_repair_subtypes` マイグレーション生成
  - 生成された migration.sql に CHECK 制約手書き追記:
    - `fiscal_year >= 2000 AND fiscal_year <= 9999`
    - `sequence >= 1 AND sequence <= 99999`
    - `tax_rate >= 0 AND tax_rate < 1`
  - `pnpm prisma migrate reset` で drift 解消
  - `pnpm build` / `pnpm test` / `pnpm lint` で既存機能が壊れていないか確認
- コミットメッセージ: `feat: 見積本体 (Estimate) と修理サブタイプ (Repair/AfterRepairEstimateDetail) を追加`

### Step 4: Phase 3 — EstimateVariation + EstimateItem + RevisedEstimateItemDetail
- 対象ファイル:
  - `prisma/schema.prisma`
  - `prisma/migrations/<timestamp>_add_estimate_variation_items/migration.sql`
- 作業内容:
  - `VariationStatus` enum を追加
  - `EstimateVariation` / `EstimateItem` / `RevisedEstimateItemDetail` モデルを追加
  - 既存マスタに逆リレーション追加:
    - `Product.estimateItems EstimateItem[] @relation("EstimateItemProduct")`
  - `pnpm db:migrate` で `add_estimate_variation_items` マイグレーション生成
  - 生成された migration.sql に CHECK 制約手書き追記:
    - バリエーション: `variation_number 1〜99`, 各種金額 `>= 0`
    - 明細: `sort_order >= 0`, `quantity >= 1`, `unit_price >= 0`, `discount_rate 0〜1`, `item_discount >= 0`, 計算結果 `>= 0`
    - 改訂明細: `delivery_price >= 0`
  - `pnpm prisma migrate reset` で drift 解消
  - `pnpm build` / `pnpm test` / `pnpm lint` で確認
  - `pnpm prisma studio` で 7 テーブル全てが見えること確認
- コミットメッセージ: `feat: バリエーション (EstimateVariation) と明細 (EstimateItem/RevisedEstimateItemDetail) を追加`

## スキーマ DSL（完成形）

### TaxRate (Phase 1)

```prisma
model TaxRate {
  id   String  @id @db.Uuid
  rate Decimal @db.Decimal(4, 3)

  effectiveFrom DateTime @unique @map("effective_from") @db.Timestamptz(3)

  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)

  @@map("tax_rates")
}
```

### Estimate + 修理サブタイプ (Phase 2)

```prisma
enum EstimateType {
  NEW
  REPAIR
  AFTER_REPAIR
}

enum SubmissionType {
  CUSTOMER
  DELIVERY_LOCATION
}

enum TaxRoundingType {
  ROUND_DOWN
  ROUND_UP
  ROUND
}

model Estimate {
  id             String @id @db.Uuid
  estimateNumber String @unique @map("estimate_number") @db.VarChar(8)

  estimateType EstimateType @map("estimate_type")

  fiscalYear Int @map("fiscal_year")
  sequence   Int

  estimateDate DateTime @map("estimate_date") @db.Timestamptz(3)
  deadline     DateTime @db.Timestamptz(3)

  submissionType SubmissionType @map("submission_type")

  customerId         String           @map("customer_id") @db.Uuid
  customer           Customer         @relation("CustomerEstimates", fields: [customerId], references: [id])
  deliveryLocationId String           @map("delivery_location_id") @db.Uuid
  deliveryLocation   DeliveryLocation @relation("DeliveryLocationEstimates", fields: [deliveryLocationId], references: [id])

  repairDetail      RepairEstimateDetail?
  afterRepairDetail AfterRepairEstimateDetail?

  taxRate         Decimal         @map("tax_rate") @db.Decimal(4, 3)
  taxRoundingType TaxRoundingType @map("tax_rounding_type")

  createdBy    String     @map("created_by") @db.Uuid
  creator      Employee   @relation("EstimateCreator", fields: [createdBy], references: [id])
  departmentId String     @map("department_id") @db.Uuid
  department   Department @relation("EstimateDepartment", fields: [departmentId], references: [id])

  variations EstimateVariation[]

  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)

  @@index([estimateNumber])
  @@index([fiscalYear, estimateType, sequence])
  @@index([createdBy])
  @@index([departmentId])
  @@index([customerId])
  @@index([deliveryLocationId])
  @@index([submissionType])
  @@map("estimates")
}

model RepairEstimateDetail {
  id         String   @id @db.Uuid
  estimateId String   @unique @map("estimate_id") @db.Uuid
  estimate   Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)

  targetProductId String  @map("target_product_id") @db.Uuid
  targetProduct   Product @relation("RepairTargetProduct", fields: [targetProductId], references: [id])

  faultDescription    String   @map("fault_description") @db.VarChar(2000)
  scheduledRepairDate DateTime @map("scheduled_repair_date") @db.Timestamptz(3)

  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)

  @@index([targetProductId])
  @@map("repair_estimate_details")
}

model AfterRepairEstimateDetail {
  id         String   @id @db.Uuid
  estimateId String   @unique @map("estimate_id") @db.Uuid
  estimate   Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)

  targetProductId String  @map("target_product_id") @db.Uuid
  targetProduct   Product @relation("AfterRepairTargetProduct", fields: [targetProductId], references: [id])

  faultDescription String   @map("fault_description") @db.VarChar(2000)
  actualRepairDate DateTime @map("actual_repair_date") @db.Timestamptz(3)
  emergencyReason  String   @map("emergency_reason") @db.VarChar(2000)

  afterServiceWarningAcknowledged Boolean @default(false) @map("after_service_warning_acknowledged")

  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)

  @@index([targetProductId])
  @@map("after_repair_estimate_details")
}
```

### バリエーション + 明細 + 改訂明細 (Phase 3)

```prisma
enum VariationStatus {
  ACTIVE
  INACTIVE
}

model EstimateVariation {
  id         String   @id @db.Uuid
  estimateId String   @map("estimate_id") @db.Uuid
  estimate   Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)

  variationNumber Int             @map("variation_number")
  status          VariationStatus @default(ACTIVE)

  customerMemo String? @map("customer_memo") @db.VarChar(2000)
  internalMemo String? @map("internal_memo") @db.VarChar(2000)

  overallDiscount Decimal @default(0) @map("overall_discount") @db.Decimal(12, 2)

  subtotal         Decimal @db.Decimal(12, 2)
  discountSubtotal Decimal @map("discount_subtotal") @db.Decimal(12, 2)
  finalSubtotal    Decimal @map("final_subtotal") @db.Decimal(12, 2)
  taxAmount        Decimal @map("tax_amount") @db.Decimal(12, 2)
  finalTotal       Decimal @map("final_total") @db.Decimal(12, 2)

  items EstimateItem[]

  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)

  @@unique([estimateId, variationNumber])
  @@index([estimateId, status])
  @@index([status])
  @@map("estimate_variations")
}

model EstimateItem {
  id          String            @id @db.Uuid
  variationId String            @map("variation_id") @db.Uuid
  variation   EstimateVariation @relation(fields: [variationId], references: [id], onDelete: Cascade)

  sortOrder Int @map("sort_order")

  productId String  @map("product_id") @db.Uuid
  product   Product @relation("EstimateItemProduct", fields: [productId], references: [id])

  itemName  String  @map("item_name") @db.VarChar(100)
  quantity  Int
  unit      String  @db.VarChar(20)
  unitPrice Decimal @map("unit_price") @db.Decimal(12, 2)

  customerMemo String? @map("customer_memo") @db.VarChar(2000)
  internalMemo String? @map("internal_memo") @db.VarChar(2000)

  discountRate Decimal @default(1.0) @map("discount_rate") @db.Decimal(5, 4)
  itemDiscount Decimal @default(0) @map("item_discount") @db.Decimal(12, 2)

  baseAmount       Decimal @map("base_amount") @db.Decimal(12, 2)
  discountedAmount Decimal @map("discounted_amount") @db.Decimal(12, 2)
  finalAmount      Decimal @map("final_amount") @db.Decimal(12, 2)

  revisedDetail RevisedEstimateItemDetail?

  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)

  @@index([variationId, sortOrder])
  @@index([productId])
  @@map("estimate_items")
}

model RevisedEstimateItemDetail {
  id             String       @id @db.Uuid
  estimateItemId String       @unique @map("estimate_item_id") @db.Uuid
  estimateItem   EstimateItem @relation(fields: [estimateItemId], references: [id], onDelete: Cascade)

  deliveryPrice Decimal @map("delivery_price") @db.Decimal(12, 2)

  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)

  @@map("revised_estimate_item_details")
}
```

## CHECK 制約 SQL（完成形）

### Phase 1: TaxRate

```sql
ALTER TABLE "tax_rates" ADD CONSTRAINT "tax_rates_rate_check"
  CHECK ("rate" >= 0 AND "rate" < 1);
```

### Phase 2: Estimate

```sql
ALTER TABLE "estimates" ADD CONSTRAINT "estimates_fiscal_year_check"
  CHECK ("fiscal_year" >= 2000 AND "fiscal_year" <= 9999);
ALTER TABLE "estimates" ADD CONSTRAINT "estimates_sequence_check"
  CHECK ("sequence" >= 1 AND "sequence" <= 99999);
ALTER TABLE "estimates" ADD CONSTRAINT "estimates_tax_rate_check"
  CHECK ("tax_rate" >= 0 AND "tax_rate" < 1);
```

### Phase 3: バリエーション + 明細 + 改訂明細

```sql
-- バリエーション
ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_variation_number_check"
  CHECK ("variation_number" >= 1 AND "variation_number" <= 99);
ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_overall_discount_check"
  CHECK ("overall_discount" >= 0);
ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_subtotal_check"
  CHECK ("subtotal" >= 0);
ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_discount_subtotal_check"
  CHECK ("discount_subtotal" >= 0);
ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_final_subtotal_check"
  CHECK ("final_subtotal" >= 0);
ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_tax_amount_check"
  CHECK ("tax_amount" >= 0);
ALTER TABLE "estimate_variations" ADD CONSTRAINT "estimate_variations_final_total_check"
  CHECK ("final_total" >= 0);

-- 明細
ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_sort_order_check"
  CHECK ("sort_order" >= 0);
ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_quantity_check"
  CHECK ("quantity" >= 1);
ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_unit_price_check"
  CHECK ("unit_price" >= 0);
ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_discount_rate_check"
  CHECK ("discount_rate" >= 0 AND "discount_rate" <= 1);
ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_item_discount_check"
  CHECK ("item_discount" >= 0);
ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_base_amount_check"
  CHECK ("base_amount" >= 0);
ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_discounted_amount_check"
  CHECK ("discounted_amount" >= 0);
ALTER TABLE "estimate_items" ADD CONSTRAINT "estimate_items_final_amount_check"
  CHECK ("final_amount" >= 0);

-- 改訂明細詳細
ALTER TABLE "revised_estimate_item_details" ADD CONSTRAINT "revised_estimate_item_details_delivery_price_check"
  CHECK ("delivery_price" >= 0);
```

## シードデータ (Phase 1)

`prisma/seed.ts` に追記:

```ts
// 削除ブロックに追加
await prisma.taxRate.deleteMany();

// 作成ブロック（商品作成の後）
console.log("Creating tax rates...");
const TAX_RATES = [
  { rate: "0.080", effectiveFrom: new Date("2014-04-01T00:00:00+09:00") },
  { rate: "0.100", effectiveFrom: new Date("2019-10-01T00:00:00+09:00") },
];
for (const tr of TAX_RATES) {
  await prisma.taxRate.create({
    data: { id: generateId(), rate: tr.rate, effectiveFrom: tr.effectiveFrom },
  });
}
console.log(`Created ${TAX_RATES.length} tax rates`);
```

## 完了条件

- `prisma/schema.prisma` に 7 モデル + 4 enum が追加されている
- 3 つのマイグレーションが生成され、それぞれ手書きの CHECK 制約が追記されている
- `pnpm prisma migrate reset` が成功する（drift なし）
- `pnpm build` / `pnpm test` / `pnpm lint` がオールグリーン
- `pnpm db:studio` で 7 テーブル（`tax_rates`, `estimates`, `repair_estimate_details`, `after_repair_estimate_details`, `estimate_variations`, `estimate_items`, `revised_estimate_item_details`）が確認できる
- `pnpm prisma db seed` で税率 2 件が投入されている
- 各 Phase が独立したコミットとしてリポジトリに記録されている

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

なお、計画の `## 設計判断` に挙げた事項のうち、CREATE DOMAIN を使わず CHECK 制約を継続する判断は本ブランチ内で ADR-0021 として起票済みです。その他（メモ系の `@db.VarChar(2000)` 統一・数値カラムへの CHECK 制約）は既存の ADR-0019 でカバーされており、残りはスキーマ単位の参照先選定（`createdBy` を Employee 参照）・マイグレーション分割・スコープ外逆リレーションの判断であり、独立した ADR は不要と判断しました。

## Test Plan

スキーマ追加のため、既存機能の非破壊と migration の整合性を確認する。

- [ ] `pnpm prisma migrate reset` が drift なしで成功する
- [ ] `pnpm build` / `pnpm test` / `pnpm lint` がオールグリーン
- [ ] `pnpm db:studio` で 7 テーブル（tax_rates / estimates / repair_estimate_details / after_repair_estimate_details / estimate_variations / estimate_items / revised_estimate_item_details）が確認できる
- [ ] `pnpm prisma db seed` で税率 2 件（0.080 / 0.100）が投入される
- [ ] 各 CHECK 制約（税率・掛率・金額・連番等）が DB に適用されている

---

Generated with [Claude Code](https://claude.ai/code)