### PR TITLE
feat: 楽観ロックを role サブドメインへ適用する（ADR-0039 横断展開）

### DIFF
--- a/src/app/(features)/roles/[roleCd]/RoleUpdateForm.tsx
+++ b/src/app/(features)/roles/[roleCd]/RoleUpdateForm.tsx
@@ -11,6 +11,8 @@ type Role = {
   name: string;
   positionName: string;
   superiorRoleId: string | null;
+  /** 楽観ロックトークン（ADR-0039）。hidden input で往復させ更新時の競合検知に使う */
+  version: number;
 };
 
 type SuperiorRoleOption = {
@@ -33,6 +35,7 @@ export function RoleUpdateForm({ role, canUpdate, superiorRoleOptions }: Props) 
     defaultValue: {
       name: role.name,
       superiorRoleId: role.superiorRoleId ?? "",
+      version: role.version,
     },
   });
 
@@ -54,6 +57,9 @@ export function RoleUpdateForm({ role, canUpdate, superiorRoleOptions }: Props) 
       )}
 
       <form {...getFormProps(form)} noValidate className="space-y-4">
+        {/* 楽観ロックトークン（ADR-0039）。画面表示時の version を更新時まで往復させる */}
+        <input {...getInputProps(fields.version, { type: "hidden" })} />
+
         <div>
           <label htmlFor="roleCd-display" className="block text-gray-700 text-sm font-bold mb-2">
             役割コード

--- a/src/app/(features)/roles/[roleCd]/actions.ts
+++ b/src/app/(features)/roles/[roleCd]/actions.ts
@@ -38,7 +38,7 @@ export async function updateRole(roleCd: string, prevState: unknown, formData: F
     return submission.reply();
   }
 
-  const { name, superiorRoleId } = submission.value;
+  const { name, superiorRoleId, version } = submission.value;
 
   // roleCdからidを取得
   const queryService = new PrismaRoleQueryService();
