### PR TITLE
feat: 税率チェック(§8.7)横断ポリシーとTaxRateマスタのドメイン実装

### DIFF
--- a/docs/claude-plans/issue-299/plan.md
+++ b/docs/claude-plans/issue-299/plan.md
@@ -1,0 +1,61 @@
+# 実装計画 — #299 税率チェック(§8.7)横断ポリシーと TaxRate マスタのドメイン実装
+
+> 本計画は #299 のグリルセッションで詰めた設計判断（PRD 本文に反映済み）を、TDD 実装手順に落としたもの。
+> PRD: https://github.com/chapplehub/estimate-management-system/issues/299
+
+## 前提・作業方針
+
+- 作業ブランチ: `feat/issue-299`（worktree なし、現ブランチで直接作業）
+- 進め方: TDD 垂直スライス（1テスト → 1実装の往復）。**横断スライス（全テスト先書き）禁止**。
+- ビルド順: 既存規約「VO → エンティティ → リポジトリ → サービス」のボトムアップ。
+
+## 確定済み設計判断（グリルより）
+
+1. **Policy ではなく DomainService**。リポジトリ依存が不可避（ADR-0023 の Policy 定義に反する）→ `domain/services/`、ADR-0011 の事実確認型（結果を返す）。
+2. **配置は estimate サブドメイン配下**（既存 `TaxRate` VO と同居。横断昇格は受注着手時に再判断）。
+3. **エンティティ名 `TaxRateMaster`**（設計書「消費税率マスタ」語彙）。フィールド: `id: TaxRateMasterId`、`rate: TaxRate`(既存VO)、`effectiveFrom: Date`(plain)。
+4. **`reconstruct()` のみ**。`create()`/UUIDv7 採番は管理画面イシュー（スコープ外）。`TaxRateMasterId` も `generate()` を付けない（UUIDv7 形式バリデーションのみ継承）。
+5. **`TaxRateRepository.findEffectiveAt(date): Promise<TaxRateMaster | null>`**。Prisma 実装は `effectiveFrom <= date ORDER BY effective_from DESC LIMIT 1`（境界 lte=等値を含む）。
+6. **null の責務分離**: リポジトリは `null` 返し、DomainService が `null → BusinessRuleViolationError` throw（想定外パニック）。
+7. **`TaxRateConsistencyCheckDomainService.check({estimateDate, deadline})`**。`TaxRate.equals` で比較。
+8. **戻り値は判別可能ユニオン**:
+   ```ts
+   type TaxRateCheckResult =
+     | { kind: "consistent"; rate: TaxRate }
+     | { kind: "mismatch"; estimateDateRate: TaxRate; deadlineRate: TaxRate }
+   ```
+   null はユニオンに含めず throw。
+
+## TDD サイクル
+
+| # | seam | 振る舞い | 種別 |
+|---|---|---|---|
+| 1 | `TaxRateMaster`(+`TaxRateMasterId`) | reconstruct した値が getter で取れる（`rate` は TaxRate VO） | 単体 |
+| 2 | `PrismaTaxRateRepository.findEffectiveAt` | 最新行より後の日付 → 最新税率(0.100)（tracer: IF+impl+mapper 誕生） | 実DB結合 |
+| 3 | 〃 | `effectiveFrom` と同日(2014-04-01) → 0.080（lte は等値を含む） | 実DB結合 |
+| 4 | 〃 | 2行の中間日(2018) → 前の行 0.080 | 実DB結合 |
+| 5 | 〃 | 最古行より前(2013) → `null` | 実DB結合 |
+| 6 | `TaxRateConsistencyCheckDomainService` | 両日付が同一税率期間 → `{kind:"consistent", rate:0.100}`（tracer: service+結果型 誕生） | 実DB結合 |
+| 7 | 〃 | 2019-10-01 をまたぐ → `{kind:"mismatch", estimateDateRate:0.080, deadlineRate:0.100}` | 実DB結合 |
+| 8 | 〃 | 適用税率なし(2013) → `BusinessRuleViolationError` throw | 実DB結合 |
+
+最後に refactor パス（重複抽出・モジュール深化）。
+
+## テスト方針
+
+- 既存 seam のみ使用。新規 seam ゼロ。最高位 seam で検証。
+- **マッパーはリポジトリ結合テスト(#2-5)で担保**（独立単体テストは作らない＝最高位 seam 原則）。
+- テストデータは**シード史実2行**（2014-04-01→0.080, 2019-10-01→0.100）を使用、新規 INSERT しない。
+  - 一致: 両日付 ≥ 2019-10-01 / 不一致: 2019-10-01 をまたぐ / null: < 2014-04-01
+  - テスト先頭にシード前提コメント（将来のトリップワイヤ）。
+- 実DB結合テストの prior art: `PrismaEstimateNumberIssuer.test.ts`、`CustomerCodeDuplicationCheckDomainService.test.ts`。
+
+## スコープ外
+
+§A.1 税率自動設定 / 受注時チェック(3日付) / #294 への組み込み / 税率マスタ管理画面・CRUD（→ `create()`/`generate()` も対象外）/ 設定税率不正チェック / shared 昇格。
+
+## 受け入れ条件
+
+- エンティティ・IF・Prisma実装・マッパー・DomainService・各テストが `pnpm test` / `pnpm lint` 通過
+- DDD レイヤリング遵守（domain は Prisma 非依存、application は IF 経由）
+- 日付→有効税率の解決が effectiveFrom 単調タイムラインのパターンで実装

--- a/src/server/subdomains/estimate/domain/entities/TaxRateMaster.ts
+++ b/src/server/subdomains/estimate/domain/entities/TaxRateMaster.ts
@@ -1,0 +1,38 @@
+import type { TaxRate } from "../values/TaxRate";
+import type { TaxRateMasterId } from "../values/TaxRateMasterId";
+
+/**
+ * 消費税率マスタ（設計書 §11.5「消費税率マスタ」）。
+ *
+ * タイムラインの単調性（制度上ギャップなし）を利用し、各行は「この日時から税率は X」
+ * というイベントを表す。前期間の終わり = 次の行の effectiveFrom（暗黙）。
+ *
+ * 税率の "値" は値オブジェクト TaxRate が担い、本エンティティは「ある日時から有効な
+ * 税率行」というマスタの1行を表す（名前衝突を避けるため Master を付す）。
+ *
+ * 本イシューではマスタは読み取り専用。新規作成（create / UUIDv7 採番）は書き込み経路
+ * （管理画面・CRUD）のスコープであり未実装のため、永続化からの復元 reconstruct のみ提供する。
+ */
+export class TaxRateMaster {
+  private constructor(
+    private readonly _id: TaxRateMasterId,
+    private readonly _rate: TaxRate,
+    private readonly _effectiveFrom: Date
+  ) {}
+
+  static reconstruct(id: TaxRateMasterId, rate: TaxRate, effectiveFrom: Date): TaxRateMaster {
+    return new TaxRateMaster(id, rate, effectiveFrom);
+  }
+
+  get id(): TaxRateMasterId {
+    return this._id;
+  }
+
+  get rate(): TaxRate {
+    return this._rate;
+  }
+
+  get effectiveFrom(): Date {
+    return this._effectiveFrom;
+  }
+}

--- a/src/server/subdomains/estimate/domain/entities/__tests__/TaxRateMaster.test.ts
+++ b/src/server/subdomains/estimate/domain/entities/__tests__/TaxRateMaster.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { TaxRate } from "../../values/TaxRate";
+import { TaxRateMasterId } from "../../values/TaxRateMasterId";
+import { TaxRateMaster } from "../TaxRateMaster";
+
+describe("TaxRateMaster Entity", () => {
+  it("reconstruct で復元した値を getter で取得できる", () => {
+    const id = new TaxRateMasterId("0190b6d2-7f3a-7c8e-8b4f-1a2b3c4d5e6f");
+    const rate = new TaxRate(0.1);
+    const effectiveFrom = new Date("2019-10-01T00:00:00+09:00");
+
+    const master = TaxRateMaster.reconstruct(id, rate, effectiveFrom);
+
+    expect(master.id.value).toBe("0190b6d2-7f3a-7c8e-8b4f-1a2b3c4d5e6f");
+    expect(master.rate.equals(rate)).toBe(true);
+    expect(master.effectiveFrom).toEqual(effectiveFrom);
+  });
+});

--- a/src/server/subdomains/estimate/domain/repositories/TaxRateRepository.ts
+++ b/src/server/subdomains/estimate/domain/repositories/TaxRateRepository.ts
@@ -1,0 +1,22 @@
+import { TaxRateMaster } from "@subdomains/estimate/domain/entities/TaxRateMaster";
+
+/**
+ * 消費税率マスタのリポジトリポート（設計書 §11.5 / §8.7）。
+ *
+ * 税率タイムラインは制度上単調（ギャップなし）であることを利用し、適用税率は
+ * 「effectiveFrom <= 対象日時 の中で effectiveFrom が最大の行」で一意に決まる
+ * （schema コメントの設計に準拠）。この「ある日時の有効税率を引く」解決は
+ * 永続化バックエンド依存の操作であり、本ポートがドメイン契約として表現する。
+ *
+ * ドメイン層は本インターフェースのみに依存し、具体実装（ORDER BY ... LIMIT 1）は
+ * infrastructure 層が提供する（依存方向: infrastructure → domain）。
+ */
+export interface TaxRateRepository {
+  /**
+   * 指定日時に適用される消費税率マスタ行を返す。
+   *
+   * @param date 適用税率を求める対象日時
+   * @returns 適用税率行。対象日時が最古行より前で該当が無い場合は null
+   */
+  findEffectiveAt(date: Date): Promise<TaxRateMaster | null>;
+}

--- a/src/server/subdomains/estimate/domain/services/TaxRateConsistencyCheckDomainService.ts
+++ b/src/server/subdomains/estimate/domain/services/TaxRateConsistencyCheckDomainService.ts
@@ -1,0 +1,62 @@
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { TaxRateMaster } from "@subdomains/estimate/domain/entities/TaxRateMaster";
+import { TaxRateRepository } from "@subdomains/estimate/domain/repositories/TaxRateRepository";
+import { TaxRate } from "@subdomains/estimate/domain/values/TaxRate";
+
+/**
+ * 税率チェックの入力（設計書 §8.7 見積パターン）。
+ * 見積年月日・締切日はともに Date で同型のため、取り違え防止にオブジェクト引数とする。
+ */
+export type TaxRateConsistencyCheckInput = {
+  /** 見積年月日 */
+  estimateDate: Date;
+  /** 締切日 */
+  deadline: Date;
+};
+
+/**
+ * 税率チェックの結果（設計書 §8.7 見積パターン）。
+ * 一致時は確定した単一税率を、不一致時は両日付の税率を返す。
+ * 「適用税率が見つからない」想定外ケースはユニオンに含めず throw する。
+ */
+export type TaxRateCheckResult =
+  | { kind: "consistent"; rate: TaxRate }
+  | { kind: "mismatch"; estimateDateRate: TaxRate; deadlineRate: TaxRate };
+
+/**
+ * 税率チェック横断ドメインサービス（設計書 §8.7 見積パターン）。
+ *
+ * 見積年月日の税率と締切日の税率が一致するか検証する。チェック結果は返す
+ * （事実確認型 / ADR-0011）。不一致をエラーとするかは文脈依存（保存・申請=その場で
+ * 編集可能 / 受注=新バリエーション作成必須）のため、エラー化は呼び出し側の責務とする。
+ */
+export class TaxRateConsistencyCheckDomainService {
+  constructor(private readonly taxRateRepository: TaxRateRepository) {}
+
+  async check(input: TaxRateConsistencyCheckInput): Promise<TaxRateCheckResult> {
+    const estimateDateRate = await this.resolveRate(input.estimateDate);
+    const deadlineRate = await this.resolveRate(input.deadline);
+
+    if (estimateDateRate.rate.equals(deadlineRate.rate)) {
+      return { kind: "consistent", rate: estimateDateRate.rate };
+    }
+
+    return {
+      kind: "mismatch",
+      estimateDateRate: estimateDateRate.rate,
+      deadlineRate: deadlineRate.rate,
+    };
+  }
+
+  /**
+   * 対象日時の適用税率を解決する。該当が無い（マスタ最古行より前）のは想定外状態のため、
+   * null をドメイン的意味（BusinessRuleViolationError）に翻訳して即 throw する。
+   */
+  private async resolveRate(date: Date): Promise<TaxRateMaster> {
+    const taxRate = await this.taxRateRepository.findEffectiveAt(date);
+    if (taxRate === null) {
+      throw new BusinessRuleViolationError("指定された日付に適用される消費税率が見つかりません");
+    }
+    return taxRate;
+  }
+}

--- a/src/server/subdomains/estimate/domain/services/__tests__/TaxRateConsistencyCheckDomainService.test.ts
+++ b/src/server/subdomains/estimate/domain/services/__tests__/TaxRateConsistencyCheckDomainService.test.ts
@@ -1,0 +1,48 @@
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { PrismaTaxRateRepository } from "@subdomains/estimate/infrastructure/prisma/PrismaTaxRateRepository";
+import { describe, expect, it } from "vitest";
+import { TaxRateConsistencyCheckDomainService } from "../TaxRateConsistencyCheckDomainService";
+
+/**
+ * 本テストはシードの消費税率マスタ（史実2行）を前提とする:
+ *   2014-04-01 00:00 JST → 0.080 (8%)
+ *   2019-10-01 00:00 JST → 0.100 (10%)
+ * 実リポジトリ + 実DB（既存 DomainService テストの流儀）で検証する。
+ */
+describe("TaxRateConsistencyCheckDomainService", () => {
+  const service = new TaxRateConsistencyCheckDomainService(new PrismaTaxRateRepository());
+
+  it("見積年月日と締切日が同一税率期間にあるとき consistent と税率を返す", async () => {
+    const result = await service.check({
+      estimateDate: new Date("2020-01-01T00:00:00+09:00"),
+      deadline: new Date("2020-02-01T00:00:00+09:00"),
+    });
+
+    expect(result.kind).toBe("consistent");
+    if (result.kind === "consistent") {
+      expect(result.rate.value).toBe(0.1);
+    }
+  });
+
+  it("見積年月日と締切日が税率変更(2019-10-01)をまたぐとき mismatch と両税率を返す", async () => {
+    const result = await service.check({
+      estimateDate: new Date("2018-01-01T00:00:00+09:00"),
+      deadline: new Date("2020-01-01T00:00:00+09:00"),
+    });
+
+    expect(result.kind).toBe("mismatch");
+    if (result.kind === "mismatch") {
+      expect(result.estimateDateRate.value).toBe(0.08);
+      expect(result.deadlineRate.value).toBe(0.1);
+    }
+  });
+
+  it("いずれかの日付に適用税率が存在しないとき BusinessRuleViolationError を投げる", async () => {
+    await expect(
+      service.check({
+        estimateDate: new Date("2013-01-01T00:00:00+09:00"),
+        deadline: new Date("2020-01-01T00:00:00+09:00"),
+      })
+    ).rejects.toThrow(BusinessRuleViolationError);
+  });
+});

--- a/src/server/subdomains/estimate/domain/values/TaxRateMasterId.ts
+++ b/src/server/subdomains/estimate/domain/values/TaxRateMasterId.ts
@@ -1,0 +1,10 @@
+import { EntityId } from "@server/shared/domain/values/EntityId";
+
+/**
+ * 消費税率マスタID値オブジェクト
+ *
+ * UUIDv7 形式のバリデーションのみ継承する。新規採番（generate）は本イシューの
+ * スコープ外（マスタの書き込み経路 = 管理画面・CRUD は未着手）のため定義しない。
+ * 書き込み経路を実装する際に generate() を追加する。
+ */
+export class TaxRateMasterId extends EntityId<"TaxRateMasterId"> {}

--- a/src/server/subdomains/estimate/infrastructure/mappers/TaxRateMasterMapper.ts
+++ b/src/server/subdomains/estimate/infrastructure/mappers/TaxRateMasterMapper.ts
@@ -1,0 +1,21 @@
+import type { TaxRate as PrismaTaxRateRow } from "@generated/prisma/client";
+import { TaxRateMaster } from "@subdomains/estimate/domain/entities/TaxRateMaster";
+import { TaxRate } from "@subdomains/estimate/domain/values/TaxRate";
+import { TaxRateMasterId } from "@subdomains/estimate/domain/values/TaxRateMasterId";
+
+/**
+ * 消費税率マスタの Prisma レコード → ドメインエンティティ変換。
+ *
+ * rate は Decimal で取得されるため Number 経由で TaxRate VO に変換する
+ * （EstimateMapper の taxRate 復元と同型）。本イシューは読み取り専用のため
+ * toDomain のみ提供する。
+ */
+export class TaxRateMasterMapper {
+  static toDomain(row: PrismaTaxRateRow): TaxRateMaster {
+    return TaxRateMaster.reconstruct(
+      new TaxRateMasterId(row.id),
+      new TaxRate(Number(row.rate)),
+      row.effectiveFrom
+    );
+  }
+}

--- a/src/server/subdomains/estimate/infrastructure/prisma/PrismaTaxRateRepository.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/PrismaTaxRateRepository.ts
@@ -1,0 +1,23 @@
+import prisma from "@server/prisma";
+import { TaxRateMaster } from "@subdomains/estimate/domain/entities/TaxRateMaster";
+import { TaxRateRepository } from "@subdomains/estimate/domain/repositories/TaxRateRepository";
+import { TaxRateMasterMapper } from "@subdomains/estimate/infrastructure/mappers/TaxRateMasterMapper";
+
+/**
+ * TaxRateRepository の Prisma 実装（設計書 §11.5 / §8.7）。
+ *
+ * 適用税率の解決は「effectiveFrom <= 対象日時 の中で effectiveFrom が最大の1行」。
+ * 税率タイムラインの単調性（ギャップなし）を前提とし、ORDER BY effective_from DESC
+ * LIMIT 1 で取得する。
+ */
+export class PrismaTaxRateRepository implements TaxRateRepository {
+  async findEffectiveAt(date: Date): Promise<TaxRateMaster | null> {
+    const row = await prisma.taxRate.findFirst({
+      where: { effectiveFrom: { lte: date } },
+      orderBy: { effectiveFrom: "desc" },
+    });
+
+    // 対象日時が最古行より前で該当が無い場合は null を返す（ドメイン的意味づけは呼び出し側の責務）。
+    return row === null ? null : TaxRateMasterMapper.toDomain(row);
+  }
+}

--- a/src/server/subdomains/estimate/infrastructure/prisma/__tests__/PrismaTaxRateRepository.test.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/__tests__/PrismaTaxRateRepository.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { PrismaTaxRateRepository } from "../PrismaTaxRateRepository";
+
+/**
+ * 本テストはシードの消費税率マスタ（史実2行）を前提とする:
+ *   2014-04-01 00:00 JST → 0.080 (8%)
+ *   2019-10-01 00:00 JST → 0.100 (10%)
+ * これは日本の消費税の史実であり任意のフィクスチャではないため、
+ * テスト内で行を INSERT せず（単調タイムライン不変条件を歪めないため）シードをそのまま使う。
+ * シードを変更する場合は本テストの期待値も見直すこと。
+ */
+describe("PrismaTaxRateRepository.findEffectiveAt", () => {
+  const repository = new PrismaTaxRateRepository();
+
+  it("最新行の effectiveFrom より後の日時は最新税率(0.100)を返す", async () => {
+    const result = await repository.findEffectiveAt(new Date("2020-01-01T00:00:00+09:00"));
+
+    expect(result).not.toBeNull();
+    expect(result?.rate.value).toBe(0.1);
+  });
+
+  it("effectiveFrom と同日時は その行の税率(0.080)を返す（境界は等値を含む）", async () => {
+    const result = await repository.findEffectiveAt(new Date("2014-04-01T00:00:00+09:00"));
+
+    expect(result).not.toBeNull();
+    expect(result?.rate.value).toBe(0.08);
+  });
+
+  it("2行の中間日時は 前の行の税率(0.080)を返す", async () => {
+    const result = await repository.findEffectiveAt(new Date("2018-01-01T00:00:00+09:00"));
+
+    expect(result).not.toBeNull();
+    expect(result?.rate.value).toBe(0.08);
+  });
+
+  it("最古行の effectiveFrom より前の日時は null を返す", async () => {
+    const result = await repository.findEffectiveAt(new Date("2013-01-01T00:00:00+09:00"));
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

消費税率マスタ（`TaxRateMaster`）のドメイン実装と、見積年月日・締切日の税率整合性を検証する横断ドメインサービス（`TaxRateConsistencyCheckDomainService`）を実装。設計書 §8.7 の税率チェックの土台を提供し、後続 #294（C2 不変条件）が利用できるようにする。サービスは結果を判別可能ユニオンで返し、エラー化は呼び出し側に委ねる（ADR-0011 事実確認型）。

Closes #299

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### plan.md

# 実装計画 — #299 税率チェック(§8.7)横断ポリシーと TaxRate マスタのドメイン実装

> 本計画は #299 のグリルセッションで詰めた設計判断（PRD 本文に反映済み）を、TDD 実装手順に落としたもの。
> PRD: https://github.com/chapplehub/estimate-management-system/issues/299

## 前提・作業方針

- 作業ブランチ: `feat/issue-299`（worktree なし、現ブランチで直接作業）
- 進め方: TDD 垂直スライス（1テスト → 1実装の往復）。**横断スライス（全テスト先書き）禁止**。
- ビルド順: 既存規約「VO → エンティティ → リポジトリ → サービス」のボトムアップ。

## 確定済み設計判断（グリルより）

1. **Policy ではなく DomainService**。リポジトリ依存が不可避（ADR-0023 の Policy 定義に反する）→ `domain/services/`、ADR-0011 の事実確認型（結果を返す）。
2. **配置は estimate サブドメイン配下**（既存 `TaxRate` VO と同居。横断昇格は受注着手時に再判断）。
3. **エンティティ名 `TaxRateMaster`**（設計書「消費税率マスタ」語彙）。フィールド: `id: TaxRateMasterId`、`rate: TaxRate`(既存VO)、`effectiveFrom: Date`(plain)。
4. **`reconstruct()` のみ**。`create()`/UUIDv7 採番は管理画面イシュー（スコープ外）。`TaxRateMasterId` も `generate()` を付けない（UUIDv7 形式バリデーションのみ継承）。
5. **`TaxRateRepository.findEffectiveAt(date): Promise<TaxRateMaster | null>`**。Prisma 実装は `effectiveFrom <= date ORDER BY effective_from DESC LIMIT 1`（境界 lte=等値を含む）。
6. **null の責務分離**: リポジトリは `null` 返し、DomainService が `null → BusinessRuleViolationError` throw（想定外パニック）。
7. **`TaxRateConsistencyCheckDomainService.check({estimateDate, deadline})`**。`TaxRate.equals` で比較。
8. **戻り値は判別可能ユニオン**:
   ```ts
   type TaxRateCheckResult =
     | { kind: "consistent"; rate: TaxRate }
     | { kind: "mismatch"; estimateDateRate: TaxRate; deadlineRate: TaxRate }
   ```
   null はユニオンに含めず throw。

## TDD サイクル

| # | seam | 振る舞い | 種別 |
|---|---|---|---|
| 1 | `TaxRateMaster`(+`TaxRateMasterId`) | reconstruct した値が getter で取れる（`rate` は TaxRate VO） | 単体 |
| 2 | `PrismaTaxRateRepository.findEffectiveAt` | 最新行より後の日付 → 最新税率(0.100)（tracer: IF+impl+mapper 誕生） | 実DB結合 |
| 3 | 〃 | `effectiveFrom` と同日(2014-04-01) → 0.080（lte は等値を含む） | 実DB結合 |
| 4 | 〃 | 2行の中間日(2018) → 前の行 0.080 | 実DB結合 |
| 5 | 〃 | 最古行より前(2013) → `null` | 実DB結合 |
| 6 | `TaxRateConsistencyCheckDomainService` | 両日付が同一税率期間 → `{kind:"consistent", rate:0.100}`（tracer: service+結果型 誕生） | 実DB結合 |
| 7 | 〃 | 2019-10-01 をまたぐ → `{kind:"mismatch", estimateDateRate:0.080, deadlineRate:0.100}` | 実DB結合 |
| 8 | 〃 | 適用税率なし(2013) → `BusinessRuleViolationError` throw | 実DB結合 |

最後に refactor パス（重複抽出・モジュール深化）。

## テスト方針

- 既存 seam のみ使用。新規 seam ゼロ。最高位 seam で検証。
- **マッパーはリポジトリ結合テスト(#2-5)で担保**（独立単体テストは作らない＝最高位 seam 原則）。
- テストデータは**シード史実2行**（2014-04-01→0.080, 2019-10-01→0.100）を使用、新規 INSERT しない。
  - 一致: 両日付 ≥ 2019-10-01 / 不一致: 2019-10-01 をまたぐ / null: < 2014-04-01
  - テスト先頭にシード前提コメント（将来のトリップワイヤ）。
- 実DB結合テストの prior art: `PrismaEstimateNumberIssuer.test.ts`、`CustomerCodeDuplicationCheckDomainService.test.ts`。

## スコープ外

§A.1 税率自動設定 / 受注時チェック(3日付) / #294 への組み込み / 税率マスタ管理画面・CRUD（→ `create()`/`generate()` も対象外）/ 設定税率不正チェック / shared 昇格。

## 受け入れ条件

- エンティティ・IF・Prisma実装・マッパー・DomainService・各テストが `pnpm test` / `pnpm lint` 通過
- DDD レイヤリング遵守（domain は Prisma 非依存、application は IF 経由）
- 日付→有効税率の解決が effectiveFrom 単調タイムラインのパターンで実装

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

実装はすべて TDD（1テスト → 1実装）で進めており、各レイヤを最高位 seam で検証している。

- [ ] `TaxRateMaster.test.ts` — `reconstruct()` のフィールド復元と `rate` が `TaxRate` VO であることの単体テスト
- [ ] `PrismaTaxRateRepository.test.ts` — `findEffectiveAt` の境界挙動を実DBで担保（最新行より後 / `effectiveFrom` 同日(lte) / 2行の中間日 / 最古行より前→null）
- [ ] `TaxRateConsistencyCheckDomainService.test.ts` — 一致(`consistent`) / 不一致(`mismatch`) / 適用税率なし→`BusinessRuleViolationError` throw を実DBで検証
- [ ] テストデータはシード史実2行（2014-04-01→0.080, 2019-10-01→0.100）を使用、新規 INSERT しない
- [ ] `pnpm test` / `pnpm lint` がパス
- [ ] DDD レイヤリング遵守（domain は Prisma 非依存、application/domain は IF 経由）

---

Generated with [Claude Code](https://claude.ai/code)
