### PR TITLE
feat: 楽観ロックを delivery-location サブドメインへ適用する（ADR-0039 横断展開）

### DIFF
--- a/docs/claude-plans/issue-307/apply-optimistic-locking-to-delivery-location.md
+++ b/docs/claude-plans/issue-307/apply-optimistic-locking-to-delivery-location.md
@@ -1,0 +1,90 @@
+# Issue #307: 楽観ロックを delivery-location サブドメインへ適用する（ADR-0039 横断展開） — 実装計画
+
+## 概要
+
+ADR-0039 の横断ポリシーに基づき、delivery-location サブドメインの「既存集約を変更するコマンド」（`Update` / `Activate` / `Deactivate`）へ楽観ロックを適用する。`delivery_location` テーブルへの `version Int @default(1)` 列は #301 の一括マイグレーションで追加済み（不活性）。本イシューはコード側の段階展開。
+
+本質的には **customer #316 適用前 → 適用後の機械的移植**。delivery-location は customer と構造的に完全な双子（ADR-0043 で平坦化済み）であり、新規の設計判断は発生しない。リファレンスは customer サブドメイン一式。
+
+スコープ:
+
+- 対象: `UpdateDeliveryLocationCommand` / `ActivateDeliveryLocationCommand` / `DeactivateDeliveryLocationCommand`
+- 除外: `DeleteDeliveryLocationCommand`（Delete 系横断イシュー送り。`delete()` のシグネチャは本イシューで不変）
+
+## 設計判断
+
+### 状態変更（Activate/Deactivate）の version 往復経路
+- A. 詳細ページの `StatusForms` のみで version を hidden input 往復させる
+- B. 一覧にも有効化/無効化ボタンを新設し、一覧からも version を往復させる
+- **推奨・採用: A**。理由: customer のリファレンス実装は状態変更ボタンを詳細ページのみに置き、一覧（`columns.tsx`）は状態バッジ表示のみ。イシュー本文の「一覧・詳細のボタン経由」の「一覧」は ADR-0039 の一般則の引用であり、本サブドメインに一覧ボタンを新設する意図ではないとユーザー確認済み。customer に完全準拠し、スコープ外の UI 追加をしない。
+
+### 楽観ロックトークンの実体・通り道・シグネチャ
+- ADR-0039 で決定済み（`version Int` 列 / フォーム往復で引数渡し / `insert`・`update(agg, expectedVersion)` 分割）のため、本イシューでの判断は不要。customer 実装パターンをそのまま踏襲する。
+
+### CONTEXT.md / ADR
+- **CONTEXT.md 更新なし**。`version`/楽観ロックは並行制御メタデータで用語集の対象外（ADR-0039 が「業務概念ではない」と明言）。`納品先`の定義も揺るがない。
+- **新規 ADR なし**。ADR-0039 が織り込み済みの段階展開で、新しい不可逆トレードオフが発生しない。
+
+### 実装上の注意点
+- Mapper の `toPrismaUpdate` は `version` を含めない。version は条件付き `updateMany` 側で `{ increment: 1 }` として一元管理し、エンティティ→Prisma マッピングは version に触れない（customer と同じ責務分離）。
+- `update()` は条件付き `updateMany`（`WHERE id AND version` + `version: { increment: 1 }`）→ `count === 0` で `ConflictError`（ADR-0039 細目5の文言）→ version を進めた行を `findUnique` で再read して返す。
+- `expectedVersion` を渡さない更新経路がコンパイルエラーになることを確認（`save` 廃止の効果）。
+
+## ステップ
+
+### Step 1: ドメイン層リポジトリインターフェースの分割
+- 対象ファイル: `src/server/subdomains/delivery-location/domain/repositories/DeliveryLocationRepository.ts`
+- 作業内容:
+  - `save()` を廃止し `insert(deliveryLocation)` / `update(deliveryLocation, expectedVersion: number)` に分割
+  - customer の `CustomerRepository` と同じ JSDoc（楽観ロック / ADR-0039 の説明）を付す
+- コミットメッセージ: `feat: 納品先リポジトリIFをinsert/updateに分割し楽観ロックを導入する（ADR-0039）`
+
+### Step 2: Prisma リポジトリ実装の条件付き UPDATE 化
+- 対象ファイル: `src/server/subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository.ts`
+- 作業内容:
+  - `save()`（findUnique プローブ + create/update 分岐）を `insert()`（`create`）/ `update()`（条件付き `updateMany` + `ConflictError` + 再read）に置き換え
+  - Mapper の `toPrismaUpdate` が version を含まないことを確認（必要なら除外）
+- コミットメッセージ: `feat: 納品先Prismaリポジトリを条件付きupdateManyで楽観ロック化する（ADR-0039）`
+
+### Step 3: 対象コマンドへの expectedVersion 素通し
+- 対象ファイル:
+  - `src/server/subdomains/delivery-location/application/commands/UpdateDeliveryLocationCommand.ts`
+  - `.../ActivateDeliveryLocationCommand.ts`
+  - `.../DeactivateDeliveryLocationCommand.ts`
+- 作業内容:
+  - 各 Input に `expectedVersion: number` を追加（JSDoc は customer 準拠）
+  - `save()` 呼び出しを `update(entity, input.expectedVersion)` に置き換え
+- コミットメッセージ: `feat: 納品先の更新系コマンドにexpectedVersionを通す（ADR-0039）`
+
+### Step 4: クエリ側 DTO への version 追加
+- 対象ファイル: `src/server/subdomains/delivery-location/application/queries/dto/DeliveryLocationDTO.ts`（および QueryService / Mapper で version を載せる箇所）
+- 作業内容:
+  - `version: number` を DTO に追加し、クエリ取得結果に version を含める（CustomerDTO 準拠）
+- コミットメッセージ: `feat: 納品先DTOにversionを追加しフォーム往復に供給する（ADR-0039）`
+
+### Step 5: プレゼンテーション層（フォーム / schema / actions）の version 往復
+- 対象ファイル:
+  - `src/app/(features)/delivery-locations/[code]/schema.ts`（`version: z.coerce.number().int()` を extend）
+  - `.../[code]/DeliveryLocationUpdateForm.tsx`（hidden `version` input）
+  - `.../[code]/DeliveryLocationStatusForms.tsx`（`version` prop + hidden input 追加）
+  - `.../[code]/page.tsx`（StatusForms へ `version` を渡す）
+  - `.../[code]/actions.ts`（update はフォーム由来 version を素通し、activate/deactivate は `Number(formData.get("version"))` を expectedVersion へ）
+- 作業内容:
+  - customer の同名ファイル群と同じパターンを適用。一覧（`columns.tsx`）にはボタンを**新設しない**
+- コミットメッセージ: `feat: 納品先の編集・状態変更フォームでversionを往復させる（ADR-0039）`
+
+### Step 6: テスト
+- 対象ファイル:
+  - `src/server/subdomains/delivery-location/infrastructure/prisma/__tests__/PrismaDeliveryLocationRepository.test.ts`（リポジトリ統合）
+  - `src/server/subdomains/delivery-location/application/commands/__tests__/`（コマンド単体）
+- 作業内容:
+  - リポジトリ統合: stale トークンを**逐次**再現（insert → update(v1) 成功 → 再度 update(v1) が `ConflictError`、先行変更が残存）
+  - コマンド単体: `expectedVersion` がリポジトリ `update` へ素通しされることを検証
+- コミットメッセージ: `test: 納品先の楽観ロック（lost update防止・expectedVersion素通し）を検証する`
+
+## 受け入れ条件（イシュー由来）
+
+- [ ] 対象コマンド全てで version 不一致時に `ConflictError` が発生し、後勝ちによる静かな変更喪失が起きない
+- [ ] `save` が廃止され、更新経路で expectedVersion を渡さないコードがコンパイルエラーになる
+- [ ] 編集ウィンドウ（画面表示時点の version）がフォーム往復で保護される
+- [ ] lost update 防止を示すテストが存在する