@@ -56,6 +56,9 @@ export async function updateRole(roleCd: string, prevState: unknown, formData: F
 
     await command.execute({
       id,
+      // version はフォーム由来（画面表示時のトークン）を渡す。ここで再 SELECT した
+      // 最新 version を使うと編集ウィンドウを守れないため（ADR-0039 選択肢2A）。
+      version,
       name,
       superiorRoleId: superiorRoleId ?? null,
     });

--- a/src/app/(features)/roles/[roleCd]/page.tsx
+++ b/src/app/(features)/roles/[roleCd]/page.tsx
@@ -50,6 +50,7 @@ export default async function Page({ params }: { params: Promise<{ roleCd: strin
           name: role.name,
           positionName: role.positionName,
           superiorRoleId: role.superiorRoleId,
+          version: role.version,
         }}
         canUpdate={canUpdate}
         superiorRoleOptions={superiorRoleOptions}

--- a/src/app/(features)/roles/[roleCd]/schema.ts
+++ b/src/app/(features)/roles/[roleCd]/schema.ts
@@ -1,7 +1,15 @@
+import { z } from "zod";
 import { roleBaseSchema } from "../_shared/schema";
 
 /**
  * 役割更新用スキーマ
- * roleCd, positionId は不変のため含まない
+ * roleCd, positionId は不変のため含まない。
+ *
+ * version は楽観ロックトークン（ADR-0039）。編集画面表示時の値を hidden input で
+ * 往復させ、更新コマンドへ素通しして競合を検知する。フォームからは文字列で届くため
+ * coerce で数値化する。version は新規作成（insert 経路）には不要なため共通の
+ * roleBaseSchema には載せず、更新スキーマにのみ追加する。
  */
-export const updateRoleSchema = roleBaseSchema;
+export const updateRoleSchema = roleBaseSchema.extend({
+  version: z.coerce.number().int(),
+});

--- a/src/server/subdomains/role/application/commands/CreateRoleCommand.ts
+++ b/src/server/subdomains/role/application/commands/CreateRoleCommand.ts
@@ -60,6 +60,6 @@ export class CreateRoleCommand {
 
     const newRole = Role.create(roleCd, roleName, positionId, superiorRoleId);
 
-    return await this.roleRepository.save(newRole);
+    return await this.roleRepository.insert(newRole);
   }
 }

--- a/src/server/subdomains/role/application/commands/UpdateRoleCommand.ts
+++ b/src/server/subdomains/role/application/commands/UpdateRoleCommand.ts
@@ -10,6 +10,8 @@ import { ValidationError } from "@server/shared/errors/DomainError";
 
 export type UpdateRoleInput = {
   id: string;
+  /** 編集画面表示時に取得した楽観ロックトークン（ADR-0039）。フォーム往復で持ち回る */
+  version: number;
   name?: string;
   superiorRoleId?: string | null;
 };
@@ -58,7 +60,7 @@ export class UpdateRoleCommand {
       role.changeSuperiorRole(newSuperiorRoleId);
     }
 
-    return await this.roleRepository.save(role);
+    return await this.roleRepository.update(role, input.version);
   }
 
   /**

--- a/src/server/subdomains/role/application/commands/__tests__/DeleteRoleCommand.test.ts
+++ b/src/server/subdomains/role/application/commands/__tests__/DeleteRoleCommand.test.ts
@@ -51,7 +51,7 @@ describe("DeleteRoleCommand", () => {
       new RoleName("削除テスト役割"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role);
+    await roleRepository.insert(role);
 
     await command.execute({ id: role.id.value });
 
@@ -74,7 +74,7 @@ describe("DeleteRoleCommand", () => {
       new RoleName("テスト部長"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(buchouRole);
+    await roleRepository.insert(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
@@ -82,7 +82,7 @@ describe("DeleteRoleCommand", () => {
       new PositionId(kachouPositionId),
       buchouRole.id
     );
-    await roleRepository.save(kachouRole);
+    await roleRepository.insert(kachouRole);
 
     await expect(command.execute({ id: buchouRole.id.value })).rejects.toThrow(
       BusinessRuleViolationError

--- a/src/server/subdomains/role/application/commands/__tests__/UpdateRoleCommand.test.ts
+++ b/src/server/subdomains/role/application/commands/__tests__/UpdateRoleCommand.test.ts
@@ -1,6 +1,6 @@
 import prisma from "@server/prisma";
 import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
-import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { Role } from "@subdomains/role/domain/entities/Role";
 import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleName } from "@subdomains/role/domain/values/RoleName";
@@ -59,10 +59,11 @@ describe("UpdateRoleCommand", () => {
       new RoleName("更新前の名前"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role);
+    await roleRepository.insert(role);
 
     const updated = await command.execute({
       id: role.id.value,
+      version: 1,
       name: "更新後の名前",
     });
 
@@ -75,17 +76,18 @@ describe("UpdateRoleCommand", () => {
       new RoleName("テスト部長"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(buchouRole);
+    await roleRepository.insert(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("テスト課長"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(kachouRole);
+    await roleRepository.insert(kachouRole);
 
     const updated = await command.execute({
       id: kachouRole.id.value,
+      version: 1,
       superiorRoleId: buchouRole.id.value,
     });
 
@@ -96,12 +98,14 @@ describe("UpdateRoleCommand", () => {
     await expect(
       command.execute({
         id: "00000000-0000-7000-8000-000000000000",
+        version: 1,
         name: "テスト",
       })
     ).rejects.toThrow(NotFoundEntityError);
     await expect(
       command.execute({
         id: "00000000-0000-7000-8000-000000000000",
+        version: 1,
         name: "テスト",
       })
     ).rejects.toThrow("役割が見つかりません");
@@ -113,24 +117,26 @@ describe("UpdateRoleCommand", () => {
       new RoleName("既存の役割名"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role1);
+    await roleRepository.insert(role1);
 
     const role2 = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("変更前の名前"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role2);
+    await roleRepository.insert(role2);
 
     await expect(
       command.execute({
         id: role2.id.value,
+        version: 1,
         name: "既存の役割名",
       })
     ).rejects.toThrow(ValidationError);
     await expect(
       command.execute({
         id: role2.id.value,
+        version: 1,
         name: "既存の役割名",
       })
     ).rejects.toThrow("既に存在する役割名です");
@@ -142,10 +148,11 @@ describe("UpdateRoleCommand", () => {
       new RoleName("テスト役割"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role);
+    await roleRepository.insert(role);
 
     const updated = await command.execute({
       id: role.id.value,
+      version: 1,
       name: "テスト役割",
     });
 
@@ -158,11 +165,12 @@ describe("UpdateRoleCommand", () => {
       new RoleName("テスト部長"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(buchouRole);
+    await roleRepository.insert(buchouRole);
 
     await expect(
       command.execute({
         id: buchouRole.id.value,
+        version: 1,
         superiorRoleId: buchouRole.id.value,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
@@ -175,7 +183,7 @@ describe("UpdateRoleCommand", () => {
       new RoleName("循環テスト部長"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(buchouRole);
+    await roleRepository.insert(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
@@ -183,11 +191,12 @@ describe("UpdateRoleCommand", () => {
       new PositionId(kachouPositionId),
       buchouRole.id
     );
-    await roleRepository.save(kachouRole);
+    await roleRepository.insert(kachouRole);
 
     await expect(
       command.execute({
         id: buchouRole.id.value,
+        version: 1,
         superiorRoleId: kachouRole.id.value,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
@@ -199,21 +208,52 @@ describe("UpdateRoleCommand", () => {
       new RoleName("同一レベルA課長"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(kachouRole1);
+    await roleRepository.insert(kachouRole1);
 
     const kachouRole2 = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
       new RoleName("同一レベルB課長"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(kachouRole2);
+    await roleRepository.insert(kachouRole2);
 
     // 課長の上位は部長でなければならないため、同一役職レベルは設定不可
     await expect(
       command.execute({
         id: kachouRole1.id.value,
+        version: 1,
         superiorRoleId: kachouRole2.id.value,
       })
     ).rejects.toThrow(BusinessRuleViolationError);
+  });
+
+  it("古い version での更新は ConflictError になり、先行の変更は失われない（楽観ロック / ADR-0039）", async () => {
+    const role = Role.create(
+      new RoleCd(TEST_ROLE_CDS[0]),
+      new RoleName("初期名"),
+      new PositionId(kachouPositionId)
+    );
+    await roleRepository.insert(role);
+
+    // 先行更新が version 1 → 2 に進める
+    await command.execute({
+      id: role.id.value,
+      version: 1,
+      name: "先行更新後の名前",
+    });
+
+    // 古い画面（version 1）からの保存は競合として弾かれる。
+    // version が update(role, input.version) へ素通しされていなければ競合は起きない。
+    await expect(
+      command.execute({
+        id: role.id.value,
+        version: 1,
+        name: "後勝ちを狙う名前",
+      })
+    ).rejects.toThrow(ConflictError);
+
+    // 先行更新の内容が残っている（lost update が起きていない）
+    const finalRow = await prisma.role.findUnique({ where: { id: role.id.value } });
+    expect(finalRow!.name).toBe("先行更新後の名前");
   });
 });

--- a/src/server/subdomains/role/application/queries/__tests__/GetAllRolesQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetAllRolesQuery.test.ts
@@ -49,8 +49,8 @@ describe("GetAllRolesQuery", () => {
       new RoleName("全取得テストB"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role1);
-    await roleRepository.save(role2);
+    await roleRepository.insert(role1);
+    await roleRepository.insert(role2);
 
     const result = await query.execute({});
 
@@ -70,8 +70,8 @@ describe("GetAllRolesQuery", () => {
       new RoleName("全取得ソートB"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role1);
-    await roleRepository.save(role2);
+    await roleRepository.insert(role1);
+    await roleRepository.insert(role2);
 
     const result = await query.execute({
       options: { orderBy: { field: "roleCd", direction: "desc" } },

--- a/src/server/subdomains/role/application/queries/__tests__/GetRoleByIdQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetRoleByIdQuery.test.ts
@@ -44,7 +44,7 @@ describe("GetRoleByIdQuery", () => {
       new RoleName("ID取得テスト役割"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role);
+    await roleRepository.insert(role);
 
     const result = await query.execute({ id: role.id.value });
 

--- a/src/server/subdomains/role/application/queries/__tests__/GetRoleByRoleCdQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetRoleByRoleCdQuery.test.ts
@@ -44,7 +44,7 @@ describe("GetRoleByRoleCdQuery", () => {
       new RoleName("コード取得テスト役割"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role);
+    await roleRepository.insert(role);
 
     const result = await query.execute({ roleCd: TEST_ROLE_CDS[0] });
 

--- a/src/server/subdomains/role/application/queries/__tests__/GetRolesByPositionQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/GetRolesByPositionQuery.test.ts
@@ -54,8 +54,8 @@ describe("GetRolesByPositionQuery", () => {
       new RoleName("役職別テスト部長"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(role1);
-    await roleRepository.save(role2);
+    await roleRepository.insert(role1);
+    await roleRepository.insert(role2);
 
     const result = await query.execute({ positionId: kachouPositionId });
 

--- a/src/server/subdomains/role/application/queries/__tests__/SearchRolesQuery.test.ts
+++ b/src/server/subdomains/role/application/queries/__tests__/SearchRolesQuery.test.ts
@@ -54,8 +54,8 @@ describe("SearchRolesQuery", () => {
       new RoleName("検索東京開発課長"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role1);
-    await roleRepository.save(role2);
+    await roleRepository.insert(role1);
+    await roleRepository.insert(role2);
 
     const result = await query.execute({ criteria: { name: "大阪" } });
 
@@ -70,7 +70,7 @@ describe("SearchRolesQuery", () => {
       new RoleName("検索コードテスト"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role);
+    await roleRepository.insert(role);
 
     const result = await query.execute({ criteria: { roleCd: TEST_ROLE_CDS[0] } });
 
@@ -89,8 +89,8 @@ describe("SearchRolesQuery", () => {
       new RoleName("検索役職部長"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(role1);
-    await roleRepository.save(role2);
+    await roleRepository.insert(role1);
+    await roleRepository.insert(role2);
 
     const result = await query.execute({ criteria: { positionId: kachouPositionId } });
 
@@ -105,7 +105,7 @@ describe("SearchRolesQuery", () => {
       new RoleName("検索上位部長"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(buchouRole);
+    await roleRepository.insert(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
@@ -113,7 +113,7 @@ describe("SearchRolesQuery", () => {
       new PositionId(kachouPositionId),
       buchouRole.id
     );
-    await roleRepository.save(kachouRole);
+    await roleRepository.insert(kachouRole);
 
     const result = await query.execute({ criteria: { superiorRoleId: buchouRole.id.value } });
 
@@ -128,7 +128,7 @@ describe("SearchRolesQuery", () => {
       new RoleName("検索ルート部長"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(buchouRole);
+    await roleRepository.insert(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
@@ -136,7 +136,7 @@ describe("SearchRolesQuery", () => {
       new PositionId(kachouPositionId),
       buchouRole.id
     );
-    await roleRepository.save(kachouRole);
+    await roleRepository.insert(kachouRole);
 
     const result = await query.execute({ criteria: { superiorRoleId: null } });
 
@@ -151,7 +151,7 @@ describe("SearchRolesQuery", () => {
       new RoleName("検索DTO部長"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(buchouRole);
+    await roleRepository.insert(buchouRole);
 
     const kachouRole = Role.create(
       new RoleCd(TEST_ROLE_CDS[1]),
@@ -159,7 +159,7 @@ describe("SearchRolesQuery", () => {
       new PositionId(kachouPositionId),
       buchouRole.id
     );
-    await roleRepository.save(kachouRole);
+    await roleRepository.insert(kachouRole);
 
     const result = await query.execute({ criteria: { roleCd: TEST_ROLE_CDS[1] } });
 
@@ -183,8 +183,8 @@ describe("SearchRolesQuery", () => {
       new RoleName("検索オプB課長"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(role1);
-    await roleRepository.save(role2);
+    await roleRepository.insert(role1);
+    await roleRepository.insert(role2);
 
     const result = await query.execute({
       criteria: { name: "検索オプ" },

--- a/src/server/subdomains/role/application/queries/dto/RoleDTO.ts
+++ b/src/server/subdomains/role/application/queries/dto/RoleDTO.ts
@@ -11,6 +11,8 @@ export type RoleDTO = {
   positionName: string;
   superiorRoleId: string | null;
   superiorRoleName: string | null;
+  /** 楽観ロックトークン（ADR-0039）。編集フォームで往復させ更新時の競合検知に使う */
+  version: number;
   createdAt: Date;
   updatedAt: Date;
 };

