### PR TITLE
feat: 見積一覧画面（フロントエンド）を実装する

### DIFF
--- a/docs/claude-plans/issue-345/deviations.md
+++ b/docs/claude-plans/issue-345/deviations.md
@@ -1,0 +1,6 @@
+# 計画からの逸脱記録
+
+## 逸脱 1: 「#345 = 純フロント」前提を破棄し EstimateSummaryDTO を additive 拡張（Q1-b）
+- **計画**: 元の issue #345 は「見積一覧画面（フロントエンド）」であり、当初は presentation 層のみ（純フロント）で完結させ、BE の read model（`EstimateSummaryDTO` / `PrismaEstimateQueryService`）には手を入れない想定だった。
+- **実際**: 一覧に「納品先」列を出すため、凍結契約 `EstimateSummaryDTO` に `deliveryLocationName: string` を additive 追加し、`ESTIMATE_SUMMARY_INCLUDE` に `deliveryLocation: { select: { name: true } }`、`toSummaryDTO` に `e.deliveryLocation.name` の解決を加えた（commit ea4218e）。表示は名前のみのため `deliveryLocationCode` は足さない（Q1 の得意先コード非表示方針と一貫・YAGNI）。grill-with-docs の Q1-b で BE 拡張を採用と合意し、保存済み計画にも反映済み。
+- **理由**: 既存 `EstimateSummaryDTO` は納品先を一切持たず、純フロントのままでは一覧に納品先名を表示できない。名前解決は ADR-0013 の「リレーション越しの名前解決」既存パターンに従う additive 変更で、後方互換を壊さない（`Estimate.deliveryLocationId` は NOT NULL のため全行が必ず納品先を持ち、required で追加して presentation 側の null 分岐を不要にできる）。新規 ADR は不要（不可逆性・驚き・真のトレードオフの 3 条件を満たさない）。

