### PR TITLE
feat: 楽観ロックを employee サブドメインへ適用する（ADR-0039 横断展開）

### DIFF
--- a/docs/claude-plans/issue-304/apply-optimistic-locking-to-employee.md
+++ b/docs/claude-plans/issue-304/apply-optimistic-locking-to-employee.md
@@ -1,0 +1,114 @@
+# Issue #304: 楽観ロックを employee サブドメインへ適用する（ADR-0039 横断展開） — 実装計画
+
+## 概要
+
+ADR-0039 の横断ポリシーに基づき、employee サブドメインの更新コマンドへ楽観ロックを適用する。#316（customer 適用、コミット 281b296）のパターンを忠実に移植する。
+
+- `EmployeeRepository` の `save` を `insert` / `update(employee, expectedVersion)` に分割
+- Prisma 実装は条件付き `updateMany`（`WHERE id AND version` + `version: { increment: 1 }`）、count = 0 で `ConflictError`
+- `UpdateEmployeeCommand` の Input に `expectedVersion` を追加して素通し
+- `EmployeeDTO` に `version` を追加し、編集フォームの hidden input + Zod で往復させる
+
+新規 ADR は不要（ADR-0039 の忠実な横断展開であり、新しい設計判断を含まない）。CONTEXT.md への用語追加も不要（楽観ロックはドメイン語彙ではなく横断技術ポリシー）。
+
+### 事前調査で確認済みの前提
+
+- `employee` テーブルの `version Int @default(1)` 列は #301 のマイグレーションで追加済み
+- employee に Activate/Deactivate コマンドは存在しない（対象は `UpdateEmployeeCommand` のみ）
+- `DeleteEmployeeCommand` は対象外（Delete 系横断イシューで扱う。#316 でも delete は version を読んでいない）
+- `save` の呼び出し元は `CreateEmployeeCommand` / `UpdateEmployeeCommand` の2箇所のみ
+- 編集ページは `GetEmployeeByEmployeeCdQuery` → `EmployeeDTO` で version が流れる
+- `User.role` / `User.email` の更新経路は `UpdateEmployeeCommand` のみ（バイパス経路なし）
+
+## 設計判断
+
+### User 同期（email/role）の楽観ロック保護方式
+
+`UpdateEmployeeCommand` は employee 行の保存後に `UserManagementService` 経由で User テーブルを非トランザクションで更新する。role は User の属性だが employee 編集フォームで一緒に編集されるため、保護が必要。
+
+- A. 実行順序への依存を受容し、明示化する — employee 行の条件付き UPDATE が先に走るため、stale フォームは `ConflictError` で User 同期に到達しない。この順序が保護の前提であることをコードコメントで明記し、コマンド単体テスト（`ConflictError` 時に `UserManagementService` が呼ばれない）で順序を固定する
+- B. 本イシューで User を Employee 集約に取り込む — 根本解決だが認証基盤との境界をまたぐ大改修でスコープ逸脱
+- 採用: A。B の集約境界再設計は #317 として起票済み
+
+### フォームテストの範囲
+
+`EmployeeUpdateForm.test.tsx` が既に存在する（customer には無かった employee 固有の資産）。
+
+- A. version の hidden input の存在検証まで追加する — フォーム往復はチェーンの中で唯一型に守られない箇所であり、テストで補強する
+- B. 既存テストが通るよう修正するだけ（#316 との対称性）
+- 採用: A
+
+### コミット分割
+
+- A. 1コミット縦切り — `save` 廃止→コマンド→アクション→フォームが型でつながるコンパイル原子的な変更であり、#316 の customer 適用も1コミット（`feat: customer サブドメインへ楽観ロックを適用する（ADR-0039）`）だった
+- B. `save` を温存して段階コミット — 各コミットは動くが、楽観ロックの効かない経路が一時併存し中間状態に意味がない
+- 採用: A
+
+### その他（先例踏襲のため判断不要）
+
+- 命名: コマンド Input は `expectedVersion`、フォーム/Zod は `version`（`UpdateCustomerCommand.ts` / customer `schema.ts` 踏襲）
+- Prisma 実装: 平坦集約のためトランザクション不要。単発 `updateMany` + 更新後の読み直し（`PrismaCustomerRepository.ts:31-46` と同型）
+- `ConflictError` メッセージ: ADR-0039 細目5の文言「他のユーザーによって更新または削除されています。画面を再読み込みして最新の内容を確認してください。」
+- DTO: 一覧・詳細共用の `EmployeeDTO` 1本に `version: number` を追加（`CustomerDTO.ts:17` 踏襲）
+- Zod: `z.coerce.number().int()`（customer `schema.ts:11-13` 踏襲）
+
+## ステップ
+
+以下は作業順序であり、コミットは Step 6 完了時の1回（設計判断「コミット分割」参照）。
+
+### Step 1: リポジトリインターフェース分割
+
+- 対象ファイル: `src/server/subdomains/employee/domain/repositories/EmployeeRepository.ts`
+- 作業内容:
+  - `save` を削除し `insert(employee)` / `update(employee, expectedVersion: number)` を定義（JSDoc は `CustomerRepository.ts` 踏襲）
+
+### Step 2: Prisma リポジトリ実装
+
+- 対象ファイル: `src/server/subdomains/employee/infrastructure/prisma/PrismaEmployeeRepository.ts`
+- 作業内容:
+  - `save`（upsert 分岐）を廃止し、`insert` = `create`、`update` = 条件付き `updateMany` + count = 0 で `ConflictError` + 読み直し
+
+### Step 3: コマンド対応
+
+- 対象ファイル: `src/server/subdomains/employee/application/commands/UpdateEmployeeCommand.ts`, `CreateEmployeeCommand.ts`
+- 作業内容:
+  - `UpdateEmployeeInput` に `expectedVersion: number` を追加し `update()` へ素通し
+  - employee 行の `update()` が User 同期より先に走る順序が User 側保護の前提であることをコメントで明記（#317 参照）
+  - `CreateEmployeeCommand` を `insert` へ切替
+
+### Step 4: クエリ側 DTO
+
+- 対象ファイル: `src/server/subdomains/employee/application/queries/dto/EmployeeDTO.ts`, `src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts`
+- 作業内容:
+  - `EmployeeDTO` に `version: number` を追加し、クエリサービスでマッピング
+
+### Step 5: プレゼンテーション層
+
+- 対象ファイル: `src/app/(features)/employees/[employeeCd]/schema.ts`, `EmployeeUpdateForm.tsx`, `actions.ts`
+- 作業内容:
+  - `updateEmployeeSchema` に `version: z.coerce.number().int()` を追加
+  - フォームの defaultValue に `version: String(employee.version)`、hidden input を配置（`CustomerUpdateForm.tsx:41,59` 踏襲）
+  - アクションで version を読み `expectedVersion` としてコマンドへ渡す
+
+### Step 6: テスト
+
+- 対象ファイル: `src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts`, `src/server/subdomains/employee/application/commands/__tests__/UpdateEmployeeCommand.test.ts`（および Create 側の既存テスト修正）, `src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.test.tsx`
+- 作業内容:
+  - リポジトリ統合テスト: stale トークン逐次再現（`update(v1)` 成功 → 再度 `update(v1)` が `ConflictError`、先行変更が残存）
+  - コマンド単体テスト: `expectedVersion` の素通し検証 + `ConflictError` 時に `UserManagementService` が呼ばれないことの検証（順序固定）
+  - フォームテスト: version の hidden input の存在検証を追加
+- コミットメッセージ: `feat: employee サブドメインへ楽観ロックを適用する（ADR-0039）`
+  - ボディに設計判断（User 同期の順序依存の明示化と #317 起票、1コミット縦切りの理由）を記載
+
+## 受け入れ条件（Issue より）
+
+- [ ] 対象コマンドで version 不一致時に `ConflictError` が発生し、後勝ちによる静かな変更喪失が起きない
+- [ ] `save` が廃止され、更新経路で expectedVersion を渡さないコードがコンパイルエラーになる
+- [ ] 編集ウィンドウ（画面表示時点の version）がフォーム往復で保護される
+- [ ] lost update 防止を示すテストが存在する
+
+## 関連
+
+- 親: #301（ADR-0039・7テーブル一括マイグレーション・estimate 縦切り）
+- 先例: #316（customer 適用、コミット 281b296）
+- 派生: #317（Employee と User の集約境界再設計 — 本イシューのグリルで起票）

