### PR TITLE
feat: 楽観ロックを department サブドメインへ適用する（ADR-0039 横断展開）

### DIFF
--- a/docs/claude-plans/issue-305/apply-optimistic-locking-to-department.md
+++ b/docs/claude-plans/issue-305/apply-optimistic-locking-to-department.md
@@ -1,0 +1,56 @@
+# Issue #305: 楽観ロックを department サブドメインへ適用する（ADR-0039 横断展開）
+
+## Context
+
+ADR-0039 で楽観ロック（optimistic concurrency control）の横断方針が決定済み。`department` テーブルへの `version Int @default(1)` 列は #301 の7テーブル一括マイグレーションで追加済み（列は使われるまで不活性）。本イシューは department の `UpdateDepartmentCommand` 経路へ段階展開する。
+
+問題: 現状の更新は「findById → メモリ上で変更 → `save`(upsert)」型で、保存時の競合チェックが無い。2人が同じ部署の編集画面を開いて順に保存すると、後勝ちで片方の変更が静かに消える（lost update）。
+
+方式（ADR-0039）: 編集画面表示時の `version` をフォーム hidden input で往復させ、リポジトリを `insert` / `update(aggregate, expectedVersion)` に分割。`updateMany({ where: { id, version }, data: { ..., version: { increment: 1 } } })` の条件付き UPDATE で「比較→更新」を DB 上で原子化し、`count === 0` を `ConflictError` として throw する。
+
+**唯一の移行済みリファレンス**: `PrismaEstimateRepository`（estimate 縦切り、#301/#310）。department は子集約を持たない単一テーブル版として同じパターンを写し取る。`role` 等のマスタ系は未移行（`save` のまま）。
+
+なお estimate は presentation 層（Server Action / フォーム）が未実装のため、`ConflictError` をユーザー向け文言に表面化する `handleCommandError` の分岐は #310 では未到達だった。UI を持つ department が初めてこのピースを埋める。
+
+## 実装ステップ（1 ステップ = 1 コミット）
+
+### Step 1: ドメイン層リポジトリインターフェースの `save` を `insert`/`update` に分割
+- `src/server/subdomains/department/domain/repositories/DepartmentRepository.ts`
+  - `save(department)` を削除し、`insert(department)` / `update(department, expectedVersion)` に分割
+  - `update` の JSDoc に expectedVersion の意味（編集画面表示時のトークン、不一致で ConflictError）を記載
+  - `delete` / `findById` / `findByDepartmentCd` / `findChildren` / `findRootDepartments` は不変
+
+### Step 2: Prisma リポジトリ実装の insert/update 分割＋条件付き UPDATE
+- `src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts`
+  - `insert`: `prisma.department.create(...)`
+  - `update`: 条件付き `updateMany({ where: { id, version: expectedVersion }, data: { ...toPrismaUpdate, version: { increment: 1 } } })`、`count === 0` で `ConflictError`（ADR-0039 細目5 の文言）、保存後を `findUnique` で読み直して返却
+  - `ConflictError` を `@server/shared/errors/ApplicationError` から import
+
+### Step 3: クエリ側 DTO に version を追加
+- `DepartmentDTO.ts`: `version: number`
+- `PrismaDepartmentQueryService.ts`: `getSelectFields()` に `version: true`、`toDTO` の引数型・返り値に `version`
+
+### Step 4: コマンド層の expectedVersion 素通し
+- `UpdateDepartmentCommand.ts`: `UpdateDepartmentInput` に `version: number`、末尾を `update(department, input.version)` に
+- `CreateDepartmentCommand.ts`: `save(...)` → `insert(...)`
+
+### Step 5: プレゼンテーション層（フォーム往復・Zod・競合メッセージ）
+- `[departmentCd]/schema.ts`: `version: z.coerce.number()` 追加
+- `[departmentCd]/DepartmentUpdateForm.tsx`: prop 型・defaultValue に version、hidden input 追加
+- `[departmentCd]/actions.ts`: `submission.value` から version 分解しコマンドへ
+- `_shared/error-handler.ts`: `handleCommandError` に `ConflictError → error.message` 分岐を追加（横断ポリシー ADR-0039 細目4/5）
+
+### Step 6: テスト
+- 既存 `UpdateDepartmentCommand.test.ts`: 全 `execute` に `version: 1` 補完、stale version → ConflictError の素通し検証を1件追加
+- 既存 `DepartmentCdDuplicationCheckDomainService.test.ts`: `repository.save` → `repository.insert`
+- 新規 `PrismaDepartmentRepository.test.ts`: insert→findById ラウンドトリップ、楽観ロック（update 連鎖）、stale トークン逐次再現（lost update なし）
+
+## 検証
+- `pnpm lint` / `pnpm test`（vitest は実 DB 統合）
+- `save` 廃止で expectedVersion 未渡しがコンパイルエラーになること
+
+## 受け入れ条件との対応
+- version 不一致で ConflictError・後勝ち喪失なし → Step 2 + Step 6
+- `save` 廃止・未渡しがコンパイルエラー → Step 1/2/4
+- 編集ウィンドウのフォーム往復保護 → Step 5
+- lost update 防止テストの存在 → Step 6

