### PR TITLE
feat: 採番 EstimateNumber 値オブジェクト（§2 の形式・年度算出）を実装する

### DIFF
--- a/docs/adr/0024-fiscal-year-as-shared-value-object.md
+++ b/docs/adr/0024-fiscal-year-as-shared-value-object.md
@@ -1,0 +1,108 @@
+# ADR-0024: 年度 (FiscalYear) を独立 VO として shared/domain/values/ に配置する
+
+| 項目         | 値         |
+| ------------ | ---------- |
+| ステータス   | 採用       |
+| 起票日       | 2026-05-23 |
+| 最終更新日   | 2026-05-23 |
+
+## コンテキスト
+
+Issue #282「採番 `EstimateNumber` 値オブジェクト（§2 の形式・年度算出）」着手時に、見積番号の年度部（4 月始まり、2 桁表記）を扱うコンポーネントが必要になった。
+
+年度の扱いは見積採番（§2）に閉じる話のように見えるが、実際には複数領域に登場する:
+
+- **見積採番**: 接頭辞 + 年度 2 桁 + 連番 5 桁（§2）
+- **消費税率マスタ**: 適用年度ごとの税率変更（§8.7、`tax_rates.fiscal_year` 等の検討箇所がある）
+- **締切管理**: 月次・年次の業務締め（§12.1）
+- **集計・分析**: 年度別の売上・粗利集計
+- **受注・請求**（将来）: 同様に年度単位の管理が想定される
+
+これらすべてに「4 月始まり・年度境界判定」というドメインルールが共通している。各領域で `getFiscalYear(date)` のような関数を再実装すると、境界判定（特に 3/31 ↔ 4/1 の JST 境界）が分散し、ロジックの一貫性とテスト容易性が低下する。
+
+## 検討した選択肢
+
+### A. EstimateNumber 内に閉じた private な計算ユーティリティとして実装する（不採用）
+
+```typescript
+class EstimateNumber {
+  static parse(text: string): EstimateNumber {
+    const yearShort = parseInt(text.substring(1, 3), 10);
+    // 年度の概念は EstimateNumber の内部実装詳細
+  }
+}
+```
+
+本 Issue のスコープを最小にできる。EstimateNumber がパース時に内部で 2 桁年度を扱うだけなら、独立した VO は不要。
+
+しかし、税率マスタや締切管理で同じ「JST 4 月始まり」のロジックが必要になった時点で再実装する羽目になる。境界判定の一貫性を保証する仕組みが弱い。
+
+### B. estimate サブドメイン内に `FiscalYear` VO を配置する（不採用）
+
+```
+src/server/subdomains/estimate/domain/values/FiscalYear.ts
+```
+
+estimate サブドメインで生まれた概念なので素直な配置。しかし、税率マスタ（estimate の外側）や受注・請求が利用するときに、サブドメインを跨いで estimate の VO を import することになる。
+
+DDD のサブドメイン境界の観点から、横断的概念をサブドメイン固有領域に置くと「どのサブドメインが持ち主か」が曖昧化する。
+
+### C. shared/domain/values/ に独立 VO として配置する（採用）
+
+```
+src/server/shared/domain/values/FiscalYear.ts
+```
+
+横断的な値オブジェクト（既存の `CompanyCode` `EntityId` 等と同列）として `shared` に置く。サブドメイン間で衝突なく再利用でき、税率マスタ・締切管理・集計のいずれからも import できる。
+
+### D. 値オブジェクトではなく純粋関数ユーティリティとして実装する（不採用）
+
+```typescript
+// src/server/shared/utils/fiscalYear.ts
+export function fiscalYearOf(date: Date): number { ... }
+export function fiscalYearToShort(year: number): string { ... }
+```
+
+軽量で実装が単純。
+
+しかし以下を失う:
+- **型による不変条件の表明**: `number` のままだと「これは年度です」という意図が型に出ない。`new FiscalYear(2025)` か `new FiscalYear(20)` か紛らわしい（後者は範囲外で reject される設計が VO なら可能）。
+- **`equals` 等の振る舞いの一貫性**: ValueObject 基底クラスの規約に乗らない。
+- **既存パターンとの整合**: 他の横断的概念（`CompanyCode` 等）はすべて VO として実装されている。
+
+## 決定
+
+`FiscalYear` を `src/server/shared/domain/values/FiscalYear.ts` に独立 VO として配置する。内部表現は西暦 4 桁数値（`number`）。`ValueObject<number, "FiscalYear">` を継承し、`from(date: Date)` ファクトリと `toShortString()` を提供する。
+
+## 根拠
+
+### 横断的概念に対する shared/ 配置の既存パターン踏襲
+
+`shared/domain/values/` には既に複数サブドメインで使う VO が並んでいる: `CompanyCode` `CompanyId` `CompanyName` `EntityId` `MailAddress` `PhoneNumber` `Address` `PostalCode` `Prefecture` `FaxNumber`。
+
+これらは「特定サブドメインの所有物ではないが、業務全体で再利用される」基本概念。`FiscalYear` も同じカテゴリに属する。配置先の判断に新規パターンを持ち込まず、既存規範に沿わせる。
+
+### 境界判定ロジックの集約
+
+4 月始まり年度の境界（JST 3/31 23:59:59 → 2024 年度 / JST 4/1 00:00:00 → 2025 年度）は、各領域で独立に実装するとミスが起きやすい。`FiscalYear.from(date)` 1 箇所に集約し、テストもそこに集約することで境界バグの再発を防ぐ。
+
+なお、JST 固定の TZ 取り扱いについては [ADR-0025](0025-jst-fixed-pure-function-in-domain-layer.md) を参照。
+
+### 内部表現に 4 桁数値を採用（2 桁数値や文字列は不採用）
+
+- **2 桁数値（25）**: 100 年衝突時に世紀情報を失う（25 が 2025 か 1925 か）。VarChar(8) の見積番号スキーマも内部的には世紀の区別を要求しないが、VO としては情報を保全すべき。
+- **文字列（"25"）**: 算術演算（前年度比較、年度差計算）ができない。年度差計算は将来「過去 5 年分の集計」「前年同期比」等で必須。
+- **4 桁数値（2025）**: 算術演算可能、世紀情報を保全、`toShortString()` で 2 桁化は一方向に派生可能。
+
+### YAGNI に対する反論
+
+「今は EstimateNumber でしか使わないので estimate サブドメイン内に置けばよい」という反論が成立しうる。しかし、税率マスタ（§8.7、`tax_rates` テーブル設計済み）は既に年度単位の運用が決定しており、近い将来 import 元になることが既知。後で shared に移す手戻りより、最初から shared に置く方が安い。
+
+## 影響
+
+- **`src/server/shared/domain/values/FiscalYear.ts` を新設**。今後、年度概念を扱うコードはこの VO を import する。
+- **税率マスタ実装時に再利用される想定**。`tax_rates.fiscal_year` の型を `FiscalYear` で扱うことで、年度単位の整合性チェックが集約される。
+- **将来 Order / Invoice サブドメインを実装する際もここから import**。年度概念の重複実装を禁止する。
+- **EstimateNumber は `parse` 内で `new FiscalYear(2000 + YY)` として復元**。年度部の解釈責務は VO に委ねる。
+- **`from(date)` の TZ 取扱い**は [ADR-0025](0025-jst-fixed-pure-function-in-domain-layer.md) に従う（JST 固定の純関数）。
+- 関連: `src/server/shared/domain/values/FiscalYear.ts`, `src/server/subdomains/estimate/domain/values/EstimateNumber.ts`, `docs/business/estimate/システム設計書(見積).md` §2 §8.7 §12.1, ADR-0025, ADR-0026