--- a/docs/claude-plans/issue-307/deviations.md
+++ b/docs/claude-plans/issue-307/deviations.md
@@ -1,0 +1,23 @@
+# Issue #307 実装計画からの逸脱記録
+
+## 1. コミット粒度（6コミット → 2コミット）
+
+- **元の計画**: Step 1〜6 を層ごとに分け、6コミットに分割する想定だった。
+- **実際の実装**: 2コミットに集約した。
+  - commit 1: リポジトリIF分割（save 残置）＋ Prisma 条件付き updateMany ＋ リポジトリ統合テスト
+  - commit 2: 更新系3コマンド ＋ DTO/QueryService ＋ プレゼン層 ＋ save 廃止 ＋ コマンドテスト
+- **逸脱の理由**: pre-commit が `tsc --noEmit`（プロジェクト全体）を実行するため、各コミットは全体で型が通る必要がある。`save` を必須引数つき `update` へ切り替える変更は、リポジトリIF・3コマンド・呼び出し側（actions.ts）・既存テストを巻き込み、途中段階では tsc が通らない。そこで「save を残した additive な追加（commit 1）」と「呼び出し側の一括移行＋save 廃止（commit 2）」の2段に分け、各コミットがコンパイル可能な状態を保った。計画自体がこの制約を「各コミットが tsc を通る状態を保つ」と前提していたため、方針転換ではなく粒度の現実的調整。
+
+## 2. CreateDeliveryLocationCommand の insert 移行（計画のステップ外）
+
+- **元の計画**: 対象は Update/Activate/Deactivate の3コマンド。Create は「新規作成（insert 経路）」としてスコープ外。
+- **実際の実装**: `CreateDeliveryLocationCommand` の `repository.save()` を `repository.insert()` に変更した。
+- **逸脱の理由**: `save` をリポジトリIFから廃止する以上、`save` を呼んでいた Create コマンドも `insert` へ移さないと tsc が通らない。楽観ロック（expectedVersion）の付与はしておらず、メソッド名の移行のみ。スコープ（楽観ロック対象）は変えていない。
+
+## 3. 付随テストの save → insert 置換（計画のテスト項目外）
+
+- **元の計画**: テストは「リポジトリ統合（stale 逐次）」「コマンド単体（expectedVersion 素通し）」の2種を想定。
+- **実際の実装**: 上記に加え、`save` を使っていた既存2テストを `insert` へ置換した。
+  - `DeleteDeliveryLocationCommand.test.ts`（beforeEach の事前作成）
+  - `DeliveryLocationCodeDuplicationCheckDomainService.test.ts`（重複データの事前作成）
+- **逸脱の理由**: `save` 廃止に伴う機械的な追従。振る舞いの検証内容は変えていない。