--- a/docs/claude-plans/issue-304/deviations.md
+++ b/docs/claude-plans/issue-304/deviations.md
@@ -1,0 +1,13 @@
+# Issue #304 実装計画からの逸脱記録
+
+## 1. ドメインサービステストの save → insert 移行（対象ファイルの追加）
+
+- **元の計画内容**: テスト変更対象は `PrismaEmployeeRepository.test.ts` / `UpdateEmployeeCommand.test.ts`（および Create 側）/ `EmployeeUpdateForm.test.tsx` の3系統。
+- **実際の実装内容**: 上記に加え `EmployeeCdDuplicationCheckDomainService.test.ts` と `MailAddressDuplicationCheckDomainService.test.ts` のフィクスチャ作成箇所を `repository.save` から `repository.insert` へ移行した。
+- **逸脱の理由**: 両テストがフィクスチャ作成に `save` を使っており、`save` 廃止（受け入れ条件）に伴う型エラーで発覚した随伴修正。計画時の `save` 呼び出し元調査がプロダクションコードのみを対象にしており、テストコードの利用箇所を見落としていた。
+
+## 2. expectedVersion 素通し検証の方式（モック検証 → 振る舞い検証）
+
+- **元の計画内容**: 「コマンド単体テストで expectedVersion の素通しを検証」（Issue 本文・ADR-0039 の文言を踏襲）。
+- **実際の実装内容**: モックリポジトリへの引数検証ではなく、既存テストスイートのスタイル（実 DB + FakeUserManagementService の統合スタイル）に合わせ、「stale な expectedVersion で実行すると ConflictError になり、employee 行と認証ユーザーが変更されない」という観測可能な振る舞いで素通しを検証した。
+- **逸脱の理由**: 既存の `UpdateEmployeeCommand.test.ts` が実 DB 統合スタイルで統一されており、モック検証を持ち込むと実装詳細（リポジトリ呼び出しのシグネチャ）に結合したテストになる。振る舞い検証なら素通しの正しさ（誤った値や再取得値を渡せばテストが落ちる）を同等以上に保証しつつ、Q1 で決めた「ConflictError 時に User 同期へ到達しない」順序固定の検証と1テストに自然に統合できるため。

--- a/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.test.tsx
+++ b/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.test.tsx
@@ -27,6 +27,7 @@ const mockEmployee = {
   employeeCd: "EMP000001",
   departmentId: "dept-1",
   role: USER_ROLES.USER,
+  version: 3,
 };
 
 // 部署選択スロットのモック
@@ -310,6 +311,34 @@ describe("EmployeeUpdateForm", () => {
       expect(formData.get("name")).toBe("田中花子");
       expect(formData.get("email")).toBe("yamada@example.com");
       expect(formData.get("role")).toBe(USER_ROLES.ADMIN);
+    });
+  });
+
+  describe("楽観ロック（ADR-0039）", () => {
+    test("編集画面表示時の version が hidden input としてフォームに含まれ、送信時に往復する", async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+        />
+      );
+
+      // hidden input が存在し、画面表示時の version を保持している
+      const versionInput = container.querySelector('input[type="hidden"][name="version"]');
+      expect(versionInput).not.toBeNull();
+      expect(versionInput).toHaveValue("3");
+
+      // 送信した FormData に version が含まれる（フォーム往復の契約）
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: "更新" }));
+      });
+      await waitFor(() => {
+        expect(mockUpdateEmployee).toHaveBeenCalled();
+      });
+      const formData = mockUpdateEmployee.mock.calls[0][2] as FormData;
+      expect(formData.get("version")).toBe("3");
     });
   });
 