--- a/docs/adr/0025-jst-fixed-pure-function-in-domain-layer.md
+++ b/docs/adr/0025-jst-fixed-pure-function-in-domain-layer.md
@@ -1,0 +1,133 @@
+# ADR-0025: ドメイン層での日時境界判定は JST 固定の純関数で行う
+
+| 項目         | 値         |
+| ------------ | ---------- |
+| ステータス   | 採用       |
+| 起票日       | 2026-05-23 |
+| 最終更新日   | 2026-05-23 |
+
+## コンテキスト
+
+Issue #282 で `FiscalYear.from(date: Date): FiscalYear` を実装する際、「4 月始まり年度」の境界判定を JST で行う必要があった。同様の TZ 依存判定は今後以下でも発生する見込み:
+
+- 消費税率の適用年月日判定（§8.7「税率チェック対象」）
+- 締切判定・月次/年次の業務締め（§12.1）
+- 受注作成日の年度判定
+- 各種「営業日」判定（将来）
+
+JavaScript の `Date` 型は内部的に UTC ミリ秒を保持し、`getMonth()` `getFullYear()` などの非 UTC メソッドは **プロセスの TZ 設定** に依存する。本番環境は以下のいずれかになりうる:
+
+- **Vercel デフォルト**: UTC（`process.env.TZ` 未設定）
+- **自前 Docker**: 設定次第（UTC・JST どちらもあり得る）
+- **ローカル開発**: 開発者の OS 設定（多くは JST だが UTC や他 TZ もあり得る）
+
+`getMonth()` を素朴に使うと、JST 4/1 00:00:00 がサーバ TZ によって 3 月扱いになる（UTC サーバの場合 UTC 3/31 15:00:00 として解釈）。この差が年度判定で 1 年のズレを生む。
+
+ドメイン層は CLAUDE.md のレイヤリングルールにより **外部依存禁止**（Prisma / Next.js / 外部ライブラリの import 不可）。`Intl.DateTimeFormat` は標準 API だが、TZ をプロセス設定経由で読む API は環境差を持ち込むため避けたい。
+
+## 検討した選択肢
+
+### A. ローカル TZ メソッド（`Date.getMonth()` 等）を素朴に使う（不採用）
+
+```typescript
+static from(date: Date): FiscalYear {
+  const month = date.getMonth() + 1;
+  const year = date.getFullYear();
+  // ...
+}
+```
+
+最もシンプル。サーバ TZ が JST に設定されていれば期待通り動く。
+
+しかし:
+- Vercel デフォルトは UTC のため、サーバ TZ 設定の前提を失念すると本番で 1 年ズレるバグが入る
+- テストが「プロセス TZ に依存」する。CI 環境（GitHub Actions 等は UTC）とローカル（多くは JST）で結果が異なりうる
+- 「ドメインロジックが暗黙にインフラ設定に依存する」状態。レイヤリング原則の精神に反する
+
+### B. サーバ TZ を強制的に JST に設定する運用（不採用）
+
+```dockerfile
+ENV TZ=Asia/Tokyo
+```
+
+```typescript
+// next.config.ts 等
+process.env.TZ = "Asia/Tokyo";
+```
+
+を起動コードに含め、`getMonth()` 等のローカルメソッドを安全に使えるようにする。
+
+しかし:
+- インフラ設定（Dockerfile / Vercel 環境変数 / Next.js 設定）が **ドメインロジックの正しさを担保する**構造になる。ドメイン層のテストがプロセス TZ に依存し、`describe.each` でクロス TZ テストするのが困難
+- Vercel ではコンテナ環境変数 `TZ` の挙動がリージョン・プランで微妙に異なる
+- 他のプロジェクトに知見を再利用しづらい
+
+### C. `Intl.DateTimeFormat("Asia/Tokyo")` で TZ 変換する（不採用）
+
+```typescript
+const fmt = new Intl.DateTimeFormat("ja-JP", { timeZone: "Asia/Tokyo", year: "numeric", month: "numeric" });
+const parts = fmt.formatToParts(date);
+```
+
+標準 API のみで TZ 変換可能。外部ライブラリ依存ゼロ。
+
+しかし:
+- 文字列フォーマット → パースという回り道で、リーダビリティが低い
+- ロケール挙動（暦の区切り、年号 = 令和等）に巻き込まれるリスク
+- 性能はそこまでクリティカルではないが、純関数の単純な算術より遅い
+
+### D. UTC ミリ秒に +9h オフセットを加えて UTC メソッドで判定する純関数（採用）
+
+```typescript
+private static readonly JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+static from(date: Date): FiscalYear {
+  const jstDate = new Date(date.getTime() + FiscalYear.JST_OFFSET_MS);
+  const month = jstDate.getUTCMonth() + 1;  // ← UTC メソッド
+  const year = jstDate.getUTCFullYear();
+  const fiscalYear = month < FiscalYear.FISCAL_START_MONTH ? year - 1 : year;
+  return new FiscalYear(fiscalYear);
+}
+```
+
+UTC ミリ秒を +9h シフトしてから `getUTC*` 系メソッドを使う。`getUTC*` はプロセス TZ に依存しないため、結果はサーバ TZ に左右されない。**完全な純関数**。
+
+## 決定
+
+ドメイン層で日時境界判定を行う場合は、**JST 固定**で、**UTC ミリ秒に +9h オフセットを加えて `getUTC*` 系メソッドを使う純関数**として実装する。`Date.getMonth()` `getFullYear()` 等のローカル TZ 依存メソッドはドメイン層では使わない。
+
+サマータイム（DST）は日本標準時に存在しないため、固定オフセット +9h で問題ない。
+
+## 根拠
+
+### 純関数性とテスト決定性
+
+オフセット計算は入力 `Date.getTime()`（UTC ミリ秒）にのみ依存するため、**テストがプロセス TZ から独立**する。CI 環境（UTC）でもローカル（JST）でも同じ結果が出る。テストデータは ISO 8601 文字列（`"2025-04-01T00:00:00+09:00"` または `"2025-03-31T15:00:00Z"`）で TZ を明示できる。
+
+### ドメイン層の外部依存ゼロ原則と整合
+
+`Intl.DateTimeFormat` は標準 API だが、ロケール DB やプロセス設定の影響を受けるブラックボックスを含む。純粋な算術 `+9 * 3600 * 1000` はそうした暗黙依存がない。CLAUDE.md の「ドメイン層は外部依存禁止」の精神（=「予測可能で純粋な計算であること」）に最も近い。
+
+### 業務システムが日本国内専用
+
+本システムは日本国内向けの見積管理であり、海外展開の予定はない。**全業務日時は JST 解釈で固定して問題ない**。多 TZ 対応が必要になった時点で改めて検討する（YAGNI）。
+
+### 不採用理由まとめ
+
+- **A（ローカルメソッド）**: 本番 TZ が UTC のとき年度が 1 年ズレるバグ源。テストもプロセス TZ 依存
+- **B（サーバ TZ 強制 JST）**: インフラ設定がドメイン正しさを担保する構造。テスト容易性が低い
+- **C（Intl.DateTimeFormat）**: 純関数性は得られるが、文字列フォーマット経由で冗長、ロケール挙動のリスクあり
+
+## 影響
+
+- **ドメイン層で日時を扱う VO・サービスはすべて本パターンを踏襲**:
+  - 税率マスタの適用年月日判定
+  - 締切判定
+  - 受注作成日の年度判定
+  - 営業日判定（将来）
+- **オフセット定数は `9 * 60 * 60 * 1000` を直接書くか、`JstClock` のようなヘルパに集約するか**は当面 VO 個別で持つ（重複が 3 ヶ所を超えたら集約検討）。`FiscalYear.JST_OFFSET_MS` を最初の例とする
+- **`Date.getMonth()` `getFullYear()` `getDate()` `getHours()` 等のローカル TZ 依存メソッドはドメイン層で禁止**。lint ルールでの強制までは行わない（コードレビューと本 ADR で運用）
+- **テストでは ISO 8601 の TZ 明示文字列**（`+09:00` または `Z`）で `Date` を作る。`new Date(2025, 3, 1)` のようなローカル TZ 依存コンストラクタは使わない
+- **サマータイム導入時は本 ADR の見直しが必要**（現時点では制定議論なし）
+- **多 TZ 対応が必要になった場合**は本 ADR を差替えとし、TZ パラメータを引数で受ける形に拡張する
+- 関連: `src/server/shared/domain/values/FiscalYear.ts`, `src/server/shared/domain/values/__tests__/FiscalYear.test.ts`, ADR-0024