--- a/docs/claude-plans/issue-305/deviations.md
+++ b/docs/claude-plans/issue-305/deviations.md
@@ -1,0 +1,43 @@
+# Issue #305 実装の逸脱記録
+
+## 逸脱1: 計画の Step1〜5 を1コミットへ統合した
+
+### 元の計画
+「1 ステップ = 1 コミット」で、Step1（ドメイン IF 分割）〜Step5（プレゼン層）を
+それぞれ独立したコミットにする。
+
+### 実際の実装
+Step1〜5＋既存テストの version 整合を**1コミット**（`feat: 楽観ロックを department
+サブドメインへ適用する`）に統合した。テストの新規追加のみ別コミットに分けた。
+
+### 逸脱の理由
+pre-commit フックがプロジェクト全体の `tsc --noEmit` を実行するため、`save` を廃止する
+破壊的なインターフェース変更は「IF・Prisma 実装・両コマンド・Server Action・Zod
+スキーマ・既存テスト」が揃って初めてコンパイルが通る。途中段階では必ず型エラーになり、
+個別コミットできない。
+
+具体的には `actions.ts` が `submission.value.version` を読む以上、`updateDepartmentSchema`
+への version 追加と `UpdateDepartmentInput` への version 追加が同一コミットに引き込まれ、
+さらに `save` を参照する既存テストの修正も同時に必要になる。これは ADR-0039 が意図した
+「expectedVersion を渡さないコードを型で検出する（細目3=A）」の裏返しの帰結であり、
+分割不能な原子的単位である。
+
+## 逸脱2: `_shared/error-handler.ts` への ConflictError 分岐追加（タスクリスト外）
+
+### 元の計画（イシューのタスクリスト）
+ドメイン IF / Prisma 実装 / コマンド Input / クエリ DTO / 編集フォーム＋Zod / テスト。
+
+### 実際の実装
+上記に加え、`handleCommandError` に `ConflictError → error.message` の分岐を追加した。
+
+### 逸脱の理由
+ADR-0039 細目5 は競合時のユーザー向け文言を品質要件として定めるが、現状の
+`handleCommandError` には ConflictError 分岐が無く、競合が汎用文言
+「処理に失敗しました…」へ潰れて要件を満たせない。
+
+estimate（#310）は presentation 層（Server Action / フォーム）が未実装のため、
+ConflictError をユーザーへ表面化するこのピースに**未到達**だった。UI を持つ department が
+横断ポリシーの最後の配線を初めて埋める形になる。共通ハンドラに置くことで後続サブドメインの
+UI 化でも再利用できる。採番衝突（ADR-0035）の ConflictError 文言もそのまま通る。
+
+ユーザーに方針を確認し、共通ハンドラへの追加で合意済み。

--- a/src/app/(features)/_shared/error-handler.ts
+++ b/src/app/(features)/_shared/error-handler.ts
@@ -1,4 +1,8 @@
-import { NotFoundEntityError, NotFoundError } from "@server/shared/errors/ApplicationError";
+import {
+  ConflictError,
+  NotFoundEntityError,
+  NotFoundError,
+} from "@server/shared/errors/ApplicationError";
 import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
 import type { ActionResult } from "@shared/types/ActionResult";
 
