### PR TITLE
docs: 見積系バックエンドのユースケース棚卸しドキュメントを追加する

### DIFF
--- a/docs/business/estimate/flows.html
+++ b/docs/business/estimate/flows.html
@@ -1,0 +1,438 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>見積フロー図 | 見積管理システム</title>
+<style>
+  :root {
+    --bg: #0f1115;
+    --panel: #171a21;
+    --panel-2: #1e2530;
+    --line: #2c3340;
+    --text: #e6e9ef;
+    --muted: #9aa4b2;
+    --accent: #5b9dff;
+
+    /* ノード種別の色（凡例と対応） */
+    --c-start:    #2f6f4f;  /* 起点・トリガ */
+    --c-process:  #2d4a7a;  /* 作成・編集など通常処理 */
+    --c-approval: #8a6d1f;  /* 申請・承認（共通申請テーブル） */
+    --c-event:    #5b3a8a;  /* 受注イベント（行の存在＝状態：§1.3） */
+    --c-warning:  #8a2f3a;  /* 警告・確認ダイアログ */
+    --c-terminal: #3a4250;  /* 終端（帳票出力など） */
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", system-ui, sans-serif;
+    line-height: 1.6;
+  }
+
+  header {
+    padding: 28px 24px 16px;
+    max-width: 980px;
+    margin: 0 auto;
+  }
+  header h1 { margin: 0 0 6px; font-size: 22px; }
+  header p { margin: 0; color: var(--muted); font-size: 14px; }
+  header .src { font-size: 12px; margin-top: 8px; }
+  header .src code { background: var(--panel-2); padding: 2px 6px; border-radius: 4px; }
+
+  .wrap { max-width: 980px; margin: 0 auto; padding: 0 24px 60px; }
+
+  /* ---- タブ ---- */
+  .tabs {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin: 18px 0 8px;
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 12px;
+  }
+  .tab {
+    background: var(--panel);
+    color: var(--muted);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 9px 16px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    transition: .15s;
+  }
+  .tab:hover { color: var(--text); border-color: #3a4456; }
+  .tab.active {
+    background: var(--panel-2);
+    color: #fff;
+    border-color: var(--accent);
+  }
+  .tab .prefix {
+    display: inline-block;
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    background: rgba(91,157,255,.18);
+    color: var(--accent);
+    border-radius: 4px;
+    padding: 0 6px;
+    margin-right: 6px;
+  }
+
+  /* ---- フロー見出し ---- */
+  .flow-head {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 16px 18px;
+    margin: 16px 0 26px;
+  }
+  .flow-head h2 { margin: 0 0 4px; font-size: 18px; }
+  .flow-head .meta { color: var(--muted); font-size: 13px; }
+  .flow-head .meta code { background: var(--panel-2); padding: 1px 6px; border-radius: 4px; }
+  .flow-head p { margin: 10px 0 0; font-size: 14px; color: #cdd4df; }
+
+  /* ---- フロー本体（縦並び） ---- */
+  .flow { display: flex; flex-direction: column; align-items: stretch; }
+
+  .step {
+    display: grid;
+    grid-template-columns: 1fr minmax(240px, 360px) 1fr;
+    align-items: center;
+    column-gap: 14px;
+  }
+
+  .node {
+    grid-column: 2;
+    border-radius: 10px;
+    padding: 12px 16px;
+    color: #fff;
+    border: 1px solid rgba(255,255,255,.12);
+    box-shadow: 0 1px 0 rgba(255,255,255,.05) inset, 0 6px 16px rgba(0,0,0,.25);
+  }
+  .node .label { font-weight: 700; font-size: 15px; display: flex; align-items: center; gap: 8px; }
+  .node .sub { font-size: 12.5px; color: rgba(255,255,255,.82); margin-top: 4px; }
+  .node .ref {
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    opacity: .7;
+    margin-left: auto;
+    flex-shrink: 0;
+  }
+
+  .node.start    { background: var(--c-start); }
+  .node.process  { background: var(--c-process); }
+  .node.approval { background: var(--c-approval); }
+  .node.event    { background: var(--c-event); }
+  .node.warning  { background: var(--c-warning); border-style: dashed; }
+  .node.terminal { background: var(--c-terminal); }
+
+  /* スキップされる工程（事後見積の承認など） */
+  .node.skipped {
+    background: transparent;
+    border: 1px dashed #4a5466;
+    color: var(--muted);
+    box-shadow: none;
+  }
+  .node.skipped .label { text-decoration: line-through; opacity: .8; }
+
+  /* 右側の補足注記 */
+  .note {
+    grid-column: 3;
+    font-size: 12px;
+    color: var(--muted);
+    border-left: 2px solid var(--line);
+    padding: 4px 0 4px 12px;
+  }
+  .note strong { color: #cdd4df; font-weight: 600; }
+
+  /* 矢印 */
+  .arrow {
+    grid-column: 2;
+    justify-self: center;
+    width: 2px;
+    height: 30px;
+    background: #495365;
+    position: relative;
+    margin: 4px 0;
+  }
+  .arrow::after {
+    content: "";
+    position: absolute;
+    bottom: -1px; left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: #495365;
+    border-bottom: 0;
+  }
+  .arrow .arrow-label {
+    position: absolute;
+    left: 12px; top: 50%;
+    transform: translateY(-50%);
+    white-space: nowrap;
+    font-size: 11.5px;
+    color: var(--muted);
+    background: var(--bg);
+    padding: 0 4px;
+  }
+
+  /* ---- 凡例 ---- */
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 18px;
+    margin: 26px 0 0;
+    padding: 14px 16px;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+  .legend .item { display: flex; align-items: center; gap: 7px; }
+  .legend .swatch { width: 14px; height: 14px; border-radius: 4px; border: 1px solid rgba(255,255,255,.15); }
+
+  /* ---- 寄稿待ちプレースホルダ ---- */
+  .placeholder {
+    border: 2px dashed #4a5466;
+    border-radius: 12px;
+    padding: 28px;
+    text-align: center;
+    color: var(--muted);
+    background: repeating-linear-gradient(45deg, transparent, transparent 10px, rgba(255,255,255,.02) 10px, rgba(255,255,255,.02) 20px);
+  }
+  .placeholder h3 { color: var(--text); margin: 0 0 10px; }
+  .placeholder code { background: var(--panel-2); padding: 2px 6px; border-radius: 4px; color: #cdd4df; }
+  .placeholder ul { text-align: left; max-width: 580px; margin: 14px auto 0; font-size: 13.5px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>見積フロー図</h1>
+  <p>見積種別ごとの基本フローと複製フロー。タブで切り替えてください。</p>
+  <p class="src">出典: <code>docs/business/estimate/システム設計書(見積).md</code> §1.1 / §5 / §6.5 — 各ノードに対応する節を <code>§</code> で併記</p>
+</header>
+
+<div class="wrap">
+  <div class="tabs" id="tabs"></div>
+  <div class="flow-head" id="flow-head"></div>
+  <div class="flow" id="flow-canvas"></div>
+
+  <div class="legend">
+    <div class="item"><span class="swatch" style="background:var(--c-start)"></span>起点・トリガ</div>
+    <div class="item"><span class="swatch" style="background:var(--c-process)"></span>通常処理（作成・編集）</div>
+    <div class="item"><span class="swatch" style="background:var(--c-approval)"></span>申請・承認（共通申請テーブル）</div>
+    <div class="item"><span class="swatch" style="background:var(--c-event)"></span>受注イベント（行の存在＝状態 §1.3）</div>
+    <div class="item"><span class="swatch" style="background:var(--c-warning)"></span>警告・確認</div>
+    <div class="item"><span class="swatch" style="background:var(--c-terminal)"></span>終端（帳票出力）</div>
+    <div class="item"><span class="swatch" style="background:transparent;border-style:dashed"></span>スキップされる工程</div>
+  </div>
+</div>
+
+<script>
+  /* =========================================================================
+     フロー定義（データ）
+     - 各ステップは { kind, label, sub, ref, note, arrowLabel, skipped } 。
+     - kind がノードの色（凡例と対応）。配列の順序がそのまま縦のフローになる。
+     - note 内の **…** は <strong> に変換される（後述の appendRichText）。
+     - 設計書が更新されたら、ここの配列を直すだけで図が追従する。
+     ========================================================================= */
+  const FLOWS = {
+    new: {
+      label: "新規見積",
+      prefix: "N",
+      title: "新規設置見積書",
+      refs: "§1.1 / §6.2",
+      desc: "新規の機械を設置する標準フロー。申請→承認を経て受注に進む。承認が必須な唯一の系統。",
+      steps: [
+        { kind: "process",  label: "見積作成",       sub: "得意先・納品先・消費税率・見積明細を入力", ref: "§6.2",
+          note: "作成時点の税率を自動設定。番号は**保存時に採番**（N + 年度 + 連番）" },
+        { kind: "process",  label: "バリエーション作成", sub: "客先折衝用に複数案（選択肢）を用意", ref: "§3.1",
+          note: "1見積に複数。ただし**申請できるのは1つ**のみ（§3.4）" },
+        { kind: "process",  label: "客先と折衝",     sub: "客先メモに折衝履歴を記録", ref: "§1.1" },
+        { kind: "approval", label: "見積申請",       sub: "上長へ申請（共通申請テーブルにレコード生成）", ref: "§3.4",
+          arrowLabel: "差戻なら再申請",
+          note: "状態は見積側に持たず**共通申請テーブル**が真実の源（ADR-0001）" },
+        { kind: "approval", label: "見積承認",       sub: "承認済レコードで「承認済」を導出", ref: "§1.3" },
+        { kind: "event",    label: "受注作成",       sub: "Order レコードを生成（DRAFT 相当）", ref: "§4.3",
+          note: "**列ではなく行の存在**で「受注作成済」を導出。以後バリエーション編集不可（§4.8）" },
+        { kind: "event",    label: "受注確定",       sub: "OrderConfirmation を生成。納期が必須", ref: "§4.5",
+          note: "納期は DRAFT 中は持たず**確定操作で初めて入力**（§4.4）" },
+        { kind: "terminal", label: "受注票出力",     sub: "正式版を出力（DRAFT は SAMPLE 印字）", ref: "§4.6" },
+      ],
+    },
+
+    repair: {
+      label: "修理見積（事前）",
+      prefix: "R",
+      title: "修理見積書",
+      refs: "§6.5 / §6.2",
+      desc: "設置済み機械の修理を、作業前に見積もる系統。新規と同じく承認が必要。修理実施は受注作成の後・確定の前に入る。",
+      steps: [
+        { kind: "start",    label: "故障連絡",       sub: "客先から修理依頼", ref: "§6.5" },
+        { kind: "process",  label: "見積作成",       sub: "修理対象機器・故障内容・修理予定日が必須", ref: "§6.2",
+          note: "修理系の必須項目は **RepairEstimateDetail**（1:1サブタイプ）に保持（§11.1.1）" },
+        { kind: "approval", label: "見積申請",       sub: "上長へ申請", ref: "§3.4", arrowLabel: "差戻なら再申請" },
+        { kind: "approval", label: "見積承認",       sub: "", ref: "§1.3" },
+        { kind: "event",    label: "受注作成",       sub: "Order レコードを生成", ref: "§4.3" },
+        { kind: "start",    label: "修理実施 ★",     sub: "受注確定の前に作業を実施", ref: "§6.5",
+          note: "新規にはないステップ。**作業 → 確定**の順" },
+        { kind: "event",    label: "受注確定",       sub: "OrderConfirmation を生成。納期が必須", ref: "§4.5" },
+        { kind: "terminal", label: "受注票出力",     sub: "", ref: "§4.6" },
+      ],
+    },
+
+    /* =====================================================================
+       事後見積（AFTER_REPAIR）— ★ここはあなたが書きます★
+
+       他の3フローは完成済みです。事後見積だけ steps を空にしてあります。
+       事後見積は「他の種別と何が違うか」を最も色濃く表すフローなので、
+       ドメインを理解しているあなたに steps 配列を書いてほしいからです。
+
+       下のプレースホルダ画面に、設計書の参照節と各ステップの意図を
+       表示してあります。FLOWS.after.steps に配列を入れてください。
+       ===================================================================== */
+    after: {
+      label: "事後見積",
+      prefix: "A",
+      title: "事後修理見積書",
+      refs: "§6.3 / §6.5",
+      desc: "緊急対応で先に修理してから見積を作る系統。承認をスキップし、受注作成が必須になる。",
+      steps: [],  // ← TODO: あなたが埋める
+    },
+
+    copy: {
+      label: "複製フロー",
+      prefix: "—",
+      title: "（種別は複製時に引き継ぎ／変更可）",
+      refs: "§5",
+      desc: "既存見積から新しい見積を作る操作フロー。全ステータスから・誰でも・無制限に複製可能。新規採番されるので別の見積になる。",
+      steps: [
+        { kind: "start",    label: "複製ボタン",     sub: "見積詳細から起動。どのステータスからでも可", ref: "§5.1",
+          note: "他人の見積も可・回数無制限（§5.1）" },
+        { kind: "process",  label: "バリエーション選択ダイアログ", sub: "複製するバリエーションを選ぶ", ref: "§5.2",
+          note: "複数選択可・**無効も選べる**・選択なし(見積のみ)も可。順序保持し 01,02… に振り直し" },
+        { kind: "process",  label: "見積新規作成画面（プレビュー）", sub: "複製データを表示。区分は変更可・単価はクリア", ref: "§5.5",
+          note: "**単価は要再入力**。申請/承認情報・受注は引き継がない（§5.3）" },
+        { kind: "process",  label: "ユーザー編集",   sub: "内容を調整", ref: "§5.5" },
+        { kind: "event",    label: "保存 → 採番 & DB保存", sub: "新しい見積番号を採番。ステータスは「作成中」", ref: "§5.5",
+          note: "出自は **EstimateVariationCopy**（派生先→派生元）に記録。本体に複製元列は持たない（§5.4）" },
+      ],
+    },
+  };
+
+  const ORDER = ["new", "repair", "after", "copy"];
+
+  /* ---- DOM 構築ヘルパ（innerHTML を使わない） ---- */
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    return node;
+  }
+
+  // "foo **bar** baz" → テキストノード + <strong>bar</strong>。innerHTML を使わず安全に強調を表現
+  function appendRichText(parent, str) {
+    str.split(/(\*\*[^*]+\*\*)/).forEach((seg) => {
+      if (!seg) return;
+      const m = seg.match(/^\*\*([^*]+)\*\*$/);
+      parent.appendChild(m ? el("strong", null, m[1]) : document.createTextNode(seg));
+    });
+  }
+
+  const tabsEl = document.getElementById("tabs");
+  const headEl = document.getElementById("flow-head");
+  const canvasEl = document.getElementById("flow-canvas");
+
+  function renderTabs(active) {
+    tabsEl.replaceChildren();
+    ORDER.forEach((key) => {
+      const f = FLOWS[key];
+      const btn = el("button", "tab" + (key === active ? " active" : ""));
+      btn.appendChild(el("span", "prefix", f.prefix));
+      btn.appendChild(document.createTextNode(f.label));
+      btn.onclick = () => render(key);
+      tabsEl.appendChild(btn);
+    });
+  }
+
+  function renderHead(f) {
+    headEl.replaceChildren();
+    headEl.appendChild(el("h2", null, f.label));
+
+    const meta = el("div", "meta");
+    meta.appendChild(document.createTextNode("見積書タイトル: "));
+    meta.appendChild(el("code", null, f.title));
+    meta.appendChild(document.createTextNode(` ／ 参照: ${f.refs}`));
+    headEl.appendChild(meta);
+
+    headEl.appendChild(el("p", null, f.desc));
+  }
+
+  function buildNode(step) {
+    const node = el("div", "node " + step.kind + (step.skipped ? " skipped" : ""));
+    const label = el("div", "label");
+    label.appendChild(document.createTextNode(step.label));
+    if (step.ref) label.appendChild(el("span", "ref", step.ref));
+    node.appendChild(label);
+    if (step.sub) node.appendChild(el("div", "sub", step.sub));
+    return node;
+  }
+
+  function buildPlaceholder() {
+    const box = el("div", "placeholder");
+    box.appendChild(el("h3", null, "事後見積フローはあなたが描きます ✍️"));
+
+    const lead = el("p");
+    lead.appendChild(el("code", null, "FLOWS.after.steps"));
+    lead.appendChild(document.createTextNode(" に配列を入れてください。設計書の該当節:"));
+    box.appendChild(lead);
+
+    const ul = el("ul");
+    [
+      "§6.5 事後見積: 故障連絡(緊急) → 修理実施 ★先に → 見積作成(承認スキップ) → 受注作成(必須) → 受注確定",
+      "§6.3: 承認不要 / 金額10万円超は警告(kind:\"warning\") / 緊急対応理由は必須",
+      "承認工程を残して skipped:true で「スキップされる」と見せる手もあります",
+    ].forEach((t) => ul.appendChild(el("li", null, t)));
+    box.appendChild(ul);
+    return box;
+  }
+
+  function render(key) {
+    const f = FLOWS[key];
+    renderTabs(key);
+    renderHead(f);
+    canvasEl.replaceChildren();
+
+    if (!f.steps.length) {
+      canvasEl.appendChild(buildPlaceholder());
+      return;
+    }
+
+    f.steps.forEach((step, i) => {
+      const stepRow = el("div", "step");
+      stepRow.appendChild(buildNode(step));
+      if (step.note) {
+        const note = el("div", "note");
+        appendRichText(note, step.note);
+        stepRow.appendChild(note);
+      }
+      canvasEl.appendChild(stepRow);
+
+      if (i < f.steps.length - 1) {
+        const arrowRow = el("div", "step");
+        const arrow = el("div", "arrow");
+        if (step.arrowLabel) arrow.appendChild(el("span", "arrow-label", step.arrowLabel));
+        arrowRow.appendChild(arrow);
+        canvasEl.appendChild(arrowRow);
+      }
+    });
+  }
+
+  render("new");
+</script>
+</body>
+</html>

--- a/docs/business/estimate/ユースケース一覧(見積).md
+++ b/docs/business/estimate/ユースケース一覧(見積).md
@@ -1,0 +1,82 @@
+# ユースケース一覧(見積)
+
+> 本書は [システム設計書(見積)](./システム設計書(見積).md) を実装観点で棚卸ししたもの。
+> 粒度は「コマンド/クエリ名 + 入出力 + 主な不変条件 + 依存」に留め、詳細仕様は設計書を正とする。
+>
+> **スコープ外**: `申請 / 承認`（共通申請テーブル・ADR-0001）は未確定のため本書では扱わない。
+> 見積側は「申請テーブルから対象IDとして参照されるだけ」を前提とする。
+
+## サブドメイン境界
+
+| サブドメイン | 集約ルート | 含む構成要素 |
+| ------------ | ---------- | ------------ |
+| **estimate**（見積） | `Estimate` | `EstimateVariation` / `EstimateItem` / 修理サブタイプ / 系譜（`EstimateVariationCopy` / `EstimateVariationRevision`） |
+| **order**（受注） | `Order` | `OrderConfirmation` / `OrderCancellation` |
+| **tax-rate**（消費税率マスタ） | `TaxRate` | – |
+
+> 集約境界メモ: §3.4「1見積につき申請できるバリエーションは1つのみ」はバリエーション横断の不変条件のため、
+> `EstimateVariation` は `Estimate` 集約に内包する方針（最終確定は実装④で）。
+
+## 集約またぎ / 集約内 の整理（重要）
+
+| 操作 | 種別 | 採番 | 説明 |
+| ---- | ---- | ---- | ---- |
+| 改訂 (C7 得意先改訂) | **集約内** | しない | 同一見積内で改訂元バリエーションから新バリエーションを生成 |
+| 複製 (C6) | **集約またぎ** | する（新見積番号） | 複製元見積からバリエーションを選択し、別の見積を新規生成 |
+
+## コマンド（状態変更：集約を経由）
+
+| # | コマンド | サブドメイン | 入力（粒度） | 主な不変条件・備考 | 申請依存 |
+| - | -------- | ------------ | ------------ | ------------------ | :------: |
+| C1 | `CreateEstimate` | estimate | ヘッダ + 最低1バリエーション + 明細（同時） | 保存時採番(§2.3) / 部署自動設定 / 作成時税率自動設定(§A.1) / estimateType と修理サブタイプの整合(ADR-0019) / 空見積不可 | – |
+| C2 | `UpdateEstimate` | estimate | estimateId + ヘッダ項目 | 受注作成後は編集不可(§4.8) / 税率チェック+再計算(§8.6) | 間接 |
+| C3 | `AddVariation` | estimate | estimateId | バリエーション番号 連番採番(§A.2) | – |
+| C4 | `UpdateVariation` | estimate | variationId + メモ/明細/全体値引 | 無効状態は編集不可(§3.4) / 保存時 再計算 | 間接 |
+| C5 | `DeactivateVariation` / `ActivateVariation` | estimate | variationId | 申請中・承認済は無効化不可 / 無効→有効は無条件(§3.4) | **直接** |
+| C6 | `DuplicateEstimate`（複製・集約またぎ） | estimate | sourceEstimateId + 選択 variationId[]（複数可・順序保持） | 選択順保持・連番振り直し / 単価クリア / 申請レコード作らない(§5) / `EstimateVariationCopy` 生成 / 新見積を新採番 | – |
+| C7 | `ReviseForCustomer`（得意先改訂・集約内） | estimate | estimateId + sourceVariationId | 同一見積内に新バリエーション生成 / 改訂元を凍結(§7.2) / `deliveryPrice` スナップショット(§8.4) / `EstimateVariationRevision` 生成 / 採番なし | – |
+| C8 | `CreateOrder` | order | variationId | 承認済 or 承認不要(事後)から(§4.3) / 納品先見積は不可(§7.2) / 税率チェック(§8.6) / `Order` 行生成 | **直接** |
+| C9 | `UpdateOrderNote` | order | orderId + メモ | メモのみ編集(§4.4) | – |
+| C10 | `ConfirmOrder` | order | orderId + 納期 | 納期必須(§4.5) → `OrderConfirmation` 生成 / 税率チェック | – |
+| C11 | `CancelOrder` | order | orderId | `OrderCancellation` 生成 + 見積複製 → 新バリエーション(§4.7) | – |
+| C12 | TaxRate マスタ保守 | tax-rate | rate + effectiveFrom | `effectiveFrom` 単調性・@unique(§11.5) | – |
+
+## クエリ（参照・導出）
+
+| # | クエリ | サブドメイン | 備考 |
+| - | ------ | ------------ | ---- |
+| Q1 | `GetEstimateDetail` | estimate | **表示ステータスを導出**(§1.3)。申請テーブル + Order 行の存在を合成 |
+| Q2 | `SearchEstimates` | estimate | 一覧。番号/ステータス/作成者/部署/得意先 で絞り込み |
+| Q3 | `GetEstimatePrintData` | estimate | 見積書帳票(§D.1)。得意先向けは粗利・粗利率を含む |
+| Q4 | `GetOrderDetail` | order | 受注表示ステータス導出(§4.4) |
+| Q5 | `SearchOrders` | order | 受注一覧 |
+| Q6 | `GetOrderPrintData` | order | 受注票(§D.2) |
+| Q7 | `GetTaxRateAt(date)` | tax-rate | §11.5 の `findFirst({ effectiveFrom: { lte: D } }, desc)` |
+| Q8 | `GetDeadlineAlerts` | estimate | ダッシュボード 締切1週間前通知(§12.1) |
+
+## 横断ポリシー / ドメインサービス（UCではないが UC が依存）
+
+| 名称 | 役割 | 参照 |
+| ---- | ---- | ---- |
+| 金額計算ポリシー | 明細→小計→税→合計のパイプライン、端数処理 | §8 |
+| 採番 sequence 払い出し | fiscalYear + estimateType 単位の連番（欠番許容） | §2 |
+| 税率チェック | 見積年月日/締切日（受注時は受注年月日も）の税率整合 | §8.7 |
+| 権限チェック `PermissionService` | 作成者 + 同部署メンバー判定 | §9 |
+| 排他的サブタイプ整合 | estimateType と修理詳細テーブル、系譜の二重派生禁止 | ADR-0019 |
+
+## 実装の最小縦スライス（推奨着手点）
+
+**C1 `CreateEstimate`（新規・バリエーション1件・明細あり・申請/受注なし）**
+
+- §1.3 導出ルールで自動的に「作成中」になり、申請・受注に依存しない
+- 採番・金額計算・サブタイプ整合という核を一通り貫通する最小経路
+- 依存する横断ポリシー: 金額計算 / 採番 / 税率取得
+
+## 着手順序（バックエンド）
+
+1. ✅ ユースケース棚卸し（本書）
+2. ⬜ 金額計算の値オブジェクト + 計算ポリシー（§8、依存ゼロ・即テスト可）
+3. ⬜ 採番 `EstimateNumber` 値オブジェクト（§2 の形式・年度算出）
+4. ⬜ エンティティ/集約（`EstimateItem` → `EstimateVariation` → `Estimate`）
+5. ⬜ リポジトリ interface
+6. ⬜ アプリ層を1スライスずつ（C1 から）


### PR DESCRIPTION
## Summary

見積系バックエンドのユースケース棚卸しドキュメント(`ユースケース一覧(見積).md`)と業務フロー図(`flows.html`)を `docs/business/estimate/` 配下に追加。システム設計書(見積)を実装観点で棚卸しし、コマンド/クエリ/横断ポリシー・サブドメイン境界・集約境界・着手順序の地図を整備した。

Closes #277

## 主な内容

- コマンド(C1〜C12)/クエリ(Q1〜Q8)/横断ポリシーの棚卸し
- サブドメイン境界の整理(estimate / order / tax-rate)
- 集約またぎ/集約内の区別を確定
  - **改訂(得意先改訂)** = 同一見積内のバリエーション派生(集約内・採番なし)
  - **複製** = 別見積の新規生成(集約またぎ・新採番)
- **CreateEstimate** はヘッダ + 最低1バリエーション + 明細を1コマンドで同時生成(空見積不可)
- 申請/承認(共通申請テーブル・ADR-0001)は仕様未確定のためスコープ外
- 最小縦スライス = **CreateEstimate(新規・申請/受注なし)** とし、バックエンド着手順序を明記

## 実装計画

実装計画なしで実装を行いました。(ドキュメント追加のため plan mode の計画ファイルは作成していません)

## Test Plan

ドキュメント(Markdown / HTML)の追加のみで、コード変更・テスト追加はありません。

- [ ] `docs/business/estimate/ユースケース一覧(見積).md` の記述内容(コマンド/クエリ棚卸し・集約境界・着手順序)がシステム設計書と整合しているかレビュー
- [ ] `docs/business/estimate/flows.html` の業務フロー図がブラウザで正しく表示されるか確認

---

Generated with [Claude Code](https://claude.ai/code)