--- a/docs/claude-plans/issue-345/implement-estimate-list-page.md
+++ b/docs/claude-plans/issue-345/implement-estimate-list-page.md
@@ -1,0 +1,122 @@
+# Issue #345: 見積一覧画面（フロントエンド）を実装する — 実装計画
+
+## 概要
+
+`/estimates` 見積一覧画面（presentation）を実装する。商品一覧（`products/page.tsx`）のパターンを写経し、`searchEstimatesQueryFactory()`（#344）と #354 で実装済みの検索フィルタ（`EstimateSearchCriteria` 4項目）を利用する。
+
+本 issue は presentation 中心だが、一覧に「納品先」列を出すため `EstimateSummaryDTO` に `deliveryLocationName` を additive 拡張する小さな BE 作業（Q1-b）を含む。「#345＝純フロント」の前提は破棄する。
+
+依存関係:
+- #344（CLOSED）: `EstimateSummaryDTO` / `searchEstimatesQueryFactory()` を提供済み。
+- #354（マージ＆rebase 取り込み済み・commit ff74a48）: `EstimateSearchCriteria` を実フィルタ4項目（`estimateNumber`/`customerName` 部分一致・`estimateType`/`activeStatus` 等値/some-none）へ拡張済み。
+- #351（予定）: 見積作成画面 `/estimates/new`。本 issue では新規登録ボタンのリンク先として参照のみ（現状 dead link）。
+- #348（別 issue）: `displayStatus`（表示ステータス）列。本 issue では出さない。
+
+スコープ外: 検索フィルタの BE 実装（#354 で完了済み）、作成画面（#351）、表示ステータス列（#348）、列ヘッダのクリックソート。
+
+## 設計判断
+
+### Q1: 表示列セット（8列・左→右）
+- 見積番号(Link)／区分(Badge)／得意先／納品先／作成者／締切(formatDate)／金額(formatYen)／有効・無効(Badge)
+- 列順は得意先 → 納品先 → 作成者（得意先と納品先を隣接）
+- 見積日（estimateDate）・得意先コード（customerCode）は出さない
+- 理由: 一覧で必要な識別・判断に足る最小列。コード類は一覧では冗長。
+
+### Q1-b: 納品先のスコープと DTO 拡張
+- A. この PR で BE も拡張する（採用）
+- B. 純フロントに留め納品先を出さない
+- 採用理由: 一覧に納品先名を出すため。表示は名前のみ。
+- DTO に足すフィールド: `deliveryLocationName` のみ（`deliveryLocationCode` は足さない）
+  - 理由: Q1 で得意先コードを出さない方針と一貫。表示しない値を凍結契約に増やさない（YAGNI）。既存 customerCode/creatorCode が code を持つのは別文脈の名残で、機械的に揃える必要はない。
+- 名前解決は ADR-0013 の既存パターン（リレーション越しの名前解決）に従う。
+
+### Q2: 「状態」列の意味と見出し
+- 列見出しは曖昧語「状態」を避け「有効/無効」とする
+- 理由: CONTEXT.md は「状態」を表示ステータス／バリエーション状態の両義で `_Avoid_`。本 issue で非 null に出せるのは `activeStatus`（代表の有効/無効）のみ。
+- `displayStatus`（表示ステータス）列は今回出さない（#348。依存 #275 共通申請テーブル・受注実装が未着手のため常に null）。
+
+### Q3: SearchForm を出すか
+- 検索を出す（4項目）。初期はデフォルト絞り込み無し（全件表示）。
+- フィールド: text `estimateNumber`（部分一致）／ text `customerName`（部分一致）／ select `estimateType`（新規/修理/事後）／ select `activeStatus`（有効/無効）
+- 理由: #354 で BE フィルタ4項目が実装済み。商品 page.tsx と完全対称に組める。初期に activeStatus を「有効のみ」にしない理由は ADR-0051 の「一覧で全無効見積を識別できる」意義と商品一覧の初期フィルタ無し挙動に合わせるため。
+- 空文字は criteria に渡さない（`getStringParam` が undefined 化、`buildWhereClause` が未指定スキップ）。
+
+### Q4: page から渡す orderBy
+- A. orderBy を渡さず BE 既定 `[deadline asc, createdAt asc, estimateNumber asc]`（締切昇順）に委ねる（採用）
+- B. estimateNumber 昇順を明示指定
+- C. 新着順（estimateDate/createdAt desc）を明示指定
+- 採用理由: `DataTable` はクリックソート無し（`getSortedRowModel` 不在）＝サーバが返す順で固定。締切列を出すので締切昇順は自己説明的かつ業務優先軸（締切が近い順）。第2・3キーで決定的（E2E 安定）。最小コード。
+
+### Q5: 新規登録ボタン ＋ ダッシュボード導線
+- (A) 新規登録ボタンを置く。`href="/estimates/new"`（#351 予定・現状 dead link だが開発中ゆえ可）
+  - 表示条件: `isAdmin` ゲート無し＝認証済みユーザー全員に表示
+  - 理由: 見積はトランザクションデータで担当者の日常業務。マスタ系の `isAdmin` ゲートを機械適用しない。#351 の認可確定時に再調整。
+- (B) ダッシュボード `navigationItems` の先頭に「見積管理」(`/estimates`・説明「見積の一覧表示・閲覧を行います。」) を追加
+  - 理由: 共通ヘッダに機能ナビが無く、ダッシュボードが唯一の入口。追加しないと一覧が到達不能。
+
+### Q6: 代表が INACTIVE（全無効見積）の行の見た目
+- 行のグレーアウトはしない。有効/無効バッジのみで識別（商品一覧と同一）
+- 理由: ADR-0051 の「全無効見積を識別できる」要件はバッジで達成済み。二重符号化のノイズ回避。全無効でも見積番号リンクから詳細は開けるため、行を暗くするのは実挙動と矛盾し誤読を招く。
+
+### Q7: E2E `estimates-list.e2e.ts` の範囲
+- 商品 E2E を写経（一覧表示／検索4種／クリア）＋見積固有を追加
+- 見積固有: (1) 新規登録ボタンは admin・一般ユーザー両方で可視（商品の「一般には見えない」を反転＝Q5 の回帰防止）、(2) 代表選択（ADR-0051）の end-to-end 検証（`N9905001` は V1=ACTIVE 代表→有効＋金額、`N9905002` は全 INACTIVE→無効、`activeStatus` フィルタで出し分け）、(3) 納品先列の表示
+- read-only のため `serial` 不要（商品 list と同じ非直列）。テスト内で Prisma 直接利用しない（ADR-0012）。
+
+### ドキュメント方針
+- CONTEXT.md: 追記不要（`代表バリエーション`/`バリエーション状態`/`表示ステータス` は定義済みで、本決定はその用語法を遵守）。
+- ADR: 新規不要（納品先追加は ADR-0013 既存パターン、代表選択は ADR-0051、displayStatus は #348。不可逆性・驚き・真のトレードオフの3条件を満たさない）。
+- deviations.md: Q1-b（純フロント前提を破棄し BE 契約を additive 拡張）を実装完了時に記録。
+
+## ステップ
+
+### Step 1: 一覧 read model に納品先名を追加（Q1-b）
+- 対象ファイル:
+  - `src/server/subdomains/estimate/application/queries/dto/EstimateSummaryDTO.ts`
+  - `src/server/subdomains/estimate/infrastructure/queries/PrismaEstimateQueryService.ts`
+  - `src/server/subdomains/estimate/application/queries/__tests__/SearchEstimatesQuery.test.ts`
+- 作業内容:
+  - `EstimateSummaryDTO` に `deliveryLocationName: string` を追加（name のみ・code は足さない）
+  - `ESTIMATE_SUMMARY_INCLUDE` に `deliveryLocation: { select: { name: true } }` を追加
+  - `toSummaryDTO` で `e.deliveryLocation.name` を解決（ADR-0013）
+  - 単体テストに納品先名解決のアサーションを追加
+- コミットメッセージ: `feat: 見積一覧 read model に納品先名を追加する`
+  - body: 凍結契約 `EstimateSummaryDTO` を additive 拡張。表示は名前のみのため code は足さない（Q1 の得意先コード非表示方針と一貫・YAGNI）。名前解決は ADR-0013 の既存パターン。
+
+### Step 2: 見積一覧の列定義
+- 対象ファイル: `src/app/(features)/estimates/_components/columns.tsx`（新規）
+- 作業内容:
+  - `EstimateRow` 型と8列の `ColumnDef` を定義（商品 columns.tsx を写経）
+  - 見積番号は `/estimates/[estimateNumber]` への青リンク、区分は Badge＋`ESTIMATE_TYPE_LABELS`、有効/無効は Badge（default/secondary）、締切は `formatDate`、金額は `formatYen`
+  - ラベル/整形は `estimates/_shared/labels.ts` を再利用
+- コミットメッセージ: `feat: 見積一覧の列定義（8列）を実装する`
+
+### Step 3: 見積一覧ページ
+- 対象ファイル: `src/app/(features)/estimates/page.tsx`（新規）
+- 作業内容:
+  - `verifySession()` で認証、`searchParams` から `getStringParam` ×4 で `EstimateSearchCriteria` を組み立て（空文字は渡さない）
+  - `searchEstimatesQueryFactory().execute(criteria, { limit: LIST_FETCH_LIMIT })`（orderBy は渡さず BE 既定）
+  - `SearchForm`（4フィールド・初期デフォルト絞り込み無し）＋ `DataTable`
+  - 新規登録ボタン（`/estimates/new`・`isAdmin` ゲート無しで全員表示）
+- コミットメッセージ: `feat: 見積一覧ページ（検索・一覧・新規登録導線）を実装する`
+  - body: 新規登録ボタンは isAdmin ゲートを付けず全員表示。理由: 見積はトランザクションデータで担当者の日常業務のため（#351 の認可確定時に再調整）。orderBy は渡さず BE 既定（締切昇順）に委ねる（DataTable はクリックソート無し）。
+
+### Step 4: ダッシュボードに見積管理導線を追加
+- 対象ファイル: `src/app/(features)/dashboard/page.tsx`
+- 作業内容:
+  - `navigationItems` の先頭に `{ href: "/estimates", title: "見積管理", description: "見積の一覧表示・閲覧を行います。" }` を追加
+- コミットメッセージ: `feat: ダッシュボードに見積管理導線を追加する`
+
+### Step 5: 見積一覧 E2E テスト
+- 対象ファイル: `src/app/(features)/estimates/estimates-list.e2e.ts`（新規）
+- 作業内容:
+  - 商品 E2E を写経（一覧表示／検索4種＝見積番号・得意先名・区分・有効無効／クリア）
+  - 見積固有: 新規登録ボタンが admin・一般ユーザー両方で可視／代表選択 ADR-0051 検証（`N9905001`→有効＋金額、`N9905002`→無効、activeStatus フィルタで出し分け）／納品先列の表示
+  - 非直列（read-only）。Prisma 直接利用しない（ADR-0012）。シードは `prisma/seed-estimates.ts`（`N9905001`〜`004`/`R9905001`）に対しアサーション。実値（金額・納品先名）は実装時にシードで確認。
+- コミットメッセージ: `test: 見積一覧画面の E2E テストを追加する`
+
+### Step 6: 逸脱記録（deviations.md）
+- 対象ファイル: `docs/claude-plans/issue-345/deviations.md`（新規）
+- 作業内容:
+  - Q1-b（「#345＝純フロント」前提を破棄し `EstimateSummaryDTO` を additive 拡張した）の{元の計画}/{実際の実装}/{逸脱理由}を記録
+- コミットメッセージ: `docs: 見積一覧実装の計画逸脱（DTO 契約拡張）を記録する`