--- a/src/server/subdomains/role/domain/repositories/RoleRepository.ts
+++ b/src/server/subdomains/role/domain/repositories/RoleRepository.ts
@@ -10,7 +10,22 @@ import { RoleId } from "../values/RoleId";
  */
 export interface RoleRepository {
   /**
+   * 役割を新規作成
+   */
+  insert(role: Role): Promise<Role>;
+
+  /**
+   * 既存役割を更新（楽観ロック / ADR-0039）
+   *
+   * @param expectedVersion 編集画面表示時に取得した version（フォーム往復で持ち回るトークン）。
+   *   保存時点の version と一致しない場合は ConflictError を throw し、後勝ちの変更喪失を防ぐ。
+   */
+  update(role: Role, expectedVersion: number): Promise<Role>;
+
+  /**
    * 役割を保存（新規作成・更新）
+   *
+   * @deprecated insert / update へ移行中の一時併存メソッド（ADR-0039）。新規コードでは使用しない。
    */
   save(role: Role): Promise<Role>;
 

--- a/src/server/subdomains/role/domain/repositories/RoleRepository.ts
+++ b/src/server/subdomains/role/domain/repositories/RoleRepository.ts
@@ -23,13 +23,6 @@ export interface RoleRepository {
   update(role: Role, expectedVersion: number): Promise<Role>;
 
   /**
-   * 役割を保存（新規作成・更新）
-   *
-   * @deprecated insert / update へ移行中の一時併存メソッド（ADR-0039）。新規コードでは使用しない。
-   */
-  save(role: Role): Promise<Role>;
-
-  /**
    * 役割を削除
    */
   delete(id: RoleId): Promise<void>;

--- a/src/server/subdomains/role/domain/services/__tests__/RoleCdDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/role/domain/services/__tests__/RoleCdDuplicationCheckDomainService.test.ts
@@ -48,7 +48,7 @@ describe("RoleCdDuplicationCheckDomainService", () => {
       new RoleName("テスト役割"),
       new PositionId(positionId)
     );
-    await repository.save(role);
+    await repository.insert(role);
 
     const isDuplicated = await service.execute(new RoleCd(TEST_ROLE_CD));
     expect(isDuplicated).toBe(true);

--- a/src/server/subdomains/role/domain/services/__tests__/RoleNameDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/role/domain/services/__tests__/RoleNameDuplicationCheckDomainService.test.ts
@@ -48,7 +48,7 @@ describe("RoleNameDuplicationCheckDomainService", () => {
       new RoleName(TEST_ROLE_NAME),
       new PositionId(positionId)
     );
-    await repository.save(role);
+    await repository.insert(role);
 
     const isDuplicated = await service.execute(TEST_ROLE_NAME);
     expect(isDuplicated).toBe(true);
@@ -60,7 +60,7 @@ describe("RoleNameDuplicationCheckDomainService", () => {
       new RoleName(TEST_ROLE_NAME),
       new PositionId(positionId)
     );
-    const savedRole = await repository.save(role);
+    const savedRole = await repository.insert(role);
 
     const isDuplicated = await service.execute(TEST_ROLE_NAME, savedRole.id);
     expect(isDuplicated).toBe(false);

--- a/src/server/subdomains/role/domain/services/__tests__/SuperiorRoleValidationDomainService.test.ts
+++ b/src/server/subdomains/role/domain/services/__tests__/SuperiorRoleValidationDomainService.test.ts
@@ -53,7 +53,7 @@ describe("SuperiorRoleValidationDomainService", () => {
       new RoleName("テスト部長"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(buchouRole);
+    await roleRepository.insert(buchouRole);
 
     // 課長ポジションから部長ポジションの役割を上位に指定 → OK
     await expect(
@@ -67,7 +67,7 @@ describe("SuperiorRoleValidationDomainService", () => {
       new RoleName("テスト役割"),
       new PositionId(buchouPositionId)
     );
-    await roleRepository.save(someRole);
+    await roleRepository.insert(someRole);
 
     // 社長ポジションから上位役割を指定 → エラー
     await expect(service.execute(new PositionId(shachouPositionId), someRole.id)).rejects.toThrow(
@@ -85,7 +85,7 @@ describe("SuperiorRoleValidationDomainService", () => {
       new RoleName("テスト課長"),
       new PositionId(kachouPositionId)
     );
-    await roleRepository.save(kachouRole);
+    await roleRepository.insert(kachouRole);
 
     // 課長ポジションから同じ課長ポジションの役割を上位に指定 → エラー
     // （課長の上位は部長でなければならない）

--- a/src/server/subdomains/role/infrastructure/prisma/PrismaRoleRepository.ts
+++ b/src/server/subdomains/role/infrastructure/prisma/PrismaRoleRepository.ts
@@ -48,19 +48,6 @@ export class PrismaRoleRepository implements RoleRepository {
     return RoleMapper.toDomain(updated);
   }
 
-  /**
-   * @deprecated insert / update へ移行中の一時併存メソッド（ADR-0039）。新規コードでは使用しない。
-   */
-  async save(role: Role): Promise<Role> {
-    const prismaRole = await prisma.role.upsert({
-      where: { id: role.id.value },
-      create: RoleMapper.toPrismaCreate(role),
-      update: RoleMapper.toPrismaUpdate(role),
-    });
-
-    return RoleMapper.toDomain(prismaRole);
-  }
-
   async delete(id: RoleId): Promise<void> {
     await prisma.role.delete({
       where: { id: id.value },

--- a/src/server/subdomains/role/infrastructure/prisma/PrismaRoleRepository.ts
+++ b/src/server/subdomains/role/infrastructure/prisma/PrismaRoleRepository.ts
@@ -4,8 +4,53 @@ import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
 import { RoleId } from "@subdomains/role/domain/values/RoleId";
 import { RoleMapper } from "@subdomains/role/infrastructure/mappers/RoleMapper";
 import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
 
 export class PrismaRoleRepository implements RoleRepository {
+  async insert(role: Role): Promise<Role> {
+    const prismaRole = await prisma.role.create({
+      data: RoleMapper.toPrismaCreate(role),
+    });
+
+    return RoleMapper.toDomain(prismaRole);
+  }
+
+  /**
+   * 既存役割を更新（楽観ロック / ADR-0039）。
+   *
+   * Role は子を持たない単一テーブル集約のため、WHERE id AND version の条件付き
+   * updateMany 1 文で「比較→更新」を DB 上で原子化できる（estimate のような
+   * トランザクション＋差分 upsert は不要）。成功時に version を +1 する。
+   * count 0 は「version 不一致（先行更新あり）」と「行の消失（削除済み）」の両方を
+   * 含むが UPDATE 文からは区別できないため、両方を覆うメッセージで競合として扱う。
+   */
+  async update(role: Role, expectedVersion: number): Promise<Role> {
+    const result = await prisma.role.updateMany({
+      where: { id: role.id.value, version: expectedVersion },
+      data: {
+        ...RoleMapper.toPrismaUpdate(role),
+        version: { increment: 1 },
+      },
+    });
+
+    if (result.count === 0) {
+      throw new ConflictError(
+        "他のユーザーによって更新または削除されています。画面を再読み込みして最新の内容を確認してください。"
+      );
+    }
+
+    // updateMany は更新後の行を返さないため、+1 された version を含めて読み直す。
+    const updated = await prisma.role.findUnique({ where: { id: role.id.value } });
+    if (!updated) {
+      throw new Error(`保存した役割の再取得に失敗しました: ${role.id.value}`);
+    }
+
+    return RoleMapper.toDomain(updated);
+  }
+
+  /**
+   * @deprecated insert / update へ移行中の一時併存メソッド（ADR-0039）。新規コードでは使用しない。
+   */
   async save(role: Role): Promise<Role> {
     const prismaRole = await prisma.role.upsert({
       where: { id: role.id.value },

--- a/src/server/subdomains/role/infrastructure/prisma/__tests__/PrismaRoleRepository.test.ts
+++ b/src/server/subdomains/role/infrastructure/prisma/__tests__/PrismaRoleRepository.test.ts
@@ -1,0 +1,115 @@
+import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { Role } from "@subdomains/role/domain/entities/Role";
+import { RoleCd } from "@subdomains/role/domain/values/RoleCd";
+import { RoleName } from "@subdomains/role/domain/values/RoleName";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
+import { PrismaRoleRepository } from "../PrismaRoleRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * PrismaRoleRepository の統合テスト（実 DB）。
+ *
+ * 主眼は ADR-0039 の楽観ロックを「逐次の stale トークン再現」で実証すること。
+ * 防御の実体は条件付き updateMany 1 文の原子性（PostgreSQL 保証）なので、
+ * Promise.all による真の並行テストは flaky の割に証明力が増えないため採らない。
+ */
+describe("PrismaRoleRepository", () => {
+  let repository: PrismaRoleRepository;
+
+  // 他テストファイルとの並列実行衝突を避けるため未使用の roleCd を専有する
+  const TEST_ROLE_CDS = ["ROLE901", "ROLE902", "ROLE903"];
+
+  let kachouPositionId: string;
+
+  async function cleanup() {
+    await prisma.role.updateMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+      data: { superiorRoleId: null },
+    });
+    await prisma.role.deleteMany({
+      where: { roleCd: { in: TEST_ROLE_CDS } },
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+
+    const kachou = await prisma.position.findUnique({ where: { positionCd: "POS001" } });
+    kachouPositionId = kachou!.id;
+
+    repository = new PrismaRoleRepository();
+  });
+
+  afterEach(cleanup);
+
+  function buildRole(roleCd: string, name: string): Role {
+    return Role.create(new RoleCd(roleCd), new RoleName(name), new PositionId(kachouPositionId));
+  }
+
+  describe("insert → findById ラウンドトリップ", () => {
+    it("新規作成した役割を ID で取得できる", async () => {
+      const role = buildRole(TEST_ROLE_CDS[0], "ラウンドトリップ役割");
+
+      await repository.insert(role);
+      const found = await repository.findById(role.id);
+
+      expect(found).not.toBeNull();
+      expect(found!.roleCd.value).toBe(TEST_ROLE_CDS[0]);
+      expect(found!.name.value).toBe("ラウンドトリップ役割");
+    });
+  });
+
+  describe("update（楽観ロック）", () => {
+    it("insert した役割（version 1）を expectedVersion=1 で更新でき、更新後は 2 で更新できる", async () => {
+      const role = buildRole(TEST_ROLE_CDS[0], "初期名");
+      await repository.insert(role);
+
+      // insert 直後の version は 1。一致するトークンでの更新は成功し、version は 2 に進む
+      role.changeName(new RoleName("1回目更新"));
+      const first = await repository.update(role, 1);
+      expect(first.name.value).toBe("1回目更新");
+
+      // 進んだ version 2 を提示すれば続けて更新できる
+      first.changeName(new RoleName("2回目更新"));
+      await expect(repository.update(first, 2)).resolves.toBeDefined();
+
+      const finalRow = await prisma.role.findUnique({ where: { id: role.id.value } });
+      expect(finalRow!.version).toBe(3);
+      expect(finalRow!.name).toBe("2回目更新");
+    });
+
+    it("古い expectedVersion での更新は ConflictError になり、先行の変更は失われない", async () => {
+      const role = buildRole(TEST_ROLE_CDS[0], "初期名");
+      await repository.insert(role);
+
+      // 2人のユーザーが同じ version 1 の画面を開いた状況を再現
+      const loadedByA = await repository.findById(role.id);
+      const loadedByB = await repository.findById(role.id);
+      expect(loadedByA).not.toBeNull();
+      expect(loadedByB).not.toBeNull();
+
+      // B が先に保存（version 1 → 2）
+      loadedByB!.changeName(new RoleName("Bの変更"));
+      await repository.update(loadedByB!, 1);
+
+      // A は古い version 1 を提示 → 競合として弾かれる
+      loadedByA!.changeName(new RoleName("Aの変更"));
+      await expect(repository.update(loadedByA!, 1)).rejects.toThrow(ConflictError);
+
+      // B の先行変更が残存している（lost update が起きていない）
+      const finalRow = await prisma.role.findUnique({ where: { id: role.id.value } });
+      expect(finalRow!.name).toBe("Bの変更");
+      expect(finalRow!.version).toBe(2);
+    });
+
+    it("存在しない（削除済み）役割の更新は ConflictError になる", async () => {
+      const role = buildRole(TEST_ROLE_CDS[0], "消える役割");
+      await repository.insert(role);
+      await repository.delete(role.id);
+
+      role.changeName(new RoleName("更新試行"));
+      await expect(repository.update(role, 1)).rejects.toThrow(ConflictError);
+    });
+  });
+});

--- a/src/server/subdomains/role/infrastructure/queries/PrismaRoleQueryService.ts
+++ b/src/server/subdomains/role/infrastructure/queries/PrismaRoleQueryService.ts
@@ -114,6 +114,7 @@ export class PrismaRoleQueryService implements RoleQueryService {
       position: { select: { name: true } },
       superiorRoleId: true,
       superiorRole: { select: { name: true } },
+      version: true,
       createdAt: true,
       updatedAt: true,
     } as const;
@@ -127,6 +128,7 @@ export class PrismaRoleQueryService implements RoleQueryService {
     position: { name: string };
     superiorRoleId: string | null;
     superiorRole: { name: string } | null;
+    version: number;
     createdAt: Date;
     updatedAt: Date;
   }): RoleDTO {
@@ -138,6 +140,7 @@ export class PrismaRoleQueryService implements RoleQueryService {
       positionName: role.position.name,
       superiorRoleId: role.superiorRoleId,
       superiorRoleName: role.superiorRole?.name ?? null,
+      version: role.version,
       createdAt: role.createdAt,
       updatedAt: role.updatedAt,
     };


### PR DESCRIPTION
## Summary

ADR-0039 の横断ポリシーに基づき、role サブドメインの既存集約を変更するコマンド（`UpdateRoleCommand`）へ楽観ロックを適用する。`RoleRepository` を `insert` / `update(aggregate, expectedVersion)` に分割し、条件付き UPDATE（`updateMany({ where: { id, version } })` + `version: { increment: 1 }`）で原子的に整合性をチェック。count = 0 時に `ConflictError` を throw して後勝ちによる静かな変更喪失を防ぐ。編集画面の version をフォーム（hidden input）で往復させ編集ウィンドウを保護する。`save` は廃止し、更新経路で expectedVersion を渡さないコードはコンパイルエラーになる。

Closes #308

## 計画からの逸脱

実装計画なしで実装を行いました。

## Test Plan

- [x] リポジトリ統合テスト（`PrismaRoleRepository.test.ts`）: stale トークンを逐次再現（`update(v1)` 成功 → 再度 `update(v1)` が `ConflictError`、先行変更が残存することを検証）
- [x] コマンド単体テスト（`UpdateRoleCommand.test.ts`）: `expectedVersion` がリポジトリへ素通しされることを検証
- [x] クエリ系テスト（`RoleDTO` / 各 Query テスト）: DTO への `version` 追加に伴う期待値更新
- [ ] `pnpm test` 全体グリーン確認
- [ ] `pnpm lint` 確認

---

Generated with [Claude Code](https://claude.ai/code)