--- a/docs/adr/0026-numbering-value-object-exposes-parse-only.md
+++ b/docs/adr/0026-numbering-value-object-exposes-parse-only.md
@@ -1,0 +1,146 @@
+# ADR-0026: 採番系の値オブジェクトは `parse` のみを公開し、払い出しはリポジトリ層に分離する
+
+| 項目         | 値         |
+| ------------ | ---------- |
+| ステータス   | 採用       |
+| 起票日       | 2026-05-23 |
+| 最終更新日   | 2026-05-23 |
+
+## コンテキスト
+
+Issue #282 で見積番号 `EstimateNumber` 値オブジェクト（VO）を実装するにあたり、「番号文字列を分解する `parse`」と「次番号を払い出す `issue`」のどちらを VO に持たせるか、または両方持たせるかの判断が必要になった。
+
+見積番号の仕様（システム設計書 §2）:
+- 形式: `[接頭辞 1][年度 2][連番 5]` = 8 文字（例: `N2500001`）
+- **連番は `fiscalYear + estimateType` 単位で年度ごとリセット**、欠番許容
+- 採番タイミングは見積保存時（C1 `CreateEstimate`）
+
+ユースケース棚卸し（`docs/business/estimate/ユースケース一覧(見積).md`）の「横断ポリシー」セクションは以下を明記している:
+
+> 採番 sequence 払い出し | fiscalYear + estimateType 単位の連番（欠番許容）
+
+つまり、**連番の払い出しはドメインの横断ポリシー**として識別されており、`EstimateNumber` VO の責務として規定されていない。
+
+「次の連番」を決めるには:
+- 現在の `fiscalYear + estimateType` で最も大きい既存連番を取得する
+- それに +1 した値を返す
+- 同時並行採番に対する一意性を担保する（DB のユニーク制約 + リトライ、または `UPDATE ... RETURNING` を使ったカウンタテーブル等）
+
+これらは **永続化（リポジトリ）の関心事**であり、VO 内で完結できない。
+
+将来、受注番号 `OrderNumber`、請求番号 `InvoiceNumber` 等も同型の採番ルール（接頭辞 + 年度 + 連番）を持つことが想定される。同じ判断を再現するための規範を残す必要がある。
+
+## 検討した選択肢
+
+### A. VO に `parse(text)` のみを公開、払い出しはリポジトリ層に分離（採用）
+
+```typescript
+export class EstimateNumber extends ValueObject<string, "EstimateNumber"> {
+  private constructor(value: string) { super(value); }
+
+  static parse(text: string): EstimateNumber {
+    return new EstimateNumber(text);
+  }
+  // issue / fromParts は提供しない
+}
+
+// 払い出しはリポジトリ層の責務
+interface EstimateNumberIssuer {
+  issue(type: EstimateType, fiscalYear: FiscalYear): Promise<EstimateNumber>;
+}
+```
+
+VO は **「保存済みの採番値を検証・分解する」純粋な責務**に閉じる。テストは入出力のみで完結し、永続化の関心事を持ち込まない。
+
+### B. VO に `parse(text)` + `fromParts(type, year, seq)` の両方を公開（不採用）
+
+```typescript
+static fromParts(type: EstimateType, year: FiscalYear, sequence: number): EstimateNumber {
+  return new EstimateNumber(`${type.prefix}${year.toShortString()}${String(sequence).padStart(5, "0")}`);
+}
+```
+
+「払い出された連番（数値）からVOを組み立てる」中間ファクトリ。リポジトリ層が `INSERT ... RETURNING sequence` で得た数値を VO に変換するときに使う。
+
+しかし以下の懸念がある:
+- **連番の出所が不透明化**: `fromParts(type, year, 1)` を呼ぶ箇所が「正しく払い出された連番か」「テストで適当に渡した連番か」を見分けにくい
+- **`issue()` との混在で責務境界が曖昧**: 「VO の責務 = 構築だけ」「払い出しはリポジトリ」と境界を引いたつもりが、`fromParts` を VO 経由で呼ぶ箇所が「ほぼ払い出し」のような実装になりやすい
+- **YAGNI**: 当面リポジトリは「8 文字の文字列を `RETURNING` で受けて `parse` する」設計で十分
+
+将来本当に必要になった時点で導入する判断もできる。最初から両方公開する積極理由がない。
+
+### C. VO に `parse(text)` + `issue(type, year, sequenceProvider)` を公開（不採用）
+
+```typescript
+static async issue(
+  type: EstimateType,
+  year: FiscalYear,
+  sequenceProvider: () => Promise<number>
+): Promise<EstimateNumber> {
+  const seq = await sequenceProvider();
+  return EstimateNumber.fromParts(type, year, seq);
+}
+```
+
+払い出し責務を VO に持たせつつ、永続化依存を関数注入で外出しする。
+
+しかし:
+- **ドメイン層が `Promise` を持ち込む**: 同期関数だった VO ファクトリが async になる。基底クラス `ValueObject` の規約と整合しない
+- **責務逆転**: 「払い出しはリポジトリの責務」と明言しているのに、VO に呼び口を持たせると「形式的には VO 経由」「実質はリポジトリ操作」というねじれが生まれる
+- **テストが複雑化**: モック `sequenceProvider` を毎回用意する必要がある
+
+### D. VO ではなくドメインサービス `EstimateNumberFactory` を別に作る（部分的に採用）
+
+`parse` を VO のメソッドに残しつつ、`issue` をドメインサービス `EstimateNumberIssuer`（interface） + インフラ実装 `PrismaEstimateNumberIssuer` として別に持つ。
+
+これは **A の方針と矛盾しない**。本 ADR は VO の責務を限定する判断であり、リポジトリ層の実装方式は別途決める。後続 Issue（採番リポジトリ実装）で D の interface 設計を行う想定。
+
+## 決定
+
+採番系の VO（`EstimateNumber`、将来の `OrderNumber` `InvoiceNumber` 等）は **`parse(text: string)` のみを公開**する。連番の払い出し（次番号生成）は **リポジトリ層 / ドメインサービスの責務**として VO の外側で実装する。
+
+## 根拠
+
+### VO の責務を「不変条件の表明」に集約
+
+`ValueObject<T, U>` 基底クラスの設計（`src/server/shared/ValueObject.ts`）は「不変条件を持つ値の検証と分解」を VO の主責務として規定している（ADR-0022 参照）。`parse` は「保存済み値の検証と分解」というこの責務に完全に一致する。
+
+`issue` / `fromParts` を加えると、VO が「払い出された連番を組み立てる中間状態」を取り扱うことになり、責務が分散する。
+
+### 永続化との結合を VO に持ち込まない
+
+連番の払い出しには以下が必要:
+
+- 既存最大連番の取得（DB クエリ）
+- 同時並行採番に対する一意性担保（DB ユニーク制約・トランザクション・リトライ）
+- 採番カウンタの永続化（あるいは見積テーブル自体への INSERT 後の `RETURNING`）
+
+これらは **明確にリポジトリ層の関心事**。VO に呼び口を作るとレイヤリングが曖昧化する。
+
+### テスト容易性
+
+`parse` のみの VO は、テストが「入力文字列 → 期待される VO/エラー」という純粋な入出力で完結する。`issue` を VO に持たせると、テストでモック `sequenceProvider` や DB のスタブが必要になり、ユニットテストの粒度が大きくなる。
+
+### 業務文書（ユースケース棚卸し）の語彙との一致
+
+ユースケース棚卸しが「採番 sequence 払い出し」を **横断ポリシー** として独立カテゴリで扱っている事実を、コードのレイヤ分離に反映する。「文書とコードの語彙を一致させる」運用方針（ADR-0023 と同じ哲学）。
+
+### 将来の採番系 VO への規範性
+
+`OrderNumber`「`InvoiceNumber`」も同型の課題に直面する。本 ADR を「採番系 VO 全般の規範」として定めることで、毎回同じ議論を繰り返さない。
+
+### 不採用理由まとめ
+
+- **B（parse + fromParts）**: 連番の出所不透明化、責務境界の曖昧化。YAGNI
+- **C（parse + 非同期 issue）**: VO が Promise を持ち込み、責務逆転
+- **D（別ドメインサービス）**: 本 ADR と矛盾せず、後続 Issue で interface を設計する（本 ADR は VO 側の責務限定にスコープを絞る）
+
+## 影響
+
+- **`EstimateNumber` 等の採番系 VO は `parse(text)` のみを公開**。`fromParts` / `issue` 等のパーツファクトリ・払い出しメソッドを持たない
+- **採番（払い出し）は別 interface（例: `EstimateNumberIssuer`）として後続 Issue で実装**。インフラ実装は `PrismaEstimateNumberIssuer`（仮）として `infrastructure/prisma/` に配置する想定
+- **将来の `OrderNumber` `InvoiceNumber` 等も本 ADR を踏襲**
+- **テストはユニットテスト（`parse` の入出力）に閉じる**。採番ロジックのテストは「リポジトリ＋実 DB」の統合テストで行う（ADR-0012 のテスト DB 分離方針に従う）
+- **見積保存（C1 `CreateEstimate`）のフロー**は「アプリ層が `EstimateNumberIssuer.issue(...)` で `EstimateNumber` を取得 → 集約に渡して INSERT」になる
+- **「連番の同時並行採番に対する一意性担保」の実装方式**（リトライ vs カウンタテーブル vs RETURNING）は本 ADR のスコープ外。インフラ実装時に別 ADR を起票するか、コミットボディに記録する
+- 関連: `src/server/subdomains/estimate/domain/values/EstimateNumber.ts`, `docs/business/estimate/システム設計書(見積).md` §2, `docs/business/estimate/ユースケース一覧(見積).md`（横断ポリシー）, ADR-0022, ADR-0024

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -44,6 +44,9 @@
 | [0018](0018-separate-activate-deactivate-commands.md) | エンティティの有効/無効切り替えを専用コマンドで実装する | 採用 | 2026-04-14 |
 | [0022](0022-money-pattern-for-domain-amounts.md) | ドメインの金額表現に Money パターン（整数最小単位 + Currency）を採用する | 採用 | 2026-05-23 |
 | [0023](0023-domain-policies-directory-for-calculation-rules.md) | ドメイン計算規約は domain/policies/ の Policy クラスとして配置する | 採用 | 2026-05-23 |
+| [0024](0024-fiscal-year-as-shared-value-object.md) | 年度 (FiscalYear) を独立 VO として shared/domain/values/ に配置する | 採用 | 2026-05-23 |
+| [0025](0025-jst-fixed-pure-function-in-domain-layer.md) | ドメイン層での日時境界判定は JST 固定の純関数で行う | 採用 | 2026-05-23 |
+| [0026](0026-numbering-value-object-exposes-parse-only.md) | 採番系の値オブジェクトは parse のみを公開し、払い出しはリポジトリ層に分離する | 採用 | 2026-05-23 |
 
 ## アプリケーション（クエリ・DTO）
 