--- a/src/app/(features)/dashboard/page.tsx
+++ b/src/app/(features)/dashboard/page.tsx
@@ -3,6 +3,11 @@ import Link from "next/link";
 
 const navigationItems = [
   {
+    href: "/estimates",
+    title: "見積管理",
+    description: "見積の一覧表示・閲覧を行います。",
+  },
+  {
     href: "/employees",
     title: "従業員管理",
     description: "従業員の一覧表示、登録、編集、削除を行います。",

--- a/src/app/(features)/estimates/_components/columns.tsx
+++ b/src/app/(features)/estimates/_components/columns.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Link from "next/link";
+import { type ColumnDef } from "@/app/_components/shared/DataTable";
+import { Badge } from "@/app/_components/shadcnui/badge";
+import { ESTIMATE_TYPE_LABELS, formatDate, formatYen } from "../_shared/labels";
+
+/**
+ * 見積一覧の 1 行（presentation 用）。EstimateSummaryDTO から表示に要る項目だけを写す。
+ * 金額・締切は整形を cell に集約するため生値（number / Date）で持つ（RSC→Client は
+ * React Flight が Date をネイティブ復元するため Date のまま渡せる）。
+ */
+export type EstimateRow = {
+  estimateId: string;
+  estimateNumber: string;
+  estimateType: string;
+  customerName: string;
+  deliveryLocationName: string;
+  creatorName: string;
+  deadline: Date;
+  finalTotal: number;
+  activeStatus: string;
+};
+
+/**
+ * 見積一覧の列定義（8 列・左→右、計画 Q1）。得意先と納品先を隣接させる。
+ * クリックソートは持たない（DataTable に getSortedRowModel 不在・Q4）。
+ */
+export const columns: ColumnDef<EstimateRow, unknown>[] = [
+  {
+    accessorKey: "estimateNumber",
+    header: "見積番号",
+    cell: ({ row }) => (
+      <Link
+        href={`/estimates/${row.original.estimateNumber}`}
+        className="text-blue-600 hover:text-blue-800 hover:underline"
+      >
+        {row.original.estimateNumber}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: "estimateType",
+    header: "区分",
+    cell: ({ row }) => (
+      <Badge variant="outline">
+        {ESTIMATE_TYPE_LABELS[row.original.estimateType] ?? row.original.estimateType}
+      </Badge>
+    ),
+  },
+  {
+    accessorKey: "customerName",
+    header: "得意先",
+  },
+  {
+    accessorKey: "deliveryLocationName",
+    header: "納品先",
+  },
+  {
+    accessorKey: "creatorName",
+    header: "作成者",
+  },
+  {
+    accessorKey: "deadline",
+    header: "締切",
+    cell: ({ row }) => formatDate(row.original.deadline),
+  },
+  {
+    accessorKey: "finalTotal",
+    header: "金額",
+    cell: ({ row }) => formatYen(row.original.finalTotal),
+  },
+  {
+    // 列見出しは曖昧語「状態」を避け「有効/無効」とする（Q2・CONTEXT.md）。
+    // 本 issue で非 null に出せるのは代表バリエーション由来の activeStatus のみ。
+    accessorKey: "activeStatus",
+    header: "有効/無効",
+    cell: ({ row }) => (
+      <Badge variant={row.original.activeStatus === "ACTIVE" ? "default" : "secondary"}>
+        {row.original.activeStatus === "ACTIVE" ? "有効" : "無効"}
+      </Badge>
+    ),
+  },
+];

--- a/src/app/(features)/estimates/estimates-list.e2e.ts
+++ b/src/app/(features)/estimates/estimates-list.e2e.ts
@@ -1,0 +1,165 @@
+import { type Page, expect, test } from "@playwright/test";
+
+/**
+ * 見積一覧画面 S1 の E2E。seed-estimates.ts の決定的データに対し、一覧表示・検索 4 種・
+ * クリア・代表選択（ADR-0051）の end-to-end・納品先列・新規登録ボタンの可視性を検証する。
+ * read-only のため非 serial（商品一覧と同方針・ADR-0017）。Prisma 直接利用しない（ADR-0012）。
+ *
+ * 全シード見積は最小コード納品先 D001「山田製作所 東京倉庫」（親得意先 C001
+ * 「株式会社山田製作所」）を参照する（seedEstimates の findFirst 既定順）。
+ */
+const FULL = "N9905001"; // 代表 V1=ACTIVE（NEW）→ 有効 + 代表金額
+const ALL_INACTIVE = "N9905002"; // 全バリ INACTIVE → 無効
+const REPAIR = "R9905001"; // REPAIR 区分
+
+const CUSTOMER_NAME = "株式会社山田製作所";
+const DELIVERY_LOCATION_NAME = "山田製作所 東京倉庫";
+// 代表 V1 の永続合計（ADR-0033）: 明細小計 32,500（A 20,000 + B 4,500 + C 8,000）
+// − 全体値引 1,000 ＝ 31,500、税 10% 3,150 → 34,650 円。
+const FULL_REPRESENTATIVE_TOTAL = "34,650円";
+
+/**
+ * 一覧画面のハイドレーション完了を待つ。SearchForm（"use client"）の onSubmit が機能するには
+ * React のハイドレーションが必要。DataTable の行表示でページがインタラクティブと判断する。
+ */
+async function waitForListReady(page: Page) {
+  await expect(page.getByRole("heading", { name: "見積管理" })).toBeVisible();
+  await expect(page.locator("table tbody tr").first()).toBeVisible();
+}
+
+/** ヘッダー名からカラム位置（1始まり）を取得する。 */
+async function getColumnIndex(page: Page, headerName: string) {
+  const headers = await page.locator("table thead th").allTextContents();
+  return headers.indexOf(headerName) + 1;
+}
+
+test.describe("見積一覧（管理者）", () => {
+  test("一覧が表示され、管理者には「新規登録」ボタンが見える", async ({ page }) => {
+    await page.goto("/estimates");
+    await waitForListReady(page);
+
+    await expect(page.getByRole("heading", { name: "見積管理" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "新規登録" })).toBeVisible();
+
+    await expect(page.getByRole("heading", { name: "見積一覧" })).toBeVisible();
+    const rows = page.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible();
+  });
+
+  test("見積番号で検索（部分一致）できる", async ({ page }) => {
+    await page.goto("/estimates");
+    await waitForListReady(page);
+
+    await page.getByLabel("見積番号").fill(FULL);
+    await page.getByRole("button", { name: "検索" }).click();
+
+    await expect(page).toHaveURL(/estimateNumber=N9905001/, { timeout: 10000 });
+    await expect(page.getByRole("link", { name: FULL })).toBeVisible();
+  });
+
+  test("得意先名で検索（部分一致）できる", async ({ page }) => {
+    await page.goto("/estimates");
+    await waitForListReady(page);
+
+    await page.getByLabel("得意先名").fill("山田");
+    await page.getByRole("button", { name: "検索" }).click();
+
+    await expect(page).toHaveURL(/customerName=/, { timeout: 10000 });
+    await expect(page.getByText(CUSTOMER_NAME).first()).toBeVisible();
+  });
+
+  test("区分で検索できる", async ({ page }) => {
+    await page.goto("/estimates");
+    await waitForListReady(page);
+
+    await page.getByLabel("区分").selectOption("REPAIR");
+    await page.getByRole("button", { name: "検索" }).click();
+
+    await expect(page).toHaveURL(/estimateType=REPAIR/, { timeout: 10000 });
+    // 表示されている区分バッジがすべて「修理」であること（REPAIR シードは R9905001）。
+    await expect(page.getByRole("link", { name: REPAIR })).toBeVisible();
+    const typeCol = await getColumnIndex(page, "区分");
+    const typeBadges = page.locator(`table tbody tr td:nth-child(${typeCol}) span`);
+    const count = await typeBadges.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(typeBadges.nth(i)).toHaveText("修理");
+    }
+  });
+
+  test("有効/無効で検索できる（代表由来・ADR-0051）", async ({ page }) => {
+    await page.goto("/estimates");
+    await waitForListReady(page);
+
+    await page.getByLabel("有効/無効").selectOption("ACTIVE");
+    await page.getByRole("button", { name: "検索" }).click();
+
+    await expect(page).toHaveURL(/activeStatus=ACTIVE/, { timeout: 10000 });
+    // 代表が ACTIVE の見積のみ。全無効の N9905002 は除外される。
+    const statusCol = await getColumnIndex(page, "有効/無効");
+    const statusBadges = page.locator(`table tbody tr td:nth-child(${statusCol}) span`);
+    const count = await statusBadges.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(statusBadges.nth(i)).toHaveText("有効");
+    }
+  });
+
+  test("クリアボタンで検索条件がリセットされる", async ({ page }) => {
+    await page.goto(`/estimates?estimateNumber=${FULL}`);
+    await waitForListReady(page);
+
+    await expect(page.getByLabel("見積番号")).toHaveValue(FULL);
+
+    await page.getByRole("button", { name: "クリア" }).click();
+
+    await expect(page).toHaveURL(/\/estimates$/, { timeout: 10000 });
+    await expect(page.getByLabel("見積番号")).toHaveValue("");
+  });
+
+  test("代表選択（ADR-0051）: 代表 ACTIVE は有効＋代表金額、全無効は無効", async ({ page }) => {
+    // N9905001..004 を一括表示（R9905001 は接頭辞 R なので含まれない）。
+    await page.goto("/estimates?estimateNumber=N990500");
+    await waitForListReady(page);
+
+    const statusCol = await getColumnIndex(page, "有効/無効");
+    const amountCol = await getColumnIndex(page, "金額");
+
+    // 代表 = V1（ACTIVE 最小番号）→ 有効バッジ ＋ V1 の永続合計。
+    const fullRow = page.locator("table tbody tr", { hasText: FULL });
+    await expect(fullRow.locator(`td:nth-child(${statusCol}) span`)).toHaveText("有効");
+    await expect(fullRow.locator(`td:nth-child(${amountCol})`)).toHaveText(
+      FULL_REPRESENTATIVE_TOTAL
+    );
+
+    // 全 INACTIVE → ACTIVE 不在でフォールバック、状態は正直に無効。
+    const inactiveRow = page.locator("table tbody tr", { hasText: ALL_INACTIVE });
+    await expect(inactiveRow.locator(`td:nth-child(${statusCol}) span`)).toHaveText("無効");
+  });
+
+  test("納品先列が表示される", async ({ page }) => {
+    await page.goto(`/estimates?estimateNumber=${FULL}`);
+    await waitForListReady(page);
+
+    const deliveryCol = await getColumnIndex(page, "納品先");
+    const fullRow = page.locator("table tbody tr", { hasText: FULL });
+    await expect(fullRow.locator(`td:nth-child(${deliveryCol})`)).toHaveText(
+      DELIVERY_LOCATION_NAME
+    );
+  });
+});
+
+test.describe("見積一覧（一般ユーザー）", () => {
+  test.use({ storageState: "playwright/.auth/user.json" });
+
+  test("一般ユーザーにも「新規登録」ボタンが見える（Q5: isAdmin ゲート無し）", async ({ page }) => {
+    await page.goto("/estimates");
+    await waitForListReady(page);
+
+    await expect(page.getByRole("heading", { name: "見積管理" })).toBeVisible();
+    const rows = page.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible();
+    // 商品一覧の「一般には見えない」を反転。見積は担当者の日常業務のため全員に表示。
+    await expect(page.getByRole("link", { name: "新規登録" })).toBeVisible();
+  });
+});

--- a/src/app/(features)/estimates/page.tsx
+++ b/src/app/(features)/estimates/page.tsx
@@ -1,0 +1,100 @@
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { searchEstimatesQueryFactory } from "@subdomains/estimate/application/factories/estimateQueryFactory";
+import type { EstimateSearchCriteria } from "@subdomains/estimate/application/queries/dto/EstimateSearchCriteria";
+import Link from "next/link";
+import { SearchForm, type SearchFieldDef } from "@/app/_components/shared/SearchForm";
+import { DataTable } from "@/app/_components/shared/DataTable";
+import { columns, type EstimateRow } from "./_components/columns";
+import { type SearchParams, LIST_FETCH_LIMIT, getStringParam } from "@/app/_lib/searchParams";
+
+const searchFields: SearchFieldDef[] = [
+  { type: "text", key: "estimateNumber", label: "見積番号", placeholder: "部分一致" },
+  { type: "text", key: "customerName", label: "得意先名", placeholder: "部分一致" },
+  {
+    type: "select",
+    key: "estimateType",
+    label: "区分",
+    options: [
+      { value: "NEW", label: "新規" },
+      { value: "REPAIR", label: "修理" },
+      { value: "AFTER_REPAIR", label: "事後" },
+    ],
+  },
+  {
+    type: "select",
+    key: "activeStatus",
+    label: "有効/無効",
+    options: [
+      { value: "ACTIVE", label: "有効" },
+      { value: "INACTIVE", label: "無効" },
+    ],
+  },
+];
+
+export default async function EstimateListPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  // 認証のみ。新規登録ボタンは isAdmin ゲートを付けず全員表示（Q5）。
+  await verifySession();
+  const params = await searchParams;
+
+  // 空文字は getStringParam が undefined 化し、buildWhereClause が未指定としてスキップする（Q3）。
+  const criteria: EstimateSearchCriteria = {
+    estimateNumber: getStringParam(params, "estimateNumber"),
+    customerName: getStringParam(params, "customerName"),
+    estimateType: getStringParam(params, "estimateType"),
+    activeStatus: getStringParam(params, "activeStatus"),
+  };
+
+  // orderBy は渡さず BE 既定 [deadline asc, createdAt asc, estimateNumber asc] に委ねる（Q4）。
+  const searchQuery = searchEstimatesQueryFactory();
+  const estimates = await searchQuery.execute(criteria, { limit: LIST_FETCH_LIMIT });
+
+  const rows: EstimateRow[] = estimates.map((estimate) => ({
+    estimateId: estimate.estimateId,
+    estimateNumber: estimate.estimateNumber,
+    estimateType: estimate.estimateType,
+    customerName: estimate.customerName,
+    deliveryLocationName: estimate.deliveryLocationName,
+    creatorName: estimate.creatorName,
+    deadline: estimate.deadline,
+    finalTotal: estimate.finalTotal,
+    activeStatus: estimate.activeStatus,
+  }));
+
+  const defaultSearchValues = {
+    estimateNumber: getStringParam(params, "estimateNumber") ?? "",
+    customerName: getStringParam(params, "customerName") ?? "",
+    estimateType: getStringParam(params, "estimateType") ?? "",
+    activeStatus: getStringParam(params, "activeStatus") ?? "",
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex justify-between items-center mb-2 px-4 pt-4">
+        <h1 className="text-3xl font-bold">見積管理</h1>
+        {/* 見積はトランザクションデータで担当者の日常業務のため isAdmin ゲートを付けない（Q5）。 */}
+        <Link
+          href="/estimates/new"
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+        >
+          新規登録
+        </Link>
+      </div>
+
+      <div className="px-4">
+        <SearchForm fields={searchFields} defaultValues={defaultSearchValues} />
+      </div>
+
+      <div className="flex-1 flex flex-col min-h-0 bg-white shadow-md rounded mx-4 mb-4 text-gray-500">
+        <div className="px-8 pt-6 pb-2">
+          <h2 className="text-xl font-semibold">見積一覧</h2>
+        </div>
+
+        <DataTable columns={columns} data={rows} emptyMessage="見積が登録されていません" />
+      </div>
+    </div>
+  );
+}

