### PR TITLE
refactor: department 更新スキーマの version を z.coerce.number().int() に統一する

### DIFF
--- a/src/app/(features)/departments/[departmentCd]/schema.ts
+++ b/src/app/(features)/departments/[departmentCd]/schema.ts
@@ -10,7 +10,7 @@ import { departmentBaseSchema } from "../_shared/schema";
  */
 export const updateDepartmentSchema = departmentBaseSchema.extend({
   isActive: z.coerce.boolean(),
-  version: z.coerce.number(),
+  version: z.coerce.number().int(),
 });
 
 export type UpdateDepartmentInput = z.infer<typeof updateDepartmentSchema>;


### PR DESCRIPTION
## Summary

department 更新スキーマの `version` を `z.coerce.number()` から `z.coerce.number().int()` に変更し、role 更新スキーマと Zod 表現を統一した。version 列は Prisma 上 `Int`（ADR-0039 の楽観ロックトークン）であり、`.int()` 強制により hidden input 改竄等による小数値（例: `"2.5"`）の通過を防ぐ。

Closes #312

## 計画からの逸脱

実装計画なしで実装を行いました。1行のスキーマ表現統一であり、計画ファイルは作成していません。

## Test Plan

- [ ] department 更新スキーマの `version` が `.int()` で整数強制されることを確認
- [ ] role 更新スキーマと department 更新スキーマで version の Zod 表現が一致することを確認
- [ ] `pnpm lint` / `pnpm test` がパスすること

---

Generated with [Claude Code](https://claude.ai/code)