--- a/docs/claude-plans/issue-282/estimate-number-value-object-plan.md
+++ b/docs/claude-plans/issue-282/estimate-number-value-object-plan.md
@@ -1,0 +1,170 @@
+# Issue #282: 採番 `EstimateNumber` 値オブジェクト（§2 の形式・年度算出）を実装する — 実装計画
+
+## Context
+
+見積（Estimate）には一意な採番（例: `N2500001`）が必要で、その形式と年度算出ロジックはシステム設計書 §2「見積番号の採番ルール」で定義されている。採番ルールはビジネスルールであり、形式バリデーション・分解・年度判定を 1 箇所にカプセル化するため、ドメイン層に値オブジェクト（VO）として実装する。
+
+`docs/business/estimate/ユースケース一覧(見積).md` のバックエンド着手順序:
+1. ✅ Prisma スキーマ（完了）
+2. ✅ 金額計算の値オブジェクト + 計算ポリシー（PR #281 で完了）
+3. 🟢 **採番 `EstimateNumber` 値オブジェクト（§2 の形式・年度算出）** ← 本計画
+4. ⬜ エンティティ/集約
+5. ⬜ リポジトリ interface
+
+本 Issue のスコープは「**払い出し済みの連番を受け取って組み立て・パース・分解する VO**」に限定する。連番（sequence）の払い出しは `fiscalYear + estimateType` 単位の横断ポリシーとしてリポジトリ層の責務であり、後続 Issue で実装する。
+
+## 仕様（システム設計書 §2 抜粋）
+
+- **形式**: `[接頭辞1文字][年度2桁][連番5桁]` = 計 8 文字（Prisma `estimate_number VARCHAR(8)`）
+- **接頭辞**: `N`（新規）/ `R`（修理）/ `A`（事後修理）
+- **年度**: 4 月始まり（2025-04-01〜2026-03-31 = 2025 年度）
+- **連番**: 年度ごとリセット、欠番許容、5 桁ゼロパディング、`00001`〜`99999`
+- **採番タイミング**: 見積保存時（C1 `CreateEstimate`）
+
+## 設計判断
+
+### 1. `FiscalYear` を独立 VO として `shared/domain/values/` に新設
+年度は税率マスタ・締切管理・集計など横断的概念のため、`shared/domain/values/FiscalYear.ts` に配置。内部表現は **西暦 4 桁数値**（例: `2025`）として保持し、`toShortString()` で `"25"` を返す。2 桁数値で保持すると 100 年衝突時に世紀情報を失うため不採用。
+
+### 2. TZ は JST 固定（VO 内で純関数化）
+ドメイン層は外部依存禁止のため、`Date.getMonth()` 等のローカル TZ 依存メソッドは使わない。`date.getTime() + 9 * 60 * 60 * 1000` で UTC ミリ秒を JST 相当に正規化してから `getUTCMonth/getUTCFullYear` を使う。サーバ TZ や `process.env.TZ` 設定に影響されず、テストが決定的。
+
+### 3. `EstimateType` を独立 VO として同時実装
+Prisma の `EstimateType` enum（`NEW`/`REPAIR`/`AFTER_REPAIR`）と接頭辞（`N`/`R`/`A`）の対応はドメイン側で表現する必要がある（Domain 層は Prisma を import 不可）。`ProductCategory.ts` を規範として `private constructor` + `static readonly` パターンで列挙。
+- **`from(value)`**: Prisma 値（永続化復元用）
+- **`fromPrefix(prefix)`**: 採番形式の接頭辞用（`EstimateNumber.parse` から呼ぶ）
+- **アクセサ**: `value` / `prefix` / `label`（"新規" / "修理" / "事後"、§1.1 業務用語）
+
+### 4. `EstimateNumber` の公開ファクトリは `parse(text)` のみ
+パーツからの生成（`issue` / `fromParts`）は本 Issue では持たない。連番払い出しはリポジトリ層の責務であり、ここに置くと採番カウンタの永続化との結合が漏れる。`parse` のみに絞ることで「保存済み採番値の検証・分解」という単一責務に閉じる。
+
+### 5. 年度 2 桁→4 桁復元は `2000 + YY` 固定
+Prisma `VarChar(8)` + 2 桁年度は構造的に 100 年（2000〜2099）が上限。現在日時依存のスライディングウィンドウは過去レコードの復元が時刻に依存しテストが脆くなるため不採用。固定マッピングを採用し **ADR は起票せず、コミットボディに判断理由を記録**する。
+
+### 6. バリデーションは早期リターン（最初に検出した 1 原因のみエラー）
+既存 VO（`CompanyCode` 等）の規範に合わせる。順序: **長さ → 全体パターン → 連番≧1**。
+
+### 7. `ValueObject<T, U>` 基底クラスを直接継承
+3 VO とも `src/server/shared/ValueObject.ts` のブランド型基底を直接継承する。`StringValueObject` は単純な「文字列＋正規表現」用途のため、構造分解（接頭辞・年度・連番）を持つ VO や数値表現の VO には適さない。`ProductCategory` / `Money` / `TaxRate` と同型。
+
+## 参照する既存ファイル
+
+- `src/server/shared/ValueObject.ts` — 基底クラス（継承）
+- `src/server/shared/errors/DomainError.ts` — `ValidationError`（形式不正用、`InvalidArgumentError` ではない）
+- `src/server/subdomains/product/domain/values/ProductCategory.ts` — enum 風 VO の規範（`EstimateType` で踏襲）
+- `src/server/subdomains/estimate/domain/values/Money.ts` — 複雑系 VO の構造規範
+- `docs/business/estimate/システム設計書(見積).md` §2 — 採番仕様
+- `prisma/schema.prisma:422-446` — `EstimateType` enum と `estimate_number VARCHAR(8)`
+
+## ステップ
+
+依存関係: `FiscalYear` ← `EstimateNumber` → `EstimateType`。依存順に 3 コミットに分割（実装＋テストを 1 コミットにまとめる）。
+
+### Step 1: `FiscalYear` 値オブジェクトを追加
+
+- **対象ファイル**:
+  - `src/server/shared/domain/values/FiscalYear.ts`（新規）
+  - `src/server/shared/domain/values/__tests__/FiscalYear.test.ts`（新規）
+- **作業内容**:
+  - `ValueObject<number, "FiscalYear">` を継承、内部値は西暦 4 桁数値
+  - `static from(date: Date): FiscalYear` — JST 正規化（UTC ms + 9h）後の月で 1-3 月なら `year - 1`、4-12 月なら `year`
+  - `toShortString(): string` — 下 2 桁ゼロ詰め
+  - `validate`: 整数チェック・範囲 1900〜2999
+  - 公開定数 `FISCAL_START_MONTH = 4`
+  - テスト: 正常系（境界値 3/31→4/1 を含む）／異常系（非整数・範囲外）／equals／`from` の JST 純関数性
+- **コミットメッセージ**:
+  ```
+  feat: FiscalYear 値オブジェクトを追加する（§2）
+
+  4月始まり年度を西暦4桁数値で保持する横断VOを shared/domain/values に追加。
+  EstimateNumber の年度部および将来の年度横断機能（税率マスタ・締切管理等）で共有する。
+
+  設計判断:
+  - 内部表現: 西暦4桁数値（2025）。2桁数値は世紀情報を失うため不採用。
+  - TZ: JST固定。UTCミリ秒 + 9hオフセット → getUTCMonth/Year で純関数化し
+    実行環境TZ依存を排除（ドメイン層の外部依存禁止に従う）。
+  - 配置: shared/domain/values。estimate以外でも年度を扱う可能性があるため。
+  ```
+
+### Step 2: `EstimateType` 値オブジェクトを追加
+
+- **対象ファイル**:
+  - `src/server/subdomains/estimate/domain/values/EstimateType.ts`（新規）
+  - `src/server/subdomains/estimate/domain/values/__tests__/EstimateType.test.ts`（新規）
+- **作業内容**:
+  - `ValueObject<string, "EstimateType">` を継承、`ProductCategory.ts` を規範に `private constructor` + `static readonly NEW/REPAIR/AFTER_REPAIR`
+  - `static from(value)`: Prisma 値（`"NEW"`等）→ インスタンス（switch-case）
+  - `static fromPrefix(prefix)`: `"N"`/`"R"`/`"A"` → インスタンス
+  - アクセサ: `value` / `prefix` / `label`（"新規" / "修理" / "事後"）
+  - テスト: 各インスタンス生成／`from`／`fromPrefix`（大文字固定）／`prefix`・`label` アクセサ／equals／異常系
+- **コミットメッセージ**:
+  ```
+  feat: EstimateType 値オブジェクトを追加する（§2）
+
+  Prisma の EstimateType enum と採番接頭辞 N/R/A の対応をドメイン側で保持する。
+
+  設計判断:
+  - ProductCategory パターン踏襲（private constructor + static インスタンス）。
+  - from(value) は Prisma 値、fromPrefix(prefix) は採番形式の接頭辞という
+    2系統入口を提供。EstimateNumber.parse は fromPrefix を使うことで
+    接頭辞→Prisma値マッピングをこのVO内に集約する。
+  - label アクセサ（「新規」/「修理」/「事後」）は §1.1 業務用語をドメイン側に保持。
+  ```
+
+### Step 3: `EstimateNumber` 値オブジェクトを追加
+
+- **対象ファイル**:
+  - `src/server/subdomains/estimate/domain/values/EstimateNumber.ts`（新規）
+  - `src/server/subdomains/estimate/domain/values/__tests__/EstimateNumber.test.ts`（新規）
+- **作業内容**:
+  - `ValueObject<string, "EstimateNumber">` を直接継承、`private constructor`
+  - `static parse(text: string): EstimateNumber` — 唯一の公開ファクトリ
+  - 正規表現 `/^[NRA]\d{7}$/` でパターン検証
+  - バリデーション順序: 長さ8 → パターン → 連番≧1（`00000` 拒否）
+  - アクセサ: `value` / `prefix` / `estimateType`（`EstimateType.fromPrefix`）/ `fiscalYear`（`new FiscalYear(2000 + YY)`）/ `sequence`（先頭ゼロ除去後の整数）
+  - テスト: 正常系（`N2500001`/`R2500123`/`A2510500`、連番境界 1/99999、年度境界 00/99）／長さ違い／不正接頭辞（`X`、小文字 `n`）／連番00000／年度非数字／空白混入／全アクセサ／equals
+- **コミットメッセージ**:
+  ```
+  feat: EstimateNumber 値オブジェクトを追加する（§2）
+
+  採番済み見積番号（接頭辞1+年度2+連番5=計8文字）をパースして
+  構造化された値オブジェクトに変換する。FiscalYear/EstimateType と協調。
+
+  設計判断:
+  - 公開ファクトリは parse(text) のみ。連番（sequence）払い出しはリポジトリ層の
+    別ポリシー責務として本VOには持たせない（採番カウンタの永続化と原子性が必要）。
+  - 年度2桁→4桁復元は 2000+YY 固定。VarChar(8) + 2桁年度は元来 100年制限の
+    ある仕様であり、現在日時依存のスライディング解決は予測不能性のため不採用。
+  - バリデーション順序: 長さ→パターン→連番≧1。「最初に検出した1原因のみ通知」
+    で既存VO（CompanyCode等）の規範に合わせる。
+  ```
+
+## 移動・後処理
+
+Plan mode 終了後、本ファイルを `docs/claude-plans/issue-282/plan.md` へ移動し、`.claude/settings.local.json` の `plansDirectory` を `docs/claude-plans/issue-282` に更新する（PreToolUse hook のリマインド）。
+
+## Verification
+
+各ステップ完了時:
+
+```bash
+pnpm lint
+pnpm vitest run src/server/shared/domain/values/__tests__/FiscalYear.test.ts          # Step 1
+pnpm vitest run src/server/subdomains/estimate/domain/values/__tests__/EstimateType.test.ts   # Step 2
+pnpm vitest run src/server/subdomains/estimate/domain/values/__tests__/EstimateNumber.test.ts # Step 3
+```
+
+全ステップ完了後:
+
+```bash
+pnpm lint
+pnpm test                      # 既存テストへの影響がないこと（ドメイン純粋追加のため影響しない想定）
+pnpm exec tsc --noEmit         # 型エラーがないこと
+```
+
+## 受け入れ条件チェック（Issue 本文）
+
+- [x] §2 で定義された採番形式に準拠して値オブジェクトが生成・検証できる → Step 3
+- [x] 年度算出ロジックが §2 の仕様通りに動作する → Step 1（境界値 3/31・4/1 をテストで担保）
+- [x] Domain 層のレイヤリングルール（外部依存禁止）を遵守 → Prisma/Next.js を import しない・JST は純関数で表現
+- [x] 単体テストが追加され、グリーン → 各 Step で並行追加