--- a/src/server/subdomains/estimate/application/queries/__tests__/SearchEstimatesQuery.test.ts
+++ b/src/server/subdomains/estimate/application/queries/__tests__/SearchEstimatesQuery.test.ts
@@ -129,6 +129,8 @@ describe("SearchEstimatesQuery", () => {
       expect(dto.customerName).toBe("見積テスト得意先");
       expect(dto.creatorCode).toBe("EMP999091");
       expect(dto.creatorName).toBe("見積テスト作成者");
+      // 納品先は名前のみ（Q1-b・code は載せない）。一覧の「納品先」列の供給元。
+      expect(dto.deliveryLocationName).toBe("見積テスト納品先");
       // 永続集計（ADR-0033）。デフォルト 1 バリエーション = 2750。
       expect(dto.finalTotal).toBe(2750);
       expect(dto.activeStatus).toBe("ACTIVE");

--- a/src/server/subdomains/estimate/application/queries/dto/EstimateSummaryDTO.ts
+++ b/src/server/subdomains/estimate/application/queries/dto/EstimateSummaryDTO.ts
@@ -16,6 +16,11 @@ export type EstimateSummaryDTO = {
   // ADR-0013: リレーション先の名前・コードを含める（FK の ID は一覧では持たない）
   customerCode: string;
   customerName: string;
+  /**
+   * 納品先名（一覧「納品先」列・Q1-b）。表示は名前のみのため code は持たない
+   * （Q1 の得意先コード非表示方針と一貫・YAGNI）。名前解決は ADR-0013 のリレーション越し。
+   */
+  deliveryLocationName: string;
   /** 作成者（見積担当者）の社員コード（Employee.employeeCd）。 */
   creatorCode: string;
   creatorName: string;

--- a/src/server/subdomains/estimate/infrastructure/queries/PrismaEstimateQueryService.ts
+++ b/src/server/subdomains/estimate/infrastructure/queries/PrismaEstimateQueryService.ts
@@ -60,6 +60,8 @@ type SetGroupRow = VariationRow["setGroups"][number];
  */
 const ESTIMATE_SUMMARY_INCLUDE = {
   customer: { select: { code: true, name: true } },
+  // 一覧「納品先」列は名前のみ（Q1-b）。code は引かない。
+  deliveryLocation: { select: { name: true } },
   creator: { select: { employeeCd: true, name: true } },
   variations: {
     orderBy: { variationNumber: "asc" },
@@ -184,6 +186,8 @@ export class PrismaEstimateQueryService implements EstimateQueryService {
       // ADR-0013: リレーション先の名前・コードを解決する。
       customerCode: e.customer.code,
       customerName: e.customer.name,
+      // 納品先は名前のみ（Q1-b）。
+      deliveryLocationName: e.deliveryLocation.name,
       creatorCode: e.creator.employeeCd,
       creatorName: e.creator.name,
       // 永続集計をそのまま読む（再計算しない・ADR-0033）。


### PR DESCRIPTION
## Summary

`/estimates` 見積一覧画面（presentation）を実装。商品一覧のパターンを写経し、`searchEstimatesQueryFactory()`（#344）と検索フィルタ4項目（#354）を利用して一覧・検索・新規登録導線を構成。一覧に納品先列を出すため `EstimateSummaryDTO` を additive 拡張し、ダッシュボードに見積管理導線を追加。

Closes #345

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### implement-estimate-list-page.md

#### 概要

`/estimates` 見積一覧画面（presentation）を実装する。商品一覧（`products/page.tsx`）のパターンを写経し、`searchEstimatesQueryFactory()`（#344）と #354 で実装済みの検索フィルタ（`EstimateSearchCriteria` 4項目）を利用する。

本 issue は presentation 中心だが、一覧に「納品先」列を出すため `EstimateSummaryDTO` に `deliveryLocationName` を additive 拡張する小さな BE 作業（Q1-b）を含む。「#345＝純フロント」の前提は破棄する。

依存関係:
- #344（CLOSED）: `EstimateSummaryDTO` / `searchEstimatesQueryFactory()` を提供済み。
- #354（取り込み済み）: `EstimateSearchCriteria` を実フィルタ4項目（`estimateNumber`/`customerName` 部分一致・`estimateType`/`activeStatus` 等値/some-none）へ拡張済み。
- #351（予定）: 見積作成画面 `/estimates/new`。本 issue では新規登録ボタンのリンク先として参照のみ（現状 dead link）。
- #348（別 issue）: `displayStatus`（表示ステータス）列。本 issue では出さない。

スコープ外: 検索フィルタの BE 実装（#354 で完了済み）、作成画面（#351）、表示ステータス列（#348）、列ヘッダのクリックソート。

#### 設計判断

**Q1: 表示列セット（8列・左→右）**
- 見積番号(Link)／区分(Badge)／得意先／納品先／作成者／締切(formatDate)／金額(formatYen)／有効・無効(Badge)
- 列順は得意先 → 納品先 → 作成者（得意先と納品先を隣接）。見積日・得意先コードは出さない。
- 理由: 一覧で必要な識別・判断に足る最小列。コード類は一覧では冗長。

**Q1-b: 納品先のスコープと DTO 拡張**
- A. この PR で BE も拡張する（採用） / B. 純フロントに留め納品先を出さない
- DTO に足すフィールドは `deliveryLocationName` のみ（`deliveryLocationCode` は足さない）。理由: Q1 で得意先コードを出さない方針と一貫。表示しない値を凍結契約に増やさない（YAGNI）。
- 名前解決は ADR-0013 の既存パターン（リレーション越しの名前解決）に従う。

**Q2: 「状態」列の意味と見出し**
- 列見出しは曖昧語「状態」を避け「有効/無効」とする。本 issue で非 null に出せるのは `activeStatus`（代表の有効/無効）のみ。
- `displayStatus`（表示ステータス）列は今回出さない（#348。依存未着手のため常に null）。

**Q3: SearchForm を出すか**
- 検索を出す（4項目）。初期はデフォルト絞り込み無し（全件表示）。
- フィールド: text `estimateNumber`（部分一致）／ text `customerName`（部分一致）／ select `estimateType`／ select `activeStatus`
- 空文字は criteria に渡さない（`getStringParam` が undefined 化）。

**Q4: page から渡す orderBy**
- A. orderBy を渡さず BE 既定 `[deadline asc, createdAt asc, estimateNumber asc]`（締切昇順）に委ねる（採用）
- 理由: `DataTable` はクリックソート無し＝サーバが返す順で固定。締切列を出すので締切昇順は自己説明的。第2・3キーで決定的（E2E 安定）。

**Q5: 新規登録ボタン ＋ ダッシュボード導線**
- (A) 新規登録ボタンを置く（`href="/estimates/new"`）。`isAdmin` ゲート無し＝認証済みユーザー全員に表示。理由: 見積はトランザクションデータで担当者の日常業務。
- (B) ダッシュボード `navigationItems` の先頭に「見積管理」を追加。理由: ダッシュボードが唯一の入口。

**Q6: 代表が INACTIVE（全無効見積）の行の見た目**
- 行のグレーアウトはしない。有効/無効バッジのみで識別（商品一覧と同一）。

**Q7: E2E `estimates-list.e2e.ts` の範囲**
- 商品 E2E を写経（一覧表示／検索4種／クリア）＋見積固有を追加（新規登録ボタン両ロール可視／代表選択 ADR-0051 検証／納品先列の表示）。
- read-only のため非直列。テスト内で Prisma 直接利用しない（ADR-0012）。

**ドキュメント方針**
- CONTEXT.md: 追記不要。ADR: 新規不要（ADR-0013/ADR-0051/#348 の既存決定に従う）。deviations.md: Q1-b を記録。

#### ステップ
1. 一覧 read model に納品先名を追加（DTO / QueryService / 単体テスト）
2. 見積一覧の列定義（columns.tsx・8列）
3. 見積一覧ページ（page.tsx・検索＋一覧＋新規登録導線）
4. ダッシュボードに見積管理導線を追加
5. 見積一覧 E2E テスト
6. 逸脱記録（deviations.md）

</details>

## 計画からの逸脱

### 逸脱 1: 「#345 = 純フロント」前提を破棄し EstimateSummaryDTO を additive 拡張（Q1-b）

- **計画**: 当初は presentation 層のみ（純フロント）で完結させ、BE の read model には手を入れない想定だった。
- **実際**: 一覧に「納品先」列を出すため、凍結契約 `EstimateSummaryDTO` に `deliveryLocationName: string` を additive 追加し、`ESTIMATE_SUMMARY_INCLUDE` に `deliveryLocation: { select: { name: true } }`、`toSummaryDTO` に名前解決を加えた（commit ea4218e）。表示は名前のみのため `deliveryLocationCode` は足さない。
- **理由**: 既存 DTO は納品先を持たず、純フロントのままでは納品先名を表示できない。`Estimate.deliveryLocationId` は NOT NULL のため required で追加でき、後方互換を壊さない additive 変更（ADR-0013 の既存パターン）。新規 ADR は不要（不可逆性・驚き・真のトレードオフを満たさない）。

## Test Plan

- [ ] 単体テスト: `SearchEstimatesQuery.test.ts` に納品先名解決のアサーション追加（`pnpm test`）
- [ ] E2E: `estimates-list.e2e.ts`（`pnpm e2e`）
  - [ ] `/estimates` で見積一覧が表示される
  - [ ] 検索4種（見積番号・得意先名・区分・有効/無効）とクリアが動作する
  - [ ] 各行（見積番号）から `/estimates/[estimateNumber]` に遷移できる
  - [ ] 新規登録ボタンが admin・一般ユーザー両方で可視（Q5 回帰防止）
  - [ ] 代表選択（ADR-0051）の検証（`N9905001`→有効＋金額、`N9905002`→無効、activeStatus フィルタで出し分け）
  - [ ] 納品先列が表示される
- [ ] ダッシュボードから見積管理（`/estimates`）に遷移できる

---

Generated with [Claude Code](https://claude.ai/code)
