### PR TITLE
feat: 受注(Order)系・バリエーション系譜(複製/改訂)の Prisma スキーマを追加する

### DIFF
--- a/docs/claude-plans/issue-274/deviations.md
+++ b/docs/claude-plans/issue-274/deviations.md
@@ -1,0 +1,33 @@
+# Issue #274 実装の逸脱記録
+
+計画（`plan.md`）および設計書（`docs/business/estimate/システム設計書(見積).md`）からの逸脱を記録する。
+
+## 1. 作成者FKの参照先を User → Employee に置換
+
+- **元の計画/設計**: 設計書 §11.4 では `Order.createdBy` / `OrderConfirmation.confirmedBy` / `OrderCancellation.cancelledBy` はいずれも `User` を参照していた。
+- **実際の実装**: 3つとも `Employee` を参照するよう変更した。これに伴い `Employee` に逆リレーション `createdOrders` / `confirmedOrders` / `cancelledOrders` を追加した。
+- **逸脱の理由**: #272 で `Estimate.createdBy` を `Employee` 参照に変更済みであり、業務エンティティは認証ユーザー(`User`, better-auth)を直接参照しない方針で統一されている。また §9 の部署権限チェックで `departmentId` を辿る必要があり、`Employee` 参照が必須。着手時にユーザー確認のうえ決定。
+
+## 2. 業務日時カラムを createdAt に集約
+
+- **元の計画/設計**: 設計書 §11.4 では `Order.orderDate` / `OrderConfirmation.confirmedAt` / `OrderCancellation.cancelledAt` を業務日時として個別に保持していた。
+- **実際の実装**: これら3カラムを設けず、各テーブルの `createdAt` に集約した。納期 `OrderConfirmation.deliveryDate` は保持。
+- **逸脱の理由**: イベントテーブル（確定/取消）の行は挿入と同時に確定し、`createdAt` が状態発生時刻そのものになる。業務日時を別カラムにすると同一トランザクション挿入で `createdAt` と冗長になりNULL排除/最小スキーマ方針に反する。`deliveryDate` は挿入時刻と無関係な未来日のため独立カラムで保持。着手時にユーザー確認のうえ決定。
+
+## 3. 金額/数値の手書き CHECK 制約は追記なし
+
+- **元の計画/Issueタスク**: Issue 実装タスクに「マイグレーション SQL に金額/数値の手書き CHECK 制約を追記する」が含まれていた。
+- **実際の実装**: CHECK 制約を一切追記しなかった。
+- **逸脱の理由**: 受注系・系譜の5モデルは金額/数量などの数値カラムを一切持たない（受注明細・金額は `EstimateVariation → EstimateItem` を辿って得る設計, §4.2）。CHECK の対象が存在しないため該当なし。Issue タスク項目は #272 からの定型的な引き継ぎであり、本 Issue には適用対象がないと判断（着手時にユーザー確認済み）。
+
+## 4. 逆リレーション追加コミットを独立させず各モデル追加コミットに統合
+
+- **元の計画**: `plan.md` の実装ステップでは「ステップ3: 逆リレーション追加」を独立コミットとしていた。
+- **実際の実装**: 逆リレーションを各モデル追加コミットに分散させた（受注系3モデル＋Employee逆参照＋EstimateVariation.order を1コミット、系譜2モデル＋EstimateVariation の copy/revision 逆参照を1コミット）。
+- **逸脱の理由**: Prisma はリレーションの双方向定義を必須とするため、片側のモデルだけを追加したコミットでは `prisma validate` が失敗する。各コミットを独立して valid に保つため、逆リレーションを対応するモデル追加コミットに含めた。
+
+## 5. 全イベント/交差テーブルに updatedAt を付与
+
+- **元の計画/設計**: 設計書 §11.4 / §11.2.1 の概念 Prisma では `OrderConfirmation` / `OrderCancellation` / `EstimateVariationCopy` / `EstimateVariationRevision` に `createdAt` のみを記載（`updatedAt` なし）。
+- **実際の実装**: 4テーブルすべてに `updatedAt @updatedAt` を付与した。
+- **逸脱の理由**: 既存リポジトリの全モデル（join テーブル含む）が `createdAt` + `updatedAt` を持つ慣習に揃えた。設計書の表記は概念上のものであり、実装規約（既存スキーマの一貫性）が優先される（§11 冒頭注記）。