--- a/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.tsx
+++ b/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.tsx
@@ -14,6 +14,8 @@ type Employee = {
   employeeCd: string;
   departmentId: string;
   role: UserRole | null;
+  /** 楽観ロックトークン（ADR-0039）。編集画面表示時の値をフォームで往復させる */
+  version: number;
 };
 
 type Props = {
@@ -35,6 +37,7 @@ export function EmployeeUpdateForm({ employee, canUpdate, departmentSelectSlot }
       email: employee.email,
       departmentId: employee.departmentId,
       role: employee.role ?? USER_ROLES.USER,
+      version: String(employee.version),
     },
   });
 
@@ -56,6 +59,8 @@ export function EmployeeUpdateForm({ employee, canUpdate, departmentSelectSlot }
       )}
 
       <form {...getFormProps(form)} noValidate className="space-y-4">
+        {/* 楽観ロックトークン（ADR-0039）。編集画面表示時の version を往復させる。 */}
+        <input {...getInputProps(fields.version, { type: "hidden" })} />
         <div>
           <label htmlFor={fields.name.id} className="block text-gray-700 text-sm font-bold mb-2">
             名前

--- a/src/app/(features)/employees/[employeeCd]/actions.ts
+++ b/src/app/(features)/employees/[employeeCd]/actions.ts
@@ -33,9 +33,10 @@ export async function updateEmployee(employeeCd: string, prevState: unknown, for
     return submission.reply();
   }
 
-  const { name, email, role, departmentId } = submission.value;
+  const { name, email, role, departmentId, version } = submission.value;
 
-  // employeeCdからidを取得
+  // employeeCdからidを取得（version は再取得値ではなくフォーム由来の値を使う。
+  // 再取得値を使うと常に最新 version でチェックが素通りし、編集ウィンドウを守れない / ADR-0039）
   const queryService = new PrismaEmployeeQueryService();
   const employee = await queryService.findByEmployeeCd(employeeCd);
   if (!employee) {
@@ -60,6 +61,7 @@ export async function updateEmployee(employeeCd: string, prevState: unknown, for
       employeeCd,
       departmentId,
       role,
+      expectedVersion: version,
     });
 
     revalidatePath("/employees");

--- a/src/app/(features)/employees/[employeeCd]/schema.ts
+++ b/src/app/(features)/employees/[employeeCd]/schema.ts
@@ -4,9 +4,11 @@ import { employeeBaseSchema } from "../_shared/schema";
 /**
  * 従業員更新フォームのバリデーションスキーマ
  * 基盤スキーマ + departmentId（id, employeeCdはURLパラメータから取得）
+ * version は楽観ロックトークン（ADR-0039）。編集画面表示時の値を hidden input で往復させる
  */
 export const updateEmployeeSchema = employeeBaseSchema.extend({
   departmentId: z.string().min(1, "部署を選択してください"),
+  version: z.coerce.number().int(),
 });
 
 export type UpdateEmployeeInput = z.infer<typeof updateEmployeeSchema>;

