### PR TITLE
refactor: VariationCreateForm / VariationEditForm のフォーム共通化

### DIFF
--- a/docs/claude-plans/issue-363/deviations.md
+++ b/docs/claude-plans/issue-363/deviations.md
@@ -1,0 +1,25 @@
+# Issue #363 実装逸脱記録
+
+## モーダルをボディ部品内ではなく別エクスポート（form 外）に分離
+
+### 元の計画内容
+`/grill-me` の合意（fields 型付けの選択肢 A）では、共有ボディ部品 `VariationLineEditor` が
+共通領域を**まるごと**描画する想定で、SelectionModal・ProductSuggestDialog（モーダル2つ）も
+ボディ部品に含める前提だった。
+
+### 実際の実装内容
+ボディ部品ファイルを2エクスポートに分割した。
+- `VariationLineEditor`: `<form>` 内に置く内側共通領域（明細テーブル・全体値引・メモ・プレビュー・hidden）
+- `VariationLineEditorOverlays`: モーダル2つ。ラッパが `</form>` の**外**で描画する
+
+### 逸脱の理由
+`SelectionModal` は内部で `ModalSearchForm` を描画し、`ModalSearchForm` は `<form onSubmit>` と
+`type="submit"` ボタンを持つ。モーダルをラッパの `<form>` 内に置くと**ネスト form（不正 HTML）**
+になり、外側フォームの送信挙動を壊すリスクがある。元実装はこれを避けてモーダルを `</form>` の外に
+配置していた。完了条件「既存挙動が変わらない」を厳守するため、この DOM 構造（モーダルは form 外）を
+踏襲し、ボディ部品を form 内（フィールド）と form 外（モーダル）の2エクスポートに分けた。重複は
+生じていない。
+
+### 検証
+E2E 16件全緑（商品選択モーダル→明細追加、セット群自動展開、周辺商品サジェストを含む）。
+`pnpm lint` / `pnpm test`（1193件）/ `npx tsc --noEmit` も緑。

--- a/docs/claude-plans/issue-363/extract-variation-line-editor.md
+++ b/docs/claude-plans/issue-363/extract-variation-line-editor.md
@@ -1,0 +1,105 @@
+# Issue #363: VariationCreateForm / VariationEditForm のフォーム共通化 — 実装計画
+
+## 概要
+
+`VariationCreateForm`（C3 新規追加／複製プリフィル）と `VariationEditForm`（C4 内容編集）は、作業コピーパイプライン（nodes＝通常明細／セット群 union の client state・ADR-0047/0050）・共有部品・6ハンドラ群がほぼ同一実装で重複している。明細編集ロジックを単一実装へ集約し、両フォームを薄いラッパに置き換える。あわせて3フォーム（上記2つ＋ `EstimateHeaderForm`）に重複する定数（`productSearchFields` / `inputClass`）も共通化する。
+
+スキーマ層（`variationContentFields` ＝ version/overallDiscount/memo×2/nodes）はすでに共通化済みで、Edit は `variationId` を、Create は `submissionType` を足すだけの差分。重複しているのは React 層のみ。
+
+完了条件: 明細編集ロジックが単一実装に集約され Create/Edit 双方で再利用／C3・C4 の既存挙動不変／既存 E2E（estimates-variation-create / estimates-variation-edit / estimates-set-group-edit）緑／`pnpm lint` `pnpm test` 通過。
+
+## 設計判断
+
+### 抽出境界（最重要・他判断を支配）
+- A. フック＋共有ボディ部品（state/ハンドラはフック、共通JSXはボディ部品、useServerForm と分岐 hidden は薄いラッパに残す）
+- B. 単一コンポーネント＋mode 判別 prop
+- C. フックのみ抽出（JSX 重複は残す）
+- **採用: A**（理由: conform の `fields` 型はスキーマ依存。useServerForm を各ラッパに残し、スキーマ差をラッパ内に閉じ込められる。issue の「薄いラッパ」要件とも整合）
+
+### ボディ部品への conform 注入方式
+- A. 個別 `FieldMetadata` を明示渡し（nodes/overallDiscount/customerMemo/internalMemo）
+- B. `fields` オブジェクトを共通型で丸ごと渡す
+- C. ボディは conform 非依存にしメモ等はラッパに残す（メモブロックが再重複）
+- **採用: A**（理由: スキーマ差に依存せず `FieldMetadata<...>` 単位で型が閉じ、最も型安全。`form` 丸ごとも渡さない）
+
+### totals（previewVariationTotals）の算出位置
+- A. フックが taxRate/taxRoundingType も受け totals まで導出して返す
+- B. ボディが editor＋taxRate から導出
+- C. ラッパが導出して props 渡し
+- **採用: A**（理由: 「バリ明細編集器の状態と導出ビュー」を単一フックに凝集。ボディは導出ゼロの純表示になりラッパの薄さが一貫）
+
+### `<form>` シェル・送信ボタン・エラーバナー・分岐ヘッダの配置
+- A. ボディは内側共通領域のみ。`<form>`/getFormProps/form.errors/version hidden/分岐 hidden/送信ボタンは各ラッパに残す
+- B. ボディが `<form>` 丸ごと所有＋header スロット注入
+- C. ボタン/エラーはボディ・`<form>` タグはラッパ
+- **採用: A**（理由: `form` メタデータは `FormMetadata<Schema>` 依存。ラッパに留めれば具体スキーマ型で getFormProps が型安全。fields でスキーマ結合を避けた判断と一貫。エラーバナー/ボタンの軽微な重複は許容、必要なら後で `<FormActions>` 化）
+
+### 抽出3資産の配置
+- A. 責務別に分散（hook→`[estimateNumber]/`、body→`components/`、productSearchFields→`_shared/`）
+- B. variation 専用サブモジュールに集約
+- C. 全部 `_shared/` に集約
+- **採用: A**（理由: フックは詳細ページ固有ゆえ横断 `_hooks/` ではなく `variationLines.ts` と同居。ボディは `LineEditTable` の親プレゼンテーション層ゆえ `components/`。`productSearchFields` は選択系の凝集先 `_shared/`）
+
+### `inputClass` の disabled バリアント
+- A. 2定数（`inputClass` base ＋ `inputClassDisabled` ＝ base + `disabled:bg-gray-100`）
+- B. disabled を引数に取るユーティリティ関数
+- C. base 単一 ＋ Header 側でインライン追記
+- **採用: A**（理由: 完了条件「既存挙動不変」＝統一ではなく差の保存が正解。各サイトに現状クラスを割当て直すだけで回帰ゼロ。静的クラスゆえ関数は過剰。置き場 `_shared/formStyles.ts`）
+
+### テスト戦略
+- A. 新規フックテストなし・既存資産（variationLines.test.ts ＋ 3 E2E）に依拠
+- B. renderHook でフルテスト（server action mock）
+- C. 同期ハンドラのみ renderHook
+- **採用: A**（理由: 純関数群は既にテスト済み・同期ハンドラはその薄い委譲・非同期商品選択は3 E2E が網羅。スコープをリファクタに限定）
+
+### 外部契約
+- `VariationCreateForm` / `VariationEditForm` の Props は不変に保つ → `VariationPanel` 無改修（判断不要・既存挙動不変の構造的保証）
+
+## ステップ
+
+### Step 1: 共通定数の抽出（productSearchFields / inputClass）
+- 対象ファイル:
+  - 新規 `src/app/(features)/estimates/_shared/formStyles.ts`（`inputClass` / `inputClassDisabled`）
+  - 新規 or 追記 `src/app/(features)/estimates/_shared/productSearch.ts`（`productSearchFields`）※ `selectionColumns` への追記でも可
+  - `EstimateHeaderForm.tsx`（inputClass×9 → `inputClassDisabled`、productSearchFields を import 参照へ）
+  - `VariationCreateForm.tsx` / `VariationEditForm.tsx`（ローカル定数削除し import 参照へ）
+- 作業内容:
+  - `inputClass`(base) と `inputClassDisabled`(=base+`disabled:bg-gray-100`) を `_shared/formStyles.ts` に定義
+  - `productSearchFields` を `_shared` へ移設、3ファイルから import
+  - 各サイトに現状クラスを温存割当て（Header=Disabled、バリメモ=base）
+- コミットメッセージ: `refactor: フォーム共通定数（productSearchFields / inputClass）を_sharedへ抽出`
+  - ボディ: inputClass は disabled バリアントを別定数（inputClassDisabled）で保存。理由: EstimateHeaderForm のみ disabled:bg-gray-100 を持ち、単純共有は当該スタイルの握り潰し回帰になるため。
+
+### Step 2: useVariationLineEditor フックの抽出
+- 対象ファイル: 新規 `src/app/(features)/estimates/[estimateNumber]/useVariationLineEditor.ts`
+- 作業内容:
+  - 入力: `{ initialNodes: WorkingNode[]; initialOverallDiscount: number; taxRate: number; taxRoundingType: string }`
+  - 所有 state: nodes / overallDiscount / activeRowId / productModalOpen / suggestState
+  - 公開: 上記 state ＋ `changeLine` `deleteNode` `reorderTopLevel` `reorderInGroup` `handleProductSelect` `confirmSuggestions` ＋ setProductModalOpen / setActiveRowId 等 ＋ 導出 `totals`
+  - DTO 非依存（VariationDTO / VariationCreateInitialValues を import しない）
+- コミットメッセージ: `refactor: バリ明細編集の作業state・ハンドラ・totals導出をuseVariationLineEditorへ抽出`
+  - ボディ: 初期値は解決済みプリミティブで注入しフックをDTO非依存に。理由: Create(initialValues)/Edit(VariationDTO)の供給元差をラッパ側に閉じ込め、フックの再利用性を保つため。
+
+### Step 3: VariationLineEditor ボディ部品の抽出
+- 対象ファイル: 新規 `src/app/(features)/estimates/[estimateNumber]/components/VariationLineEditor.tsx`
+- 作業内容:
+  - props: `editor`（フック戻り値）＋個別 `FieldMetadata`（nodesField / overallDiscountField / customerMemoField / internalMemoField）＋ `isPending`
+  - 描画: 明細header＋追加ボタン・LineEditTable＋errors・全体値引・メモ×2・プレビュー・SelectionModal・ProductSuggestDialog（内側共通領域のみ）
+  - `form` 丸ごと・`<form>` タグ・送信ボタンは含めない
+- コミットメッセージ: `refactor: 明細編集の共通JSXをVariationLineEditor部品へ抽出（個別FieldMetadata注入）`
+  - ボディ: conform は fields 丸ごとでなく個別 FieldMetadata で注入。理由: Create/Editのスキーマ差（submissionType/variationId）をボディに漏らさず型を閉じるため。
+
+### Step 4: Create/Edit を薄いラッパに置き換え
+- 対象ファイル: `VariationCreateForm.tsx` / `VariationEditForm.tsx`
+- 作業内容:
+  - 各ラッパ: useServerForm（自スキーマ）＋ initial state 解決（Create=`initialValues?.nodes ?? []` / Edit=`fromVariationLines(variation.lines)`）＋ useVariationLineEditor 呼び出し
+  - `<form>` シェル・form.errors バナー・version hidden・分岐 hidden（Create=SubmissionTypeField / Edit=variationId）・送信/キャンセルボタン・`<VariationLineEditor>` を構成
+  - 外部 Props 不変を確認（VariationPanel 無改修）
+- コミットメッセージ: `refactor: VariationCreate/EditFormを共通土台の薄いラッパへ置換`
+
+### Step 5: 緑化確認と逸脱記録
+- 対象ファイル: （必要なら）`docs/claude-plans/issue-363/deviations.md`
+- 作業内容:
+  - `pnpm lint` / `pnpm test` / `pnpm e2e`（create / edit / set-group-edit）を緑確認
+  - 計画と異なる対応があれば deviations.md に記録
+- コミットメッセージ: （挙動変更なしのため原則不要。逸脱記録のみ生じた場合）`docs: issue-363 実装逸脱を記録`