--- a/docs/claude-plans/issue-274/plan.md
+++ b/docs/claude-plans/issue-274/plan.md
@@ -1,0 +1,207 @@
+# Issue #274 実装計画: 受注(Order)系・バリエーション系譜(複製/改訂) Prisma スキーマ追加
+
+## 概要
+
+#272 でスコープ外とした **受注系** と **バリエーション系譜(複製/改訂)** の Prisma スキーマ5モデルを追加する。
+真実の源は `docs/business/estimate/システム設計書(見積).md` の §11.2.1(系譜) と §11.4(受注)。
+
+## 着手時に確定した設計判断（ユーザー確認済み）
+
+| # | 論点 | 決定 | 理由 |
+|---|------|------|------|
+| 1 | 作成者FK (`createdBy`/`confirmedBy`/`cancelledBy`) の参照先 | **Employee に統一** | #272 の `Estimate.createdBy` と整合。§9 部署権限チェックで `departmentId` を辿る必要があるため業務エンティティ `Employee` を参照する。設計書の `User` 参照は概念表記として置換する。 |
+| 2 | 金額/数値の手書き CHECK 制約 | **該当なし** | 受注系5モデルは金額/数量カラムを一切持たない（明細・金額は `variation → items` を辿る設計, §4.2）。CHECK 対象が存在しないため追加しない。Issue タスク項目は「本issueでは該当なし」として `deviations.md` に記録する。 |
+| 3 | 業務日時カラム (`orderDate`/`confirmedAt`/`cancelledAt`) | **`createdAt` に集約（削除）** | イベント行の `createdAt` が「受注作成/確定/取消の時刻」そのもの。同一トランザクション挿入では業務日時と冗長になるため集約し *1事実1カラム* を保つ。ただし `deliveryDate`(納期=未来日) は挿入時刻と無関係なため NOT NULL 独立カラムとして保持する。 |
+
+## 実装規約（#272 / ADR 踏襲）
+
+- **ID**: `String @id @db.Uuid`（`@default` なし、ドメイン層で UUIDv7 採番。ADR-0009）
+- **日時**: `@db.Timestamptz(3)`（ADR-0010）。`createdAt @default(now())` / `updatedAt @updatedAt` は全モデルに付与（リポジトリ全モデルの共通慣習）
+- **文字列**: `@db.VarChar(N)`。メモ系 `orderNote` は `VarChar(2000)`（ADR-0019）
+- **NULL 排除**: 確定/取消はイベントテーブル化（行の存在＝状態）。複製/改訂は `kind` 統合せず別交差テーブルに分離
+- **二重派生の禁止**（同一バリエーションが複製かつ改訂）はドメイン層で担保（ADR-0019）。スキーマでは制約しない
+- **テーブル/カラム名**: snake_case（`@map` / `@@map`）
+
+## 追加モデル（5つ）
+
+### 1. `Order`（受注本体, テーブル `orders`）
+
+```prisma
+model Order {
+  id          String            @id @db.Uuid // ドメイン層でUUIDv7生成
+  // 見積番号を受注番号として使用。1 バリエーション : 1 受注
+  variationId String            @unique @map("variation_id") @db.Uuid
+  variation   EstimateVariation @relation("VariationOrder", fields: [variationId], references: [id])
+
+  // status カラムは持たない。確定/取消は OrderConfirmation / OrderCancellation の行の存在で導出
+  //   confirmation あり → 受注確定済 / cancellation あり → 受注取消済 / どちらもなし → 受注作成済
+  // 受注日時は createdAt に集約（業務日時 orderDate は持たない）
+
+  orderNote String? @map("order_note") @db.VarChar(2000) // 任意メモ（真に任意 → NULL 許容）
+
+  // 作成者（Employee 参照。#272 と整合）
+  createdBy String   @map("created_by") @db.Uuid
+  creator   Employee @relation("OrderCreator", fields: [createdBy], references: [id])
+
+  // 確定/取消イベント（それぞれ高々 1 件）
+  confirmation OrderConfirmation?
+  cancellation OrderCancellation?
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([variationId])
+  @@index([createdBy])
+  @@map("orders")
+}
+```
+
+### 2. `OrderConfirmation`（受注確定イベント, テーブル `order_confirmations`）
+
+```prisma
+// 行の存在＝確定済み。確定時のみ 1:1 で存在
+model OrderConfirmation {
+  id      String @id @db.Uuid // ドメイン層でUUIDv7生成
+  orderId String @unique @map("order_id") @db.Uuid
+  order   Order  @relation(fields: [orderId], references: [id], onDelete: Cascade)
+
+  deliveryDate DateTime @map("delivery_date") @db.Timestamptz(3) // 納期（確定時必須 → NOT NULL）
+
+  // 確定者（Employee 参照）。確定時刻は createdAt に集約（confirmedAt は持たない）
+  confirmedBy String   @map("confirmed_by") @db.Uuid
+  confirmer   Employee @relation("OrderConfirmer", fields: [confirmedBy], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([confirmedBy])
+  @@map("order_confirmations")
+}
+```
+
+### 3. `OrderCancellation`（受注取消イベント, テーブル `order_cancellations`）
+
+```prisma
+// 行の存在＝取消済み。取消時のみ 1:1 で存在
+model OrderCancellation {
+  id      String @id @db.Uuid // ドメイン層でUUIDv7生成
+  orderId String @unique @map("order_id") @db.Uuid
+  order   Order  @relation(fields: [orderId], references: [id], onDelete: Cascade)
+
+  // 取消者（Employee 参照）。取消時刻は createdAt に集約（cancelledAt は持たない）
+  cancelledBy String   @map("cancelled_by") @db.Uuid
+  canceller   Employee @relation("OrderCanceller", fields: [cancelledBy], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([cancelledBy])
+  @@map("order_cancellations")
+}
+```
+
+### 4. `EstimateVariationCopy`（複製による派生, テーブル `estimate_variation_copies`）
+
+```prisma
+// 見積複製による派生（§5）。target を @unique とし 1 派生先は高々 1 出自
+model EstimateVariationCopy {
+  id String @id @db.Uuid // ドメイン層でUUIDv7生成
+
+  copiedVariationId String            @unique @map("copied_variation_id") @db.Uuid
+  copiedVariation   EstimateVariation @relation("VariationCopyTarget", fields: [copiedVariationId], references: [id], onDelete: Cascade)
+
+  sourceVariationId String            @map("source_variation_id") @db.Uuid
+  sourceVariation   EstimateVariation @relation("VariationCopySource", fields: [sourceVariationId], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([sourceVariationId])
+  @@map("estimate_variation_copies")
+}
+```
+
+### 5. `EstimateVariationRevision`（得意先改訂による派生, テーブル `estimate_variation_revisions`）
+
+```prisma
+// 得意先改訂による派生（§7）
+model EstimateVariationRevision {
+  id String @id @db.Uuid // ドメイン層でUUIDv7生成
+
+  revisedVariationId String            @unique @map("revised_variation_id") @db.Uuid
+  revisedVariation   EstimateVariation @relation("VariationRevisionTarget", fields: [revisedVariationId], references: [id], onDelete: Cascade)
+
+  sourceVariationId String            @map("source_variation_id") @db.Uuid
+  sourceVariation   EstimateVariation @relation("VariationRevisionSource", fields: [sourceVariationId], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([sourceVariationId])
+  @@map("estimate_variation_revisions")
+}
+```
+
+## 既存モデルへの逆リレーション追加
+
+### `EstimateVariation` に5本の逆リレーションを追加
+
+```prisma
+  // 受注（1:1。@unique 側の逆参照なので Optional 単数）
+  order Order? @relation("VariationOrder")
+
+  // 複製系譜
+  copyTarget EstimateVariationCopy?  @relation("VariationCopyTarget")  // この V が複製で生まれた（高々1）
+  copySource EstimateVariationCopy[] @relation("VariationCopySource")  // この V を元に複製された先（複数可）
+
+  // 改訂系譜
+  revisionTarget EstimateVariationRevision?  @relation("VariationRevisionTarget")  // この V が改訂で生まれた（高々1）
+  revisionSource EstimateVariationRevision[] @relation("VariationRevisionSource")  // この V を元に改訂された先（複数可）
+```
+
+### `Employee` に作成者/確定者/取消者の逆リレーションを追加
+
+```prisma
+  // 受注関連の逆参照（Employee 参照に統一したため必要）
+  createdOrders        Order[]             @relation("OrderCreator")
+  confirmedOrders      OrderConfirmation[] @relation("OrderConfirmer")
+  cancelledOrders      OrderCancellation[] @relation("OrderCanceller")
+```
+
+## マイグレーション SQL の手書き追記
+
+- **CHECK 制約**: 受注系5モデルは数値/金額カラムを持たないため **追加なし**（決定#2）
+- Prisma が生成する SQL（CreateTable / CreateIndex / AddForeignKey）をそのまま使用
+- FK の `onDelete`:
+  - `OrderConfirmation`/`OrderCancellation` → `Order`: **Cascade**（設計書通り。受注削除でイベントも消える）
+  - `EstimateVariationCopy.copiedVariation` / `Revision.revisedVariation` → **Cascade**（派生先が消えれば系譜も消える）
+  - `*.sourceVariation` / `Order.variation` / 作成者FK → デフォルト（Restrict。出自/受注元は保護）
+
+## 実装ステップ（コミット単位）
+
+1. **スキーマ追加（受注系3モデル）** — `Order` / `OrderConfirmation` / `OrderCancellation` を `schema.prisma` に追記
+   - コミット: `feat: 受注系 Prisma モデル追加（Order＋確定/取消イベント）`
+   - ボディ: status カラム不採用（行の存在で状態導出）/ 作成者は Employee 参照 / 業務日時は createdAt 集約、の判断理由を記載
+2. **スキーマ追加（系譜2モデル）** — `EstimateVariationCopy` / `EstimateVariationRevision` を追記
+   - コミット: `feat: バリエーション系譜 Prisma モデル追加（複製/改訂の交差テーブル分離）`
+   - ボディ: kind 統合せず別表分離した理由（NULL 排除）を記載
+3. **逆リレーション追加** — `EstimateVariation`(5本) と `Employee`(3本) に逆参照を追記
+   - コミット: `feat: EstimateVariation/Employee に受注・系譜の逆リレーション追加`
+4. **マイグレーション生成・適用** — `pnpm db:migrate`（CHECK 追記は該当なし）、`pnpm db:generate`
+   - コミット: `feat: 受注系・系譜のマイグレーション追加`
+5. **deviations 記録** — `docs/claude-plans/issue-274/deviations.md` に下記を記録
+   - 設計書の `User` 参照 → `Employee` に置換（決定#1）
+   - 業務日時カラム `orderDate`/`confirmedAt`/`cancelledAt` を削除し `createdAt` に集約（決定#3）
+   - 「金額/数値 CHECK 制約」は対象なしのため未追加（決定#2）
+   - 全イベント/交差テーブルに `updatedAt` を付与（設計書概念表記は createdAt のみ。リポジトリ慣習に合わせた）
+
+## 受け入れ条件の確認方法
+
+- [ ] 5モデルが `schema.prisma` に追加され migrate 適用・`prisma generate` 成功
+- [ ] CHECK 制約は対象なし（決定#2を deviations に明記）
+- [ ] `pnpm build` / `pnpm test` / `pnpm lint` オールグリーン
+
+## DDD レイヤリング上の留意
+
+- 本 issue は **Prisma スキーマ（インフラ層の DB 定義）のみ**。ドメインエンティティ/リポジトリ実装は別 issue
+- 二重派生禁止・受注作成条件などの不変条件はドメイン層で担保する設計（本 issue では実装しない）