--- a/src/app/(features)/delivery-locations/[code]/DeliveryLocationStatusForms.tsx
+++ b/src/app/(features)/delivery-locations/[code]/DeliveryLocationStatusForms.tsx
@@ -7,12 +7,15 @@ type Props = {
   deliveryLocationId: string;
   deliveryLocationCode: string;
   isActive: boolean;
+  /** 楽観ロックトークン（ADR-0039）。状態変更時にフォームで往復させる。 */
+  version: number;
 };
 
 export function DeliveryLocationStatusForms({
   deliveryLocationId,
   deliveryLocationCode,
   isActive,
+  version,
 }: Props) {
   const [activateState, activateAction, isActivating] = useActionState(activateDeliveryLocation, {
     success: true,
@@ -42,6 +45,7 @@ export function DeliveryLocationStatusForms({
         <form noValidate action={deactivateAction}>
           <input type="hidden" name="id" value={deliveryLocationId} />
           <input type="hidden" name="code" value={deliveryLocationCode} />
+          <input type="hidden" name="version" value={version} />
           <button
             type="submit"
             disabled={isDeactivating}
@@ -54,6 +58,7 @@ export function DeliveryLocationStatusForms({
         <form noValidate action={activateAction}>
           <input type="hidden" name="id" value={deliveryLocationId} />
           <input type="hidden" name="code" value={deliveryLocationCode} />
+          <input type="hidden" name="version" value={version} />
           <button
             type="submit"
             disabled={isActivating}

--- a/src/app/(features)/delivery-locations/[code]/DeliveryLocationUpdateForm.tsx
+++ b/src/app/(features)/delivery-locations/[code]/DeliveryLocationUpdateForm.tsx
@@ -19,6 +19,7 @@ type DeliveryLocation = {
   deliveryNotes: string | null;
   customerName: string;
   customerCode: string;
+  version: number;
 };
 
 type Props = {
@@ -40,6 +41,7 @@ export function DeliveryLocationUpdateForm({ deliveryLocation }: Props) {
       faxNumber: deliveryLocation.faxNumber ?? "",
       contactPerson: deliveryLocation.contactPerson ?? "",
       deliveryNotes: deliveryLocation.deliveryNotes ?? "",
+      version: String(deliveryLocation.version),
     },
   });
 
@@ -56,6 +58,8 @@ export function DeliveryLocationUpdateForm({ deliveryLocation }: Props) {
       )}
 
       <form {...getFormProps(form)} noValidate>
+        {/* 楽観ロックトークン（ADR-0039）。編集画面表示時の version を往復させる。 */}
+        <input {...getInputProps(fields.version, { type: "hidden" })} />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label htmlFor="code-display" className="block text-gray-700 text-sm font-bold mb-2">

--- a/src/app/(features)/delivery-locations/[code]/actions.ts
+++ b/src/app/(features)/delivery-locations/[code]/actions.ts
@@ -39,9 +39,11 @@ export async function updateDeliveryLocation(code: string, prevState: unknown, f
     faxNumber,
     contactPerson,
     deliveryNotes,
+    version,
   } = submission.value;
 
-  // codeからidを取得
+  // codeからidを取得（version は再取得値ではなくフォーム由来の値を使う。
+  // 編集ウィンドウのトークンを守るため。ADR-0039）
   const query = getDeliveryLocationByCodeQueryFactory();
   const deliveryLocation = await query.execute({ code });
   if (!deliveryLocation) {
@@ -54,6 +56,7 @@ export async function updateDeliveryLocation(code: string, prevState: unknown, f
     const command = updateDeliveryLocationCommandFactory();
     await command.execute({
       id: deliveryLocation.id,
+      expectedVersion: version,
       name,
       postalCode: postalCode || null,
       prefecture: prefecture || null,
@@ -111,10 +114,11 @@ export async function activateDeliveryLocation(
 
   const id = formData.get("id") as string;
   const code = formData.get("code") as string;
+  const expectedVersion = Number(formData.get("version"));
 
   try {
     const command = activateDeliveryLocationCommandFactory();
-    await command.execute({ id });
+    await command.execute({ id, expectedVersion });
 
     revalidatePath("/delivery-locations");
     revalidatePath(`/delivery-locations/${code}`);
@@ -136,10 +140,11 @@ export async function deactivateDeliveryLocation(
 
   const id = formData.get("id") as string;
   const code = formData.get("code") as string;
+  const expectedVersion = Number(formData.get("version"));
 
   try {
     const command = deactivateDeliveryLocationCommandFactory();
-    await command.execute({ id });
+    await command.execute({ id, expectedVersion });
 
     revalidatePath("/delivery-locations");
     revalidatePath(`/delivery-locations/${code}`);

--- a/src/app/(features)/delivery-locations/[code]/page.tsx
+++ b/src/app/(features)/delivery-locations/[code]/page.tsx
@@ -49,6 +49,7 @@ export default async function DeliveryLocationDetailPage({
           deliveryLocationId={dl.id}
           deliveryLocationCode={dl.code}
           isActive={dl.isActive}
+          version={dl.version}
         />
         <DeliveryLocationDeleteForm deliveryLocationId={dl.id} />
       </div>

--- a/src/app/(features)/delivery-locations/[code]/schema.ts
+++ b/src/app/(features)/delivery-locations/[code]/schema.ts
@@ -1,7 +1,13 @@
+import { z } from "zod";
 import { deliveryLocationBaseSchema } from "../_shared/schema";
 
 /**
  * 納品先編集フォームのバリデーションスキーマ
  * code は URL パラメータから取得するため含まない
+ *
+ * version は楽観ロックトークン（ADR-0039）。編集画面表示時の値を hidden input で
+ * 往復させ、保存時の競合検知に用いる。
  */
-export const updateDeliveryLocationSchema = deliveryLocationBaseSchema;
+export const updateDeliveryLocationSchema = deliveryLocationBaseSchema.extend({
+  version: z.coerce.number().int(),
+});

--- a/src/server/subdomains/delivery-location/application/commands/ActivateDeliveryLocationCommand.ts
+++ b/src/server/subdomains/delivery-location/application/commands/ActivateDeliveryLocationCommand.ts
@@ -5,6 +5,8 @@ import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/
 
 export type ActivateDeliveryLocationInput = {
   id: string;
+  /** 一覧・詳細の有効化ボタン表示時の version（楽観ロックトークン / ADR-0039）。 */
+  expectedVersion: number;
 };
 
 /**
@@ -22,6 +24,6 @@ export class ActivateDeliveryLocationCommand {
 
     deliveryLocation.activate();
 
-    return await this.deliveryLocationRepository.save(deliveryLocation);
+    return await this.deliveryLocationRepository.update(deliveryLocation, input.expectedVersion);
   }
 }

--- a/src/server/subdomains/delivery-location/application/commands/CreateDeliveryLocationCommand.ts
+++ b/src/server/subdomains/delivery-location/application/commands/CreateDeliveryLocationCommand.ts
@@ -72,6 +72,6 @@ export class CreateDeliveryLocationCommand {
       }
     );
 
-    await this.deliveryLocationRepository.save(deliveryLocation);
+    await this.deliveryLocationRepository.insert(deliveryLocation);
   }
 }

--- a/src/server/subdomains/delivery-location/application/commands/DeactivateDeliveryLocationCommand.ts
+++ b/src/server/subdomains/delivery-location/application/commands/DeactivateDeliveryLocationCommand.ts
@@ -5,6 +5,8 @@ import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/
 
 export type DeactivateDeliveryLocationInput = {
   id: string;
+  /** 一覧・詳細の無効化ボタン表示時の version（楽観ロックトークン / ADR-0039）。 */
+  expectedVersion: number;
 };
 
 /**
@@ -22,6 +24,6 @@ export class DeactivateDeliveryLocationCommand {
 
     deliveryLocation.deactivate();
 
-    return await this.deliveryLocationRepository.save(deliveryLocation);
+    return await this.deliveryLocationRepository.update(deliveryLocation, input.expectedVersion);
   }
 }

--- a/src/server/subdomains/delivery-location/application/commands/UpdateDeliveryLocationCommand.ts
+++ b/src/server/subdomains/delivery-location/application/commands/UpdateDeliveryLocationCommand.ts
@@ -12,6 +12,8 @@ import { DeliveryNotes } from "@subdomains/delivery-location/domain/values/Deliv
 
 export type UpdateDeliveryLocationInput = {
   id: string;
+  /** 編集画面表示時の version（楽観ロックトークン / ADR-0039）。リポジトリへ素通しする。 */
+  expectedVersion: number;
   name: string;
   postalCode?: string | null;
   prefecture?: string | null;
@@ -55,6 +57,6 @@ export class UpdateDeliveryLocationCommand {
       input.deliveryNotes ? new DeliveryNotes(input.deliveryNotes) : null
     );
 
-    await this.deliveryLocationRepository.save(deliveryLocation);
+    await this.deliveryLocationRepository.update(deliveryLocation, input.expectedVersion);
   }
 }

--- a/src/server/subdomains/delivery-location/application/commands/__tests__/DeleteDeliveryLocationCommand.test.ts
+++ b/src/server/subdomains/delivery-location/application/commands/__tests__/DeleteDeliveryLocationCommand.test.ts
@@ -43,7 +43,7 @@ describe("DeleteDeliveryLocationCommand", () => {
       new CompanyName("削除テスト納品先"),
       savedCustomer.id
     );
-    const savedDl = await dlRepository.save(dl);
+    const savedDl = await dlRepository.insert(dl);
     testDeliveryLocationId = savedDl.id.value;
   });
 

--- a/src/server/subdomains/delivery-location/application/commands/__tests__/UpdateDeliveryLocationCommand.test.ts
+++ b/src/server/subdomains/delivery-location/application/commands/__tests__/UpdateDeliveryLocationCommand.test.ts
@@ -1,5 +1,5 @@
 import prisma from "@server/prisma";
-import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
 import { CompanyName } from "@server/shared/domain/values/CompanyName";
 import { Customer } from "@subdomains/customer/domain/entities/Customer";
@@ -43,7 +43,7 @@ describe("UpdateDeliveryLocationCommand", () => {
       new CompanyName("更新前納品先"),
       savedCustomer.id
     );
-    const savedDl = await dlRepository.save(dl);
+    const savedDl = await dlRepository.insert(dl);
     testDeliveryLocationId = savedDl.id.value;
   });
 
@@ -59,6 +59,7 @@ describe("UpdateDeliveryLocationCommand", () => {
   it("納品先情報を更新できる（名前変更）", async () => {
     await command.execute({
       id: testDeliveryLocationId,
+      expectedVersion: 1,
       name: "更新後納品先",
     });
 
@@ -70,6 +71,7 @@ describe("UpdateDeliveryLocationCommand", () => {
   it("住所・連絡先・配送メモを更新できる", async () => {
     await command.execute({
       id: testDeliveryLocationId,
+      expectedVersion: 1,
       name: "更新前納品先",
       postalCode: "300-0003",
       prefecture: "愛知県",
@@ -92,9 +94,10 @@ describe("UpdateDeliveryLocationCommand", () => {
   });
 
   it("nullを渡すとオプション項目をクリアできる", async () => {
-    // まず値を設定
+    // まず値を設定（version 1 → 2）
     await command.execute({
       id: testDeliveryLocationId,
+      expectedVersion: 1,
       name: "更新前納品先",
       postalCode: "300-0003",
       prefecture: "愛知県",
@@ -105,9 +108,10 @@ describe("UpdateDeliveryLocationCommand", () => {
       deliveryNotes: "午前中のみ受付可能",
     });
 
-    // nullで全クリア
+    // nullで全クリア（version 2 → 3）
     await command.execute({
       id: testDeliveryLocationId,
+      expectedVersion: 2,
       name: "更新前納品先",
       postalCode: null,
       prefecture: null,
@@ -133,14 +137,27 @@ describe("UpdateDeliveryLocationCommand", () => {
     await expect(
       command.execute({
         id: "00000000-0000-7000-8000-000000000000",
+        expectedVersion: 1,
         name: "存在しない",
       })
     ).rejects.toThrow(NotFoundEntityError);
     await expect(
       command.execute({
         id: "00000000-0000-7000-8000-000000000000",
+        expectedVersion: 1,
         name: "存在しない",
       })
     ).rejects.toThrow("納品先が見つかりません");
+  });
+
+  it("古い expectedVersion を渡すと ConflictError（リポジトリの楽観ロックへ素通しされる）", async () => {
+    // 現在の version は 1。stale なトークン（999）を渡すと条件付き UPDATE が count=0 になる
+    await expect(
+      command.execute({
+        id: testDeliveryLocationId,
+        expectedVersion: 999,
+        name: "競合する更新",
+      })
+    ).rejects.toThrow(ConflictError);
   });
 });

--- a/src/server/subdomains/delivery-location/application/queries/dto/DeliveryLocationDTO.ts
+++ b/src/server/subdomains/delivery-location/application/queries/dto/DeliveryLocationDTO.ts
@@ -16,6 +16,8 @@ export type DeliveryLocationDTO = {
   customerName: string;
   customerCode: string;
   deliveryNotes: string | null;
+  /** 楽観ロックトークン（ADR-0039）。編集・状態変更フォームで往復させる。 */
+  version: number;
   createdAt: Date;
   updatedAt: Date;
 };

--- a/src/server/subdomains/delivery-location/domain/repositories/DeliveryLocationRepository.ts
+++ b/src/server/subdomains/delivery-location/domain/repositories/DeliveryLocationRepository.ts
@@ -10,8 +10,23 @@ import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/
 export interface DeliveryLocationRepository {
   /**
    * 納品先を保存（新規作成・更新）
+   *
+   * @deprecated insert / update へ移行中（ADR-0039）。新規コードでは使用しない。
    */
   save(deliveryLocation: DeliveryLocation): Promise<DeliveryLocation>;
+
+  /**
+   * 納品先を新規作成
+   */
+  insert(deliveryLocation: DeliveryLocation): Promise<DeliveryLocation>;
+
+  /**
+   * 既存納品先を更新（楽観ロック / ADR-0039）
+   *
+   * @param expectedVersion 編集画面表示時に取得した version（フォーム往復で持ち回るトークン）。
+   *   保存時点の version と一致しない場合は ConflictError を throw し、後勝ちの変更喪失を防ぐ。
+   */
+  update(deliveryLocation: DeliveryLocation, expectedVersion: number): Promise<DeliveryLocation>;
 
   /**
    * 納品先を削除

--- a/src/server/subdomains/delivery-location/domain/repositories/DeliveryLocationRepository.ts
+++ b/src/server/subdomains/delivery-location/domain/repositories/DeliveryLocationRepository.ts
@@ -9,13 +9,6 @@ import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/
  */
 export interface DeliveryLocationRepository {
   /**
-   * 納品先を保存（新規作成・更新）
-   *
-   * @deprecated insert / update へ移行中（ADR-0039）。新規コードでは使用しない。
-   */
-  save(deliveryLocation: DeliveryLocation): Promise<DeliveryLocation>;
-
-  /**
    * 納品先を新規作成
    */
   insert(deliveryLocation: DeliveryLocation): Promise<DeliveryLocation>;

--- a/src/server/subdomains/delivery-location/domain/services/__tests__/DeliveryLocationCodeDuplicationCheckDomainService.test.ts
+++ b/src/server/subdomains/delivery-location/domain/services/__tests__/DeliveryLocationCodeDuplicationCheckDomainService.test.ts
@@ -55,7 +55,7 @@ describe("DeliveryLocationCodeDuplicationCheckDomainService", () => {
   it("重複がある場合、trueを返す", async () => {
     const code = new CompanyCode(DL_TEST_CODES[0]);
     const dl = DeliveryLocation.create(code, new CompanyName("テスト倉庫"), customerId);
-    await dlRepository.save(dl);
+    await dlRepository.insert(dl);
 
     const isDuplicated = await service.execute(code);
     expect(isDuplicated).toBe(true);
@@ -64,7 +64,7 @@ describe("DeliveryLocationCodeDuplicationCheckDomainService", () => {
   it("異なるコードで重複がない場合、falseを返す", async () => {
     const existingCode = new CompanyCode(DL_TEST_CODES[0]);
     const dl = DeliveryLocation.create(existingCode, new CompanyName("テスト倉庫"), customerId);
-    await dlRepository.save(dl);
+    await dlRepository.insert(dl);
 
     const newCode = new CompanyCode(DL_TEST_CODES[1]);
     const isDuplicated = await service.execute(newCode);

--- a/src/server/subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository.ts
+++ b/src/server/subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository.ts
@@ -7,23 +7,6 @@ import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/
 import { DeliveryLocationMapper } from "@subdomains/delivery-location/infrastructure/mappers/DeliveryLocationMapper";
 
 export class PrismaDeliveryLocationRepository implements DeliveryLocationRepository {
-  async save(deliveryLocation: DeliveryLocation): Promise<DeliveryLocation> {
-    const existing = await prisma.deliveryLocation.findUnique({
-      where: { id: deliveryLocation.id.value },
-    });
-
-    const prismaDeliveryLocation = existing
-      ? await prisma.deliveryLocation.update({
-          where: { id: deliveryLocation.id.value },
-          data: DeliveryLocationMapper.toPrismaUpdate(deliveryLocation),
-        })
-      : await prisma.deliveryLocation.create({
-          data: DeliveryLocationMapper.toPrismaCreate(deliveryLocation),
-        });
-
-    return DeliveryLocationMapper.toDomain(prismaDeliveryLocation);
-  }
-
   /**
    * 納品先を新規作成（version は @default(1)）
    */

--- a/src/server/subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository.ts
+++ b/src/server/subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository.ts
@@ -1,5 +1,6 @@
 import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
 import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
 import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
 import { DeliveryLocationRepository } from "@subdomains/delivery-location/domain/repositories/DeliveryLocationRepository";
 import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
@@ -21,6 +22,56 @@ export class PrismaDeliveryLocationRepository implements DeliveryLocationReposit
         });
 
     return DeliveryLocationMapper.toDomain(prismaDeliveryLocation);
+  }
+
+  /**
+   * 納品先を新規作成（version は @default(1)）
+   */
+  async insert(deliveryLocation: DeliveryLocation): Promise<DeliveryLocation> {
+    const prismaDeliveryLocation = await prisma.deliveryLocation.create({
+      data: DeliveryLocationMapper.toPrismaCreate(deliveryLocation),
+    });
+
+    return DeliveryLocationMapper.toDomain(prismaDeliveryLocation);
+  }
+
+  /**
+   * 既存納品先を更新（楽観ロック / ADR-0039）
+   *
+   * WHERE id AND version の条件付き UPDATE で「比較→更新」を DB 上で原子化し、
+   * 成功時に version を +1 する。count = 0 は「version 不一致（先行更新あり）」と
+   * 「行の消失（削除済み）」の両方を含むが、UPDATE 文からは区別できないため
+   * 両方を覆うメッセージで競合として扱う（ADR-0039 細目5/6）。
+   *
+   * @param expectedVersion 編集画面表示時のトークン（フォーム往復で持ち回った値）
+   */
+  async update(
+    deliveryLocation: DeliveryLocation,
+    expectedVersion: number
+  ): Promise<DeliveryLocation> {
+    const result = await prisma.deliveryLocation.updateMany({
+      where: { id: deliveryLocation.id.value, version: expectedVersion },
+      data: {
+        ...DeliveryLocationMapper.toPrismaUpdate(deliveryLocation),
+        version: { increment: 1 },
+      },
+    });
+
+    if (result.count === 0) {
+      throw new ConflictError(
+        "他のユーザーによって更新または削除されています。画面を再読み込みして最新の内容を確認してください。"
+      );
+    }
+
+    // version を進めた最新行を読み直して返す
+    const row = await prisma.deliveryLocation.findUnique({
+      where: { id: deliveryLocation.id.value },
+    });
+    if (!row) {
+      throw new Error(`保存した納品先の再取得に失敗しました: ${deliveryLocation.id.value}`);
+    }
+
+    return DeliveryLocationMapper.toDomain(row);
   }
 
   async delete(id: DeliveryLocationId): Promise<void> {

--- a/src/server/subdomains/delivery-location/infrastructure/prisma/__tests__/PrismaDeliveryLocationRepository.test.ts
+++ b/src/server/subdomains/delivery-location/infrastructure/prisma/__tests__/PrismaDeliveryLocationRepository.test.ts
@@ -1,0 +1,128 @@
+import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PrismaDeliveryLocationRepository } from "../PrismaDeliveryLocationRepository";
+
+// 実データ・他テストと衝突しない予約コード帯（DLLK97x = delivery-location 楽観ロックテスト）。
+const TEST_CODES = ["DLLK970", "DLLK971", "DLLK972"] as const;
+// 親得意先（FK: delivery_location.customer_id → customer.id）用の予約コード。
+const PARENT_CUSTOMER_CODE = "CMLKDL97";
+
+function buildDeliveryLocation(
+  code: string,
+  customerId: CustomerId,
+  name = "テスト納品先"
+): DeliveryLocation {
+  return DeliveryLocation.create(new CompanyCode(code), new CompanyName(name), customerId);
+}
+
+async function cleanup(): Promise<void> {
+  await prisma.deliveryLocation.deleteMany({ where: { code: { in: [...TEST_CODES] } } });
+  await prisma.customer.deleteMany({ where: { code: PARENT_CUSTOMER_CODE } });
+}
+
+describe("PrismaDeliveryLocationRepository", () => {
+  let repository: PrismaDeliveryLocationRepository;
+  let parentCustomerId: CustomerId;
+
+  beforeEach(async () => {
+    repository = new PrismaDeliveryLocationRepository();
+    await cleanup();
+
+    // 納品先は得意先を親に持つ（独立集約だが FK 制約あり）。先に親を作る。
+    const customerRepository = new PrismaCustomerRepository();
+    const parent = await customerRepository.insert(
+      Customer.create(new CompanyCode(PARENT_CUSTOMER_CODE), new CompanyName("親得意先"))
+    );
+    parentCustomerId = parent.id;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("insert → findById ラウンドトリップ", () => {
+    it("新規納品先を等価に再構築でき、version は 1 で始まる", async () => {
+      const saved = await repository.insert(
+        buildDeliveryLocation(TEST_CODES[0], parentCustomerId, "配送センター")
+      );
+
+      const found = await repository.findById(saved.id);
+
+      expect(found).not.toBeNull();
+      if (!found) return;
+      expect(found.id.value).toBe(saved.id.value);
+      expect(found.code.value).toBe(TEST_CODES[0]);
+      expect(found.name.value).toBe("配送センター");
+      expect(found.isActive).toBe(true);
+
+      // version 列は @default(1)。DB 行を直接確認する
+      const row = await prisma.deliveryLocation.findUnique({ where: { id: saved.id.value } });
+      expect(row?.version).toBe(1);
+    });
+  });
+
+  describe("楽観ロック（ADR-0039）", () => {
+    it("insert した納品先（version 1）を expectedVersion=1 で更新でき、更新後は 2 で更新できる", async () => {
+      const saved = await repository.insert(buildDeliveryLocation(TEST_CODES[0], parentCustomerId));
+
+      saved.changeName(new CompanyName("第1版"));
+      const first = await repository.update(saved, 1);
+      expect(first.id.value).toBe(saved.id.value);
+      expect(first.name.value).toBe("第1版");
+
+      // version は 2 へ進んでいる。一致トークンを提示すれば続けて更新できる
+      const rowAfterFirst = await prisma.deliveryLocation.findUnique({
+        where: { id: saved.id.value },
+      });
+      expect(rowAfterFirst?.version).toBe(2);
+
+      first.changeName(new CompanyName("第2版"));
+      await expect(repository.update(first, 2)).resolves.toBeDefined();
+    });
+
+    it("古い expectedVersion での更新は ConflictError になり、先行の変更は失われない", async () => {
+      const saved = await repository.insert(
+        buildDeliveryLocation(TEST_CODES[0], parentCustomerId, "配送センター")
+      );
+
+      // 2人のユーザーが同じ version 1 の編集画面を開いた状況を再現
+      const loadedByB = await repository.findById(saved.id);
+      const loadedByA = await repository.findById(saved.id);
+      expect(loadedByB).not.toBeNull();
+      expect(loadedByA).not.toBeNull();
+      if (!loadedByB || !loadedByA) return;
+
+      // B が先に保存（version 1 → 2）
+      loadedByB.changeName(new CompanyName("Bの変更"));
+      await repository.update(loadedByB, 1);
+
+      // A が古いトークン 1 のまま保存 → 競合として弾かれる
+      loadedByA.changeName(new CompanyName("Aの変更"));
+      await expect(repository.update(loadedByA, 1)).rejects.toThrow(ConflictError);
+
+      // B の変更が残っている（後勝ちによる lost update が起きていない）
+      const found = await repository.findById(saved.id);
+      expect(found?.name.value).toBe("Bの変更");
+    });
+
+    it("存在しない（削除済み）行への更新も count=0 として ConflictError になる", async () => {
+      const saved = await repository.insert(buildDeliveryLocation(TEST_CODES[0], parentCustomerId));
+      const loaded = await repository.findById(saved.id);
+      expect(loaded).not.toBeNull();
+      if (!loaded) return;
+
+      // 画面表示後に行が物理削除された状況
+      await repository.delete(saved.id);
+
+      loaded.changeName(new CompanyName("消えた行への更新"));
+      await expect(repository.update(loaded, 1)).rejects.toThrow(ConflictError);
+    });
+  });
+});

--- a/src/server/subdomains/delivery-location/infrastructure/queries/PrismaDeliveryLocationQueryService.ts
+++ b/src/server/subdomains/delivery-location/infrastructure/queries/PrismaDeliveryLocationQueryService.ts
@@ -95,6 +95,7 @@ export class PrismaDeliveryLocationQueryService implements DeliveryLocationQuery
       isActive: true,
       customerId: true,
       deliveryNotes: true,
+      version: true,
       createdAt: true,
       updatedAt: true,
       // 親得意先の名称・コード（一覧DTOにリレーション先名を含める / ADR-0013）
@@ -120,6 +121,7 @@ export class PrismaDeliveryLocationQueryService implements DeliveryLocationQuery
     isActive: boolean;
     customerId: string;
     deliveryNotes: string | null;
+    version: number;
     createdAt: Date;
     updatedAt: Date;
     customer: {
@@ -142,6 +144,7 @@ export class PrismaDeliveryLocationQueryService implements DeliveryLocationQuery
       customerName: dl.customer.name,
       customerCode: dl.customer.code,
       deliveryNotes: dl.deliveryNotes,
+      version: dl.version,
       createdAt: dl.createdAt,
       updatedAt: dl.updatedAt,
     };


### PR DESCRIPTION
## Summary

ADR-0039 の横断ポリシーに基づき、delivery-location サブドメインの既存集約を変更するコマンド（Update / Activate / Deactivate）へ楽観ロックを適用する。リポジトリを `insert` / `update(aggregate, expectedVersion)` に分割し、条件付き `updateMany`（`WHERE id AND version` + `increment`）で原子的にバージョンを検証、不一致時は `ConflictError` を throw する。編集画面表示時の version をフォーム（hidden input）で往復させ、後勝ちによる静かな変更喪失を防止する。

Closes #307

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### 概要

ADR-0039 の横断ポリシーに基づき、delivery-location サブドメインの「既存集約を変更するコマンド」（`Update` / `Activate` / `Deactivate`）へ楽観ロックを適用する。`delivery_location` テーブルへの `version Int @default(1)` 列は #301 の一括マイグレーションで追加済み（不活性）。本イシューはコード側の段階展開。

本質的には **customer #316 適用前 → 適用後の機械的移植**。delivery-location は customer と構造的に完全な双子（ADR-0043 で平坦化済み）であり、新規の設計判断は発生しない。リファレンスは customer サブドメイン一式。

スコープ:

- 対象: `UpdateDeliveryLocationCommand` / `ActivateDeliveryLocationCommand` / `DeactivateDeliveryLocationCommand`
- 除外: `DeleteDeliveryLocationCommand`（Delete 系横断イシュー送り。`delete()` のシグネチャは本イシューで不変）

### 設計判断

**状態変更（Activate/Deactivate）の version 往復経路**
- 採用: 詳細ページの `StatusForms` のみで version を hidden input 往復させる。理由: customer のリファレンス実装は状態変更ボタンを詳細ページのみに置き、一覧は状態バッジ表示のみ。customer に完全準拠し、スコープ外の UI 追加をしない。

**楽観ロックトークンの実体・通り道・シグネチャ**
- ADR-0039 で決定済み（`version Int` 列 / フォーム往復で引数渡し / `insert`・`update(agg, expectedVersion)` 分割）のため判断不要。customer 実装パターンをそのまま踏襲。

**CONTEXT.md / ADR**
- CONTEXT.md 更新なし。`version`/楽観ロックは並行制御メタデータで用語集の対象外。
- 新規 ADR なし。ADR-0039 が織り込み済みの段階展開で、新しい不可逆トレードオフが発生しない。

**実装上の注意点**
- Mapper の `toPrismaUpdate` は `version` を含めない。version は条件付き `updateMany` 側で `{ increment: 1 }` として一元管理。
- `update()` は条件付き `updateMany` → `count === 0` で `ConflictError` → version を進めた行を `findUnique` で再read。
- `expectedVersion` を渡さない更新経路がコンパイルエラーになることを確認（`save` 廃止の効果）。

### ステップ

1. ドメイン層リポジトリIFの分割（`save` 廃止 → `insert` / `update(deliveryLocation, expectedVersion)`）
2. Prisma リポジトリ実装の条件付き UPDATE 化（条件付き `updateMany` + `ConflictError` + 再read）
3. 対象コマンドへの `expectedVersion` 素通し
4. クエリ側 DTO への version 追加
5. プレゼンテーション層（フォーム / schema / actions）の version 往復
6. テスト（リポジトリ統合: stale 逐次再現 / コマンド単体: expectedVersion 素通し）

</details>

## 計画からの逸脱

1. **コミット粒度（6コミット → 2コミット）**: pre-commit が `tsc --noEmit`（プロジェクト全体）を実行するため、各コミットは全体で型が通る必要がある。`save` → 必須引数つき `update` への切り替えは複数層を巻き込み途中段階では tsc が通らないため、「save を残した additive な追加」と「呼び出し側の一括移行＋save 廃止」の2段に分けた。方針転換ではなく粒度の現実的調整。

2. **`CreateDeliveryLocationCommand` の insert 移行（ステップ外）**: `save` をリポジトリIFから廃止する以上、Create も `insert` へ移さないと tsc が通らない。楽観ロック（expectedVersion）の付与はせず、メソッド名の移行のみ。スコープは不変。

3. **付随テストの save → insert 置換（テスト項目外）**: `save` を使っていた既存2テスト（`DeleteDeliveryLocationCommand.test.ts` / `DeliveryLocationCodeDuplicationCheckDomainService.test.ts`）を `insert` へ機械的に追従。検証内容は不変。

## Test Plan

- [ ] リポジトリ統合テスト: stale トークンの逐次再現（insert → update(v1) 成功 → 再度 update(v1) が `ConflictError`、先行変更が残存）
- [ ] コマンド単体テスト: `expectedVersion` がリポジトリ `update` へ素通しされることを検証
- [ ] 新規納品先の version が 1 で始まることを確認
- [ ] 全テストスイートがグリーン（pre-push で検証済み）

---

Generated with [Claude Code](https://claude.ai/code)