--- a/src/app/(features)/estimates/[estimateNumber]/EstimateHeaderForm.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/EstimateHeaderForm.tsx
@@ -6,7 +6,9 @@ import { useServerForm } from "@/app/_hooks/useServerForm";
 import { SelectionModal } from "@/app/_components/shared/SelectionModal";
 import type { SearchFieldDef } from "@/app/_components/shared/SearchForm";
 import { toDateInputValue } from "../_shared/date";
+import { inputClassDisabled } from "../_shared/formStyles";
 import { TAX_ROUNDING_TYPE_LABELS } from "../_shared/labels";
+import { productSearchFields } from "../_shared/productSearch";
 import {
   companySelectionColumns,
   productSelectionColumns,
@@ -70,14 +72,6 @@ const companySearchFields: SearchFieldDef[] = [
   { type: "text", key: "code", label: "コード", placeholder: "部分一致" },
   { type: "text", key: "name", label: "名称", placeholder: "部分一致" },
 ];
-
-const productSearchFields: SearchFieldDef[] = [
-  { type: "text", key: "code", label: "商品コード", placeholder: "部分一致" },
-  { type: "text", key: "name", label: "商品名", placeholder: "部分一致" },
-];
-
-const inputClass =
-  "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100";
 
 export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
   // 改訂が存在すると見積年月日・得意先・納品先・税端数は変更不可（§7.2）。最終強制は
@@ -234,7 +228,7 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
               <select
                 {...getSelectProps(fields.departmentId)}
                 disabled={isPending}
-                className={inputClass}
+                className={inputClassDisabled}
               >
                 {departments.map((d) => (
                   <option key={d.id} value={d.id}>
@@ -266,7 +260,7 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
                 value={estimateDate}
                 onChange={(e) => setEstimateDate(e.target.value)}
                 disabled={locked || isPending}
-                className={inputClass}
+                className={inputClassDisabled}
               />
               {fields.estimateDate.errors && (
                 <p className="text-red-500 text-xs mt-1">{fields.estimateDate.errors[0]}</p>
@@ -284,7 +278,7 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
               <input
                 {...getInputProps(fields.deadline, { type: "date" })}
                 disabled={isPending}
-                className={inputClass}
+                className={inputClassDisabled}
               />
               {fields.deadline.errors && (
                 <p className="text-red-500 text-xs mt-1">{fields.deadline.errors[0]}</p>
@@ -311,7 +305,7 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
                 value={taxRoundingType}
                 onChange={(e) => setTaxRoundingType(e.target.value)}
                 disabled={locked || isPending}
-                className={inputClass}
+                className={inputClassDisabled}
               >
                 {Object.entries(TAX_ROUNDING_TYPE_LABELS).map(([value, label]) => (
                   <option key={value} value={value}>
@@ -363,7 +357,7 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
                 <input
                   {...getInputProps(fields.repairScheduledRepairDate, { type: "date" })}
                   disabled={isPending}
-                  className={inputClass}
+                  className={inputClassDisabled}
                 />
                 {fields.repairScheduledRepairDate.errors && (
                   <p className="text-red-500 text-xs mt-1">
@@ -382,7 +376,7 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
                   {...getTextareaProps(fields.repairFaultDescription)}
                   disabled={isPending}
                   rows={3}
-                  className={inputClass}
+                  className={inputClassDisabled}
                 />
                 {fields.repairFaultDescription.errors && (
                   <p className="text-red-500 text-xs mt-1">
@@ -431,7 +425,7 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
                 <input
                   {...getInputProps(fields.afterRepairActualRepairDate, { type: "date" })}
                   disabled={isPending}
-                  className={inputClass}
+                  className={inputClassDisabled}
                 />
                 {fields.afterRepairActualRepairDate.errors && (
                   <p className="text-red-500 text-xs mt-1">
@@ -450,7 +444,7 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
                   {...getTextareaProps(fields.afterRepairEmergencyReason)}
                   disabled={isPending}
                   rows={2}
-                  className={inputClass}
+                  className={inputClassDisabled}
                 />
                 {fields.afterRepairEmergencyReason.errors && (
                   <p className="text-red-500 text-xs mt-1">
@@ -469,7 +463,7 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
                   {...getTextareaProps(fields.afterRepairFaultDescription)}
                   disabled={isPending}
                   rows={3}
-                  className={inputClass}
+                  className={inputClassDisabled}
                 />
                 {fields.afterRepairFaultDescription.errors && (
                   <p className="text-red-500 text-xs mt-1">

--- a/src/app/(features)/estimates/[estimateNumber]/VariationCreateForm.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationCreateForm.tsx
@@ -1,40 +1,14 @@
 "use client";
 
-import { getFormProps, getInputProps, getTextareaProps } from "@conform-to/react";
+import { getFormProps, getInputProps } from "@conform-to/react";
 import { useState } from "react";
 import { useServerForm } from "@/app/_hooks/useServerForm";
-import { SelectionModal } from "@/app/_components/shared/SelectionModal";
-import { inputClass } from "../_shared/formStyles";
 import { SUBMISSION_TYPE_LABELS } from "../_shared/labels";
-import { productSearchFields } from "../_shared/productSearch";
-import {
-  expandSetComponents,
-  getProductLineSnapshot,
-  getProductSuggestions,
-  searchProductsForSelection,
-  type SuggestedProduct,
-} from "../_shared/selection-actions";
-import { productSelectionColumns, type ProductSelectionRow } from "../_shared/selectionColumns";
-import { LineEditTable } from "./components/LineEditTable";
-import { ProductSuggestDialog } from "./components/ProductSuggestDialog";
-import { PreviewRow } from "./components/PreviewRow";
-import { previewVariationTotals } from "./previewAmounts";
+import { VariationLineEditor, VariationLineEditorOverlays } from "./components/VariationLineEditor";
 import { addVariation } from "./actions";
+import { useVariationLineEditor } from "./useVariationLineEditor";
 import { addVariationNodeSchema } from "./variationSchema";
 import type { VariationCreateInitialValues } from "./variationDuplication";
-import {
-  changeNodeLine,
-  createWorkingLine,
-  createWorkingSetGroup,
-  flattenPricedLines,
-  insertNodesBelow,
-  removeNode,
-  reorderComponents,
-  reorderNodes,
-  toNodePayload,
-  type WorkingLine,
-  type WorkingNode,
-} from "./variationLines";
 
 type Props = {
   estimateNumber: string;
@@ -51,12 +25,12 @@ type Props = {
 };
 
 /**
- * バリエーション作成フォーム（C3・新規追加／複製プリフィル）。C4 編集フォームと同じ作業コピー
- * パイプライン（nodes＝通常明細／セット群 union を client state で保持し submit 時に単一 hidden へ
- * JSON 化・ADR-0047/0050）と共有部品（LineEditTable / previewAmounts / 商品選択・周辺サジェスト）を
- * 再利用する。差分は (1) variationId を持たず提出区分を入力する点、(2) 初期値が複製元 DTO 由来
- * （新規追加は白紙）の 2 点。提出区分は複製＝引き継ぎ固定、新規追加＝選択（SubmissionTypeField）。
- * version はフォーム由来の楽観ロックトークン（ADR-0039・追加型でも必須）。
+ * バリエーション作成フォーム（C3・新規追加／複製プリフィル）。明細編集の作業コピーパイプライン
+ * （nodes＝通常明細／セット群 union を client state で保持し submit 時に単一 hidden へ JSON 化・
+ * ADR-0047/0050）は {@link useVariationLineEditor}＋{@link VariationLineEditor} に集約し、C4 編集
+ * フォームと共有する。この薄いラッパが持つ差分は (1) variationId を持たず提出区分を入力する点、
+ * (2) 初期値が複製元 DTO 由来（新規追加は白紙）の 2 点。提出区分は複製＝引き継ぎ固定、新規追加＝
+ * 選択（SubmissionTypeField）。version はフォーム由来の楽観ロックトークン（ADR-0039・追加型でも必須）。
  */
 export function VariationCreateForm({
   estimateNumber,
@@ -78,80 +52,19 @@ export function VariationCreateForm({
     },
   });
 
-  // 作業コピー: 複製は複製元の作業ノード（改訂列ドロップ済み・セット群スナップショット保持）、
-  // 新規追加は空配列で開始する。overallDiscount も同様。
+  // 提出区分は複製＝引き継ぎ固定／新規追加＝選択。明細以外の差分なのでラッパが state を持つ。
   const [submissionType, setSubmissionType] = useState<string>(
     initialValues?.submissionType ?? "CUSTOMER"
   );
-  const [nodes, setNodes] = useState<WorkingNode[]>(() => initialValues?.nodes ?? []);
-  const [overallDiscount, setOverallDiscount] = useState(initialValues?.overallDiscount ?? 0);
-  const [activeRowId, setActiveRowId] = useState<string | null>(null);
-  const [productModalOpen, setProductModalOpen] = useState(false);
-  const [suggestState, setSuggestState] = useState<{
-    mainRowId: string;
-    mainName: string;
-    suggestions: SuggestedProduct[];
-  } | null>(null);
 
-  const totals = previewVariationTotals({
-    lines: flattenPricedLines(nodes),
-    overallDiscount,
+  // 作業コピー: 複製は複製元の作業ノード（改訂列ドロップ済み・セット群スナップショット保持）、
+  // 新規追加は空配列で開始する。overallDiscount も同様。
+  const editor = useVariationLineEditor({
+    initialNodes: initialValues?.nodes ?? [],
+    initialOverallDiscount: initialValues?.overallDiscount ?? 0,
     taxRate,
     taxRoundingType,
   });
-
-  const changeLine = (rowId: string, patch: Partial<WorkingLine>) => {
-    setNodes((prev) => changeNodeLine(prev, rowId, patch));
-  };
-
-  const deleteNode = (rowId: string) => {
-    setNodes((prev) => removeNode(prev, rowId));
-    if (activeRowId === rowId) setActiveRowId(null);
-  };
-
-  const reorderTopLevel = (from: number, to: number) => {
-    setNodes((prev) => reorderNodes(prev, from, to));
-  };
-
-  const reorderInGroup = (groupRowId: string, from: number, to: number) => {
-    setNodes((prev) => reorderComponents(prev, groupRowId, from, to));
-  };
-
-  // 商品選択（C4 編集フォームと同一）。セット商品は構成展開して群挿入、通常商品はスナップショット挿入。
-  const handleProductSelect = async (rows: ProductSelectionRow[]) => {
-    const picked = rows[0];
-    if (!picked) return;
-
-    if (picked.category === "SET") {
-      const expanded = await expandSetComponents(picked.id);
-      if (!expanded) return;
-      const groupRowId = crypto.randomUUID();
-      const group = createWorkingSetGroup(groupRowId, expanded, () => crypto.randomUUID());
-      setNodes((prev) => insertNodesBelow(prev, activeRowId, [group]));
-      setActiveRowId(groupRowId);
-      return;
-    }
-
-    const snapshot = await getProductLineSnapshot(picked.id);
-    if (!snapshot) return;
-    const newLine = createWorkingLine(crypto.randomUUID(), snapshot);
-    setNodes((prev) => insertNodesBelow(prev, activeRowId, [newLine]));
-    setActiveRowId(newLine.rowId);
-
-    const suggestions = await getProductSuggestions(snapshot.id);
-    if (suggestions.length > 0) {
-      setSuggestState({ mainRowId: newLine.rowId, mainName: snapshot.name, suggestions });
-    }
-  };
-
-  const confirmSuggestions = (selected: SuggestedProduct[]) => {
-    if (!suggestState) return;
-    const peripheralLines = selected.map((s) =>
-      createWorkingLine(crypto.randomUUID(), s, { quantity: s.quantity })
-    );
-    setNodes((prev) => insertNodesBelow(prev, suggestState.mainRowId, peripheralLines));
-    setSuggestState(null);
-  };
 
   return (
     <>
@@ -168,14 +81,8 @@ export function VariationCreateForm({
       )}
 
       <form {...getFormProps(form)} noValidate>
-        {/* 楽観ロックトークン・明細 JSON・全体値引（state を hidden で送る）。variationId は持たない。 */}
+        {/* 楽観ロックトークン（state を hidden で送る）。variationId は持たない。 */}
         <input {...getInputProps(fields.version, { type: "hidden" })} />
-        <input
-          type="hidden"
-          name={fields.nodes.name}
-          value={JSON.stringify(toNodePayload(nodes))}
-        />
-        <input type="hidden" name={fields.overallDiscount.name} value={String(overallDiscount)} />
 
         <SubmissionTypeField
           fieldName={fields.submissionType.name}
@@ -186,83 +93,14 @@ export function VariationCreateForm({
           disabled={isPending}
         />
 
-        <div className="flex justify-between items-center mb-3">
-          <h3 className="text-lg font-semibold text-gray-700">明細</h3>
-          <button
-            type="button"
-            onClick={() => setProductModalOpen(true)}
-            disabled={isPending}
-            className="bg-green-600 hover:bg-green-700 text-white text-sm font-bold py-2 px-4 rounded disabled:bg-gray-400"
-          >
-            明細追加
-          </button>
-        </div>
-
-        <LineEditTable
-          nodes={nodes}
-          activeRowId={activeRowId}
-          onSelectRow={setActiveRowId}
-          onChangeLine={changeLine}
-          onRemoveNode={deleteNode}
-          onReorderNodes={reorderTopLevel}
-          onReorderComponents={reorderInGroup}
+        <VariationLineEditor
+          editor={editor}
+          nodesField={fields.nodes}
+          overallDiscountField={fields.overallDiscount}
+          customerMemoField={fields.customerMemo}
+          internalMemoField={fields.internalMemo}
+          isPending={isPending}
         />
-        {fields.nodes.errors && (
-          <p className="text-red-500 text-xs mt-1">{fields.nodes.errors[0]}</p>
-        )}
-
-        {/* 全体値引（プレビューに効くため controlled）。 */}
-        <div className="mt-6 flex justify-end">
-          <label className="flex items-center gap-2 text-sm font-bold text-gray-700">
-            全体値引
-            <input
-              type="number"
-              min={0}
-              step={1}
-              aria-label="全体値引"
-              value={overallDiscount}
-              onChange={(e) =>
-                setOverallDiscount(e.target.value === "" ? 0 : Number(e.target.value))
-              }
-              className="w-40 border rounded px-2 py-1 text-right focus:outline-none focus:ring-1 focus:ring-blue-400"
-            />
-          </label>
-        </div>
-        {fields.overallDiscount.errors && (
-          <p className="text-red-500 text-xs mt-1 text-right">{fields.overallDiscount.errors[0]}</p>
-        )}
-
-        {/* バリメモ（conform フィールド）。 */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-          <div>
-            <label
-              htmlFor={fields.customerMemo.id}
-              className="block text-sm font-bold text-gray-700 mb-1"
-            >
-              顧客メモ
-            </label>
-            <textarea {...getTextareaProps(fields.customerMemo)} rows={3} className={inputClass} />
-          </div>
-          <div>
-            <label
-              htmlFor={fields.internalMemo.id}
-              className="block text-sm font-bold text-gray-700 mb-1"
-            >
-              社内メモ
-            </label>
-            <textarea {...getTextareaProps(fields.internalMemo)} rows={3} className={inputClass} />
-          </div>
-        </div>
-
-        {/* 金額ライブプレビュー（概算・確定はドメイン）。 */}
-        <div className="mt-6 flex justify-end">
-          <dl className="w-full md:w-80 space-y-1 text-sm">
-            <PreviewRow label="小計" value={totals.subtotal} />
-            <PreviewRow label="税抜合計" value={totals.afterOverallDiscount} />
-            <PreviewRow label="消費税（概算）" value={totals.taxAmount} />
-            <PreviewRow label="合計（概算）" value={totals.finalTotal} emphasize />
-          </dl>
-        </div>
 
         <div className="flex gap-4 mt-6">
           <button
@@ -283,26 +121,7 @@ export function VariationCreateForm({
         </div>
       </form>
 
-      <SelectionModal<ProductSelectionRow>
-        isOpen={productModalOpen}
-        onClose={() => setProductModalOpen(false)}
-        title="明細追加 — 商品を選択"
-        searchFields={productSearchFields}
-        searchAction={searchProductsForSelection}
-        columns={productSelectionColumns}
-        onConfirm={handleProductSelect}
-        getRowId={(row) => row.id}
-        emptyMessage="該当する商品が見つかりません"
-      />
-
-      {suggestState && (
-        <ProductSuggestDialog
-          mainProductName={suggestState.mainName}
-          suggestions={suggestState.suggestions}
-          onConfirm={confirmSuggestions}
-          onCancel={() => setSuggestState(null)}
-        />
-      )}
+      <VariationLineEditorOverlays editor={editor} />
     </>
   );
 }

--- a/src/app/(features)/estimates/[estimateNumber]/VariationCreateForm.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationCreateForm.tsx
@@ -4,8 +4,9 @@ import { getFormProps, getInputProps, getTextareaProps } from "@conform-to/react
 import { useState } from "react";
 import { useServerForm } from "@/app/_hooks/useServerForm";
 import { SelectionModal } from "@/app/_components/shared/SelectionModal";
-import type { SearchFieldDef } from "@/app/_components/shared/SearchForm";
+import { inputClass } from "../_shared/formStyles";
 import { SUBMISSION_TYPE_LABELS } from "../_shared/labels";
+import { productSearchFields } from "../_shared/productSearch";
 import {
   expandSetComponents,
   getProductLineSnapshot,
@@ -48,14 +49,6 @@ type Props = {
   initialValues?: VariationCreateInitialValues;
   onCancel: () => void;
 };
-
-const productSearchFields: SearchFieldDef[] = [
-  { type: "text", key: "code", label: "商品コード", placeholder: "部分一致" },
-  { type: "text", key: "name", label: "商品名", placeholder: "部分一致" },
-];
-
-const inputClass =
-  "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline";
 
 /**
  * バリエーション作成フォーム（C3・新規追加／複製プリフィル）。C4 編集フォームと同じ作業コピー

--- a/src/app/(features)/estimates/[estimateNumber]/VariationEditForm.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationEditForm.tsx
@@ -1,40 +1,13 @@
 "use client";
 
-import { getFormProps, getInputProps, getTextareaProps } from "@conform-to/react";
-import { useState } from "react";
+import { getFormProps, getInputProps } from "@conform-to/react";
 import { useServerForm } from "@/app/_hooks/useServerForm";
-import { SelectionModal } from "@/app/_components/shared/SelectionModal";
 import type { VariationDTO } from "@subdomains/estimate/application/queries/dto/EstimateDetailDTO";
-import { inputClass } from "../_shared/formStyles";
-import { productSearchFields } from "../_shared/productSearch";
-import {
-  expandSetComponents,
-  getProductLineSnapshot,
-  getProductSuggestions,
-  searchProductsForSelection,
-  type SuggestedProduct,
-} from "../_shared/selection-actions";
-import { productSelectionColumns, type ProductSelectionRow } from "../_shared/selectionColumns";
-import { LineEditTable } from "./components/LineEditTable";
-import { ProductSuggestDialog } from "./components/ProductSuggestDialog";
-import { PreviewRow } from "./components/PreviewRow";
-import { previewVariationTotals } from "./previewAmounts";
+import { VariationLineEditor, VariationLineEditorOverlays } from "./components/VariationLineEditor";
 import { updateVariationContent } from "./actions";
+import { useVariationLineEditor } from "./useVariationLineEditor";
 import { updateVariationContentNodeSchema } from "./variationSchema";
-import {
-  changeNodeLine,
-  createWorkingLine,
-  createWorkingSetGroup,
-  flattenPricedLines,
-  fromVariationLines,
-  insertNodesBelow,
-  removeNode,
-  reorderComponents,
-  reorderNodes,
-  toNodePayload,
-  type WorkingLine,
-  type WorkingNode,
-} from "./variationLines";
+import { fromVariationLines } from "./variationLines";
 
 type Props = {
   estimateNumber: string;
@@ -47,12 +20,12 @@ type Props = {
 };
 
 /**
- * バリ内容編集フォーム（S4/S5・C4）。明細はモーダル選択・インライン編集・D&D で client state が
- * 真実になるため作業コピー（nodes＝通常明細／セット群の union・overallDiscount）を React state で
- * 保持し、submit 時に単一の hidden へ JSON 化して往復する（往復形状 A・ADR-0047/0050）。version は
- * hidden で往復（ADR-0039）。全体値引はプレビューに効くため controlled state。バリメモは conform
- * フィールド。確定金額はドメインが唯一の真実（ADR-0033）で保存後 DTO で上書きされ、ここでは簡易
- * ライブプレビューのみ表示する。セット商品選択時は構成を自動展開して群ノードを挿入する（ADR-0047）。
+ * バリ内容編集フォーム（S4/S5・C4）。明細編集の作業コピーパイプライン（nodes＝通常明細／セット群
+ * union を client state で保持し submit 時に単一 hidden へ JSON 化・往復形状 A・ADR-0047/0050）は
+ * {@link useVariationLineEditor}＋{@link VariationLineEditor} に集約し、C3 追加フォームと共有する。
+ * この薄いラッパが持つ差分は (1) 編集対象 variationId を hidden で運ぶ点、(2) 初期値が閲覧 DTO 由来
+ * の 2 点。version は hidden で往復（ADR-0039）。確定金額はドメインが唯一の真実（ADR-0033）で保存後
+ * DTO で上書きされ、ここでは簡易ライブプレビューのみ表示する。
  */
 export function VariationEditForm({
   estimateNumber,
@@ -75,80 +48,12 @@ export function VariationEditForm({
   });
 
   // 作業コピー: 閲覧 DTO の行配列（通常明細 ＋ セット群）をノード union へ写す（往復形状 A・ADR-0047）。
-  const [nodes, setNodes] = useState<WorkingNode[]>(() => fromVariationLines(variation.lines));
-  const [overallDiscount, setOverallDiscount] = useState(variation.overallDiscount);
-  const [activeRowId, setActiveRowId] = useState<string | null>(null);
-  const [productModalOpen, setProductModalOpen] = useState(false);
-  // 本体追加直後の周辺商品サジェスト（提案あり時のみ）。挿入は本体行（mainRowId）の直下。
-  const [suggestState, setSuggestState] = useState<{
-    mainRowId: string;
-    mainName: string;
-    suggestions: SuggestedProduct[];
-  } | null>(null);
-
-  // 金額プレビューは価格付き末端行（通常明細＋全構成）のフラット列で計算する（群は価格を持たない）。
-  const totals = previewVariationTotals({
-    lines: flattenPricedLines(nodes),
-    overallDiscount,
+  const editor = useVariationLineEditor({
+    initialNodes: fromVariationLines(variation.lines),
+    initialOverallDiscount: variation.overallDiscount,
     taxRate,
     taxRoundingType,
   });
-
-  const changeLine = (rowId: string, patch: Partial<WorkingLine>) => {
-    setNodes((prev) => changeNodeLine(prev, rowId, patch));
-  };
-
-  const deleteNode = (rowId: string) => {
-    setNodes((prev) => removeNode(prev, rowId));
-    if (activeRowId === rowId) setActiveRowId(null);
-  };
-
-  const reorderTopLevel = (from: number, to: number) => {
-    setNodes((prev) => reorderNodes(prev, from, to));
-  };
-
-  const reorderInGroup = (groupRowId: string, from: number, to: number) => {
-    setNodes((prev) => reorderComponents(prev, groupRowId, from, to));
-  };
-
-  // 商品選択: セット商品なら構成を自動展開して群ノードを挿入、通常商品ならスナップショット解決して
-  // 通常行を挿入する。挿入位置はアクティブノード直下（構成/群がアクティブなら群の直後＝トップレベル）。
-  const handleProductSelect = async (rows: ProductSelectionRow[]) => {
-    const picked = rows[0];
-    if (!picked) return;
-
-    if (picked.category === "SET") {
-      const expanded = await expandSetComponents(picked.id);
-      if (!expanded) return;
-      const groupRowId = crypto.randomUUID();
-      const group = createWorkingSetGroup(groupRowId, expanded, () => crypto.randomUUID());
-      setNodes((prev) => insertNodesBelow(prev, activeRowId, [group]));
-      setActiveRowId(groupRowId);
-      // セット商品は周辺商品サジェストの対象外（構成は自動展開で確定）。
-      return;
-    }
-
-    const snapshot = await getProductLineSnapshot(picked.id);
-    if (!snapshot) return;
-    const newLine = createWorkingLine(crypto.randomUUID(), snapshot);
-    setNodes((prev) => insertNodesBelow(prev, activeRowId, [newLine]));
-    setActiveRowId(newLine.rowId);
-
-    const suggestions = await getProductSuggestions(snapshot.id);
-    if (suggestions.length > 0) {
-      setSuggestState({ mainRowId: newLine.rowId, mainName: snapshot.name, suggestions });
-    }
-  };
-
-  // 提案された周辺商品（選択分）を本体直下に通常行として挿入する（数量＝relation・他は新規行既定）。
-  const confirmSuggestions = (selected: SuggestedProduct[]) => {
-    if (!suggestState) return;
-    const peripheralLines = selected.map((s) =>
-      createWorkingLine(crypto.randomUUID(), s, { quantity: s.quantity })
-    );
-    setNodes((prev) => insertNodesBelow(prev, suggestState.mainRowId, peripheralLines));
-    setSuggestState(null);
-  };
 
   return (
     <>
@@ -165,93 +70,18 @@ export function VariationEditForm({
       )}
 
       <form {...getFormProps(form)} noValidate>
-        {/* 楽観ロックトークン・対象バリ・明細 JSON・全体値引（state を hidden で送る）。 */}
+        {/* 楽観ロックトークン・対象バリ（state を hidden で送る）。 */}
         <input {...getInputProps(fields.version, { type: "hidden" })} />
         <input type="hidden" name={fields.variationId.name} value={variation.variationId} />
-        <input
-          type="hidden"
-          name={fields.nodes.name}
-          value={JSON.stringify(toNodePayload(nodes))}
+
+        <VariationLineEditor
+          editor={editor}
+          nodesField={fields.nodes}
+          overallDiscountField={fields.overallDiscount}
+          customerMemoField={fields.customerMemo}
+          internalMemoField={fields.internalMemo}
+          isPending={isPending}
         />
-        <input type="hidden" name={fields.overallDiscount.name} value={String(overallDiscount)} />
-
-        <div className="flex justify-between items-center mb-3">
-          <h3 className="text-lg font-semibold text-gray-700">明細</h3>
-          <button
-            type="button"
-            onClick={() => setProductModalOpen(true)}
-            disabled={isPending}
-            className="bg-green-600 hover:bg-green-700 text-white text-sm font-bold py-2 px-4 rounded disabled:bg-gray-400"
-          >
-            明細追加
-          </button>
-        </div>
-
-        <LineEditTable
-          nodes={nodes}
-          activeRowId={activeRowId}
-          onSelectRow={setActiveRowId}
-          onChangeLine={changeLine}
-          onRemoveNode={deleteNode}
-          onReorderNodes={reorderTopLevel}
-          onReorderComponents={reorderInGroup}
-        />
-        {fields.nodes.errors && (
-          <p className="text-red-500 text-xs mt-1">{fields.nodes.errors[0]}</p>
-        )}
-
-        {/* 全体値引（プレビューに効くため controlled）。 */}
-        <div className="mt-6 flex justify-end">
-          <label className="flex items-center gap-2 text-sm font-bold text-gray-700">
-            全体値引
-            <input
-              type="number"
-              min={0}
-              step={1}
-              aria-label="全体値引"
-              value={overallDiscount}
-              onChange={(e) =>
-                setOverallDiscount(e.target.value === "" ? 0 : Number(e.target.value))
-              }
-              className="w-40 border rounded px-2 py-1 text-right focus:outline-none focus:ring-1 focus:ring-blue-400"
-            />
-          </label>
-        </div>
-        {fields.overallDiscount.errors && (
-          <p className="text-red-500 text-xs mt-1 text-right">{fields.overallDiscount.errors[0]}</p>
-        )}
-
-        {/* バリメモ（conform フィールド）。 */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-          <div>
-            <label
-              htmlFor={fields.customerMemo.id}
-              className="block text-sm font-bold text-gray-700 mb-1"
-            >
-              顧客メモ
-            </label>
-            <textarea {...getTextareaProps(fields.customerMemo)} rows={3} className={inputClass} />
-          </div>
-          <div>
-            <label
-              htmlFor={fields.internalMemo.id}
-              className="block text-sm font-bold text-gray-700 mb-1"
-            >
-              社内メモ
-            </label>
-            <textarea {...getTextareaProps(fields.internalMemo)} rows={3} className={inputClass} />
-          </div>
-        </div>
-
-        {/* 金額ライブプレビュー（概算・確定はドメイン）。 */}
-        <div className="mt-6 flex justify-end">
-          <dl className="w-full md:w-80 space-y-1 text-sm">
-            <PreviewRow label="小計" value={totals.subtotal} />
-            <PreviewRow label="税抜合計" value={totals.afterOverallDiscount} />
-            <PreviewRow label="消費税（概算）" value={totals.taxAmount} />
-            <PreviewRow label="合計（概算）" value={totals.finalTotal} emphasize />
-          </dl>
-        </div>
 
         <div className="flex gap-4 mt-6">
           <button
@@ -272,26 +102,7 @@ export function VariationEditForm({
         </div>
       </form>
 
-      <SelectionModal<ProductSelectionRow>
-        isOpen={productModalOpen}
-        onClose={() => setProductModalOpen(false)}
-        title="明細追加 — 商品を選択"
-        searchFields={productSearchFields}
-        searchAction={searchProductsForSelection}
-        columns={productSelectionColumns}
-        onConfirm={handleProductSelect}
-        getRowId={(row) => row.id}
-        emptyMessage="該当する商品が見つかりません"
-      />
-
-      {suggestState && (
-        <ProductSuggestDialog
-          mainProductName={suggestState.mainName}
-          suggestions={suggestState.suggestions}
-          onConfirm={confirmSuggestions}
-          onCancel={() => setSuggestState(null)}
-        />
-      )}
+      <VariationLineEditorOverlays editor={editor} />
     </>
   );
 }

--- a/src/app/(features)/estimates/[estimateNumber]/VariationEditForm.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationEditForm.tsx
@@ -4,8 +4,9 @@ import { getFormProps, getInputProps, getTextareaProps } from "@conform-to/react
 import { useState } from "react";
 import { useServerForm } from "@/app/_hooks/useServerForm";
 import { SelectionModal } from "@/app/_components/shared/SelectionModal";
-import type { SearchFieldDef } from "@/app/_components/shared/SearchForm";
 import type { VariationDTO } from "@subdomains/estimate/application/queries/dto/EstimateDetailDTO";
+import { inputClass } from "../_shared/formStyles";
+import { productSearchFields } from "../_shared/productSearch";
 import {
   expandSetComponents,
   getProductLineSnapshot,
@@ -44,14 +45,6 @@ type Props = {
   taxRoundingType: string;
   onCancel: () => void;
 };
-
-const productSearchFields: SearchFieldDef[] = [
-  { type: "text", key: "code", label: "商品コード", placeholder: "部分一致" },
-  { type: "text", key: "name", label: "商品名", placeholder: "部分一致" },
-];
-
-const inputClass =
-  "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline";
 
 /**
  * バリ内容編集フォーム（S4/S5・C4）。明細はモーダル選択・インライン編集・D&D で client state が

--- a/src/app/(features)/estimates/[estimateNumber]/components/VariationLineEditor.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/components/VariationLineEditor.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { getTextareaProps, type FieldMetadata } from "@conform-to/react";
+import { SelectionModal } from "@/app/_components/shared/SelectionModal";
+import { inputClass } from "../../_shared/formStyles";
+import { productSearchFields } from "../../_shared/productSearch";
+import { searchProductsForSelection } from "../../_shared/selection-actions";
+import { productSelectionColumns, type ProductSelectionRow } from "../../_shared/selectionColumns";
+import type { VariationLineEditor as VariationLineEditorState } from "../useVariationLineEditor";
+import { toNodePayload } from "../variationLines";
+import { LineEditTable } from "./LineEditTable";
+import { PreviewRow } from "./PreviewRow";
+import { ProductSuggestDialog } from "./ProductSuggestDialog";
+
+type Props = {
+  editor: VariationLineEditorState;
+  /** 明細ノード配列の hidden field（JSON 化して往復・ADR-0050）。name/errors のみ使用。 */
+  nodesField: FieldMetadata<unknown>;
+  /** 全体値引の hidden field。name/errors のみ使用。 */
+  overallDiscountField: FieldMetadata<number>;
+  customerMemoField: FieldMetadata<string | undefined>;
+  internalMemoField: FieldMetadata<string | undefined>;
+  isPending: boolean;
+};
+
+/**
+ * バリ明細編集フォームの内側共通領域（C3 追加／C4 編集で共有）。明細テーブル・全体値引・メモ・金額
+ * ライブプレビューと、editor state を運ぶ hidden（明細 JSON・全体値引）を描画する。`<form>` シェル・
+ * version/分岐 hidden・送信ボタンはラッパが持つ。conform は fields 丸ごとではなく個別 FieldMetadata
+ * で注入し、Create/Edit のスキーマ差（submissionType / variationId）をこの部品に漏らさない。
+ * 商品選択・周辺サジェストのモーダルは {@link VariationLineEditorOverlays} が `<form>` の外で描画する
+ * （ModalSearchForm が内部に `<form>` を持つためネスト form を避ける）。
+ */
+export function VariationLineEditor({
+  editor,
+  nodesField,
+  overallDiscountField,
+  customerMemoField,
+  internalMemoField,
+  isPending,
+}: Props) {
+  return (
+    <>
+      {/* 明細 JSON・全体値引（editor state を hidden で送る）。 */}
+      <input
+        type="hidden"
+        name={nodesField.name}
+        value={JSON.stringify(toNodePayload(editor.nodes))}
+      />
+      <input
+        type="hidden"
+        name={overallDiscountField.name}
+        value={String(editor.overallDiscount)}
+      />
+
+      <div className="flex justify-between items-center mb-3">
+        <h3 className="text-lg font-semibold text-gray-700">明細</h3>
+        <button
+          type="button"
+          onClick={() => editor.setProductModalOpen(true)}
+          disabled={isPending}
+          className="bg-green-600 hover:bg-green-700 text-white text-sm font-bold py-2 px-4 rounded disabled:bg-gray-400"
+        >
+          明細追加
+        </button>
+      </div>
+
+      <LineEditTable
+        nodes={editor.nodes}
+        activeRowId={editor.activeRowId}
+        onSelectRow={editor.setActiveRowId}
+        onChangeLine={editor.changeLine}
+        onRemoveNode={editor.deleteNode}
+        onReorderNodes={editor.reorderTopLevel}
+        onReorderComponents={editor.reorderInGroup}
+      />
+      {nodesField.errors && <p className="text-red-500 text-xs mt-1">{nodesField.errors[0]}</p>}
+
+      {/* 全体値引（プレビューに効くため controlled）。 */}
+      <div className="mt-6 flex justify-end">
+        <label className="flex items-center gap-2 text-sm font-bold text-gray-700">
+          全体値引
+          <input
+            type="number"
+            min={0}
+            step={1}
+            aria-label="全体値引"
+            value={editor.overallDiscount}
+            onChange={(e) =>
+              editor.setOverallDiscount(e.target.value === "" ? 0 : Number(e.target.value))
+            }
+            className="w-40 border rounded px-2 py-1 text-right focus:outline-none focus:ring-1 focus:ring-blue-400"
+          />
+        </label>
+      </div>
+      {overallDiscountField.errors && (
+        <p className="text-red-500 text-xs mt-1 text-right">{overallDiscountField.errors[0]}</p>
+      )}
+
+      {/* バリメモ（conform フィールド）。 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+        <div>
+          <label
+            htmlFor={customerMemoField.id}
+            className="block text-sm font-bold text-gray-700 mb-1"
+          >
+            顧客メモ
+          </label>
+          <textarea {...getTextareaProps(customerMemoField)} rows={3} className={inputClass} />
+        </div>
+        <div>
+          <label
+            htmlFor={internalMemoField.id}
+            className="block text-sm font-bold text-gray-700 mb-1"
+          >
+            社内メモ
+          </label>
+          <textarea {...getTextareaProps(internalMemoField)} rows={3} className={inputClass} />
+        </div>
+      </div>
+
+      {/* 金額ライブプレビュー（概算・確定はドメイン）。 */}
+      <div className="mt-6 flex justify-end">
+        <dl className="w-full md:w-80 space-y-1 text-sm">
+          <PreviewRow label="小計" value={editor.totals.subtotal} />
+          <PreviewRow label="税抜合計" value={editor.totals.afterOverallDiscount} />
+          <PreviewRow label="消費税（概算）" value={editor.totals.taxAmount} />
+          <PreviewRow label="合計（概算）" value={editor.totals.finalTotal} emphasize />
+        </dl>
+      </div>
+    </>
+  );
+}
+
+/**
+ * 明細編集のモーダル（商品選択・周辺サジェスト）。`<form>` の外で描画する＝ModalSearchForm が
+ * 内部に `<form>` を持つため、ラッパの `<form>` 内に入れるとネスト form（不正 HTML）になるのを避ける。
+ */
+export function VariationLineEditorOverlays({ editor }: { editor: VariationLineEditorState }) {
+  return (
+    <>
+      <SelectionModal<ProductSelectionRow>
+        isOpen={editor.productModalOpen}
+        onClose={() => editor.setProductModalOpen(false)}
+        title="明細追加 — 商品を選択"
+        searchFields={productSearchFields}
+        searchAction={searchProductsForSelection}
+        columns={productSelectionColumns}
+        onConfirm={editor.handleProductSelect}
+        getRowId={(row) => row.id}
+        emptyMessage="該当する商品が見つかりません"
+      />
+
+      {editor.suggestState && (
+        <ProductSuggestDialog
+          mainProductName={editor.suggestState.mainName}
+          suggestions={editor.suggestState.suggestions}
+          onConfirm={editor.confirmSuggestions}
+          onCancel={() => editor.setSuggestState(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/(features)/estimates/[estimateNumber]/useVariationLineEditor.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/useVariationLineEditor.ts
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import {
+  expandSetComponents,
+  getProductLineSnapshot,
+  getProductSuggestions,
+  type SuggestedProduct,
+} from "../_shared/selection-actions";
+import type { ProductSelectionRow } from "../_shared/selectionColumns";
+import { previewVariationTotals, type PreviewTotals } from "./previewAmounts";
+import {
+  changeNodeLine,
+  createWorkingLine,
+  createWorkingSetGroup,
+  flattenPricedLines,
+  insertNodesBelow,
+  removeNode,
+  reorderComponents,
+  reorderNodes,
+  type WorkingLine,
+  type WorkingNode,
+} from "./variationLines";
+
+type SuggestState = {
+  mainRowId: string;
+  mainName: string;
+  suggestions: SuggestedProduct[];
+};
+
+type UseVariationLineEditorParams = {
+  /** 初期作業ノード（複製元 DTO 由来／新規追加は空配列／編集は閲覧 DTO 由来）。供給元はラッパが解決する。 */
+  initialNodes: WorkingNode[];
+  /** 初期全体値引（複製・編集は引き継ぎ、新規追加は 0）。 */
+  initialOverallDiscount: number;
+  taxRate: number;
+  taxRoundingType: string;
+};
+
+/**
+ * バリ明細編集器の作業コピー（C3 追加／C4 編集で共通）。明細はモーダル選択・インライン編集・D&D で
+ * client state が真実になるため、ノード union（通常明細／セット群・ADR-0047）と全体値引を React state
+ * で保持し、submit 時にラッパが単一 hidden へ JSON 化して往復する（往復形状 A・ADR-0050）。金額は概算
+ * ライブプレビューのみここで導出（確定はドメイン・ADR-0033）。初期値は解決済みプリミティブで注入し、
+ * フックは閲覧 DTO / 複製初期値 DTO の形状に依存しない（供給元差はラッパに閉じる）。
+ */
+export function useVariationLineEditor({
+  initialNodes,
+  initialOverallDiscount,
+  taxRate,
+  taxRoundingType,
+}: UseVariationLineEditorParams) {
+  const [nodes, setNodes] = useState<WorkingNode[]>(() => initialNodes);
+  const [overallDiscount, setOverallDiscount] = useState(initialOverallDiscount);
+  const [activeRowId, setActiveRowId] = useState<string | null>(null);
+  const [productModalOpen, setProductModalOpen] = useState(false);
+  // 本体追加直後の周辺商品サジェスト（提案あり時のみ）。挿入は本体行（mainRowId）の直下。
+  const [suggestState, setSuggestState] = useState<SuggestState | null>(null);
+
+  // 金額プレビューは価格付き末端行（通常明細＋全構成）のフラット列で計算する（群は価格を持たない）。
+  const totals: PreviewTotals = previewVariationTotals({
+    lines: flattenPricedLines(nodes),
+    overallDiscount,
+    taxRate,
+    taxRoundingType,
+  });
+
+  const changeLine = (rowId: string, patch: Partial<WorkingLine>) => {
+    setNodes((prev) => changeNodeLine(prev, rowId, patch));
+  };
+
+  const deleteNode = (rowId: string) => {
+    setNodes((prev) => removeNode(prev, rowId));
+    if (activeRowId === rowId) setActiveRowId(null);
+  };
+
+  const reorderTopLevel = (from: number, to: number) => {
+    setNodes((prev) => reorderNodes(prev, from, to));
+  };
+
+  const reorderInGroup = (groupRowId: string, from: number, to: number) => {
+    setNodes((prev) => reorderComponents(prev, groupRowId, from, to));
+  };
+
+  // 商品選択: セット商品なら構成を自動展開して群ノードを挿入、通常商品ならスナップショット解決して
+  // 通常行を挿入する。挿入位置はアクティブノード直下（構成/群がアクティブなら群の直後＝トップレベル）。
+  const handleProductSelect = async (rows: ProductSelectionRow[]) => {
+    const picked = rows[0];
+    if (!picked) return;
+
+    if (picked.category === "SET") {
+      const expanded = await expandSetComponents(picked.id);
+      if (!expanded) return;
+      const groupRowId = crypto.randomUUID();
+      const group = createWorkingSetGroup(groupRowId, expanded, () => crypto.randomUUID());
+      setNodes((prev) => insertNodesBelow(prev, activeRowId, [group]));
+      setActiveRowId(groupRowId);
+      // セット商品は周辺商品サジェストの対象外（構成は自動展開で確定）。
+      return;
+    }
+
+    const snapshot = await getProductLineSnapshot(picked.id);
+    if (!snapshot) return;
+    const newLine = createWorkingLine(crypto.randomUUID(), snapshot);
+    setNodes((prev) => insertNodesBelow(prev, activeRowId, [newLine]));
+    setActiveRowId(newLine.rowId);
+
+    const suggestions = await getProductSuggestions(snapshot.id);
+    if (suggestions.length > 0) {
+      setSuggestState({ mainRowId: newLine.rowId, mainName: snapshot.name, suggestions });
+    }
+  };
+
+  // 提案された周辺商品（選択分）を本体直下に通常行として挿入する（数量＝relation・他は新規行既定）。
+  const confirmSuggestions = (selected: SuggestedProduct[]) => {
+    if (!suggestState) return;
+    const peripheralLines = selected.map((s) =>
+      createWorkingLine(crypto.randomUUID(), s, { quantity: s.quantity })
+    );
+    setNodes((prev) => insertNodesBelow(prev, suggestState.mainRowId, peripheralLines));
+    setSuggestState(null);
+  };
+
+  return {
+    nodes,
+    overallDiscount,
+    setOverallDiscount,
+    activeRowId,
+    setActiveRowId,
+    productModalOpen,
+    setProductModalOpen,
+    suggestState,
+    setSuggestState,
+    totals,
+    changeLine,
+    deleteNode,
+    reorderTopLevel,
+    reorderInGroup,
+    handleProductSelect,
+    confirmSuggestions,
+  };
+}
+
+export type VariationLineEditor = ReturnType<typeof useVariationLineEditor>;

--- a/src/app/(features)/estimates/_shared/formStyles.ts
+++ b/src/app/(features)/estimates/_shared/formStyles.ts
@@ -1,0 +1,13 @@
+/**
+ * フォーム入力欄の共通 Tailwind クラス。
+ *
+ * `inputClass` は基本スタイル。`inputClassDisabled` は disabled 時に灰背景フィードバックを加える
+ * バリアント（pending 中に入力欄を disable するフォーム向け）。EstimateHeaderForm は入力欄を
+ * pending 中に disable するため `inputClassDisabled` を、バリ編集フォームのメモ textarea は
+ * disable しないため `inputClass` を使う。両者の差（disabled スタイルの有無）は実挙動の差なので
+ * 単一定数に統合せずバリアントとして保持する。
+ */
+export const inputClass =
+  "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline";
+
+export const inputClassDisabled = `${inputClass} disabled:bg-gray-100`;

--- a/src/app/(features)/estimates/_shared/productSearch.ts
+++ b/src/app/(features)/estimates/_shared/productSearch.ts
@@ -1,0 +1,10 @@
+import type { SearchFieldDef } from "@/app/_components/shared/SearchForm";
+
+/**
+ * 商品選択モーダル（SelectionModal）の検索フィールド定義。商品コード／商品名の部分一致。
+ * EstimateHeaderForm・VariationCreateForm・VariationEditForm で共有する（3ファイル完全一致）。
+ */
+export const productSearchFields: SearchFieldDef[] = [
+  { type: "text", key: "code", label: "商品コード", placeholder: "部分一致" },
+  { type: "text", key: "name", label: "商品名", placeholder: "部分一致" },
+];


### PR DESCRIPTION
## Summary

`VariationCreateForm`（C3 新規追加／複製プリフィル）と `VariationEditForm`（C4 内容編集）に重複していた明細編集ロジックを単一実装へ集約し、両フォームを薄いラッパへ置き換えました。あわせて3フォームに散在していた共通定数（`productSearchFields` / `inputClass`）も `_shared/` へ抽出。挙動は不変で、約447行を削減しています。

Closes #363

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### 概要

`VariationCreateForm`（C3）と `VariationEditForm`（C4）は、作業コピーパイプライン（nodes＝通常明細／セット群 union の client state・ADR-0047/0050）・共有部品・6ハンドラ群がほぼ同一実装で重複していた。明細編集ロジックを単一実装へ集約し、両フォームを薄いラッパに置き換える。あわせて3フォーム（上記2つ＋ `EstimateHeaderForm`）に重複する定数（`productSearchFields` / `inputClass`）も共通化する。

スキーマ層（`variationContentFields` ＝ version/overallDiscount/memo×2/nodes）はすでに共通化済みで、Edit は `variationId` を、Create は `submissionType` を足すだけの差分。重複しているのは React 層のみ。

### 設計判断（抜粋・採用案）

- **抽出境界**: フック＋共有ボディ部品（state/ハンドラはフック `useVariationLineEditor`、共通JSXはボディ部品 `VariationLineEditor`、`useServerForm` と分岐 hidden は薄いラッパに残す）。理由: conform の `fields` 型はスキーマ依存のため、スキーマ差をラッパ内に閉じ込める。
- **conform 注入方式**: 個別 `FieldMetadata` を明示渡し（`fields` オブジェクト丸ごとは渡さない）。理由: スキーマ差に依存せず型が閉じる。
- **totals の算出位置**: フックが taxRate/taxRoundingType も受けて totals まで導出。理由: 「状態と導出ビュー」を単一フックに凝集。
- **`<form>` シェル・送信ボタン・エラーバナー・分岐 hidden**: 各ラッパに残す。理由: `FormMetadata<Schema>` 依存のため具体スキーマ型で型安全。
- **抽出3資産の配置**: フック→`[estimateNumber]/`、ボディ→`components/`、`productSearchFields`→`_shared/`（責務別に分散）。
- **`inputClass` の disabled バリアント**: 2定数化（base ＋ `inputClassDisabled`）。理由: 既存挙動不変＝差の保存が正解。
- **テスト戦略**: 新規フックテストなし。既存の純関数テスト（`variationLines.test.ts`）＋3 E2E に依拠。

### ステップ

1. 共通定数の抽出（`productSearchFields` / `inputClass` → `_shared/`）
2. `useVariationLineEditor` フックの抽出（state・6ハンドラ・totals 導出、DTO 非依存）
3. `VariationLineEditor` ボディ部品の抽出（個別 `FieldMetadata` 注入）
4. Create/Edit を薄いラッパに置き換え（外部 Props 不変・`VariationPanel` 無改修）
5. 緑化確認と逸脱記録

</details>

## 計画からの逸脱

### モーダルをボディ部品内ではなく別エクスポート（form 外）に分離

- **元の計画**: 共有ボディ部品 `VariationLineEditor` が共通領域をまるごと描画し、SelectionModal・ProductSuggestDialog（モーダル2つ）もボディ部品に含める想定だった。
- **実際の実装**: ボディ部品ファイルを2エクスポートに分割。
  - `VariationLineEditor`: `<form>` 内に置く内側共通領域（明細テーブル・全体値引・メモ・プレビュー・hidden）
  - `VariationLineEditorOverlays`: モーダル2つ。ラッパが `</form>` の**外**で描画する
- **理由**: `SelectionModal` は内部で `<form onSubmit>` と `type="submit"` を持つ `ModalSearchForm` を描画するため、ラッパの `<form>` 内に置くと**ネスト form（不正 HTML）**になり外側フォームの送信挙動を壊すリスクがある。元実装の DOM 構造（モーダルは form 外）を踏襲し、ボディ部品を form 内（フィールド）と form 外（モーダル）の2エクスポートに分けた。重複は生じていない。

## Test Plan

リファクタにつき既存テスト資産で挙動不変を担保（新規テストは追加せず・計画のテスト戦略 A）。

- [x] `pnpm lint` 緑
- [x] `pnpm test`（1193件）緑
- [x] `npx tsc --noEmit` 緑
- [x] E2E 16件全緑（`estimates-variation-create` / `estimates-variation-edit` / `estimates-set-group-edit` — 商品選択モーダル→明細追加・セット群自動展開・周辺商品サジェストを含む）

---

Generated with [Claude Code](https://claude.ai/code)