--- a/prisma/migrations/20260520083701_add_order_and_variation_lineage/migration.sql
+++ b/prisma/migrations/20260520083701_add_order_and_variation_lineage/migration.sql
@@ -1,0 +1,119 @@
+-- CreateTable
+CREATE TABLE "orders" (
+    "id" UUID NOT NULL,
+    "variation_id" UUID NOT NULL,
+    "order_note" VARCHAR(2000),
+    "created_by" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "orders_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "order_confirmations" (
+    "id" UUID NOT NULL,
+    "order_id" UUID NOT NULL,
+    "delivery_date" TIMESTAMPTZ(3) NOT NULL,
+    "confirmed_by" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "order_confirmations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "order_cancellations" (
+    "id" UUID NOT NULL,
+    "order_id" UUID NOT NULL,
+    "cancelled_by" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "order_cancellations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "estimate_variation_copies" (
+    "id" UUID NOT NULL,
+    "copied_variation_id" UUID NOT NULL,
+    "source_variation_id" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "estimate_variation_copies_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "estimate_variation_revisions" (
+    "id" UUID NOT NULL,
+    "revised_variation_id" UUID NOT NULL,
+    "source_variation_id" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "estimate_variation_revisions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "orders_variation_id_key" ON "orders"("variation_id");
+
+-- CreateIndex
+CREATE INDEX "orders_variation_id_idx" ON "orders"("variation_id");
+
+-- CreateIndex
+CREATE INDEX "orders_created_by_idx" ON "orders"("created_by");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "order_confirmations_order_id_key" ON "order_confirmations"("order_id");
+
+-- CreateIndex
+CREATE INDEX "order_confirmations_confirmed_by_idx" ON "order_confirmations"("confirmed_by");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "order_cancellations_order_id_key" ON "order_cancellations"("order_id");
+
+-- CreateIndex
+CREATE INDEX "order_cancellations_cancelled_by_idx" ON "order_cancellations"("cancelled_by");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "estimate_variation_copies_copied_variation_id_key" ON "estimate_variation_copies"("copied_variation_id");
+
+-- CreateIndex
+CREATE INDEX "estimate_variation_copies_source_variation_id_idx" ON "estimate_variation_copies"("source_variation_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "estimate_variation_revisions_revised_variation_id_key" ON "estimate_variation_revisions"("revised_variation_id");
+
+-- CreateIndex
+CREATE INDEX "estimate_variation_revisions_source_variation_id_idx" ON "estimate_variation_revisions"("source_variation_id");
+
+-- AddForeignKey
+ALTER TABLE "orders" ADD CONSTRAINT "orders_variation_id_fkey" FOREIGN KEY ("variation_id") REFERENCES "estimate_variations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "orders" ADD CONSTRAINT "orders_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "employees"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_confirmations" ADD CONSTRAINT "order_confirmations_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "orders"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_confirmations" ADD CONSTRAINT "order_confirmations_confirmed_by_fkey" FOREIGN KEY ("confirmed_by") REFERENCES "employees"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_cancellations" ADD CONSTRAINT "order_cancellations_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "orders"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_cancellations" ADD CONSTRAINT "order_cancellations_cancelled_by_fkey" FOREIGN KEY ("cancelled_by") REFERENCES "employees"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "estimate_variation_copies" ADD CONSTRAINT "estimate_variation_copies_copied_variation_id_fkey" FOREIGN KEY ("copied_variation_id") REFERENCES "estimate_variations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "estimate_variation_copies" ADD CONSTRAINT "estimate_variation_copies_source_variation_id_fkey" FOREIGN KEY ("source_variation_id") REFERENCES "estimate_variations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "estimate_variation_revisions" ADD CONSTRAINT "estimate_variation_revisions_revised_variation_id_fkey" FOREIGN KEY ("revised_variation_id") REFERENCES "estimate_variations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "estimate_variation_revisions" ADD CONSTRAINT "estimate_variation_revisions_source_variation_id_fkey" FOREIGN KEY ("source_variation_id") REFERENCES "estimate_variations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -585,6 +585,14 @@ model EstimateVariation {
   // 受注（1:1。Order.variationId が @unique のため Optional 単数）
   order Order? @relation("VariationOrder")
 
+  // 複製系譜: copyTarget=この V が複製で生まれた出自（高々1）/ copySource=この V を元に複製された先（複数可）
+  copyTarget EstimateVariationCopy?  @relation("VariationCopyTarget")
+  copySource EstimateVariationCopy[] @relation("VariationCopySource")
+
+  // 改訂系譜: revisionTarget=この V が改訂で生まれた出自（高々1）/ revisionSource=この V を元に改訂された先（複数可）
+  revisionTarget EstimateVariationRevision?  @relation("VariationRevisionTarget")
+  revisionSource EstimateVariationRevision[] @relation("VariationRevisionSource")
+
   items EstimateItem[]
 
   // タイムスタンプ
@@ -747,4 +755,51 @@ model OrderCancellation {
 
   @@index([cancelledBy])
   @@map("order_cancellations")
+}
+
+// ========================================
+// バリエーション系譜（複製・得意先改訂）
+// ========================================
+//
+// 複製（§5）と得意先改訂（§7）は形は似るが業務操作・ルール・将来増える属性が異なる別概念。
+// kind 判別子で 1 表統合すると改訂固有属性が増えた時に複製側が NULL になるため、別々の交差テーブルに分離する（§11.2.1）。
+// いずれも target 側を @unique とし、1 派生先は高々 1 出自を持つ。どちらの表にも行が無い＝オリジナル。
+// 「同じバリエーションが複製かつ改訂」になる二重派生の禁止はドメイン層で担保する（ADR-0019）。
+
+// 見積複製による派生（§5）
+model EstimateVariationCopy {
+  id String @id @db.Uuid // ドメイン層でUUIDv7生成
+
+  // 複製で生まれたバリエーション（1 件のみ → @unique）
+  copiedVariationId String            @unique @map("copied_variation_id") @db.Uuid
+  copiedVariation   EstimateVariation @relation("VariationCopyTarget", fields: [copiedVariationId], references: [id], onDelete: Cascade)
+
+  // 複製元バリエーション
+  sourceVariationId String            @map("source_variation_id") @db.Uuid
+  sourceVariation   EstimateVariation @relation("VariationCopySource", fields: [sourceVariationId], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([sourceVariationId])
+  @@map("estimate_variation_copies")
+}
+
+// 得意先改訂による派生（§7）
+model EstimateVariationRevision {
+  id String @id @db.Uuid // ドメイン層でUUIDv7生成
+
+  // 改訂で生まれた得意先バリエーション（1 件のみ → @unique）
+  revisedVariationId String            @unique @map("revised_variation_id") @db.Uuid
+  revisedVariation   EstimateVariation @relation("VariationRevisionTarget", fields: [revisedVariationId], references: [id], onDelete: Cascade)
+
+  // 改訂元の納品先バリエーション
+  sourceVariationId String            @map("source_variation_id") @db.Uuid
+  sourceVariation   EstimateVariation @relation("VariationRevisionSource", fields: [sourceVariationId], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([sourceVariationId])
+  @@map("estimate_variation_revisions")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,9 +5,9 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client"
-  output   = "../generated/prisma"
-  engineType      = "client"
+  provider   = "prisma-client"
+  output     = "../generated/prisma"
+  engineType = "client"
 }
 
 datasource db {
@@ -103,6 +103,11 @@ model Employee {
 
   // 見積作成者としての逆参照
   createdEstimates Estimate[] @relation("EstimateCreator")
+
+  // 受注関連の逆参照（作成者/確定者/取消者を Employee 参照に統一したため必要）
+  createdOrders   Order[]             @relation("OrderCreator")
+  confirmedOrders OrderConfirmation[] @relation("OrderConfirmer")
+  cancelledOrders OrderCancellation[] @relation("OrderCanceller")
 
   // タイムスタンプ
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
@@ -318,27 +323,27 @@ model DeliveryLocation {
 enum ProductCategory {
   INDIVIDUAL // 個別商品
   CONSUMABLE // 消耗品
-  SET        // セット商品
+  SET // セット商品
 }
 
 // 単位
 enum ProductUnit {
-  UNIT  // 台
+  UNIT // 台
   PIECE // 個
-  ROLL  // 本
-  BOX   // 箱
+  ROLL // 本
+  BOX // 箱
   SHEET // 枚
-  SET   // セット
+  SET // セット
 }
 
 model Product {
   id          String          @id @db.Uuid // ドメイン層でUUIDv7生成
   code        String          @unique @db.VarChar(50) // 商品コード (英数字, 最大50桁)
   name        String          @unique @db.VarChar(100) // 商品名
-  category    ProductCategory              // 商品区分
+  category    ProductCategory // 商品区分
   description String?         @db.VarChar(1000) // 商品説明
   note        String?         @db.VarChar(1000) // 備考
-  unit        ProductUnit                  // 単位
+  unit        ProductUnit // 単位
   costPrice   Decimal?        @map("cost_price") @db.Decimal(12, 2) // 原価
   isActive    Boolean         @default(true) @map("is_active") // 有効フラグ
 
@@ -348,7 +353,7 @@ model Product {
   relatedByProducts ProductRelation[] @relation("ProductRelationTarget")
 
   // セット商品構成 (この商品がセット商品)
-  setComponents  SetProductComponent[] @relation("SetProduct")
+  setComponents   SetProductComponent[] @relation("SetProduct")
   // セット商品構成 (この商品が構成商品)
   componentOfSets SetProductComponent[] @relation("ComponentProduct")
 
@@ -371,8 +376,8 @@ model Product {
 
 model ProductRelation {
   // 設定元 (個別商品のみ)
-  productId      String  @map("product_id") @db.Uuid
-  product        Product @relation("ProductRelationSource", fields: [productId], references: [id], onDelete: Cascade)
+  productId String  @map("product_id") @db.Uuid
+  product   Product @relation("ProductRelationSource", fields: [productId], references: [id], onDelete: Cascade)
 
   // 設定先 (個別商品 or 消耗品)
   relatedProductId String  @map("related_product_id") @db.Uuid
@@ -391,8 +396,8 @@ model ProductRelation {
 
 model SetProductComponent {
   // セット商品
-  setProductId     String  @map("set_product_id") @db.Uuid
-  setProduct       Product @relation("SetProduct", fields: [setProductId], references: [id], onDelete: Cascade)
+  setProductId String  @map("set_product_id") @db.Uuid
+  setProduct   Product @relation("SetProduct", fields: [setProductId], references: [id], onDelete: Cascade)
 
   // 構成商品 (個別商品 or 消耗品)
   componentProductId String  @map("component_product_id") @db.Uuid
@@ -415,22 +420,22 @@ model SetProductComponent {
 
 // 見積区分
 enum EstimateType {
-  NEW          // 新規
-  REPAIR       // 修理（事前）
+  NEW // 新規
+  REPAIR // 修理（事前）
   AFTER_REPAIR // 事後修理
 }
 
 // 提出区分
 enum SubmissionType {
-  CUSTOMER          // 得意先向け
+  CUSTOMER // 得意先向け
   DELIVERY_LOCATION // 納品先向け
 }
 
 // 消費税の端数処理
 enum TaxRoundingType {
   ROUND_DOWN // 切捨
-  ROUND_UP   // 切上
-  ROUND      // 四捨五入
+  ROUND_UP // 切上
+  ROUND // 四捨五入
 }
 
 model Estimate {
@@ -441,10 +446,10 @@ model Estimate {
   estimateType EstimateType @map("estimate_type")
 
   fiscalYear Int @map("fiscal_year") // 西暦4桁（採番用）
-  sequence   Int                       // 区分内連番（最大99999）
+  sequence   Int // 区分内連番（最大99999）
 
   estimateDate DateTime @map("estimate_date") @db.Timestamptz(3) // 見積年月日
-  deadline     DateTime @db.Timestamptz(3)                       // 締切年月日
+  deadline     DateTime @db.Timestamptz(3) // 締切年月日
 
   // 提出区分
   submissionType SubmissionType @map("submission_type")
@@ -549,7 +554,7 @@ model AfterRepairEstimateDetail {
 
 // バリエーション状態
 enum VariationStatus {
-  ACTIVE   // 有効
+  ACTIVE // 有効
   INACTIVE // 無効
 }
 
@@ -569,14 +574,16 @@ model EstimateVariation {
   overallDiscount Decimal @default(0) @map("overall_discount") @db.Decimal(12, 2)
 
   // 集計金額（計算結果を保存）
-  subtotal         Decimal @db.Decimal(12, 2)                              // 明細金額小計
-  discountSubtotal Decimal @map("discount_subtotal") @db.Decimal(12, 2)    // 明細値引金額小計
-  finalSubtotal    Decimal @map("final_subtotal") @db.Decimal(12, 2)       // 最終明細金額小計
-  taxAmount        Decimal @map("tax_amount") @db.Decimal(12, 2)           // 消費税額
-  finalTotal       Decimal @map("final_total") @db.Decimal(12, 2)          // 最終合計金額
+  subtotal         Decimal @db.Decimal(12, 2) // 明細金額小計
+  discountSubtotal Decimal @map("discount_subtotal") @db.Decimal(12, 2) // 明細値引金額小計
+  finalSubtotal    Decimal @map("final_subtotal") @db.Decimal(12, 2) // 最終明細金額小計
+  taxAmount        Decimal @map("tax_amount") @db.Decimal(12, 2) // 消費税額
+  finalTotal       Decimal @map("final_total") @db.Decimal(12, 2) // 最終合計金額
 
   // 申請・承認情報は本モデルに持たない（共通申請テーブル ADR-0001 が別 issue で参照）
-  // 複製元・改訂元・Order との逆リレーションは別 issue で追加する
+
+  // 受注（1:1。Order.variationId が @unique のため Optional 単数）
+  order Order? @relation("VariationOrder")
 
   items EstimateItem[]
 
@@ -614,12 +621,12 @@ model EstimateItem {
 
   // 値引き
   discountRate Decimal @default(1.0) @map("discount_rate") @db.Decimal(5, 4) // 掛率（1.0 = 値引なし）
-  itemDiscount Decimal @default(0) @map("item_discount") @db.Decimal(12, 2)  // 明細値引金額
+  itemDiscount Decimal @default(0) @map("item_discount") @db.Decimal(12, 2) // 明細値引金額
 
   // 計算結果（保存）
-  baseAmount       Decimal @map("base_amount") @db.Decimal(12, 2)       // 基本金額（数量×単価）
+  baseAmount       Decimal @map("base_amount") @db.Decimal(12, 2) // 基本金額（数量×単価）
   discountedAmount Decimal @map("discounted_amount") @db.Decimal(12, 2) // 掛率適用後金額
-  finalAmount      Decimal @map("final_amount") @db.Decimal(12, 2)      // 最終明細金額
+  finalAmount      Decimal @map("final_amount") @db.Decimal(12, 2) // 最終明細金額
 
   // 得意先改訂で生まれた明細だけが持つ固有属性は別サブタイプ表に分離（§11.3.1）
   revisedDetail RevisedEstimateItemDetail?
@@ -668,4 +675,76 @@ model TaxRate {
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   @@map("tax_rates")
+}
+
+// ========================================
+// 受注関連
+// ========================================
+//
+// 受注のライフサイクル状態は status カラムで持たず、確定/取消イベント行の存在から導出する（§1.3 / §11.4）:
+//   OrderConfirmation あり → 受注確定済 / OrderCancellation あり → 受注取消済 / どちらもなし → 受注作成済
+// 受注明細は持たない。明細は variation → items（EstimateItem）を辿る（受注明細 = 見積明細が常に一致するため。§4.2）
+
+model Order {
+  id String @id @db.Uuid // ドメイン層でUUIDv7生成
+
+  // 見積バリエーションを受注番号として使用（1 バリエーション : 1 受注）
+  variationId String            @unique @map("variation_id") @db.Uuid
+  variation   EstimateVariation @relation("VariationOrder", fields: [variationId], references: [id])
+
+  // 任意メモ（真に任意の値属性 → NULL 許容。ADR-0019: メモ系は VarChar(2000)）
+  orderNote String? @map("order_note") @db.VarChar(2000)
+
+  // 作成者（Employee を参照。#272 の Estimate.createdBy と整合。§9 部署権限で departmentId を辿る）
+  createdBy String   @map("created_by") @db.Uuid
+  creator   Employee @relation("OrderCreator", fields: [createdBy], references: [id])
+
+  // 確定/取消イベント（それぞれ高々 1 件。行の存在＝その状態）
+  confirmation OrderConfirmation?
+  cancellation OrderCancellation?
+
+  // 受注日時は createdAt に集約（業務日時 orderDate は冗長なため持たない）
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([variationId])
+  @@index([createdBy])
+  @@map("orders")
+}
+
+// 受注確定イベント。確定したときのみ 1:1 で存在する（行の存在＝確定済み）
+model OrderConfirmation {
+  id      String @id @db.Uuid // ドメイン層でUUIDv7生成
+  orderId String @unique @map("order_id") @db.Uuid
+  order   Order  @relation(fields: [orderId], references: [id], onDelete: Cascade)
+
+  // 納期（確定時必須 → NOT NULL）。挿入時刻とは無関係な未来日のため独立カラムで保持
+  deliveryDate DateTime @map("delivery_date") @db.Timestamptz(3)
+
+  // 確定者（Employee 参照）。確定時刻は createdAt に集約（confirmedAt は持たない）
+  confirmedBy String   @map("confirmed_by") @db.Uuid
+  confirmer   Employee @relation("OrderConfirmer", fields: [confirmedBy], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([confirmedBy])
+  @@map("order_confirmations")
+}
+
+// 受注取消イベント。取消したときのみ 1:1 で存在する（行の存在＝取消済み）
+model OrderCancellation {
+  id      String @id @db.Uuid // ドメイン層でUUIDv7生成
+  orderId String @unique @map("order_id") @db.Uuid
+  order   Order  @relation(fields: [orderId], references: [id], onDelete: Cascade)
+
+  // 取消者（Employee 参照）。取消時刻は createdAt に集約（cancelledAt は持たない）
+  cancelledBy String   @map("cancelled_by") @db.Uuid
+  canceller   Employee @relation("OrderCanceller", fields: [cancelledBy], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([cancelledBy])
+  @@map("order_cancellations")
 }


### PR DESCRIPTION
## Summary

#272 でスコープ外とした「受注(Order)系」と「バリエーション系譜(複製/改訂)」の Prisma スキーマ5モデルを追加し、見積〜受注のデータモデルを揃えた。受注の状態は status カラムではなく確定/取消イベントテーブルの行の存在で表現し、複製/改訂は `kind` 統合せず別々の交差テーブルに分離している。

Closes #274

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### 着手時に確定した設計判断（ユーザー確認済み）

| # | 論点 | 決定 | 理由 |
|---|------|------|------|
| 1 | 作成者FK (`createdBy`/`confirmedBy`/`cancelledBy`) の参照先 | **Employee に統一** | #272 の `Estimate.createdBy` と整合。§9 部署権限チェックで `departmentId` を辿る必要があるため業務エンティティ `Employee` を参照する。設計書の `User` 参照は概念表記として置換。 |
| 2 | 金額/数値の手書き CHECK 制約 | **該当なし** | 受注系5モデルは金額/数量カラムを一切持たない（明細・金額は `variation → items` を辿る設計, §4.2）。CHECK 対象が存在しない。 |
| 3 | 業務日時カラム (`orderDate`/`confirmedAt`/`cancelledAt`) | **`createdAt` に集約（削除）** | イベント行の `createdAt` が状態発生時刻そのもの。冗長を避け *1事実1カラム* を保つ。`deliveryDate`(納期) は挿入時刻と無関係なため独立カラムで保持。 |

### 追加モデル（5つ）

- **Order**（`orders`）— `variationId @unique` で 1:1。status カラムなし、確定/取消イベントの行の存在で状態導出。`orderNote VarChar(2000)`、作成者は `Employee` 参照
- **OrderConfirmation**（`order_confirmations`）— 行の存在＝確定済。`deliveryDate` NOT NULL、`orderId @unique`、`onDelete: Cascade`
- **OrderCancellation**（`order_cancellations`）— 行の存在＝取消済。`orderId @unique`、`onDelete: Cascade`
- **EstimateVariationCopy**（`estimate_variation_copies`）— 複製派生。`copiedVariationId @unique`（target は Cascade、source は Restrict）
- **EstimateVariationRevision**（`estimate_variation_revisions`）— 改訂派生。`revisedVariationId @unique`（同上）

### 既存モデルへの逆リレーション追加

- `EstimateVariation` に5本（`order` / `copyTarget` / `copySource` / `revisionTarget` / `revisionSource`）
- `Employee` に3本（`createdOrders` / `confirmedOrders` / `cancelledOrders`）

### 実装規約（#272 / ADR 踏襲）

- ID: `String @id @db.Uuid`（ドメイン層で UUIDv7 採番。ADR-0009）
- 日時: `@db.Timestamptz(3)`（ADR-0010）、全モデルに `createdAt`/`updatedAt`
- NULL 排除: 確定/取消はイベントテーブル化、複製/改訂は別交差テーブルに分離
- 二重派生の禁止はドメイン層で担保（本 issue では実装しない）
- テーブル/カラム名: snake_case（`@map`/`@@map`）

### DDD レイヤリング上の留意

本 issue は **Prisma スキーマ（インフラ層の DB 定義）のみ**。ドメインエンティティ/リポジトリ実装・不変条件の担保は別 issue。

</details>

## 計画からの逸脱

設計書（`システム設計書(見積).md`）および当初 Issue タスクからの逸脱は以下5点。1〜3は着手時にユーザー確認済み、4〜5は実装上の整合性に基づく判断。

1. **作成者FKの参照先を User → Employee に置換** — `Order.createdBy` / `OrderConfirmation.confirmedBy` / `OrderCancellation.cancelledBy` を `Employee` 参照に変更。#272 の方針（業務エンティティは認証ユーザーを直接参照しない、§9 部署権限チェックで `departmentId` が必要）に統一。`Employee` に逆リレーション3本を追加。
2. **業務日時カラムを createdAt に集約** — `orderDate` / `confirmedAt` / `cancelledAt` を設けず各テーブルの `createdAt` に集約。イベント行は挿入と同時に確定し `createdAt` が状態発生時刻になるため。`deliveryDate` は未来日のため独立カラムで保持。
3. **金額/数値の手書き CHECK 制約は追記なし** — 受注系・系譜5モデルは数値カラムを持たない（金額は `EstimateVariation → EstimateItem` を辿る設計）ため対象なし。Issue タスク項目は #272 からの定型引き継ぎで本 Issue には適用対象なしと判断。
4. **逆リレーション追加コミットを独立させず各モデル追加コミットに統合** — Prisma はリレーションの双方向定義を必須とし、片側だけのコミットでは `prisma validate` が失敗するため、各コミットを独立して valid に保つよう逆リレーションを対応モデルのコミットに含めた。
5. **全イベント/交差テーブルに updatedAt を付与** — 設計書概念表記は `createdAt` のみだが、既存リポジトリ全モデル（join テーブル含む）の `createdAt`+`updatedAt` 慣習に揃えた。

## Test Plan

本 PR は Prisma スキーマ + マイグレーション SQL のみの変更（ドメイン/アプリ層のロジック変更なし）。

- [ ] `pnpm db:migrate` でマイグレーションが適用される
- [ ] `pnpm db:generate`（`prisma generate`）が成功する
- [ ] `pnpm build` がグリーン
- [ ] `pnpm test` がグリーン
- [ ] `pnpm lint` がグリーン

---

Generated with [Claude Code](https://claude.ai/code)