--- a/src/server/shared/domain/values/FiscalYear.ts
+++ b/src/server/shared/domain/values/FiscalYear.ts
@@ -1,0 +1,58 @@
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { ValueObject } from "@server/shared/ValueObject";
+
+/**
+ * 年度（4月始まり）を表す値オブジェクト。
+ *
+ * 内部値は西暦4桁数値（例: 2025）。`toShortString()` で下2桁文字列（"25"）を返し、
+ * 見積番号 §2 の年度部および将来の年度横断機能（税率マスタ・締切管理等）で共有する。
+ *
+ * `from(date)` は JST 基準で年度を導出する。ドメイン層は外部依存禁止のため、
+ * Date オブジェクトの UTC ミリ秒に +9h オフセットを加えた純関数として実装する
+ * （実行環境TZや `process.env.TZ` に依存しない）。
+ */
+export class FiscalYear extends ValueObject<number, "FiscalYear"> {
+  /** 年度開始月（4月始まり）。 */
+  static readonly FISCAL_START_MONTH = 4;
+
+  private static readonly MIN_YEAR = 1900;
+  private static readonly MAX_YEAR = 2999;
+  private static readonly JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+  constructor(value: number) {
+    super(value);
+  }
+
+  get value(): number {
+    return this._value;
+  }
+
+  /** 下2桁ゼロ詰め（例: 2025 → "25"、2007 → "07"、2100 → "00"）。 */
+  toShortString(): string {
+    return String(this._value % 100).padStart(2, "0");
+  }
+
+  /**
+   * 任意の Date から JST 基準で年度を導出する。
+   *
+   * 例: 2025-03-31 23:59 JST → 2024 年度 / 2025-04-01 00:00 JST → 2025 年度。
+   */
+  static from(date: Date): FiscalYear {
+    const jstDate = new Date(date.getTime() + FiscalYear.JST_OFFSET_MS);
+    const month = jstDate.getUTCMonth() + 1;
+    const year = jstDate.getUTCFullYear();
+    const fiscalYear = month < FiscalYear.FISCAL_START_MONTH ? year - 1 : year;
+    return new FiscalYear(fiscalYear);
+  }
+
+  protected validate(value: number): void {
+    if (!Number.isInteger(value)) {
+      throw new ValidationError(`年度は整数である必要があります: ${value}`);
+    }
+    if (value < FiscalYear.MIN_YEAR || value > FiscalYear.MAX_YEAR) {
+      throw new ValidationError(
+        `年度は${FiscalYear.MIN_YEAR}〜${FiscalYear.MAX_YEAR}の範囲である必要があります: ${value}`
+      );
+    }
+  }
+}

--- a/src/server/shared/domain/values/__tests__/FiscalYear.test.ts
+++ b/src/server/shared/domain/values/__tests__/FiscalYear.test.ts
@@ -71,9 +71,9 @@ describe("FiscalYear", () => {
       expect(FiscalYear.from(date).value).toBe(2025);
     });
 