--- a/src/server/subdomains/employee/application/commands/CreateEmployeeCommand.ts
+++ b/src/server/subdomains/employee/application/commands/CreateEmployeeCommand.ts
@@ -58,7 +58,7 @@ export class CreateEmployeeCommand {
     const newEmployee = Employee.create(employeeCd, mailAddress, employeeName, departmentId);
 
     // Employee を保存
-    await this.employeeRepository.save(newEmployee);
+    await this.employeeRepository.insert(newEmployee);
 
     // 認証ユーザー（User/Account）を作成（roleはUser側で管理）
     const userResult = await this.userManagementService.createUser({

--- a/src/server/subdomains/employee/application/commands/UpdateEmployeeCommand.ts
+++ b/src/server/subdomains/employee/application/commands/UpdateEmployeeCommand.ts
@@ -13,6 +13,8 @@ import { EmployeeName } from "@subdomains/employee/domain/values/EmployeeName";
 export type UpdateEmployeeInput = {
   id: string;
   employeeCd: string;
+  /** 編集画面表示時の version（楽観ロックトークン / ADR-0039）。リポジトリへ素通しする。 */
+  expectedVersion: number;
   email: string;
   name: string;
   /** 所属部署ID */
@@ -58,7 +60,10 @@ export class UpdateEmployeeCommand {
     targetEmployee.changeEmail(newMailAddress);
     targetEmployee.changeDepartment(new DepartmentId(input.departmentId));
 
-    await this.employeeRepository.save(targetEmployee);
+    // 注意: この条件付き UPDATE（楽観ロック / ADR-0039）が後続の User 同期より先に走る順序が、
+    // User.email/role を employee の version で間接的に守る前提になっている。
+    // stale なフォームはここで ConflictError になり User 同期に到達しない（集約境界の再設計は #317）。
+    await this.employeeRepository.update(targetEmployee, input.expectedVersion);
 
     // 認証ユーザーの更新（email, role）
     const user = await this.userManagementService.findUserByEmployeeId(input.id);

--- a/src/server/subdomains/employee/application/commands/__tests__/UpdateEmployeeCommand.test.ts
+++ b/src/server/subdomains/employee/application/commands/__tests__/UpdateEmployeeCommand.test.ts
@@ -2,7 +2,7 @@ import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepart
 import prisma from "@server/prisma";
 import { FakeUserManagementService } from "@server/shared/auth/fake/FakeUserManagementService";
 import { USER_ROLES } from "@server/shared/auth/types";
-import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { ValidationError } from "@server/shared/errors/DomainError";
 import { MailAddressDuplicationCheckDomainService } from "@subdomains/employee/domain/services/MailAddressDuplicationCheckDomainService";
 import { PrismaEmployeeRepository } from "@subdomains/employee/infrastructure/prisma/PrismaEmployeeRepository";
@@ -94,6 +94,7 @@ describe("UpdateEmployeeCommand", () => {
       name: "更新後従業員",
       departmentId: TEST_DEPT_ID,
       role: USER_ROLES.USER,
+      expectedVersion: 1,
     });
 
     // DBに反映されたことを確認
@@ -113,6 +114,7 @@ describe("UpdateEmployeeCommand", () => {
       name: "既存従業員",
       departmentId: TEST_DEPT_ID,
       role: USER_ROLES.USER,
+      expectedVersion: 1,
     });
 
     // DBに反映されたことを確認
@@ -134,11 +136,51 @@ describe("UpdateEmployeeCommand", () => {
       name: "既存従業員",
       departmentId: TEST_DEPT_ID,
       role: USER_ROLES.ADMIN, // USER -> ADMIN に変更
+      expectedVersion: 1,
     });
 
     // 認証ユーザーのroleが更新されたことを確認
     const authUser = fakeUserManagementService.getUser(TEST_EMPLOYEE_ID);
     expect(authUser?.role).toBe(USER_ROLES.ADMIN);
+  });
+
+  it("stale な expectedVersion では ConflictError になり、認証ユーザーへの同期も行われない", async () => {
+    // 別ユーザーが先に保存して version が進んだ状況（1 → 2）を再現
+    await command.execute({
+      id: TEST_EMPLOYEE_ID,
+      employeeCd: "EMP999912",
+      email: "existing@example.com",
+      name: "先行ユーザーの変更",
+      departmentId: TEST_DEPT_ID,
+      role: USER_ROLES.USER,
+      expectedVersion: 1,
+    });
+
+    // 古い編集画面（version 1）からの保存 → 競合
+    await expect(
+      command.execute({
+        id: TEST_EMPLOYEE_ID,
+        employeeCd: "EMP999912",
+        email: "stale@example.com",
+        name: "後追いユーザーの変更",
+        departmentId: TEST_DEPT_ID,
+        role: USER_ROLES.ADMIN,
+        expectedVersion: 1,
+      })
+    ).rejects.toThrow(ConflictError);
+
+    // employee は先行ユーザーの変更のまま（lost update が起きていない）
+    const employee = await prisma.employee.findUnique({
+      where: { id: TEST_EMPLOYEE_ID },
+    });
+    expect(employee?.name).toBe("先行ユーザーの変更");
+    expect(employee?.email).toBe("existing@example.com");
+
+    // 認証ユーザーへの同期（email/role）にも到達していない。
+    // employee 行の条件付き UPDATE が User 同期より先に走る順序が、この保護の前提（#317）
+    const authUser = fakeUserManagementService.getUser(TEST_EMPLOYEE_ID);
+    expect(authUser?.email).toBe("existing@example.com");
+    expect(authUser?.role).toBe(USER_ROLES.USER);
   });
 
   it("存在しない従業員IDの場合はNotFoundEntityErrorがスローされる", async () => {
@@ -150,6 +192,7 @@ describe("UpdateEmployeeCommand", () => {
         name: "更新テスト",
         departmentId: TEST_DEPT_ID,
         role: USER_ROLES.USER,
+        expectedVersion: 1,
       })
     ).rejects.toThrow(NotFoundEntityError);
     await expect(
@@ -160,6 +203,7 @@ describe("UpdateEmployeeCommand", () => {
         name: "更新テスト",
         departmentId: TEST_DEPT_ID,
         role: USER_ROLES.USER,
+        expectedVersion: 1,
       })
     ).rejects.toThrow("従業員が見つかりません");
   });
@@ -173,6 +217,7 @@ describe("UpdateEmployeeCommand", () => {
         name: "既存従業員",
         departmentId: TEST_DEPT_ID,
         role: USER_ROLES.USER,
+        expectedVersion: 1,
       })
     ).rejects.toThrow(ValidationError);
     await expect(
@@ -183,6 +228,7 @@ describe("UpdateEmployeeCommand", () => {
         name: "既存従業員",
         departmentId: TEST_DEPT_ID,
         role: USER_ROLES.USER,
+        expectedVersion: 1,
       })
     ).rejects.toThrow("既に存在するメールアドレスです");
 

--- a/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmployeeCdQuery.test.ts
+++ b/src/server/subdomains/employee/application/queries/__tests__/GetEmployeeByEmployeeCdQuery.test.ts
@@ -86,6 +86,8 @@ describe("GetEmployeeByEmployeeCdQuery", () => {
     expect(result).not.toBeNull();
     expect(result?.employeeCd).toBe(TEST_CODES[0]);
     expect(result?.email).toBe("getbycd-query@example.com");
+    // 楽観ロックトークン（ADR-0039）。編集画面はこの値をフォームで往復させる
+    expect(result?.version).toBe(1);
   });
 
   it("存在しない従業員CDの場合nullを返す", async () => {

--- a/src/server/subdomains/employee/application/queries/dto/EmployeeDTO.ts
+++ b/src/server/subdomains/employee/application/queries/dto/EmployeeDTO.ts
@@ -17,6 +17,8 @@ export type EmployeeDTO = {
   departmentName: string;
   /** ユーザーロール（User.roleから取得、Userが存在しない場合はnull） */
   role: UserRole | null;
+  /** 楽観ロックトークン（ADR-0039）。編集画面表示時の値をフォームで往復させる */
+  version: number;
   createdAt: Date;
   updatedAt: Date;
 };

--- a/src/server/subdomains/employee/domain/repositories/EmployeeRepository.ts
+++ b/src/server/subdomains/employee/domain/repositories/EmployeeRepository.ts
@@ -13,9 +13,17 @@ import { MailAddress } from "@server/shared/domain/values/MailAddress";
  */
 export interface EmployeeRepository {
   /**
-   * 従業員を保存（新規作成・更新）
+   * 従業員を新規作成
    */
-  save(employee: Employee): Promise<Employee>;
+  insert(employee: Employee): Promise<Employee>;
+
+  /**
+   * 既存従業員を更新（楽観ロック / ADR-0039）
+   *
+   * @param expectedVersion 編集画面表示時に取得した version（フォーム往復で持ち回るトークン）。
+   *   保存時点の version と一致しない場合は ConflictError を throw し、後勝ちの変更喪失を防ぐ。
+   */
+  update(employee: Employee, expectedVersion: number): Promise<Employee>;
 
   /**
    * 従業員を削除

--- a/src/server/subdomains/employee/domain/services/__tests__/EmployeeCdDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/employee/domain/services/__tests__/EmployeeCdDuplicationCheckDomainService.test.ts
@@ -45,7 +45,7 @@ describe("EmployeeCdDuplicationCheckDomainService", () => {
       new EmployeeName("テスト太郎"),
       TEST_DEPT_ID
     );
-    await repository.save(employee);
+    await repository.insert(employee);
 
     const isDuplicated = await service.execute(new EmployeeCd(TEST_CODES[0]));
     expect(isDuplicated).toBe(true);
@@ -58,7 +58,7 @@ describe("EmployeeCdDuplicationCheckDomainService", () => {
       new EmployeeName("テスト太郎"),
       TEST_DEPT_ID
     );
-    await repository.save(employee);
+    await repository.insert(employee);
 
     const isDuplicated = await service.execute(new EmployeeCd(TEST_CODES[1]));
     expect(isDuplicated).toBe(false);

--- a/src/server/subdomains/employee/domain/services/__tests__/MailAddressDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/employee/domain/services/__tests__/MailAddressDuplicationCheckDomainService.test.ts
@@ -45,7 +45,7 @@ describe("MailAddressDuplicationCheckDomainService", () => {
       new EmployeeName("テスト太郎"),
       TEST_DEPT_ID
     );
-    await repository.save(employee);
+    await repository.insert(employee);
 
     const isDuplicated = await service.execute(new MailAddress("ds-mail-dup-existing@example.com"));
     expect(isDuplicated).toBe(true);
@@ -58,7 +58,7 @@ describe("MailAddressDuplicationCheckDomainService", () => {
       new EmployeeName("テスト太郎"),
       TEST_DEPT_ID
     );
-    await repository.save(employee);
+    await repository.insert(employee);
 
     const isDuplicated = await service.execute(new MailAddress("ds-mail-dup-new@example.com"));
     expect(isDuplicated).toBe(false);

--- a/src/server/subdomains/employee/infrastructure/prisma/PrismaEmployeeRepository.ts
+++ b/src/server/subdomains/employee/infrastructure/prisma/PrismaEmployeeRepository.ts
@@ -5,34 +5,55 @@ import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { EmployeeMapper } from "@subdomains/employee/infrastructure/mappers/EmployeeMapper";
 import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
 
 export class PrismaEmployeeRepository implements EmployeeRepository {
   // ClientManagerをDIする
   // constructor(private prisma: PrismaClientManager) {}
 
   /**
-   * 従業員を保存（新規作成・更新の両方に対応）
-   *
-   * @param employee 従業員エンティティ
-   * @returns 保存後の従業員エンティティ
+   * 従業員を新規作成（version は @default(1)）
    */
-  async save(employee: Employee): Promise<Employee> {
-    let prismaEmployee;
-
-    if (employee.id.value) {
-      // IDが存在する場合：upsert（更新 or 作成）
-      prismaEmployee = await prisma.employee.upsert({
-        where: { id: employee.id.value },
-        create: EmployeeMapper.toPrismaCreate(employee),
-        update: EmployeeMapper.toPrismaUpdate(employee),
-      });
-    } else {
-      // IDが空の場合：新規作成
-      const data = EmployeeMapper.toPrismaCreate(employee);
-      prismaEmployee = await prisma.employee.create({ data });
-    }
+  async insert(employee: Employee): Promise<Employee> {
+    const prismaEmployee = await prisma.employee.create({
+      data: EmployeeMapper.toPrismaCreate(employee),
+    });
 
     return EmployeeMapper.toDomain(prismaEmployee);
+  }
+
+  /**
+   * 既存従業員を更新（楽観ロック / ADR-0039）
+   *
+   * WHERE id AND version の条件付き UPDATE で「比較→更新」を DB 上で原子化し、
+   * 成功時に version を +1 する。count = 0 は「version 不一致（先行更新あり）」と
+   * 「行の消失（削除済み）」の両方を含むが、UPDATE 文からは区別できないため
+   * 両方を覆うメッセージで競合として扱う（ADR-0039 細目5/6）。
+   *
+   * @param expectedVersion 編集画面表示時のトークン（フォーム往復で持ち回った値）
+   */
+  async update(employee: Employee, expectedVersion: number): Promise<Employee> {
+    const result = await prisma.employee.updateMany({
+      where: { id: employee.id.value, version: expectedVersion },
+      data: {
+        ...EmployeeMapper.toPrismaUpdate(employee),
+        version: { increment: 1 },
+      },
+    });
+
+    if (result.count === 0) {
+      throw new ConflictError(
+        "他のユーザーによって更新または削除されています。画面を再読み込みして最新の内容を確認してください。"
+      );
+    }
+
+    // version を進めた最新行を読み直して返す
+    const row = await prisma.employee.findUnique({ where: { id: employee.id.value } });
+    if (!row) {
+      throw new Error(`保存した従業員の再取得に失敗しました: ${employee.id.value}`);
+    }
+
+    return EmployeeMapper.toDomain(row);
   }
 
   /**

--- a/src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts
+++ b/src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts
@@ -7,6 +7,7 @@ import { MailAddress } from "@server/shared/domain/values/MailAddress";
 import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
 import { PrismaEmployeeRepository } from "../PrismaEmployeeRepository";
 import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("PrismaEmployeeRepository", () => {
@@ -39,8 +40,8 @@ describe("PrismaEmployeeRepository", () => {
     });
   });
 
-  describe("save", () => {
-    it("新規従業員を保存できる", async () => {
+  describe("insert", () => {
+    it("新規従業員を保存でき、version は 1 で始まる", async () => {
       const employee = Employee.create(
         new EmployeeCd("EMP999001"),
         new MailAddress("test-save@example.com"),
@@ -48,7 +49,7 @@ describe("PrismaEmployeeRepository", () => {
         TEST_DEPT_ID
       );
 
-      const savedEmployee = await repository.save(employee);
+      const savedEmployee = await repository.insert(employee);
 
       // 保存されたエンティティを確認
       expect(savedEmployee).not.toBeNull();
@@ -57,7 +58,7 @@ describe("PrismaEmployeeRepository", () => {
       expect(savedEmployee.email.value).toBe("test-save@example.com");
       expect(savedEmployee.name.value).toBe("テスト太郎");
 
-      // DBから取得して確認
+      // DBから取得して確認（version 列は @default(1)）
       const saved = await prisma.employee.findUnique({
         where: { employeeCd: "EMP999001" },
       });
@@ -66,11 +67,12 @@ describe("PrismaEmployeeRepository", () => {
       expect(saved?.employeeCd).toBe("EMP999001");
       expect(saved?.email).toBe("test-save@example.com");
       expect(saved?.name).toBe("テスト太郎");
+      expect(saved?.version).toBe(1);
     });
   });
 
-  describe("save (update)", () => {
-    it("既存従業員を更新できる", async () => {
+  describe("update", () => {
+    it("一致する expectedVersion で更新でき、version が 1 進む", async () => {
       // まず保存
       const employee = Employee.create(
         new EmployeeCd("EMP999001"),
@@ -78,22 +80,55 @@ describe("PrismaEmployeeRepository", () => {
         new EmployeeName("更新前の名前"),
         TEST_DEPT_ID
       );
-      const savedEmployee = await repository.save(employee);
+      const savedEmployee = await repository.insert(employee);
 
       // 名前を変更
       savedEmployee.changeName(new EmployeeName("更新後の名前"));
-      const updatedEmployee = await repository.save(savedEmployee);
+      const updatedEmployee = await repository.update(savedEmployee, 1);
 
       // 更新されたエンティティを確認
       expect(updatedEmployee.name.value).toBe("更新後の名前");
       expect(updatedEmployee.id.value).toBe(savedEmployee.id.value);
 
-      // DBから再取得して確認
+      // DBから再取得して確認（version は 1 → 2 へ進む）
       const updated = await prisma.employee.findUnique({
         where: { employeeCd: "EMP999001" },
       });
 
       expect(updated?.name).toBe("更新後の名前");
+      expect(updated?.version).toBe(2);
+    });
+  });
+
+  describe("楽観ロック（ADR-0039）", () => {
+    it("古い expectedVersion での更新は ConflictError になり、先行の変更は失われない", async () => {
+      const saved = await repository.insert(
+        Employee.create(
+          new EmployeeCd("EMP999001"),
+          new MailAddress("test-lock@example.com"),
+          new EmployeeName("競合テスト"),
+          TEST_DEPT_ID
+        )
+      );
+
+      // 2人のユーザーが同じ version 1 の編集画面を開いた状況を再現
+      const loadedByB = await repository.findById(saved.id);
+      const loadedByA = await repository.findById(saved.id);
+      expect(loadedByB).not.toBeNull();
+      expect(loadedByA).not.toBeNull();
+      if (!loadedByB || !loadedByA) return;
+
+      // B が先に保存（version 1 → 2）
+      loadedByB.changeName(new EmployeeName("Bの変更"));
+      await repository.update(loadedByB, 1);
+
+      // A が古いトークン 1 のまま保存 → 競合として弾かれる
+      loadedByA.changeName(new EmployeeName("Aの変更"));
+      await expect(repository.update(loadedByA, 1)).rejects.toThrow(ConflictError);
+
+      // B の変更が残っている（後勝ちによる lost update が起きていない）
+      const found = await repository.findById(saved.id);
+      expect(found?.name.value).toBe("Bの変更");
     });
   });
 
@@ -106,7 +141,7 @@ describe("PrismaEmployeeRepository", () => {
         new EmployeeName("削除テスト"),
         TEST_DEPT_ID
       );
-      const savedEmployee = await repository.save(employee);
+      const savedEmployee = await repository.insert(employee);
 
       // 削除
       await repository.delete(savedEmployee.id);
@@ -128,7 +163,7 @@ describe("PrismaEmployeeRepository", () => {
         new EmployeeName("ID検索テスト"),
         TEST_DEPT_ID
       );
-      const savedEmployee = await repository.save(employee);
+      const savedEmployee = await repository.insert(employee);
 
       // findByIdで検索
       const found = await repository.findById(savedEmployee.id);
@@ -158,7 +193,7 @@ describe("PrismaEmployeeRepository", () => {
         new EmployeeName("社員コード検索テスト"),
         TEST_DEPT_ID
       );
-      await repository.save(employee);
+      await repository.insert(employee);
 
       // findByEmployeeCdで検索
       const found = await repository.findByEmployeeCd(new EmployeeCd("EMP999002"));
@@ -190,8 +225,8 @@ describe("PrismaEmployeeRepository", () => {
         TEST_DEPT_ID
       );
 
-      await repository.save(employee1);
-      await repository.save(employee2);
+      await repository.insert(employee1);
+      await repository.insert(employee2);
 
       // EMP999003を検索
       const found = await repository.findByEmployeeCd(new EmployeeCd("EMP999003"));

--- a/src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts
+++ b/src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts
@@ -115,6 +115,7 @@ export class PrismaEmployeeQueryService implements EmployeeQueryService {
       email: true,
       name: true,
       departmentId: true,
+      version: true,
       createdAt: true,
       updatedAt: true,
       // Department.nameを取得
@@ -142,6 +143,7 @@ export class PrismaEmployeeQueryService implements EmployeeQueryService {
     name: string;
     departmentId: string;
     department: { name: string };
+    version: number;
     createdAt: Date;
     updatedAt: Date;
     user: { role: string | null } | null;
@@ -155,6 +157,7 @@ export class PrismaEmployeeQueryService implements EmployeeQueryService {
       departmentName: employee.department.name,
       // User.roleを使用（"admin" | "user" | null）
       role: (employee.user?.role as UserRole) ?? null,
+      version: employee.version,
       createdAt: employee.createdAt,
       updatedAt: employee.updatedAt,
     };


### PR DESCRIPTION
## Summary

ADR-0039 の横断ポリシーに基づき、employee サブドメインの `UpdateEmployeeCommand` へ楽観ロックを適用しました。`EmployeeRepository` の `save` を `insert` / `update(employee, expectedVersion)` に分割し、条件付き `updateMany`（`WHERE id AND version` + `version: { increment: 1 }`）で lost update を原子的に防ぎます。編集画面表示時の version を hidden input でフォーム往復させ、不一致時は `ConflictError` を throw します（#316 の customer 適用パターンを踏襲）。

Closes #304

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### apply-optimistic-locking-to-employee.md

# Issue #304: 楽観ロックを employee サブドメインへ適用する（ADR-0039 横断展開） — 実装計画

## 概要

ADR-0039 の横断ポリシーに基づき、employee サブドメインの更新コマンドへ楽観ロックを適用する。#316（customer 適用、コミット 281b296）のパターンを忠実に移植する。

- `EmployeeRepository` の `save` を `insert` / `update(employee, expectedVersion)` に分割
- Prisma 実装は条件付き `updateMany`（`WHERE id AND version` + `version: { increment: 1 }`）、count = 0 で `ConflictError`
- `UpdateEmployeeCommand` の Input に `expectedVersion` を追加して素通し
- `EmployeeDTO` に `version` を追加し、編集フォームの hidden input + Zod で往復させる

新規 ADR は不要（ADR-0039 の忠実な横断展開であり、新しい設計判断を含まない）。CONTEXT.md への用語追加も不要（楽観ロックはドメイン語彙ではなく横断技術ポリシー）。

### 事前調査で確認済みの前提

- `employee` テーブルの `version Int @default(1)` 列は #301 のマイグレーションで追加済み
- employee に Activate/Deactivate コマンドは存在しない（対象は `UpdateEmployeeCommand` のみ）
- `DeleteEmployeeCommand` は対象外（Delete 系横断イシューで扱う。#316 でも delete は version を読んでいない）
- `save` の呼び出し元は `CreateEmployeeCommand` / `UpdateEmployeeCommand` の2箇所のみ
- 編集ページは `GetEmployeeByEmployeeCdQuery` → `EmployeeDTO` で version が流れる
- `User.role` / `User.email` の更新経路は `UpdateEmployeeCommand` のみ（バイパス経路なし）

## 設計判断

### User 同期（email/role）の楽観ロック保護方式

`UpdateEmployeeCommand` は employee 行の保存後に `UserManagementService` 経由で User テーブルを非トランザクションで更新する。role は User の属性だが employee 編集フォームで一緒に編集されるため、保護が必要。

- A. 実行順序への依存を受容し、明示化する — employee 行の条件付き UPDATE が先に走るため、stale フォームは `ConflictError` で User 同期に到達しない。この順序が保護の前提であることをコードコメントで明記し、コマンド単体テスト（`ConflictError` 時に `UserManagementService` が呼ばれない）で順序を固定する
- B. 本イシューで User を Employee 集約に取り込む — 根本解決だが認証基盤との境界をまたぐ大改修でスコープ逸脱
- 採用: A。B の集約境界再設計は #317 として起票済み

### フォームテストの範囲

`EmployeeUpdateForm.test.tsx` が既に存在する（customer には無かった employee 固有の資産）。

- A. version の hidden input の存在検証まで追加する — フォーム往復はチェーンの中で唯一型に守られない箇所であり、テストで補強する
- B. 既存テストが通るよう修正するだけ（#316 との対称性）
- 採用: A

### コミット分割

- A. 1コミット縦切り — `save` 廃止→コマンド→アクション→フォームが型でつながるコンパイル原子的な変更であり、#316 の customer 適用も1コミット（`feat: customer サブドメインへ楽観ロックを適用する（ADR-0039）`）だった
- B. `save` を温存して段階コミット — 各コミットは動くが、楽観ロックの効かない経路が一時併存し中間状態に意味がない
- 採用: A

### その他（先例踏襲のため判断不要）

- 命名: コマンド Input は `expectedVersion`、フォーム/Zod は `version`（`UpdateCustomerCommand.ts` / customer `schema.ts` 踏襲）
- Prisma 実装: 平坦集約のためトランザクション不要。単発 `updateMany` + 更新後の読み直し（`PrismaCustomerRepository.ts:31-46` と同型）
- `ConflictError` メッセージ: ADR-0039 細目5の文言「他のユーザーによって更新または削除されています。画面を再読み込みして最新の内容を確認してください。」
- DTO: 一覧・詳細共用の `EmployeeDTO` 1本に `version: number` を追加（`CustomerDTO.ts:17` 踏襲）
- Zod: `z.coerce.number().int()`（customer `schema.ts:11-13` 踏襲）

## ステップ

以下は作業順序であり、コミットは Step 6 完了時の1回（設計判断「コミット分割」参照）。

### Step 1: リポジトリインターフェース分割

- 対象ファイル: `src/server/subdomains/employee/domain/repositories/EmployeeRepository.ts`
- 作業内容:
  - `save` を削除し `insert(employee)` / `update(employee, expectedVersion: number)` を定義（JSDoc は `CustomerRepository.ts` 踏襲）

### Step 2: Prisma リポジトリ実装

- 対象ファイル: `src/server/subdomains/employee/infrastructure/prisma/PrismaEmployeeRepository.ts`
- 作業内容:
  - `save`（upsert 分岐）を廃止し、`insert` = `create`、`update` = 条件付き `updateMany` + count = 0 で `ConflictError` + 読み直し

### Step 3: コマンド対応

- 対象ファイル: `src/server/subdomains/employee/application/commands/UpdateEmployeeCommand.ts`, `CreateEmployeeCommand.ts`
- 作業内容:
  - `UpdateEmployeeInput` に `expectedVersion: number` を追加し `update()` へ素通し
  - employee 行の `update()` が User 同期より先に走る順序が User 側保護の前提であることをコメントで明記（#317 参照）
  - `CreateEmployeeCommand` を `insert` へ切替

### Step 4: クエリ側 DTO

- 対象ファイル: `src/server/subdomains/employee/application/queries/dto/EmployeeDTO.ts`, `src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts`
- 作業内容:
  - `EmployeeDTO` に `version: number` を追加し、クエリサービスでマッピング

### Step 5: プレゼンテーション層

- 対象ファイル: `src/app/(features)/employees/[employeeCd]/schema.ts`, `EmployeeUpdateForm.tsx`, `actions.ts`
- 作業内容:
  - `updateEmployeeSchema` に `version: z.coerce.number().int()` を追加
  - フォームの defaultValue に `version: String(employee.version)`、hidden input を配置（`CustomerUpdateForm.tsx:41,59` 踏襲）
  - アクションで version を読み `expectedVersion` としてコマンドへ渡す

### Step 6: テスト

- 対象ファイル: `src/server/subdomains/employee/infrastructure/prisma/__tests__/PrismaEmployeeRepository.test.ts`, `src/server/subdomains/employee/application/commands/__tests__/UpdateEmployeeCommand.test.ts`（および Create 側の既存テスト修正）, `src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.test.tsx`
- 作業内容:
  - リポジトリ統合テスト: stale トークン逐次再現（`update(v1)` 成功 → 再度 `update(v1)` が `ConflictError`、先行変更が残存）
  - コマンド単体テスト: `expectedVersion` の素通し検証 + `ConflictError` 時に `UserManagementService` が呼ばれないことの検証（順序固定）
  - フォームテスト: version の hidden input の存在検証を追加
- コミットメッセージ: `feat: employee サブドメインへ楽観ロックを適用する（ADR-0039）`
  - ボディに設計判断（User 同期の順序依存の明示化と #317 起票、1コミット縦切りの理由）を記載

## 受け入れ条件（Issue より）

- [ ] 対象コマンドで version 不一致時に `ConflictError` が発生し、後勝ちによる静かな変更喪失が起きない
- [ ] `save` が廃止され、更新経路で expectedVersion を渡さないコードがコンパイルエラーになる
- [ ] 編集ウィンドウ（画面表示時点の version）がフォーム往復で保護される
- [ ] lost update 防止を示すテストが存在する

## 関連

- 親: #301（ADR-0039・7テーブル一括マイグレーション・estimate 縦切り）
- 先例: #316（customer 適用、コミット 281b296）
- 派生: #317（Employee と User の集約境界再設計 — 本イシューのグリルで起票）

</details>

## 計画からの逸脱

2件の逸脱がありました（いずれも軽微）。

### 1. ドメインサービステストの save → insert 移行（対象ファイルの追加）

- **計画**: テスト変更対象は `PrismaEmployeeRepository.test.ts` / `UpdateEmployeeCommand.test.ts`（および Create 側）/ `EmployeeUpdateForm.test.tsx` の3系統
- **実際**: 上記に加え `EmployeeCdDuplicationCheckDomainService.test.ts` と `MailAddressDuplicationCheckDomainService.test.ts` のフィクスチャ作成箇所を `repository.save` から `repository.insert` へ移行
- **理由**: 両テストがフィクスチャ作成に `save` を使っており、`save` 廃止（受け入れ条件）に伴う型エラーで発覚した随伴修正。計画時の `save` 呼び出し元調査がプロダクションコードのみを対象にしており、テストコードの利用箇所を見落としていた

### 2. expectedVersion 素通し検証の方式（モック検証 → 振る舞い検証）

- **計画**: コマンド単体テストで expectedVersion の素通しを検証（Issue 本文・ADR-0039 の文言を踏襲）
- **実際**: モックリポジトリへの引数検証ではなく、既存テストスイートのスタイル（実 DB + FakeUserManagementService の統合スタイル）に合わせ、「stale な expectedVersion で実行すると ConflictError になり、employee 行と認証ユーザーが変更されない」という観測可能な振る舞いで検証
- **理由**: 既存の `UpdateEmployeeCommand.test.ts` が実 DB 統合スタイルで統一されており、モック検証は実装詳細に結合する。振る舞い検証なら素通しの正しさを同等以上に保証しつつ、「ConflictError 時に User 同期へ到達しない」順序固定の検証と1テストに自然に統合できるため

## Test Plan

- [ ] リポジトリ統合テスト: stale トークン逐次再現（`update(v1)` 成功 → 再度 `update(v1)` が `ConflictError`、先行変更が残存）— `PrismaEmployeeRepository.test.ts`
- [ ] コマンド統合テスト: stale な `expectedVersion` で `ConflictError` となり、employee 行と認証ユーザーが変更されない（User 同期未到達の順序固定）— `UpdateEmployeeCommand.test.ts`
- [ ] フォームテスト: version の hidden input の存在検証 — `EmployeeUpdateForm.test.tsx`
- [ ] ドメインサービステスト: フィクスチャ作成を `insert` へ移行後も既存テストが通ること
- [ ] `pnpm test` フルスイートが通ること
- [ ] 手動確認: 2画面で同一従業員の編集画面を開き、片方で保存後にもう片方を保存すると競合エラーになること

---

Generated with [Claude Code](https://claude.ai/code)