@@ -45,6 +49,12 @@ export function handleCommandError(error: unknown): ActionResult {
 
   if (error instanceof NotFoundEntityError || error instanceof NotFoundError) {
     return { success: false, error: "指定されたリソースが見つかりません" };
+  }
+
+  // 楽観ロック競合（ADR-0039）・採番衝突（ADR-0035）はいずれもユーザー向けに
+  // 整形済みの文言を持つため、メッセージをそのまま表面化する。
+  if (error instanceof ConflictError) {
+    return { success: false, error: error.message };
   }
 
   return {

--- a/src/app/(features)/departments/[departmentCd]/DepartmentUpdateForm.tsx
+++ b/src/app/(features)/departments/[departmentCd]/DepartmentUpdateForm.tsx
@@ -12,6 +12,8 @@ type Department = {
   abbreviation: string;
   isActive: boolean;
   parentId: string | null;
+  /** 楽観ロックトークン（ADR-0039）。hidden input でフォーム往復させる */
+  version: number;
 };
 
 type Props = {
@@ -32,6 +34,7 @@ export function DepartmentUpdateForm({ department, canUpdate, parentDepartmentSe
       abbreviation: department.abbreviation,
       parentId: department.parentId ?? "",
       isActive: department.isActive,
+      version: department.version,
     },
   });
 
@@ -53,6 +56,9 @@ export function DepartmentUpdateForm({ department, canUpdate, parentDepartmentSe
       )}
 
       <form {...getFormProps(form)} noValidate className="space-y-4">
+        {/* 楽観ロックトークン（ADR-0039）。画面表示時の version を往復させ、保存時の競合検知に使う */}
+        <input {...getInputProps(fields.version, { type: "hidden" })} />
+
         <div>
           <label
             htmlFor="departmentCd-display"

--- a/src/app/(features)/departments/[departmentCd]/actions.ts
+++ b/src/app/(features)/departments/[departmentCd]/actions.ts
@@ -40,7 +40,7 @@ export async function updateDepartment(
     return submission.reply();
   }
 
-  const { name, abbreviation, parentId, isActive } = submission.value;
+  const { name, abbreviation, parentId, isActive, version } = submission.value;
 
   // departmentCdからidを取得
   const queryService = new PrismaDepartmentQueryService();
@@ -58,6 +58,7 @@ export async function updateDepartment(
 
     await command.execute({
       id,
+      version,
       name,
       abbreviation,
       parentId: parentId ?? null,

--- a/src/app/(features)/departments/[departmentCd]/schema.ts
+++ b/src/app/(features)/departments/[departmentCd]/schema.ts
@@ -3,10 +3,14 @@ import { departmentBaseSchema } from "../_shared/schema";
 
 /**
  * 部署更新フォームのバリデーションスキーマ
- * 基盤スキーマ + isActive（departmentCdはURLパラメータから取得）
+ * 基盤スキーマ + isActive + version（departmentCdはURLパラメータから取得）
+ *
+ * version は楽観ロックトークン（ADR-0039）。編集画面表示時の値を hidden input で
+ * 往復させ、保存時の競合検知に用いる。
  */
 export const updateDepartmentSchema = departmentBaseSchema.extend({
   isActive: z.coerce.boolean(),
+  version: z.coerce.number(),
 });
 
 export type UpdateDepartmentInput = z.infer<typeof updateDepartmentSchema>;

--- a/src/server/subdomains/department/application/commands/CreateDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/CreateDepartmentCommand.ts
@@ -52,6 +52,6 @@ export class CreateDepartmentCommand {
 
     const newDepartment = Department.create(departmentCd, name, abbreviation, parentId);
 
-    return await this.departmentRepository.save(newDepartment);
+    return await this.departmentRepository.insert(newDepartment);
   }
 }

--- a/src/server/subdomains/department/application/commands/UpdateDepartmentCommand.ts
+++ b/src/server/subdomains/department/application/commands/UpdateDepartmentCommand.ts
@@ -8,6 +8,8 @@ import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 
 export type UpdateDepartmentInput = {
   id: string;
+  /** 編集画面表示時に取得した楽観ロックトークン（ADR-0039）。フォーム往復で持ち回る */
+  version: number;
   name?: string;
   abbreviation?: string;
   parentId?: string | null;
@@ -64,7 +66,7 @@ export class UpdateDepartmentCommand {
       }
     }
 
-    return await this.departmentRepository.save(department);
+    return await this.departmentRepository.update(department, input.version);
   }
 
   /**

--- a/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
@@ -1,6 +1,6 @@
 import { generateId } from "@server/shared/generateId";
 import prisma from "@server/prisma";
-import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
 import { PrismaDepartmentRepository } from "@subdomains/department/infrastructure/prisma/PrismaDepartmentRepository";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -259,5 +259,29 @@ describe("UpdateDepartmentCommand", () => {
         parentId: deptCId,
       })
     ).rejects.toThrow("循環参照が発生するため、この親部署は設定できません");
+  });
+
+  it("古い version で更新すると ConflictError（expectedVersion がリポジトリへ素通しされる / ADR-0039）", async () => {
+    // 1 回目の更新は version 1 で成功し、DB の version は 2 へ進む
+    const updated = await command.execute({
+      id: baseDeptId,
+      version: 1,
+      name: "第1版",
+    });
+    expect(updated.name.value).toBe("第1版");
+
+    // 同じ古いトークン（version 1）で再度更新 → コマンドが素通しした expectedVersion が
+    // リポジトリの条件付き UPDATE で弾かれ、ConflictError になる
+    await expect(
+      command.execute({
+        id: baseDeptId,
+        version: 1,
+        name: "第2版",
+      })
+    ).rejects.toThrow(ConflictError);
+
+    // 先行の変更（第1版）が残っている（lost update なし）
+    const found = await repository.findById(updated.id);
+    expect(found?.name.value).toBe("第1版");
   });
 });

--- a/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
+++ b/src/server/subdomains/department/application/commands/__tests__/UpdateDepartmentCommand.test.ts
@@ -47,6 +47,7 @@ describe("UpdateDepartmentCommand", () => {
   it("部署名を更新できる", async () => {
     const result = await command.execute({
       id: baseDeptId,
+      version: 1,
       name: "新営業部",
     });
 
@@ -56,6 +57,7 @@ describe("UpdateDepartmentCommand", () => {
   it("略称を更新できる", async () => {
     const result = await command.execute({
       id: baseDeptId,
+      version: 1,
       abbreviation: "新営業",
     });
 
@@ -66,12 +68,14 @@ describe("UpdateDepartmentCommand", () => {
     await expect(
       command.execute({
         id: "00000000-0000-7000-8000-000000000000",
+        version: 1,
         name: "新営業部",
       })
     ).rejects.toThrow(NotFoundEntityError);
     await expect(
       command.execute({
         id: "00000000-0000-7000-8000-000000000000",
+        version: 1,
         name: "新営業部",
       })
     ).rejects.toThrow("部署が見つかりません");
@@ -86,6 +90,7 @@ describe("UpdateDepartmentCommand", () => {
 
     const result = await command.execute({
       id: baseDeptId,
+      version: 1,
       isActive: true,
     });
 
@@ -95,6 +100,7 @@ describe("UpdateDepartmentCommand", () => {
   it("部署を無効化できる", async () => {
     const result = await command.execute({
       id: baseDeptId,
+      version: 1,
       isActive: false,
     });
 
@@ -117,12 +123,14 @@ describe("UpdateDepartmentCommand", () => {
     await expect(
       command.execute({
         id: baseDeptId,
+        version: 1,
         isActive: false,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
     await expect(
       command.execute({
         id: baseDeptId,
+        version: 1,
         isActive: false,
       })
     ).rejects.toThrow("有効な子部署が存在するため、この部署を無効化できません");
@@ -142,6 +150,7 @@ describe("UpdateDepartmentCommand", () => {
 
     const result = await command.execute({
       id: baseDeptId,
+      version: 1,
       parentId: newParentId,
     });
 
@@ -152,12 +161,14 @@ describe("UpdateDepartmentCommand", () => {
     await expect(
       command.execute({
         id: baseDeptId,
+        version: 1,
         parentId: baseDeptId,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
     await expect(
       command.execute({
         id: baseDeptId,
+        version: 1,
         parentId: baseDeptId,
       })
     ).rejects.toThrow("自分自身を親部署にすることはできません");
@@ -167,12 +178,14 @@ describe("UpdateDepartmentCommand", () => {
     await expect(
       command.execute({
         id: baseDeptId,
+        version: 1,
         parentId: "00000000-0000-7000-8000-000000000001",
       })
     ).rejects.toThrow(BusinessRuleViolationError);
     await expect(
       command.execute({
         id: baseDeptId,
+        version: 1,
         parentId: "00000000-0000-7000-8000-000000000001",
       })
     ).rejects.toThrow("親部署が存在しません");
@@ -193,12 +206,14 @@ describe("UpdateDepartmentCommand", () => {
     await expect(
       command.execute({
         id: baseDeptId,
+        version: 1,
         parentId: inactiveParentId,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
     await expect(
       command.execute({
         id: baseDeptId,
+        version: 1,
         parentId: inactiveParentId,
       })
     ).rejects.toThrow("無効な部署を親部署に設定することはできません");
@@ -233,12 +248,14 @@ describe("UpdateDepartmentCommand", () => {
     await expect(
       command.execute({
         id: baseDeptId,
+        version: 1,
         parentId: deptCId,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
     await expect(
       command.execute({
         id: baseDeptId,
+        version: 1,
         parentId: deptCId,
       })
     ).rejects.toThrow("循環参照が発生するため、この親部署は設定できません");

--- a/src/server/subdomains/department/application/queries/dto/DepartmentDTO.ts
+++ b/src/server/subdomains/department/application/queries/dto/DepartmentDTO.ts
@@ -9,6 +9,8 @@ export type DepartmentDTO = {
   abbreviation: string;
   isActive: boolean;
   parentId: string | null;
+  /** 楽観ロックトークン（ADR-0039）。編集フォームへ往復させる */
+  version: number;
   createdAt: Date;
   updatedAt: Date;
 };

--- a/src/server/subdomains/department/domain/repositories/DepartmentRepository.ts
+++ b/src/server/subdomains/department/domain/repositories/DepartmentRepository.ts
@@ -10,9 +10,17 @@ import { DepartmentId } from "../values/DepartmentId";
  */
 export interface DepartmentRepository {
   /**
-   * 部署を保存（新規作成・更新）
+   * 部署を新規作成
    */
-  save(department: Department): Promise<Department>;
+  insert(department: Department): Promise<Department>;
+
+  /**
+   * 既存部署を更新（楽観ロック / ADR-0039）
+   *
+   * @param expectedVersion 編集画面表示時に取得した version（フォーム往復で持ち回るトークン）。
+   *   保存時点の version と一致しない場合は ConflictError を throw し、後勝ちの変更喪失を防ぐ。
+   */
+  update(department: Department, expectedVersion: number): Promise<Department>;
 
   /**
    * 部署を削除

--- a/src/server/subdomains/department/domain/services/__tests__/DepartmentCdDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/department/domain/services/__tests__/DepartmentCdDuplicationCheckDomainService.test.ts
@@ -39,7 +39,7 @@ describe("DepartmentCdDuplicationCheckDomainService", () => {
       new DepartmentName("テスト部署"),
       new Abbreviation("テスト")
     );
-    await repository.save(department);
+    await repository.insert(department);
 
     const isDuplicated = await service.execute(new DepartmentCd(TEST_CODES[0]));
     expect(isDuplicated).toBe(true);

--- a/src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts
+++ b/src/server/subdomains/department/infrastructure/prisma/PrismaDepartmentRepository.ts
@@ -4,31 +4,57 @@ import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd"
 import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { DepartmentMapper } from "@subdomains/department/infrastructure/mappers/DepartmentMapper";
 import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
 
 export class PrismaDepartmentRepository implements DepartmentRepository {
   /**
-   * 部署を保存（新規作成・更新の両方に対応）
+   * 部署を新規作成
    *
    * @param department 部署エンティティ
-   * @returns 保存後の部署エンティティ
+   * @returns 保存後の部署エンティティ（version は @default(1)）
    */
-  async save(department: Department): Promise<Department> {
-    let prismaDepartment;
-
-    if (department.id.value) {
-      // IDが存在する場合：upsert（更新 or 作成）
-      prismaDepartment = await prisma.department.upsert({
-        where: { id: department.id.value },
-        create: DepartmentMapper.toPrismaCreate(department),
-        update: DepartmentMapper.toPrismaUpdate(department),
-      });
-    } else {
-      // IDが空の場合：新規作成
-      const data = DepartmentMapper.toPrismaCreate(department);
-      prismaDepartment = await prisma.department.create({ data });
-    }
+  async insert(department: Department): Promise<Department> {
+    const prismaDepartment = await prisma.department.create({
+      data: DepartmentMapper.toPrismaCreate(department),
+    });
 
     return DepartmentMapper.toDomain(prismaDepartment);
+  }
+
+  /**
+   * 既存部署を更新（楽観ロック / ADR-0039）
+   *
+   * WHERE id AND version の条件付き UPDATE で「比較→更新」を DB 上で原子化し、
+   * 成功時に version を +1 する。count = 0 は「version 不一致（先行更新あり）」と
+   * 「行の消失（削除済み）」の両方を含むが、UPDATE 文からは区別できないため
+   * 両方を覆うメッセージで競合として扱う（ADR-0039 細目5/6）。
+   *
+   * @param department 更新後の部署エンティティ
+   * @param expectedVersion 編集画面表示時のトークン（フォーム往復で持ち回った値）
+   * @returns 更新後（version 反映済み）の部署エンティティ
+   */
+  async update(department: Department, expectedVersion: number): Promise<Department> {
+    const result = await prisma.department.updateMany({
+      where: { id: department.id.value, version: expectedVersion },
+      data: {
+        ...DepartmentMapper.toPrismaUpdate(department),
+        version: { increment: 1 },
+      },
+    });
+
+    if (result.count === 0) {
+      throw new ConflictError(
+        "他のユーザーによって更新または削除されています。画面を再読み込みして最新の内容を確認してください。"
+      );
+    }
+
+    // version を進めた最新行を読み直して返す
+    const row = await prisma.department.findUnique({ where: { id: department.id.value } });
+    if (!row) {
+      throw new Error(`保存した部署の再取得に失敗しました: ${department.id.value}`);
+    }
+
+    return DepartmentMapper.toDomain(row);
   }
 
   /**

--- a/src/server/subdomains/department/infrastructure/prisma/__tests__/PrismaDepartmentRepository.test.ts
+++ b/src/server/subdomains/department/infrastructure/prisma/__tests__/PrismaDepartmentRepository.test.ts
@@ -1,0 +1,110 @@
+import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { Department } from "@subdomains/department/domain/entities/Department";
+import { Abbreviation } from "@subdomains/department/domain/values/Abbreviation";
+import { DepartmentCd } from "@subdomains/department/domain/values/DepartmentCd";
+import { DepartmentName } from "@subdomains/department/domain/values/DepartmentName";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PrismaDepartmentRepository } from "../PrismaDepartmentRepository";
+
+// 実データ・他テストと衝突しない予約コード帯（DEPT96x）。
+const TEST_CODES = ["DEPT960", "DEPT961", "DEPT962"] as const;
+
+function buildDepartment(code: string, name = "テスト部署", abbr = "テスト"): Department {
+  return Department.create(
+    new DepartmentCd(code),
+    new DepartmentName(name),
+    new Abbreviation(abbr)
+  );
+}
+
+async function cleanup(): Promise<void> {
+  await prisma.department.deleteMany({ where: { departmentCd: { in: [...TEST_CODES] } } });
+}
+
+describe("PrismaDepartmentRepository", () => {
+  let repository: PrismaDepartmentRepository;
+
+  beforeEach(async () => {
+    repository = new PrismaDepartmentRepository();
+    await cleanup();
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("insert → findById ラウンドトリップ", () => {
+    it("新規部署を等価に再構築でき、version は 1 で始まる", async () => {
+      const saved = await repository.insert(buildDepartment(TEST_CODES[0], "営業部", "営業"));
+
+      const found = await repository.findById(saved.id);
+
+      expect(found).not.toBeNull();
+      if (!found) return;
+      expect(found.id.value).toBe(saved.id.value);
+      expect(found.departmentCd.value).toBe(TEST_CODES[0]);
+      expect(found.name.value).toBe("営業部");
+      expect(found.abbreviation.value).toBe("営業");
+      expect(found.isActive).toBe(true);
+
+      // version 列は @default(1)。DB 行を直接確認する
+      const row = await prisma.department.findUnique({ where: { id: saved.id.value } });
+      expect(row?.version).toBe(1);
+    });
+  });
+
+  describe("楽観ロック（ADR-0039）", () => {
+    it("insert した部署（version 1）を expectedVersion=1 で更新でき、更新後は 2 で更新できる", async () => {
+      const saved = await repository.insert(buildDepartment(TEST_CODES[0]));
+
+      saved.changeName(new DepartmentName("第1版"));
+      const first = await repository.update(saved, 1);
+      expect(first.id.value).toBe(saved.id.value);
+      expect(first.name.value).toBe("第1版");
+
+      // version は 2 へ進んでいる。一致トークンを提示すれば続けて更新できる
+      const rowAfterFirst = await prisma.department.findUnique({ where: { id: saved.id.value } });
+      expect(rowAfterFirst?.version).toBe(2);
+
+      first.changeName(new DepartmentName("第2版"));
+      await expect(repository.update(first, 2)).resolves.toBeDefined();
+    });
+
+    it("古い expectedVersion での更新は ConflictError になり、先行の変更は失われない", async () => {
+      const saved = await repository.insert(buildDepartment(TEST_CODES[0], "営業部"));
+
+      // 2人のユーザーが同じ version 1 の編集画面を開いた状況を再現
+      const loadedByB = await repository.findById(saved.id);
+      const loadedByA = await repository.findById(saved.id);
+      expect(loadedByB).not.toBeNull();
+      expect(loadedByA).not.toBeNull();
+      if (!loadedByB || !loadedByA) return;
+
+      // B が先に保存（version 1 → 2）
+      loadedByB.changeName(new DepartmentName("Bの変更"));
+      await repository.update(loadedByB, 1);
+
+      // A が古いトークン 1 のまま保存 → 競合として弾かれる
+      loadedByA.changeName(new DepartmentName("Aの変更"));
+      await expect(repository.update(loadedByA, 1)).rejects.toThrow(ConflictError);
+
+      // B の変更が残っている（後勝ちによる lost update が起きていない）
+      const found = await repository.findById(saved.id);
+      expect(found?.name.value).toBe("Bの変更");
+    });
+
+    it("存在しない（削除済み）行への更新も count=0 として ConflictError になる", async () => {
+      const saved = await repository.insert(buildDepartment(TEST_CODES[0]));
+      const loaded = await repository.findById(saved.id);
+      expect(loaded).not.toBeNull();
+      if (!loaded) return;
+
+      // 画面表示後に行が物理削除された状況
+      await repository.delete(saved.id);
+
+      loaded.changeName(new DepartmentName("消えた行への更新"));
+      await expect(repository.update(loaded, 1)).rejects.toThrow(ConflictError);
+    });
+  });
+});

--- a/src/server/subdomains/department/infrastructure/queries/PrismaDepartmentQueryService.ts
+++ b/src/server/subdomains/department/infrastructure/queries/PrismaDepartmentQueryService.ts
@@ -190,6 +190,7 @@ export class PrismaDepartmentQueryService implements DepartmentQueryService {
       abbreviation: true,
       isActive: true,
       parentId: true,
+      version: true,
       createdAt: true,
       updatedAt: true,
     } as const;
@@ -205,6 +206,7 @@ export class PrismaDepartmentQueryService implements DepartmentQueryService {
     abbreviation: string;
     isActive: boolean;
     parentId: string | null;
+    version: number;
     createdAt: Date;
     updatedAt: Date;
   }): DepartmentDTO {
@@ -215,6 +217,7 @@ export class PrismaDepartmentQueryService implements DepartmentQueryService {
       abbreviation: department.abbreviation,
       isActive: department.isActive,
       parentId: department.parentId,
+      version: department.version,
       createdAt: department.createdAt,
       updatedAt: department.updatedAt,
     };


### PR DESCRIPTION
## Summary

ADR-0039 の横断ポリシーに基づき、department サブドメインの `UpdateDepartmentCommand` 経路へ楽観ロック（optimistic concurrency control）を適用する。リポジトリを `insert` / `update(aggregate, expectedVersion)` に分割し、条件付き `updateMany`（`where: { id, version }` + `version: { increment: 1 }`）で「比較→更新」を DB 上で原子化、`count === 0` を `ConflictError` として throw することで lost update（後勝ちによる静かな変更喪失）を防止する。UI を持つ department が横断ポリシーの最後の配線（`ConflictError` のユーザー向け表面化）を初めて埋める。

Closes #305

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### Context

ADR-0039 で楽観ロックの横断方針が決定済み。`department` テーブルへの `version Int @default(1)` 列は #301 の7テーブル一括マイグレーションで追加済み（列は使われるまで不活性）。本イシューは department の `UpdateDepartmentCommand` 経路へ段階展開する。

問題: 現状の更新は「findById → メモリ上で変更 → `save`(upsert)」型で、保存時の競合チェックが無い。2人が同じ部署の編集画面を開いて順に保存すると、後勝ちで片方の変更が静かに消える（lost update）。

方式（ADR-0039）: 編集画面表示時の `version` をフォーム hidden input で往復させ、リポジトリを `insert` / `update(aggregate, expectedVersion)` に分割。条件付き UPDATE で「比較→更新」を DB 上で原子化し、`count === 0` を `ConflictError` として throw する。

**唯一の移行済みリファレンス**: `PrismaEstimateRepository`（estimate 縦切り、#301/#310）。department は子集約を持たない単一テーブル版として同じパターンを写し取る。

### 実装ステップ（1 ステップ = 1 コミット）

- **Step 1**: ドメイン層リポジトリ IF の `save` を `insert` / `update(department, expectedVersion)` に分割
- **Step 2**: Prisma 実装の insert/update 分割＋条件付き `updateMany`、`count === 0` で `ConflictError`
- **Step 3**: クエリ側 DTO（`DepartmentDTO` / `PrismaDepartmentQueryService`）に version を追加
- **Step 4**: コマンド層の expectedVersion 素通し（`UpdateDepartmentCommand` / `CreateDepartmentCommand`）
- **Step 5**: プレゼンテーション層（フォーム往復・Zod・`handleCommandError` の競合メッセージ）
- **Step 6**: テスト（コマンド単体での素通し検証、Prisma 統合での stale トークン逐次再現）

### 検証

- `pnpm lint` / `pnpm test`（vitest は実 DB 統合）
- `save` 廃止で expectedVersion 未渡しがコンパイルエラーになること

</details>

## 計画からの逸脱

### 逸脱1: Step1〜5 を1コミットへ統合

「1 ステップ = 1 コミット」の計画に対し、Step1〜5＋既存テストの version 整合を1コミットへ統合した（テスト新規追加のみ別コミット）。

理由: pre-commit フックがプロジェクト全体の `tsc --noEmit` を実行するため、`save` を廃止する破壊的なインターフェース変更は「IF・Prisma 実装・両コマンド・Server Action・Zod スキーマ・既存テスト」が揃って初めてコンパイルが通る。これは ADR-0039 が意図した「expectedVersion を渡さないコードを型で検出する」の裏返しの帰結であり、分割不能な原子的単位である。

### 逸脱2: `_shared/error-handler.ts` への ConflictError 分岐追加（タスクリスト外）

タスクリスト外の作業として、`handleCommandError` に `ConflictError → error.message` の分岐を追加した。

理由: ADR-0039 細目5 は競合時のユーザー向け文言を品質要件として定めるが、既存の `handleCommandError` には ConflictError 分岐が無く、競合が汎用文言「処理に失敗しました…」へ潰れて要件を満たせない。estimate（#310）は presentation 層が未実装でこのピースに未到達だったため、UI を持つ department が横断ポリシーの最後の配線を初めて埋める。共通ハンドラに置くことで後続サブドメインの UI 化でも再利用でき、採番衝突（ADR-0035）の ConflictError 文言もそのまま通る。ユーザーに方針を確認し合意済み。

## Test Plan

- [x] `UpdateDepartmentCommand.test.ts`: 全 `execute` に `version` を補完し、stale version → `ConflictError` の素通しを検証
- [x] `PrismaDepartmentRepository.test.ts`（新規）: insert→findById ラウンドトリップ、update 連鎖での version increment、stale トークン逐次再現（update(v1) 成功 → 再度 update(v1) が `ConflictError`、先行変更が残存し lost update が起きない）
- [x] `DepartmentCdDuplicationCheckDomainService.test.ts`: `repository.save` → `repository.insert` へ追従
- [ ] `pnpm lint` / `pnpm test`（実 DB 統合）がグリーン

---

Generated with [Claude Code](https://claude.ai/code)