-    it("UTC 表示で 4月の Date でも JST に直すと 3月なら旧年度", () => {
-      // UTC 2025-04-01 14:59:59 < JST 2025-04-01 00:00 ではない (UTC04-01-14:59 = JST04-01-23:59)
-      // 正しくは: UTC 2025-03-31 14:59:59 = JST 2025-03-31 23:59:59 → 2024 年度
+    it("JST 4月1日 00:00 の1秒前（UTC 3月31日 14:59:59Z）は旧年度", () => {
+      // 前のテスト（UTC 15:00:00Z = JST 4/1 00:00:00 = 新年度）と対をなす境界。
+      // JST 3/31 23:59:59 はまだ 3 月なので 2024 年度。
       const date = new Date("2025-03-31T14:59:59Z");
       expect(FiscalYear.from(date).value).toBe(2024);
     });

--- a/src/server/shared/domain/values/__tests__/FiscalYear.test.ts
+++ b/src/server/shared/domain/values/__tests__/FiscalYear.test.ts
@@ -1,0 +1,112 @@
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { describe, expect, it } from "vitest";
+import { FiscalYear } from "../FiscalYear";
+
+describe("FiscalYear", () => {
+  describe("正常系", () => {
+    it("西暦4桁数値で生成できる", () => {
+      const fy = new FiscalYear(2025);
+      expect(fy.value).toBe(2025);
+    });
+
+    it('toShortString は下2桁ゼロ詰め文字列を返す（2025 → "25"）', () => {
+      expect(new FiscalYear(2025).toShortString()).toBe("25");
+    });
+
+    it('toShortString は10未満でも2桁化される（2007 → "07"）', () => {
+      expect(new FiscalYear(2007).toShortString()).toBe("07");
+    });
+
+    it('toShortString は世紀境界でゼロ詰めされる（2100 → "00"）', () => {
+      expect(new FiscalYear(2100).toShortString()).toBe("00");
+    });
+
+    it("下限 1900 を受け入れる", () => {
+      expect(new FiscalYear(1900).value).toBe(1900);
+    });
+
+    it("上限 2999 を受け入れる", () => {
+      expect(new FiscalYear(2999).value).toBe(2999);
+    });
+
+    it("FISCAL_START_MONTH 定数は 4", () => {
+      expect(FiscalYear.FISCAL_START_MONTH).toBe(4);
+    });
+  });
+
+  describe("from(date) — JST 4月始まりの年度導出", () => {
+    it("2025年4月1日 00:00 JST は 2025 年度", () => {
+      const date = new Date("2025-04-01T00:00:00+09:00");
+      expect(FiscalYear.from(date).value).toBe(2025);
+    });
+
+    it("2025年3月31日 23:59 JST は 2024 年度", () => {
+      const date = new Date("2025-03-31T23:59:59+09:00");
+      expect(FiscalYear.from(date).value).toBe(2024);
+    });
+
+    it("2025年12月31日 23:59 JST は 2025 年度", () => {
+      const date = new Date("2025-12-31T23:59:59+09:00");
+      expect(FiscalYear.from(date).value).toBe(2025);
+    });
+
+    it("2026年1月1日 00:00 JST は 2025 年度", () => {
+      const date = new Date("2026-01-01T00:00:00+09:00");
+      expect(FiscalYear.from(date).value).toBe(2025);
+    });
+
+    it("2026年3月31日 23:59 JST は 2025 年度", () => {
+      const date = new Date("2026-03-31T23:59:59+09:00");
+      expect(FiscalYear.from(date).value).toBe(2025);
+    });
+
+    it("2026年4月1日 00:00 JST は 2026 年度", () => {
+      const date = new Date("2026-04-01T00:00:00+09:00");
+      expect(FiscalYear.from(date).value).toBe(2026);
+    });
+
+    it("UTC 表示で 3月の Date でも JST に直すと 4月なら新年度", () => {
+      // UTC 2025-03-31 15:00:00 = JST 2025-04-01 00:00:00
+      const date = new Date("2025-03-31T15:00:00Z");
+      expect(FiscalYear.from(date).value).toBe(2025);
+    });
+
+    it("UTC 表示で 4月の Date でも JST に直すと 3月なら旧年度", () => {
+      // UTC 2025-04-01 14:59:59 < JST 2025-04-01 00:00 ではない (UTC04-01-14:59 = JST04-01-23:59)
+      // 正しくは: UTC 2025-03-31 14:59:59 = JST 2025-03-31 23:59:59 → 2024 年度
+      const date = new Date("2025-03-31T14:59:59Z");
+      expect(FiscalYear.from(date).value).toBe(2024);
+    });
+  });
+
+  describe("異常系", () => {
+    it("整数でない値はエラー（2025.5）", () => {
+      expect(() => new FiscalYear(2025.5)).toThrow(ValidationError);
+      expect(() => new FiscalYear(2025.5)).toThrow("年度は整数である必要があります");
+    });
+
+    it("NaN はエラー", () => {
+      expect(() => new FiscalYear(Number.NaN)).toThrow(ValidationError);
+    });
+
+    it("範囲下限未満はエラー（1899）", () => {
+      expect(() => new FiscalYear(1899)).toThrow(ValidationError);
+      expect(() => new FiscalYear(1899)).toThrow("年度は1900〜2999の範囲である必要があります");
+    });
+
+    it("範囲上限超過はエラー（3000）", () => {
+      expect(() => new FiscalYear(3000)).toThrow(ValidationError);
+      expect(() => new FiscalYear(3000)).toThrow("年度は1900〜2999の範囲である必要があります");
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ年度は等しい", () => {
+      expect(new FiscalYear(2025).equals(new FiscalYear(2025))).toBe(true);
+    });
+
+    it("異なる年度は等しくない", () => {
+      expect(new FiscalYear(2025).equals(new FiscalYear(2026))).toBe(false);
+    });
+  });
+});

--- a/src/server/subdomains/estimate/domain/values/EstimateNumber.ts
+++ b/src/server/subdomains/estimate/domain/values/EstimateNumber.ts
@@ -1,0 +1,85 @@
+import { FiscalYear } from "@server/shared/domain/values/FiscalYear";
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { ValueObject } from "@server/shared/ValueObject";
+import { EstimateType } from "./EstimateType";
+
+type EstimateNumberPrefix = "N" | "R" | "A";
+
+/**
+ * 見積番号の値オブジェクト（§2 見積番号の採番ルール）。
+ *
+ * 形式: `[接頭辞1文字][年度2桁][連番5桁]` = 計 8 文字（例: `N2500001`）。
+ *
+ * 公開ファクトリは `parse(text)` のみ。連番の払い出し（次番号生成）は
+ * `fiscalYear + estimateType` 単位の横断ポリシーとしてリポジトリ層の責務であり、
+ * 本 VO は「保存済み採番値の検証・分解」に責務を限定する。
+ *
+ * 年度 2 桁→4 桁の復元は `2000 + YY` 固定。Prisma `VarChar(8)` + 2 桁年度は
+ * 構造的に 100 年（2000〜2099）が上限であり、現在日時依存のスライディングは
+ * 過去レコードの復元が時刻に依存するため不採用。
+ */
+export class EstimateNumber extends ValueObject<string, "EstimateNumber"> {
+  static readonly LENGTH = 8;
+  static readonly SEQUENCE_MIN = 1;
+  static readonly SEQUENCE_MAX = 99999;
+  static readonly PATTERN = /^[NRA]\d{7}$/;
+  private static readonly CENTURY_BASE = 2000;
+
+  private readonly _prefix: EstimateNumberPrefix;
+  private readonly _estimateType: EstimateType;
+  private readonly _fiscalYear: FiscalYear;
+  private readonly _sequence: number;
+
+  private constructor(value: string) {
+    super(value);
+    // super で validate を通過済みのため、以下の分解は安全に行える
+    this._prefix = value[0] as EstimateNumberPrefix;
+    this._estimateType = EstimateType.fromPrefix(this._prefix);
+    const yearShort = Number.parseInt(value.substring(1, 3), 10);
+    this._fiscalYear = new FiscalYear(EstimateNumber.CENTURY_BASE + yearShort);
+    this._sequence = Number.parseInt(value.substring(3), 10);
+  }
+
+  /** 唯一の公開ファクトリ。永続化値の検証・分解に使用する。 */
+  static parse(text: string): EstimateNumber {
+    return new EstimateNumber(text);
+  }
+
+  get value(): string {
+    return this._value;
+  }
+
+  get prefix(): EstimateNumberPrefix {
+    return this._prefix;
+  }
+
+  get estimateType(): EstimateType {
+    return this._estimateType;
+  }
+
+  get fiscalYear(): FiscalYear {
+    return this._fiscalYear;
+  }
+
+  /** 連番（1〜99999、先頭ゼロを除去した整数）。 */
+  get sequence(): number {
+    return this._sequence;
+  }
+
+  protected validate(value: string): void {
+    if (value.length !== EstimateNumber.LENGTH) {
+      throw new ValidationError(
+        `見積番号は${EstimateNumber.LENGTH}文字である必要があります: ${value}`
+      );
+    }
+    if (!EstimateNumber.PATTERN.test(value)) {
+      throw new ValidationError(`見積番号の形式が正しくありません: ${value}`);
+    }
+    const sequence = Number.parseInt(value.substring(3), 10);
+    if (sequence < EstimateNumber.SEQUENCE_MIN) {
+      throw new ValidationError(
+        `見積番号の連番は${EstimateNumber.SEQUENCE_MIN}以上である必要があります: ${value}`
+      );
+    }
+  }
+}

--- a/src/server/subdomains/estimate/domain/values/EstimateType.ts
+++ b/src/server/subdomains/estimate/domain/values/EstimateType.ts
@@ -1,0 +1,95 @@
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { ValueObject } from "@server/shared/ValueObject";
+
+const VALID_VALUES = ["NEW", "REPAIR", "AFTER_REPAIR"] as const;
+type EstimateTypeValue = (typeof VALID_VALUES)[number];
+
+const VALID_PREFIXES = ["N", "R", "A"] as const;
+type EstimateTypePrefix = (typeof VALID_PREFIXES)[number];
+
+const PREFIX_MAP: Record<EstimateTypeValue, EstimateTypePrefix> = {
+  NEW: "N",
+  REPAIR: "R",
+  AFTER_REPAIR: "A",
+};
+
+const VALUE_BY_PREFIX: Record<EstimateTypePrefix, EstimateTypeValue> = {
+  N: "NEW",
+  R: "REPAIR",
+  A: "AFTER_REPAIR",
+};
+
+const LABEL_MAP: Record<EstimateTypeValue, string> = {
+  NEW: "新規",
+  REPAIR: "修理",
+  AFTER_REPAIR: "事後",
+};
+
+/**
+ * 見積区分の値オブジェクト
+ *
+ * Prisma の `EstimateType` enum と採番接頭辞 (`N` / `R` / `A`) の対応を
+ * ドメイン側で保持する。`from(value)` は Prisma 値（永続化復元用）、
+ * `fromPrefix(prefix)` は採番形式の接頭辞用（`EstimateNumber.parse` から呼ぶ）。
+ *
+ * NEW: 新規見積 — 通常の見積
+ * REPAIR: 修理見積（事前） — 修理対象品の事前見積
+ * AFTER_REPAIR: 事後見積 — 修理完了後に作成する見積
+ */
+export class EstimateType extends ValueObject<string, "EstimateType"> {
+  static readonly NEW = new EstimateType("NEW");
+  static readonly REPAIR = new EstimateType("REPAIR");
+  static readonly AFTER_REPAIR = new EstimateType("AFTER_REPAIR");
+
+  private constructor(value: string) {
+    super(value);
+  }
+
+  get value(): string {
+    return this._value;
+  }
+
+  /** 採番接頭辞（`N` / `R` / `A`）。 */
+  get prefix(): EstimateTypePrefix {
+    return PREFIX_MAP[this._value as EstimateTypeValue];
+  }
+
+  /** 業務表示名（「新規」/「修理」/「事後」、§1.1）。 */
+  get label(): string {
+    return LABEL_MAP[this._value as EstimateTypeValue];
+  }
+
+  /** Prisma 値（"NEW" / "REPAIR" / "AFTER_REPAIR"）から生成する。 */
+  static from(value: string): EstimateType {
+    switch (value) {
+      case "NEW":
+        return EstimateType.NEW;
+      case "REPAIR":
+        return EstimateType.REPAIR;
+      case "AFTER_REPAIR":
+        return EstimateType.AFTER_REPAIR;
+      default:
+        throw new ValidationError(
+          `不正な見積区分です: ${value}（有効値: ${VALID_VALUES.join(", ")}）`
+        );
+    }
+  }
+
+  /** 採番接頭辞（"N" / "R" / "A"）から生成する。 */
+  static fromPrefix(prefix: string): EstimateType {
+    if (!(prefix in VALUE_BY_PREFIX)) {
+      throw new ValidationError(
+        `不正な見積区分の接頭辞です: ${prefix}（有効値: ${VALID_PREFIXES.join(", ")}）`
+      );
+    }
+    return EstimateType.from(VALUE_BY_PREFIX[prefix as EstimateTypePrefix]);
+  }
+
+  protected validate(value: string): void {
+    if (!VALID_VALUES.includes(value as EstimateTypeValue)) {
+      throw new ValidationError(
+        `不正な見積区分です: ${value}（有効値: ${VALID_VALUES.join(", ")}）`
+      );
+    }
+  }
+}

--- a/src/server/subdomains/estimate/domain/values/__tests__/EstimateNumber.test.ts
+++ b/src/server/subdomains/estimate/domain/values/__tests__/EstimateNumber.test.ts
@@ -1,0 +1,155 @@
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { describe, expect, it } from "vitest";
+import { EstimateNumber } from "../EstimateNumber";
+import { EstimateType } from "../EstimateType";
+
+describe("EstimateNumber", () => {
+  describe("parse — 正常系", () => {
+    it("N2500001 をパースできる", () => {
+      const num = EstimateNumber.parse("N2500001");
+      expect(num.value).toBe("N2500001");
+    });
+
+    it("R2500123 をパースできる", () => {
+      const num = EstimateNumber.parse("R2500123");
+      expect(num.value).toBe("R2500123");
+    });
+
+    it("A2510500 をパースできる", () => {
+      const num = EstimateNumber.parse("A2510500");
+      expect(num.value).toBe("A2510500");
+    });
+
+    it("連番最小値 N2500001 を受け入れる", () => {
+      expect(EstimateNumber.parse("N2500001").sequence).toBe(1);
+    });
+
+    it("連番最大値 N2599999 を受け入れる", () => {
+      expect(EstimateNumber.parse("N2599999").sequence).toBe(99999);
+    });
+
+    it("年度2桁の境界 N0000001（西暦2000）を受け入れる", () => {
+      expect(EstimateNumber.parse("N0000001").fiscalYear.value).toBe(2000);
+    });
+
+    it("年度2桁の境界 N9900001（西暦2099）を受け入れる", () => {
+      expect(EstimateNumber.parse("N9900001").fiscalYear.value).toBe(2099);
+    });
+  });
+
+  describe("アクセサ", () => {
+    it("value は元文字列を返す", () => {
+      expect(EstimateNumber.parse("N2500001").value).toBe("N2500001");
+    });
+
+    it("prefix は接頭辞を返す（N2500001 → 'N'）", () => {
+      expect(EstimateNumber.parse("N2500001").prefix).toBe("N");
+    });
+
+    it("estimateType は EstimateType を返す（R... → REPAIR）", () => {
+      expect(EstimateNumber.parse("R2500123").estimateType).toBe(EstimateType.REPAIR);
+    });
+
+    it("estimateType は EstimateType を返す（A... → AFTER_REPAIR）", () => {
+      expect(EstimateNumber.parse("A2510500").estimateType).toBe(EstimateType.AFTER_REPAIR);
+    });
+
+    it("fiscalYear は西暦4桁の FiscalYear を返す（25 → 2025）", () => {
+      expect(EstimateNumber.parse("N2500001").fiscalYear.value).toBe(2025);
+    });
+
+    it("fiscalYear.toShortString は2桁年度を返す", () => {
+      expect(EstimateNumber.parse("N2500001").fiscalYear.toShortString()).toBe("25");
+    });
+
+    it("sequence は先頭ゼロを除去した整数を返す（N2500001 → 1）", () => {
+      expect(EstimateNumber.parse("N2500001").sequence).toBe(1);
+    });
+
+    it("sequence は5桁いっぱい（N2599999 → 99999）", () => {
+      expect(EstimateNumber.parse("N2599999").sequence).toBe(99999);
+    });
+
+    it("toString は元文字列を返す（基底クラス由来）", () => {
+      expect(EstimateNumber.parse("N2500001").toString()).toBe("N2500001");
+    });
+  });
+
+  describe("parse — 異常系（長さ）", () => {
+    it("7文字はエラー", () => {
+      expect(() => EstimateNumber.parse("N250001")).toThrow(ValidationError);
+      expect(() => EstimateNumber.parse("N250001")).toThrow("見積番号は8文字である必要があります");
+    });
+
+    it("9文字はエラー", () => {
+      expect(() => EstimateNumber.parse("N25000001")).toThrow(ValidationError);
+      expect(() => EstimateNumber.parse("N25000001")).toThrow(
+        "見積番号は8文字である必要があります"
+      );
+    });
+
+    it("空文字はエラー", () => {
+      expect(() => EstimateNumber.parse("")).toThrow(ValidationError);
+    });
+  });
+
+  describe("parse — 異常系（接頭辞）", () => {
+    it("不正な接頭辞 X2500001 はエラー", () => {
+      expect(() => EstimateNumber.parse("X2500001")).toThrow(ValidationError);
+      expect(() => EstimateNumber.parse("X2500001")).toThrow("見積番号の形式が正しくありません");
+    });
+
+    it("小文字 n2500001 はエラー", () => {
+      expect(() => EstimateNumber.parse("n2500001")).toThrow(ValidationError);
+    });
+
+    it("数字始まりはエラー（12500001）", () => {
+      expect(() => EstimateNumber.parse("12500001")).toThrow(ValidationError);
+    });
+  });
+
+  describe("parse — 異常系（連番）", () => {
+    it("連番 00000 はエラー（N2500000）", () => {
+      expect(() => EstimateNumber.parse("N2500000")).toThrow(ValidationError);
+      expect(() => EstimateNumber.parse("N2500000")).toThrow(
+        "見積番号の連番は1以上である必要があります"
+      );
+    });
+  });
+
+  describe("parse — 異常系（その他）", () => {
+    it("年度部が数字でないとエラー（NAA00001）", () => {
+      expect(() => EstimateNumber.parse("NAA00001")).toThrow(ValidationError);
+    });
+
+    it("連番部が数字でないとエラー（N25ABCDE）", () => {
+      expect(() => EstimateNumber.parse("N25ABCDE")).toThrow(ValidationError);
+    });
+
+    it("先頭の空白はエラー（' N250001'）", () => {
+      expect(() => EstimateNumber.parse(" N250001")).toThrow(ValidationError);
+    });
+
+    it("末尾の空白はエラー（'N250001 '）", () => {
+      expect(() => EstimateNumber.parse("N250001 ")).toThrow(ValidationError);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ番号は等しい", () => {
+      expect(EstimateNumber.parse("N2500001").equals(EstimateNumber.parse("N2500001"))).toBe(true);
+    });
+
+    it("異なる連番は等しくない（N2500001 vs N2500002）", () => {
+      expect(EstimateNumber.parse("N2500001").equals(EstimateNumber.parse("N2500002"))).toBe(false);
+    });
+
+    it("接頭辞違いは等しくない（N2500001 vs R2500001）", () => {
+      expect(EstimateNumber.parse("N2500001").equals(EstimateNumber.parse("R2500001"))).toBe(false);
+    });
+
+    it("年度違いは等しくない（N2500001 vs N2600001）", () => {
+      expect(EstimateNumber.parse("N2500001").equals(EstimateNumber.parse("N2600001"))).toBe(false);
+    });
+  });
+});

--- a/src/server/subdomains/estimate/domain/values/__tests__/EstimateType.test.ts
+++ b/src/server/subdomains/estimate/domain/values/__tests__/EstimateType.test.ts
@@ -1,0 +1,123 @@
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { describe, expect, it } from "vitest";
+import { EstimateType } from "../EstimateType";
+
+describe("EstimateType", () => {
+  describe("static インスタンス", () => {
+    it("NEW を取得できる（value === 'NEW'）", () => {
+      expect(EstimateType.NEW.value).toBe("NEW");
+    });
+
+    it("REPAIR を取得できる", () => {
+      expect(EstimateType.REPAIR.value).toBe("REPAIR");
+    });
+
+    it("AFTER_REPAIR を取得できる", () => {
+      expect(EstimateType.AFTER_REPAIR.value).toBe("AFTER_REPAIR");
+    });
+  });
+
+  describe("from() — Prisma 値からの生成", () => {
+    it("'NEW' から EstimateType.NEW が返る（同一インスタンス）", () => {
+      expect(EstimateType.from("NEW")).toBe(EstimateType.NEW);
+    });
+
+    it("'REPAIR' から EstimateType.REPAIR が返る", () => {
+      expect(EstimateType.from("REPAIR")).toBe(EstimateType.REPAIR);
+    });
+
+    it("'AFTER_REPAIR' から EstimateType.AFTER_REPAIR が返る", () => {
+      expect(EstimateType.from("AFTER_REPAIR")).toBe(EstimateType.AFTER_REPAIR);
+    });
+
+    it("不正な値はエラー（'INVALID'）", () => {
+      expect(() => EstimateType.from("INVALID")).toThrow(ValidationError);
+      expect(() => EstimateType.from("INVALID")).toThrow("不正な見積区分です");
+    });
+
+    it("接頭辞 'N' を from に渡すとエラー（fromPrefix を使うべき）", () => {
+      expect(() => EstimateType.from("N")).toThrow(ValidationError);
+    });
+
+    it("空文字はエラー", () => {
+      expect(() => EstimateType.from("")).toThrow(ValidationError);
+    });
+
+    it("小文字はエラー", () => {
+      expect(() => EstimateType.from("new")).toThrow(ValidationError);
+    });
+  });
+
+  describe("fromPrefix() — 採番接頭辞からの生成", () => {
+    it("'N' → EstimateType.NEW", () => {
+      expect(EstimateType.fromPrefix("N")).toBe(EstimateType.NEW);
+    });
+
+    it("'R' → EstimateType.REPAIR", () => {
+      expect(EstimateType.fromPrefix("R")).toBe(EstimateType.REPAIR);
+    });
+
+    it("'A' → EstimateType.AFTER_REPAIR", () => {
+      expect(EstimateType.fromPrefix("A")).toBe(EstimateType.AFTER_REPAIR);
+    });
+
+    it("不正な接頭辞はエラー（'X'）", () => {
+      expect(() => EstimateType.fromPrefix("X")).toThrow(ValidationError);
+      expect(() => EstimateType.fromPrefix("X")).toThrow("不正な見積区分の接頭辞です");
+    });
+
+    it("小文字はエラー（'n'）— 採番形式は大文字固定（§2.1）", () => {
+      expect(() => EstimateType.fromPrefix("n")).toThrow(ValidationError);
+    });
+
+    it("空文字はエラー", () => {
+      expect(() => EstimateType.fromPrefix("")).toThrow(ValidationError);
+    });
+
+    it("複数文字はエラー（'NR'）", () => {
+      expect(() => EstimateType.fromPrefix("NR")).toThrow(ValidationError);
+    });
+  });
+
+  describe("prefix アクセサ", () => {
+    it("NEW.prefix === 'N'", () => {
+      expect(EstimateType.NEW.prefix).toBe("N");
+    });
+
+    it("REPAIR.prefix === 'R'", () => {
+      expect(EstimateType.REPAIR.prefix).toBe("R");
+    });
+
+    it("AFTER_REPAIR.prefix === 'A'", () => {
+      expect(EstimateType.AFTER_REPAIR.prefix).toBe("A");
+    });
+  });
+
+  describe("label アクセサ", () => {
+    it("NEW.label === '新規'", () => {
+      expect(EstimateType.NEW.label).toBe("新規");
+    });
+
+    it("REPAIR.label === '修理'", () => {
+      expect(EstimateType.REPAIR.label).toBe("修理");
+    });
+
+    it("AFTER_REPAIR.label === '事後'", () => {
+      expect(EstimateType.AFTER_REPAIR.label).toBe("事後");
+    });
+  });
+
+  describe("equals", () => {
+    it("同じインスタンスは等しい", () => {
+      expect(EstimateType.NEW.equals(EstimateType.NEW)).toBe(true);
+    });
+
+    it("from で取得しても同一インスタンスのため等しい", () => {
+      expect(EstimateType.from("NEW").equals(EstimateType.NEW)).toBe(true);
+    });
+
+    it("異なるインスタンスは等しくない（NEW vs REPAIR）", () => {
+      expect(EstimateType.NEW.equals(EstimateType.REPAIR)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

見積採番ロジックを担う `EstimateNumber` 値オブジェクトを §2 の仕様に従って実装。年度算出を担う横断 VO `FiscalYear` と、Prisma enum と接頭辞 N/R/A を対応付ける `EstimateType` を併せて追加し、3 VO 構成でドメイン層に閉じた採番ドメインを表現する。設計判断は ADR-0024/0025/0026 として起票。

Closes #282

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

# Issue #282: 採番 `EstimateNumber` 値オブジェクト（§2 の形式・年度算出）を実装する — 実装計画

## Context

見積（Estimate）には一意な採番（例: `N2500001`）が必要で、その形式と年度算出ロジックはシステム設計書 §2「見積番号の採番ルール」で定義されている。採番ルールはビジネスルールであり、形式バリデーション・分解・年度判定を 1 箇所にカプセル化するため、ドメイン層に値オブジェクト（VO）として実装する。

`docs/business/estimate/ユースケース一覧(見積).md` のバックエンド着手順序:
1. ✅ Prisma スキーマ（完了）
2. ✅ 金額計算の値オブジェクト + 計算ポリシー（PR #281 で完了）
3. 🟢 **採番 `EstimateNumber` 値オブジェクト（§2 の形式・年度算出）** ← 本計画
4. ⬜ エンティティ/集約
5. ⬜ リポジトリ interface

本 Issue のスコープは「**払い出し済みの連番を受け取って組み立て・パース・分解する VO**」に限定する。連番（sequence）の払い出しは `fiscalYear + estimateType` 単位の横断ポリシーとしてリポジトリ層の責務であり、後続 Issue で実装する。

## 仕様（システム設計書 §2 抜粋）

- **形式**: `[接頭辞1文字][年度2桁][連番5桁]` = 計 8 文字（Prisma `estimate_number VARCHAR(8)`）
- **接頭辞**: `N`（新規）/ `R`（修理）/ `A`（事後修理）
- **年度**: 4 月始まり（2025-04-01〜2026-03-31 = 2025 年度）
- **連番**: 年度ごとリセット、欠番許容、5 桁ゼロパディング、`00001`〜`99999`
- **採番タイミング**: 見積保存時（C1 `CreateEstimate`）

## 設計判断

### 1. `FiscalYear` を独立 VO として `shared/domain/values/` に新設
年度は税率マスタ・締切管理・集計など横断的概念のため、`shared/domain/values/FiscalYear.ts` に配置。内部表現は **西暦 4 桁数値**（例: `2025`）として保持し、`toShortString()` で `"25"` を返す。2 桁数値で保持すると 100 年衝突時に世紀情報を失うため不採用。

### 2. TZ は JST 固定（VO 内で純関数化）
ドメイン層は外部依存禁止のため、`Date.getMonth()` 等のローカル TZ 依存メソッドは使わない。`date.getTime() + 9 * 60 * 60 * 1000` で UTC ミリ秒を JST 相当に正規化してから `getUTCMonth/getUTCFullYear` を使う。サーバ TZ や `process.env.TZ` 設定に影響されず、テストが決定的。

### 3. `EstimateType` を独立 VO として同時実装
Prisma の `EstimateType` enum（`NEW`/`REPAIR`/`AFTER_REPAIR`）と接頭辞（`N`/`R`/`A`）の対応はドメイン側で表現する必要がある（Domain 層は Prisma を import 不可）。`ProductCategory.ts` を規範として `private constructor` + `static readonly` パターンで列挙。
- **`from(value)`**: Prisma 値（永続化復元用）
- **`fromPrefix(prefix)`**: 採番形式の接頭辞用（`EstimateNumber.parse` から呼ぶ）
- **アクセサ**: `value` / `prefix` / `label`（"新規" / "修理" / "事後"、§1.1 業務用語）

### 4. `EstimateNumber` の公開ファクトリは `parse(text)` のみ
パーツからの生成（`issue` / `fromParts`）は本 Issue では持たない。連番払い出しはリポジトリ層の責務であり、ここに置くと採番カウンタの永続化との結合が漏れる。`parse` のみに絞ることで「保存済み採番値の検証・分解」という単一責務に閉じる。

### 5. 年度 2 桁→4 桁復元は `2000 + YY` 固定
Prisma `VarChar(8)` + 2 桁年度は構造的に 100 年（2000〜2099）が上限。現在日時依存のスライディングウィンドウは過去レコードの復元が時刻に依存しテストが脆くなるため不採用。固定マッピングを採用し **ADR は起票せず、コミットボディに判断理由を記録**する。

### 6. バリデーションは早期リターン（最初に検出した 1 原因のみエラー）
既存 VO（`CompanyCode` 等）の規範に合わせる。順序: **長さ → 全体パターン → 連番≧1**。

### 7. `ValueObject<T, U>` 基底クラスを直接継承
3 VO とも `src/server/shared/ValueObject.ts` のブランド型基底を直接継承する。`StringValueObject` は単純な「文字列＋正規表現」用途のため、構造分解（接頭辞・年度・連番）を持つ VO や数値表現の VO には適さない。`ProductCategory` / `Money` / `TaxRate` と同型。

## 参照する既存ファイル

- `src/server/shared/ValueObject.ts` — 基底クラス（継承）
- `src/server/shared/errors/DomainError.ts` — `ValidationError`（形式不正用、`InvalidArgumentError` ではない）
- `src/server/subdomains/product/domain/values/ProductCategory.ts` — enum 風 VO の規範（`EstimateType` で踏襲）
- `src/server/subdomains/estimate/domain/values/Money.ts` — 複雑系 VO の構造規範
- `docs/business/estimate/システム設計書(見積).md` §2 — 採番仕様
- `prisma/schema.prisma:422-446` — `EstimateType` enum と `estimate_number VARCHAR(8)`

## ステップ

依存関係: `FiscalYear` ← `EstimateNumber` → `EstimateType`。依存順に 3 コミットに分割（実装＋テストを 1 コミットにまとめる）。

### Step 1: `FiscalYear` 値オブジェクトを追加

- **対象ファイル**:
  - `src/server/shared/domain/values/FiscalYear.ts`（新規）
  - `src/server/shared/domain/values/__tests__/FiscalYear.test.ts`（新規）
- **作業内容**:
  - `ValueObject<number, "FiscalYear">` を継承、内部値は西暦 4 桁数値
  - `static from(date: Date): FiscalYear` — JST 正規化（UTC ms + 9h）後の月で 1-3 月なら `year - 1`、4-12 月なら `year`
  - `toShortString(): string` — 下 2 桁ゼロ詰め
  - `validate`: 整数チェック・範囲 1900〜2999
  - 公開定数 `FISCAL_START_MONTH = 4`
  - テスト: 正常系（境界値 3/31→4/1 を含む）／異常系（非整数・範囲外）／equals／`from` の JST 純関数性
- **コミットメッセージ**:
  ```
  feat: FiscalYear 値オブジェクトを追加する（§2）

  4月始まり年度を西暦4桁数値で保持する横断VOを shared/domain/values に追加。
  EstimateNumber の年度部および将来の年度横断機能（税率マスタ・締切管理等）で共有する。

  設計判断:
  - 内部表現: 西暦4桁数値（2025）。2桁数値は世紀情報を失うため不採用。
  - TZ: JST固定。UTCミリ秒 + 9hオフセット → getUTCMonth/Year で純関数化し
    実行環境TZ依存を排除（ドメイン層の外部依存禁止に従う）。
  - 配置: shared/domain/values。estimate以外でも年度を扱う可能性があるため。
  ```

### Step 2: `EstimateType` 値オブジェクトを追加

- **対象ファイル**:
  - `src/server/subdomains/estimate/domain/values/EstimateType.ts`（新規）
  - `src/server/subdomains/estimate/domain/values/__tests__/EstimateType.test.ts`（新規）
- **作業内容**:
  - `ValueObject<string, "EstimateType">` を継承、`ProductCategory.ts` を規範に `private constructor` + `static readonly NEW/REPAIR/AFTER_REPAIR`
  - `static from(value)`: Prisma 値（`"NEW"`等）→ インスタンス（switch-case）
  - `static fromPrefix(prefix)`: `"N"`/`"R"`/`"A"` → インスタンス
  - アクセサ: `value` / `prefix` / `label`（"新規" / "修理" / "事後"）
  - テスト: 各インスタンス生成／`from`／`fromPrefix`（大文字固定）／`prefix`・`label` アクセサ／equals／異常系
- **コミットメッセージ**:
  ```
  feat: EstimateType 値オブジェクトを追加する（§2）

  Prisma の EstimateType enum と採番接頭辞 N/R/A の対応をドメイン側で保持する。

  設計判断:
  - ProductCategory パターン踏襲（private constructor + static インスタンス）。
  - from(value) は Prisma 値、fromPrefix(prefix) は採番形式の接頭辞という
    2系統入口を提供。EstimateNumber.parse は fromPrefix を使うことで
    接頭辞→Prisma値マッピングをこのVO内に集約する。
  - label アクセサ（「新規」/「修理」/「事後」）は §1.1 業務用語をドメイン側に保持。
  ```

### Step 3: `EstimateNumber` 値オブジェクトを追加

- **対象ファイル**:
  - `src/server/subdomains/estimate/domain/values/EstimateNumber.ts`（新規）
  - `src/server/subdomains/estimate/domain/values/__tests__/EstimateNumber.test.ts`（新規）
- **作業内容**:
  - `ValueObject<string, "EstimateNumber">` を直接継承、`private constructor`
  - `static parse(text: string): EstimateNumber` — 唯一の公開ファクトリ
  - 正規表現 `/^[NRA]\d{7}$/` でパターン検証
  - バリデーション順序: 長さ8 → パターン → 連番≧1（`00000` 拒否）
  - アクセサ: `value` / `prefix` / `estimateType`（`EstimateType.fromPrefix`）/ `fiscalYear`（`new FiscalYear(2000 + YY)`）/ `sequence`（先頭ゼロ除去後の整数）
  - テスト: 正常系（`N2500001`/`R2500123`/`A2510500`、連番境界 1/99999、年度境界 00/99）／長さ違い／不正接頭辞（`X`、小文字 `n`）／連番00000／年度非数字／空白混入／全アクセサ／equals
- **コミットメッセージ**:
  ```
  feat: EstimateNumber 値オブジェクトを追加する（§2）

  採番済み見積番号（接頭辞1+年度2+連番5=計8文字）をパースして
  構造化された値オブジェクトに変換する。FiscalYear/EstimateType と協調。

  設計判断:
  - 公開ファクトリは parse(text) のみ。連番（sequence）払い出しはリポジトリ層の
    別ポリシー責務として本VOには持たせない（採番カウンタの永続化と原子性が必要）。
  - 年度2桁→4桁復元は 2000+YY 固定。VarChar(8) + 2桁年度は元来 100年制限の
    ある仕様であり、現在日時依存のスライディング解決は予測不能性のため不採用。
  - バリデーション順序: 長さ→パターン→連番≧1。「最初に検出した1原因のみ通知」
    で既存VO（CompanyCode等）の規範に合わせる。
  ```

## 移動・後処理

Plan mode 終了後、本ファイルを `docs/claude-plans/issue-282/plan.md` へ移動し、`.claude/settings.local.json` の `plansDirectory` を `docs/claude-plans/issue-282` に更新する（PreToolUse hook のリマインド）。

## Verification

各ステップ完了時:

```bash
pnpm lint
pnpm vitest run src/server/shared/domain/values/__tests__/FiscalYear.test.ts          # Step 1
pnpm vitest run src/server/subdomains/estimate/domain/values/__tests__/EstimateType.test.ts   # Step 2
pnpm vitest run src/server/subdomains/estimate/domain/values/__tests__/EstimateNumber.test.ts # Step 3
```

全ステップ完了後:

```bash
pnpm lint
pnpm test                      # 既存テストへの影響がないこと（ドメイン純粋追加のため影響しない想定）
pnpm exec tsc --noEmit         # 型エラーがないこと
```

## 受け入れ条件チェック（Issue 本文）

- [x] §2 で定義された採番形式に準拠して値オブジェクトが生成・検証できる → Step 3
- [x] 年度算出ロジックが §2 の仕様通りに動作する → Step 1（境界値 3/31・4/1 をテストで担保）
- [x] Domain 層のレイヤリングルール（外部依存禁止）を遵守 → Prisma/Next.js を import しない・JST は純関数で表現
- [x] 単体テストが追加され、グリーン → 各 Step で並行追加

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

なお、計画ファイル末尾の「移動・後処理」（plan ファイルを `plan.md` にリネームし `plansDirectory` を `docs/claude-plans/issue-282` に更新）は `plansDirectory` を `docs/claude-plans` のまま運用しているため未実施。計画書ファイル名はそのまま保持しています。

## Test Plan

- [x] `FiscalYear` 単体テスト: 正常系（年度境界 3/31→4/1）／異常系（非整数・範囲外）／equals／`from` の JST 純関数性
- [x] `EstimateType` 単体テスト: 各インスタンス生成／`from`／`fromPrefix`／`prefix`・`label` アクセサ／equals／異常系
- [x] `EstimateNumber` 単体テスト: 正常系（`N2500001`/`R2500123`/`A2510500`、連番境界 1/99999、年度境界 00/99）／長さ違い／不正接頭辞／連番00000／年度非数字／空白混入／全アクセサ／equals
- [x] `pnpm lint` グリーン
- [x] `pnpm exec tsc --noEmit` 型エラーなし

---

Generated with [Claude Code](https://claude.ai/code)