### PR TITLE
feat: 見積の新規作成画面（C1 CreateEstimate の UI）

### DIFF
--- a/docs/adr/0056-create-estimate-tax-check-in-app-shared-wrapper-not-command.md
+++ b/docs/adr/0056-create-estimate-tax-check-in-app-shared-wrapper-not-command.md
@@ -1,0 +1,66 @@
+# ADR-0056: 見積作成の税率導出＋整合チェックは CreateEstimateCommand に内包せず app-shared ラッパに置く
+
+| 項目 | 値 |
+|---|---|
+| ステータス | 採用 |
+| 起票日 | 2026-06-17 |
+| 最終更新日 | 2026-06-17 |
+
+## コンテキスト
+
+見積新規作成画面（issue #351 / C1 UI）で、保存時に設計書 §8.7 の税率整合チェック（見積年月日の税率と締切日の税率が一致するか）を行い、不一致ならフォームエラーで警告する必要がある。
+
+更新系コマンド（C2 `UpdateEstimate` / C3 `AddVariation` / C4 `UpdateVariation`）は、**コマンド自身が税率チェックを内包**する設計で確立している。`execute` は `TaxCheckedSaveResult`（`saved | taxRateMismatch` の判別共用体・ADR-0037/0038）を返し、内部で共通機構 `checkTaxRateThenSave`（既存集約を楽観ロック付き `update`・ADR-0039）を呼ぶ。
+
+ところが作成系には、更新系と異なる 2 つの事情がある:
+
+1. **作成は税率を「チェックするだけでなく導出もする」**。編集画面の税率は見積年月日から自動決定され read-only（`TaxRateRepository.findEffectiveAt`）。作成画面でも同様に導出する（§A.1）。§8.7 整合チェックは見積年月日の税率を既に解決しているので、その `consistent` 結果が返す単一 `rate` をそのまま採用税率に使える。つまり作成系の税率関心は「導出＋チェック」で、更新系の「チェックのみ」より一段仕事が多い。
+2. **`CreateEstimateCommand` は他コマンドのテストフィクスチャとして多用されている**。ReviseForCustomer / AddVariation / UpdateVariation / UpdateEstimate の各テストが `new CreateEstimateCommand(...)` で前提見積を組み立て、`taxRate` を明示で渡し戻り値 `Estimate` を期待する。コマンドに税率チェックを内包させ戻り値を union に変えると、これらフィクスチャが一斉に壊れ、各所で税率サービスのモック注入＋union 分解が必要になる。
+
+## 検討した選択肢
+
+### A. CreateEstimateCommand に内包（更新系と完全対称・不採用）
+
+`CreateEstimateCommand` に `TaxRateConsistencyCheckDomainService` を注入し、`execute` を `{ created | taxRateMismatch }` の union に変える。税率は内部で導出する。
+
+- C2/C3/C4 と完全に同型（コマンドが税率関心を所有）。
+- しかし作成コマンドをフィクスチャに使う既存テストが壊れる。`CreateEstimateCommand` が「純粋なアグリゲート組立器」でなくなり、テスト前提づくりが重くなる。
+
+### B. app-shared ラッパ `checkTaxRateThenCreate`（採用）
+
+`CreateEstimateCommand` は現状のまま（`taxRate` を受け取り `Estimate` を返す純粋な組立器）。新たに app-shared `checkTaxRateThenCreate` を設け、§8.7 チェック → `consistent` なら解決税率を `taxRate` に詰めてコマンドへ委譲 → `{ created | taxRateMismatch }` を返す。実画面の Server Action はこのラッパを使う。
+
+```ts
+// app/shared: 既存の checkTaxRateThenSave と同型の税率ヘルパ
+const check = await deps.taxRateConsistencyCheck.check({
+  estimateDate: input.estimateDate,
+  deadline: input.deadline,
+});
+if (check.kind === "mismatch") {
+  return { kind: "taxRateMismatch", estimateDateRate: ..., deadlineRate: ... };
+}
+const estimate = await deps.createCommand.execute({ ...input, taxRate: check.rate.value });
+return { kind: "created", estimate };
+```
+
+- 税率関心は既存の `TaxRateConsistencyCheckDomainService` を再利用（ロジック統一）。app-shared 税率ヘルパとして `checkTaxRateThenSave` と同型（対称性は保たれるべき場所＝app-shared に置く）。
+- フィクスチャ／seed はコマンドを直接叩くので一切壊れない。
+- フォームに税率入力欄が無く、アクションは税率を受け取らない（導出に一本化）。
+
+## 決定
+
+**見積作成の税率導出＋§8.7 整合チェックは選択肢 B で行う。** `CreateEstimateCommand` は純粋な組立器として据え置き、app-shared `checkTaxRateThenCreate` が §8.7 チェック→解決税率での委譲を担い `{ created | taxRateMismatch }` を返す。Server Action はこのラッパを使い、`taxRateMismatch` をフォームエラー化する（§8.7「保存時＝その場で修正」）。
+
+## 根拠
+
+- **統一すべきはロジックであってコマンドの戻り値型ではない**: 税率導出・整合判定は既存の `TaxRateConsistencyCheckDomainService` を再利用する（同じ `findEffectiveAt` を編集画面と共有）。フィクスチャを壊してまでコマンド戻り値まで C2/C3/C4 に揃える実益は薄い。
+- **作成は更新に無い「導出」を持つ**: 作成系の税率関心は「導出＋チェック」で更新系（チェックのみ）と本質的に非対称。専用の app-shared オーケストレーションを置くのは正当な非対称であり、`checkTaxRateThenSave` ↔ `checkTaxRateThenCreate` の対比として app-shared 層では対称性が保たれる。
+- **`CreateEstimateCommand` の再利用性を守る**: 多数のフィクスチャが依存する「純粋な組立器」という性質を維持でき、テスト前提づくりが軽いまま。
+- **不採用理由（A）**: 完全対称と引き換えにフィクスチャ一斉破壊を招き、コマンドから純粋性を奪う。得られる対称性は app-shared 層で B でも確保できる。
+
+## 影響
+
+- **C1 だけ税率チェックの所在が異なる非対称が残る**: C2/C3/C4 はコマンドが所有、C1 は app-shared ラッパが所有。本 ADR がその理由（導出の有無・フィクスチャ依存）を記録する。将来 C2/C3/C4 を「導出も行う」方向へ揃える場合は、本判断の再考が要る。
+- **`CreateEstimateInput.taxRate` は実経路では常に上書き**: ラッパが導出税率を詰めるため、フォーム経路では `taxRate` 入力は実質使われない（seed/テストは引き続き明示供給）。軽い冗長として許容する。
+- **作成配線ファクトリ**: ラッパは `TaxRateConsistencyCheckDomainService`（＋ `TaxRateRepository` 実装）と `CreateEstimateCommand`（セット検証のため `PrismaProductQueryService` 注入・ADR-0052）を解決する Composition Root を新設する。
+- **関連**: ADR-0037/0038（Result union の戻り値設計）、ADR-0039（楽観ロック・更新系の `checkTaxRateThenSave` が使う）、ADR-0052（セット構成のライブ検証）、issue #351（C1 UI）、#333（S5・C1 を app/factory/domain まで配線）。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -80,6 +80,7 @@
 |---|---------|-----------|--------|
 | [0037](0037-application-command-result-union-for-predictable-outcomes.md) | アプリケーション層コマンドは予測可能な業務結果を判別共用体(Result)で返し、想定外のみ throw する | 置き換え済み（→ 0038） | 2026-06-09 |
 | [0038](0038-unify-failures-as-exceptions-and-limit-unions-to-multiple-normal-outcomes.md) | 失敗はすべて例外に統一し、判別共用体は「複数の正常な結末」の戻り値設計に限定する | 採用 | 2026-06-10 |
+| [0056](0056-create-estimate-tax-check-in-app-shared-wrapper-not-command.md) | 見積作成の税率導出＋整合チェックは CreateEstimateCommand に内包せず app-shared ラッパに置く | 採用 | 2026-06-17 |
 
 ## アプリケーション（クエリ・DTO）
 

--- a/docs/claude-plans/issue-351/create-estimate-screen.md
+++ b/docs/claude-plans/issue-351/create-estimate-screen.md
@@ -1,0 +1,116 @@
+# Issue #351: 見積の新規作成画面（C1 CreateEstimate の UI） — 実装計画
+
+## 概要
+
+新規見積作成ルート `/estimates/new` と作成フォームを実装し、`CreateEstimateCommand` を1回駆動して見積を原子的に新規作成、作成後に詳細画面（`[estimateNumber]`）へ遷移する。
+
+- ヘッダー基本情報（見積年月日・締切日・得意先・納品先・部署・税端数区分・見積区分）＋ 区分別サブタイプ詳細（修理／事後修理）＋ 初期バリエーション1件（提出区分・通常明細・自動展開セット群・全体値引・メモ）を**単一の統合フォーム**で入力し、**単一の `createEstimate` Server Action** でまとめて保存する（空見積不可＝≥1バリの原子的作成）。
+- 税率はユーザー入力にせず、見積年月日からマスタ導出して read-only 表示（編集画面と統一）。§8.7 税率不一致は保存せずフォームエラーで警告する。
+- 編集画面（#342/#346/#333 で出荷済み）と**部品・ロジックを積極的に統一**する方針（不都合がない箇所のみ）。統一の単位はラッパフォーム丸ごとではなく、内側の dumb 部品と検証ロジックの原子。
+
+**グリル中に生成済みの成果物**:
+- issue **#374**: 部署初期値を作成者の所属部署から自動解決（バックエンド込み・#351 では手動 select で進め、自動解決はこの後続 issue）。
+- **ADR-0056**: 見積作成の税率導出＋整合チェックは `CreateEstimateCommand` に内包せず app-shared ラッパに置く（採用済み・本計画 Step 1 の根拠）。
+
+## 設計判断
+
+### 税率の供給（導出 vs 手入力）
+- A. 見積年月日からマスタ導出・read-only（§8.7 チェックの `consistent.rate` を採用税率に流用）
+- B. issue 文面どおりユーザーが手入力
+- **採用: A**。編集画面の read-only 方針・CONTEXT の設計意図と一致し、整合チェックが既に解決する税率を再利用できて手入力欄も別ロジックも不要。
+
+### 税率導出＋§8.7 チェックの配置（ADR-0056）
+- A. `CreateEstimateCommand` に内包し戻り値を `{created|taxRateMismatch}` union に変更（更新系 C2/C3/C4 と完全対称）
+- B. `CreateEstimateCommand` 据え置き＋ app-shared `checkTaxRateThenCreate` を新設しアクションが使用
+- **採用: B**。既存 `TaxRateConsistencyCheckDomainService` を再利用（ロジック統一）、`checkTaxRateThenSave` と app-shared 層で対称。コマンドを純粋な組立器に保ち、多数のテストフィクスチャ（ReviseForCustomer/AddVariation/UpdateVariation/UpdateEstimate）を壊さない。作成は更新に無い「導出」を持つので専用オーケストレーションは正当な非対称。
+
+### フォーム骨格（統合 vs 分割）
+- A. 単一統合フォーム＋単一アクションで原子的作成
+- B. ヘッダーと初期バリを別アクションで段階保存
+- **採用: A**。空見積不可（≥1バリ必須）の原子性が B（下書き状態という新概念や一瞬の空見積）を構造的に排除する。
+
+### ヘッダー部の統一手段
+- a. 共有 dumb 部品（修理/事後修理塊・FK選択フィールド）を抽出し、出荷済み編集フォームも差し替え
+- b. 共有部品は新設するが編集側差し替えは別 issue へ繰り延べ
+- c. `EstimateHeaderForm` を mode:create|edit でパラメータ化
+- **採用: a**。重複を残さない統一方針に最も忠実。神コンポーネント化を避けつつ将来改修を1箇所に集約。出荷済みコードへ手が入るコストは許容（[[feedback_unify_create_with_edit_screen]]）。
+
+### 作成者・部署の解決
+- 作成者 = `session.user.employeeId`（read-only・null は作成不可）。表示名は Employee を引いて「氏名（コード）」。
+- 部署 = 有効部署の手動 select（プレースホルダ必須選択）。所属からの自動解決は後続 #374（ポート新設を伴うためスコープ外）。
+
+### 初期バリエーション件数
+- **正確に1件**。提出区分は得意先宛／納品先宛を自由選択（ADR-0045・得意先宛も直接作成可）。2件目以降は詳細画面の C3 追加／複製で足す（複数バリ管理の二重実装回避）。
+
+### セット群対応
+- 自動展開のみ（手動構成追加は #350 へ繰り延べ済み）。`VariationLineEditor`＋`useVariationLineEditor`（ADR-0050 のノード JSON 直列化）を再利用。
+- 作成配線に `PrismaProductQueryService` を注入し `assertSetComponentsValid`（ADR-0052・ペイロード防御）を C4 と同型で効かせる。
+
+### 税率プレビューの供給（作成中はまだ税率が確定しない問題）
+- a. 見積年月日変更時にサーバで有効税率をライブ解決し、ヘッダー read-only 表示＆ `VariationLineEditor` のプレビュー税率に使用（submit で案B が再確定）
+- b. 現在税率を既定値で近似
+- **採用: a**。プレビュー金額は意思決定材料で、税率境界付近の submit 食い違いを避ける。同じ `findEffectiveAt` を使い編集画面と表示・ロジックを統一。
+
+### 作成スキーマの構成・サブタイプ必須性
+- 専用 `createEstimateSchema` を共有原子（`nodesField` 等・要 export）から組む。`version`・`taxRate` は含めない。`updateEstimateHeaderSchema`/`addVariationNodeSchema` を丸ごとは再利用しない（version/taxRate 差分のため）。
+- サブタイプ必須性は schema の `superRefine` で条件必須化（NEW=不要 / REPAIR=修理3項目 / AFTER_REPAIR=事後修理3項目）。エラーは各フィールドパスへ付与。編集（アクション側担保）からの意図的乖離だが、作成は estimateType を submit に持つため正当。
+
+### テスト戦略（/tdd 前提・test-first）
+- **単体テストは各ステップ内で test-first**（red→green→refactor）で書く。テストを末尾に固めない（`/tdd` の red-green ループと矛盾するため）。
+- 単体で押さえる対象（純粋ロジック・検証）= `checkTaxRateThenCreate`（Step 1）、`createEstimateSchema` の conform 経路（Step 3）。これらは「テスト → 実装」の順で進める。
+- UI（Step 4〜6）は React コンポーネント主体で単体 TDD の対象が薄いため、**E2E を外側の受け入れループ**として検証する。Step 4 の出荷済みフォーム差し替えは既存テスト／E2E が回帰ガードになる（red-green-refactor の refactor フェーズ）。
+- **E2E（Step 7）は受け入れ条件の貫通検証（外側ループ）**。最後に置くのは「単体を後回しにする」意味ではなく、各ステップで test-first 済みの実装を統合して受け入れ確認するため。先に失敗する E2E を雛形として置いてから内側の単体ループを回す進め方（ダブルループ）でもよい。
+
+## ステップ
+
+### Step 1: app-shared `checkTaxRateThenCreate` ＋ 作成配線ファクトリ
+- 対象ファイル: `src/server/subdomains/estimate/application/shared/__tests__/checkTaxRateThenCreate.test.ts`（新規・先）、`checkTaxRateThenCreate.ts`（新規）、作成配線ファクトリ（`createEstimateCommandFactory.ts` 拡張 or 新設）
+- 作業内容（**test-first**）:
+  - **(red)** 先に `checkTaxRateThenCreate.test.ts` を書く: consistent→`created` / mismatch→`taxRateMismatch` union を、税率リポジトリのモックで 8%/10% 境界を作って検証
+  - **(green)** §8.7 チェック→`consistent` なら解決税率を `taxRate` に詰めて `CreateEstimateCommand` へ委譲→`{created|taxRateMismatch}` を返すヘルパを実装（`checkTaxRateThenSave` と同型）
+  - Composition Root で `TaxRateConsistencyCheckDomainService`（＋`PrismaTaxRateRepository`）と `CreateEstimateCommand`（`PrismaProductQueryService` 注入・ADR-0052）を解決
+- コミットメッセージ: `feat: 見積作成の税率導出＋§8.7チェックを app-shared checkTaxRateThenCreate に実装（ADR-0056）`
+
+### Step 2: 税率ライブ解決の Server Action
+- 対象ファイル: `src/app/(features)/estimates/_shared/` 配下に税率解決アクション（新規）
+- 作業内容:
+  - 見積年月日（"yyyy-mm-dd"）を JST パースし `TaxRateRepository.findEffectiveAt` で有効税率を返す薄い Server Action
+  - ヘッダー read-only 表示・プレビュー税率の供給に使う
+- コミットメッセージ: `feat: 見積年月日から有効税率を解決する Server Action を追加（作成画面プレビュー用）`
+
+### Step 3: 作成スキーマ `createEstimateSchema`
+- 対象ファイル: `src/app/(features)/estimates/new/__tests__/schema.conform.test.ts`（新規・先）、`new/schema.ts`（新規）、`variationSchema.ts`（`nodesField` を export）
+- 作業内容（**test-first**）:
+  - **(red)** 先に conform 経路テストを書く: 区分別必須（NEW=不要 / REPAIR・AFTER_REPAIR=各3項目）と空メモの undefined 化、`nodesField` のパースを検証
+  - **(green)** 共有原子（`nodesField` 等）＋ ヘッダー項目＋`estimateType`＋`submissionType`＋全体値引＋メモで `createEstimateSchema` を構成（version/taxRate なし）、`superRefine` で区分別サブタイプ必須化
+- コミットメッセージ: `feat: 見積作成フォームの createEstimateSchema を共有原子から構成（superRefineで区分別必須）`
+
+### Step 4: ヘッダー共有部品の抽出と編集フォーム差し替え（案a）
+- 対象ファイル: 共有部品（修理/事後修理フィールド塊・得意先/納品先 FK選択フィールド）を新規抽出、`EstimateHeaderForm.tsx`（差し替え）
+- 作業内容:
+  - インラインの修理／事後修理セクション・FK選択フィールドを dumb な共有コンポーネントへ抽出
+  - 出荷済みの編集ヘッダーフォームを新部品を使う形に差し替え（挙動不変）
+- コミットメッセージ: `refactor: 見積ヘッダーの修理/FK選択フィールドを共有部品へ抽出し編集フォームを差し替え`
+
+### Step 5: 作成フォーム本体（統合フォーム）
+- 対象ファイル: `src/app/(features)/estimates/new/CreateEstimateForm.tsx`（新規）、提出区分フィールドの共有化
+- 作業内容:
+  - ヘッダー（区分セレクタで NEW/REPAIR/AFTER_REPAIR を選択しサブタイプ欄を切替・税率は read-only ライブ表示・作成者 read-only・部署 select）と初期バリ1件（共有部品＋`VariationLineEditor` 再利用）を1フォームに統合
+  - 提出区分フィールド（`VariationCreateForm` から抽出して共有）を select モードで配置
+  - 税率はライブ解決値を `useVariationLineEditor` に渡しプレビュー反映
+- コミットメッセージ: `feat: 見積新規作成の統合フォーム（ヘッダー＋初期バリ）を実装`
+
+### Step 6: `createEstimate` アクション ＋ ルート ＋ リダイレクト
+- 対象ファイル: `src/app/(features)/estimates/new/actions.ts`（新規）、`new/page.tsx`（新規）、`src/shared/constants/redirect-reasons.ts`、フラッシュメッセージのマッピング
+- 作業内容:
+  - `createEstimate` Server Action: `verifySession`→`parseWithZod(createEstimateSchema)`→`checkTaxRateThenCreate` 駆動→`taxRateMismatch` はフォームエラー（両税率提示）→成功時 `revalidatePath`＋詳細へ `redirect`
+  - createdBy=session.user.employeeId（null は作成不可エラー）、部署は有効部署 query を `page.tsx` で供給
+  - `REDIRECT_REASON.ESTIMATE_CREATED` 追加＋作成成功メッセージのマッピング
+- コミットメッセージ: `feat: 見積新規作成の Server Action とルート /estimates/new を実装（成功時に詳細へ遷移）`
+
+### Step 7: E2E `estimates-create.e2e.ts`（受け入れ＝外側ループ）
+- 対象ファイル: `src/app/(features)/estimates/estimates-create.e2e.ts`（新規）
+- 位置づけ: 単体テストは Step 1・3 で test-first 済み。本ステップは統合後の受け入れ条件貫通（外側ループ）。ダブルループで進める場合は、先に失敗する E2E 雛形を置いてから Step 1〜6 の内側ループを回してもよい。
+- 作業内容（`create-e2e-test` スキル規約・ADR-0012/0017/0020 準拠）:
+  - (1) NEW 作成→詳細へ遷移、(2) 自動展開セット群を含む作成、(3) REPAIR/AFTER_REPAIR の区分別情報入力で作成、(4) 税率不一致でフォーム警告（既存 8%/10% 境界 = 見積年月日 2019-09-30／締切日 2019-10-01 を利用）
+- コミットメッセージ: `test: 見積新規作成画面の E2E（受け入れ条件4本）を追加`

--- a/docs/claude-plans/issue-351/deviations.md
+++ b/docs/claude-plans/issue-351/deviations.md
@@ -1,0 +1,22 @@
+# Issue #351 実装計画からの逸脱記録
+
+## 1. Step 2 に専用クエリ `ResolveEffectiveTaxRateQuery` を新設
+
+- **元の計画**: Step 2 は「`TaxRateRepository.findEffectiveAt` で有効税率を返す薄い Server Action」。
+- **実際の実装**: Server Action（`resolveEffectiveTaxRate`）はアプリ層クエリ `ResolveEffectiveTaxRateQuery` 経由で解決する形にした（test-first で単体テスト追加）。
+- **理由**: presentation（Server Action）がドメインリポジトリを直接握るのを避け DDD レイヤリングを保つため。単一日付の解決は 2 日付比較の `TaxRateConsistencyCheckDomainService` とは別関心のため専用クエリが素直。
+
+## 2. Step 5・6 を「コンパイル可能な意味単位」で3コミットに再分割
+
+- **元の計画**: Step 5（作成フォーム本体）→ Step 6（アクション＋ルート＋リダイレクト）の2ステップ。
+- **実際の実装**: 次の3コミットに再編した。
+  1. `SubmissionTypeField` の共有抽出（リファクタ・挙動不変）
+  2. `createEstimate` アクション＋`ESTIMATE_CREATED`（バックエンド配線・単独で tsc/lint 可能）
+  3. `CreateEstimateForm` 本体＋`/estimates/new` ルート＋作成者クエリ
+- **理由**: フォームはアクションに依存するため Step 5 単独ではコンパイルできず、壊れた中間コミットになる。CLAUDE.md「意味のあるまとまりでコミット」に従い、各コミットが tsc/lint を通る単位へ分割した。ステップの設計内容自体は不変。
+
+## 3. 作成者氏名解決のため `getEmployeeByIdQueryFactory` を新設
+
+- **元の計画**: 明示なし（作成者＝`session.user.employeeId`、表示名は「Employee を引いて『氏名（コード）』」とだけ記載）。
+- **実際の実装**: employee サブドメインに `getEmployeeByIdQueryFactory`（既存 `GetEmployeeByIdQuery` の Composition Root）を追加し、`/estimates/new` の RSC で作成者 DTO を解決。
+- **理由**: 作成者表示名の解決に既存クエリのファクトリが無かったため。計画の意図（氏名（コード）表示）の実現に必要な配線。

--- a/src/app/(features)/estimates/[estimateNumber]/EstimateHeaderForm.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/EstimateHeaderForm.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { getFormProps, getInputProps, getSelectProps, getTextareaProps } from "@conform-to/react";
+import { getFormProps, getInputProps, getSelectProps } from "@conform-to/react";
 import { useState } from "react";
 import { useServerForm } from "@/app/_hooks/useServerForm";
 import { SelectionModal } from "@/app/_components/shared/SelectionModal";
 import type { SearchFieldDef } from "@/app/_components/shared/SearchForm";
 import { toDateInputValue } from "../_shared/date";
 import { inputClassDisabled } from "../_shared/formStyles";
+import { FkSelectionField } from "../_shared/FkSelectionField";
+import { RepairDetailFields } from "../_shared/RepairDetailFields";
+import { AfterRepairDetailFields } from "../_shared/AfterRepairDetailFields";
 import { TAX_ROUNDING_TYPE_LABELS } from "../_shared/labels";
 import { productSearchFields } from "../_shared/productSearch";
 import {
@@ -172,50 +175,26 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
           <h2 className="text-xl font-semibold mb-4 text-gray-500">基本情報</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {/* 得意先（SelectionModal・改訂時ロック） */}
-            <div>
-              <span className="block text-gray-700 text-sm font-bold mb-2">得意先</span>
-              <div className="flex items-center gap-2">
-                <span className="flex-1 text-gray-900">
-                  {customer.id ? `${customer.name}（${customer.code}）` : "未選択"}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => setCustomerModalOpen(true)}
-                  disabled={locked || isPending}
-                  aria-label="得意先を選択"
-                  className="bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-bold py-1 px-3 rounded disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed"
-                >
-                  選択
-                </button>
-              </div>
-              {fields.customerId.errors && (
-                <p className="text-red-500 text-xs mt-1">{fields.customerId.errors[0]}</p>
-              )}
-            </div>
+            <FkSelectionField
+              label="得意先"
+              selectedLabel={customer.id ? `${customer.name}（${customer.code}）` : null}
+              onSelect={() => setCustomerModalOpen(true)}
+              disabled={locked || isPending}
+              selectAriaLabel="得意先を選択"
+              error={fields.customerId.errors?.[0]}
+            />
 
             {/* 納品先（SelectionModal・選択中得意先で絞り込み・改訂時ロック） */}
-            <div>
-              <span className="block text-gray-700 text-sm font-bold mb-2">納品先</span>
-              <div className="flex items-center gap-2">
-                <span className="flex-1 text-gray-900">
-                  {deliveryLocation.id
-                    ? `${deliveryLocation.name}（${deliveryLocation.code}）`
-                    : "未選択"}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => setDeliveryModalOpen(true)}
-                  disabled={locked || isPending || !customer.id}
-                  aria-label="納品先を選択"
-                  className="bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-bold py-1 px-3 rounded disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed"
-                >
-                  選択
-                </button>
-              </div>
-              {fields.deliveryLocationId.errors && (
-                <p className="text-red-500 text-xs mt-1">{fields.deliveryLocationId.errors[0]}</p>
-              )}
-            </div>
+            <FkSelectionField
+              label="納品先"
+              selectedLabel={
+                deliveryLocation.id ? `${deliveryLocation.name}（${deliveryLocation.code}）` : null
+              }
+              onSelect={() => setDeliveryModalOpen(true)}
+              disabled={locked || isPending || !customer.id}
+              selectAriaLabel="納品先を選択"
+              error={fields.deliveryLocationId.errors?.[0]}
+            />
 
             {/* 部署（select・改訂後も変更可） */}
             <div>
@@ -322,157 +301,33 @@ export function EstimateHeaderForm({ estimate, departments, onCancel }: Props) {
 
         {/* 修理情報（REPAIR・改訂後も編集可） */}
         {isRepair && (
-          <section className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
-            <h2 className="text-xl font-semibold mb-4 text-gray-500">修理情報</h2>
-            <input
-              type="hidden"
-              name={fields.repairTargetProductId.name}
-              value={targetProduct.id}
-            />
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <span className="block text-gray-700 text-sm font-bold mb-2">修理対象機器</span>
-                <div className="flex items-center gap-2">
-                  <span className="flex-1 text-gray-900">
-                    {targetProduct.id ? `${targetProduct.name}（${targetProduct.code}）` : "未選択"}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => setProductModalOpen(true)}
-                    disabled={isPending}
-                    aria-label="修理対象機器を選択"
-                    className="bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-bold py-1 px-3 rounded disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed"
-                  >
-                    選択
-                  </button>
-                </div>
-              </div>
-              <div>
-                <label
-                  htmlFor={fields.repairScheduledRepairDate.id}
-                  className="block text-gray-700 text-sm font-bold mb-2"
-                >
-                  修理予定日
-                </label>
-                <input
-                  {...getInputProps(fields.repairScheduledRepairDate, { type: "date" })}
-                  disabled={isPending}
-                  className={inputClassDisabled}
-                />
-                {fields.repairScheduledRepairDate.errors && (
-                  <p className="text-red-500 text-xs mt-1">
-                    {fields.repairScheduledRepairDate.errors[0]}
-                  </p>
-                )}
-              </div>
-              <div className="md:col-span-2">
-                <label
-                  htmlFor={fields.repairFaultDescription.id}
-                  className="block text-gray-700 text-sm font-bold mb-2"
-                >
-                  故障内容
-                </label>
-                <textarea
-                  {...getTextareaProps(fields.repairFaultDescription)}
-                  disabled={isPending}
-                  rows={3}
-                  className={inputClassDisabled}
-                />
-                {fields.repairFaultDescription.errors && (
-                  <p className="text-red-500 text-xs mt-1">
-                    {fields.repairFaultDescription.errors[0]}
-                  </p>
-                )}
-              </div>
-            </div>
-          </section>
+          <RepairDetailFields
+            targetProductIdName={fields.repairTargetProductId.name}
+            targetProductId={targetProduct.id}
+            targetProductLabel={
+              targetProduct.id ? `${targetProduct.name}（${targetProduct.code}）` : null
+            }
+            onSelectProduct={() => setProductModalOpen(true)}
+            scheduledRepairDateField={fields.repairScheduledRepairDate}
+            faultDescriptionField={fields.repairFaultDescription}
+            disabled={isPending}
+          />
         )}
 
         {/* 事後修理情報（AFTER_REPAIR・改訂後も編集可） */}
         {isAfterRepair && (
-          <section className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
-            <h2 className="text-xl font-semibold mb-4 text-gray-500">事後修理情報</h2>
-            <input
-              type="hidden"
-              name={fields.afterRepairTargetProductId.name}
-              value={targetProduct.id}
-            />
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <span className="block text-gray-700 text-sm font-bold mb-2">修理対象機器</span>
-                <div className="flex items-center gap-2">
-                  <span className="flex-1 text-gray-900">
-                    {targetProduct.id ? `${targetProduct.name}（${targetProduct.code}）` : "未選択"}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => setProductModalOpen(true)}
-                    disabled={isPending}
-                    aria-label="修理対象機器を選択"
-                    className="bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-bold py-1 px-3 rounded disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed"
-                  >
-                    選択
-                  </button>
-                </div>
-              </div>
-              <div>
-                <label
-                  htmlFor={fields.afterRepairActualRepairDate.id}
-                  className="block text-gray-700 text-sm font-bold mb-2"
-                >
-                  修理実施日
-                </label>
-                <input
-                  {...getInputProps(fields.afterRepairActualRepairDate, { type: "date" })}
-                  disabled={isPending}
-                  className={inputClassDisabled}
-                />
-                {fields.afterRepairActualRepairDate.errors && (
-                  <p className="text-red-500 text-xs mt-1">
-                    {fields.afterRepairActualRepairDate.errors[0]}
-                  </p>
-                )}
-              </div>
-              <div className="md:col-span-2">
-                <label
-                  htmlFor={fields.afterRepairEmergencyReason.id}
-                  className="block text-gray-700 text-sm font-bold mb-2"
-                >
-                  緊急対応理由
-                </label>
-                <textarea
-                  {...getTextareaProps(fields.afterRepairEmergencyReason)}
-                  disabled={isPending}
-                  rows={2}
-                  className={inputClassDisabled}
-                />
-                {fields.afterRepairEmergencyReason.errors && (
-                  <p className="text-red-500 text-xs mt-1">
-                    {fields.afterRepairEmergencyReason.errors[0]}
-                  </p>
-                )}
-              </div>
-              <div className="md:col-span-2">
-                <label
-                  htmlFor={fields.afterRepairFaultDescription.id}
-                  className="block text-gray-700 text-sm font-bold mb-2"
-                >
-                  故障内容
-                </label>
-                <textarea
-                  {...getTextareaProps(fields.afterRepairFaultDescription)}
-                  disabled={isPending}
-                  rows={3}
-                  className={inputClassDisabled}
-                />
-                {fields.afterRepairFaultDescription.errors && (
-                  <p className="text-red-500 text-xs mt-1">
-                    {fields.afterRepairFaultDescription.errors[0]}
-                  </p>
-                )}
-              </div>
-            </div>
-          </section>
+          <AfterRepairDetailFields
+            targetProductIdName={fields.afterRepairTargetProductId.name}
+            targetProductId={targetProduct.id}
+            targetProductLabel={
+              targetProduct.id ? `${targetProduct.name}（${targetProduct.code}）` : null
+            }
+            onSelectProduct={() => setProductModalOpen(true)}
+            actualRepairDateField={fields.afterRepairActualRepairDate}
+            emergencyReasonField={fields.afterRepairEmergencyReason}
+            faultDescriptionField={fields.afterRepairFaultDescription}
+            disabled={isPending}
+          />
         )}
 
         <div className="flex gap-4">

--- a/src/app/(features)/estimates/[estimateNumber]/VariationCreateForm.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationCreateForm.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { getFormProps, getInputProps, getSelectProps, type FieldMetadata } from "@conform-to/react";
+import { getFormProps, getInputProps } from "@conform-to/react";
 import { useServerForm } from "@/app/_hooks/useServerForm";
-import { SUBMISSION_TYPE_LABELS } from "../_shared/labels";
+import { SubmissionTypeField } from "../_shared/SubmissionTypeField";
 import { VariationLineEditor, VariationLineEditorOverlays } from "./components/VariationLineEditor";
 import { addVariation } from "./actions";
 import { useVariationLineEditor } from "./useVariationLineEditor";
@@ -116,53 +116,5 @@ export function VariationCreateForm(props: Props) {
 
       <VariationLineEditorOverlays editor={editor} />
     </>
-  );
-}
-
-/**
- * 提出区分フィールド。新規追加は選択式（白紙だから）、複製は引き継ぎ固定（変更不可・ADR-0045）。
- *
- * 値の保持は単一: 選択式は uncontrolled な select（conform 管理）、固定は hidden 1 つ。複製時は
- * disabled な select だと FormData に乗らないため、固定ラベル表示＋ hidden で値を運ぶ（提出区分は
- * バリ単位の不変属性・宛先切替の業務操作は存在しない・ADR-0045）。
- */
-type SubmissionTypeFieldProps = {
-  field: FieldMetadata<string>;
-} & ({ mode: "select"; disabled?: boolean } | { mode: "fixed"; value: string });
-
-function SubmissionTypeField(props: SubmissionTypeFieldProps) {
-  const { field } = props;
-  const error = field.errors?.[0];
-  return (
-    <div className="mb-6">
-      {props.mode === "fixed" ? (
-        <>
-          <label className="block text-sm font-bold text-gray-700 mb-1">提出区分</label>
-          <p className="border rounded px-3 py-2 bg-gray-50 text-gray-700">
-            {SUBMISSION_TYPE_LABELS[props.value] ?? props.value}
-            <span className="ml-2 text-xs text-gray-500">（複製元から引き継ぎ・変更不可）</span>
-          </p>
-          <input type="hidden" name={field.name} value={props.value} />
-        </>
-      ) : (
-        <>
-          <label htmlFor={field.id} className="block text-sm font-bold text-gray-700 mb-1">
-            提出区分
-          </label>
-          <select
-            {...getSelectProps(field)}
-            disabled={props.disabled}
-            className="border rounded px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-400"
-          >
-            {Object.entries(SUBMISSION_TYPE_LABELS).map(([code, label]) => (
-              <option key={code} value={code}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </>
-      )}
-      {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
-    </div>
   );
 }

--- a/src/app/(features)/estimates/[estimateNumber]/schema.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/schema.ts
@@ -9,7 +9,8 @@ import { z } from "zod";
  * 修理情報は REPAIR / AFTER_REPAIR のときだけフォームに現れるため optional とし、必須性は
  * estimateType を知る Server Action 側で担保する（単一フォーム・条件表示）。
  */
-const dateInput = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "日付を入力してください");
+/** input[type=date] の "yyyy-mm-dd"。C1 作成フォーム（new/schema.ts）でも共有するため export する。 */
+export const dateInput = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "日付を入力してください");
 
 export const updateEstimateHeaderSchema = z.object({
   /** 楽観ロックトークン（ADR-0039）。編集画面表示時の値を hidden で往復させる。 */

--- a/src/app/(features)/estimates/[estimateNumber]/variationSchema.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/variationSchema.ts
@@ -60,8 +60,11 @@ const nodeSchema = z.discriminatedUnion("kind", [lineNodeSchema, setGroupNodeSch
 export type VariationNodeInput = z.infer<typeof nodeSchema>;
 export type VariationSetGroupNodeInput = z.infer<typeof setGroupNodeSchema>;
 
-/** ノード配列フィールド: JSON 文字列をパースして判別子 union 配列へ pipe する（ADR-0050）。空配列許可。 */
-const nodesField = z
+/**
+ * ノード配列フィールド: JSON 文字列をパースして判別子 union 配列へ pipe する（ADR-0050）。空配列許可。
+ * C1 作成フォーム（new/schema.ts）でも同じ往復契約を共有するため export する。
+ */
+export const nodesField = z
   .string()
   .transform((s, ctx) => {
     try {

--- a/src/app/(features)/estimates/_shared/AfterRepairDetailFields.tsx
+++ b/src/app/(features)/estimates/_shared/AfterRepairDetailFields.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { getInputProps, getTextareaProps, type FieldMetadata } from "@conform-to/react";
+import { inputClassDisabled } from "./formStyles";
+import { FkSelectionField } from "./FkSelectionField";
+
+/**
+ * 事後修理見積（AFTER_REPAIR）サブタイプ詳細の入力塊（dumb・conform 対応）。
+ *
+ * 修理対象機器（FkSelectionField）・修理実施日・緊急対応理由・故障内容を 1 セクションへまとめる。
+ * 編集（C2）と作成（C1）はフィールド名（afterRepairTargetProductId / afterRepairActualRepairDate /
+ * afterRepairEmergencyReason / afterRepairFaultDescription）が一致するため双方で共有する。
+ */
+type Props = {
+  /** afterRepairTargetProductId の input name（hidden 送出用）。 */
+  targetProductIdName: string;
+  /** 選択中の対象機器 id（hidden value・表示判定用）。 */
+  targetProductId: string;
+  /** 対象機器の表示文字列（「名称（コード）」）。未選択は null。 */
+  targetProductLabel: string | null;
+  /** 「選択」クリックの通知（親が商品モーダルを開く）。 */
+  onSelectProduct: () => void;
+  actualRepairDateField: FieldMetadata<string>;
+  emergencyReasonField: FieldMetadata<string>;
+  faultDescriptionField: FieldMetadata<string>;
+  disabled?: boolean;
+};
+
+export function AfterRepairDetailFields({
+  targetProductIdName,
+  targetProductId,
+  targetProductLabel,
+  onSelectProduct,
+  actualRepairDateField,
+  emergencyReasonField,
+  faultDescriptionField,
+  disabled,
+}: Props) {
+  return (
+    <section className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+      <h2 className="text-xl font-semibold mb-4 text-gray-500">事後修理情報</h2>
+      <input type="hidden" name={targetProductIdName} value={targetProductId} />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <FkSelectionField
+          label="修理対象機器"
+          selectedLabel={targetProductLabel}
+          onSelect={onSelectProduct}
+          disabled={disabled}
+          selectAriaLabel="修理対象機器を選択"
+        />
+        <div>
+          <label
+            htmlFor={actualRepairDateField.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            修理実施日
+          </label>
+          <input
+            {...getInputProps(actualRepairDateField, { type: "date" })}
+            disabled={disabled}
+            className={inputClassDisabled}
+          />
+          {actualRepairDateField.errors && (
+            <p className="text-red-500 text-xs mt-1">{actualRepairDateField.errors[0]}</p>
+          )}
+        </div>
+        <div className="md:col-span-2">
+          <label
+            htmlFor={emergencyReasonField.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            緊急対応理由
+          </label>
+          <textarea
+            {...getTextareaProps(emergencyReasonField)}
+            disabled={disabled}
+            rows={2}
+            className={inputClassDisabled}
+          />
+          {emergencyReasonField.errors && (
+            <p className="text-red-500 text-xs mt-1">{emergencyReasonField.errors[0]}</p>
+          )}
+        </div>
+        <div className="md:col-span-2">
+          <label
+            htmlFor={faultDescriptionField.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            故障内容
+          </label>
+          <textarea
+            {...getTextareaProps(faultDescriptionField)}
+            disabled={disabled}
+            rows={3}
+            className={inputClassDisabled}
+          />
+          {faultDescriptionField.errors && (
+            <p className="text-red-500 text-xs mt-1">{faultDescriptionField.errors[0]}</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(features)/estimates/_shared/FkSelectionField.tsx
+++ b/src/app/(features)/estimates/_shared/FkSelectionField.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+/**
+ * SelectionModal 駆動の外部キー選択フィールド（純粋表示部品）。
+ *
+ * 「ラベル＋選択値（名称（コード）／未選択）＋選択ボタン＋エラー」という、見積ヘッダーで
+ * 得意先・納品先・修理対象機器に共通して現れる塊を 1 箇所へ集約する。モーダルの開閉状態・
+ * 検索アクション・選択ハンドラは親が持ち、本部品は表示と「選択」クリックの通知だけを担う
+ * （dumb component）。編集（C2）と作成（C1）の双方で再利用する。
+ */
+type Props = {
+  /** 見出しラベル（例: 「得意先」）。 */
+  label: string;
+  /** 選択済みの表示文字列（例: 「○○（C001）」）。未選択は null を渡す。 */
+  selectedLabel: string | null;
+  /** 「選択」ボタン押下の通知（親がモーダルを開く）。 */
+  onSelect: () => void;
+  disabled?: boolean;
+  /** 「選択」ボタンの aria-label（例: 「得意先を選択」）。 */
+  selectAriaLabel: string;
+  /** 表示するフィールドエラー（先頭1件）。 */
+  error?: string;
+};
+
+export function FkSelectionField({
+  label,
+  selectedLabel,
+  onSelect,
+  disabled,
+  selectAriaLabel,
+  error,
+}: Props) {
+  return (
+    <div>
+      <span className="block text-gray-700 text-sm font-bold mb-2">{label}</span>
+      <div className="flex items-center gap-2">
+        <span className="flex-1 text-gray-900">{selectedLabel ?? "未選択"}</span>
+        <button
+          type="button"
+          onClick={onSelect}
+          disabled={disabled}
+          aria-label={selectAriaLabel}
+          className="bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-bold py-1 px-3 rounded disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed"
+        >
+          選択
+        </button>
+      </div>
+      {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/(features)/estimates/_shared/RepairDetailFields.tsx
+++ b/src/app/(features)/estimates/_shared/RepairDetailFields.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { getInputProps, getTextareaProps, type FieldMetadata } from "@conform-to/react";
+import { inputClassDisabled } from "./formStyles";
+import { FkSelectionField } from "./FkSelectionField";
+
+/**
+ * 修理見積（事前・REPAIR）サブタイプ詳細の入力塊（dumb・conform 対応）。
+ *
+ * 修理対象機器（FkSelectionField）・修理予定日・故障内容を 1 セクションへまとめる。編集（C2）と
+ * 作成（C1）はサブタイプのフィールド名（repairTargetProductId / repairScheduledRepairDate /
+ * repairFaultDescription）が一致するため、本部品を双方で共有する。モーダル状態は親が持ち、
+ * 対象機器の表示・hidden 送出・選択通知のみ受け取る。
+ */
+type Props = {
+  /** repairTargetProductId の input name（hidden 送出用）。 */
+  targetProductIdName: string;
+  /** 選択中の対象機器 id（hidden value・表示判定用）。 */
+  targetProductId: string;
+  /** 対象機器の表示文字列（「名称（コード）」）。未選択は null。 */
+  targetProductLabel: string | null;
+  /** 「選択」クリックの通知（親が商品モーダルを開く）。 */
+  onSelectProduct: () => void;
+  scheduledRepairDateField: FieldMetadata<string>;
+  faultDescriptionField: FieldMetadata<string>;
+  disabled?: boolean;
+};
+
+export function RepairDetailFields({
+  targetProductIdName,
+  targetProductId,
+  targetProductLabel,
+  onSelectProduct,
+  scheduledRepairDateField,
+  faultDescriptionField,
+  disabled,
+}: Props) {
+  return (
+    <section className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+      <h2 className="text-xl font-semibold mb-4 text-gray-500">修理情報</h2>
+      <input type="hidden" name={targetProductIdName} value={targetProductId} />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <FkSelectionField
+          label="修理対象機器"
+          selectedLabel={targetProductLabel}
+          onSelect={onSelectProduct}
+          disabled={disabled}
+          selectAriaLabel="修理対象機器を選択"
+        />
+        <div>
+          <label
+            htmlFor={scheduledRepairDateField.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            修理予定日
+          </label>
+          <input
+            {...getInputProps(scheduledRepairDateField, { type: "date" })}
+            disabled={disabled}
+            className={inputClassDisabled}
+          />
+          {scheduledRepairDateField.errors && (
+            <p className="text-red-500 text-xs mt-1">{scheduledRepairDateField.errors[0]}</p>
+          )}
+        </div>
+        <div className="md:col-span-2">
+          <label
+            htmlFor={faultDescriptionField.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            故障内容
+          </label>
+          <textarea
+            {...getTextareaProps(faultDescriptionField)}
+            disabled={disabled}
+            rows={3}
+            className={inputClassDisabled}
+          />
+          {faultDescriptionField.errors && (
+            <p className="text-red-500 text-xs mt-1">{faultDescriptionField.errors[0]}</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(features)/estimates/_shared/SubmissionTypeField.tsx
+++ b/src/app/(features)/estimates/_shared/SubmissionTypeField.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { getSelectProps, type FieldMetadata } from "@conform-to/react";
+import { SUBMISSION_TYPE_LABELS } from "./labels";
+
+/**
+ * 提出区分フィールド（dumb・conform 対応・ADR-0045）。
+ *
+ * 提出区分はバリエーション単位の不変属性で、宛先切替の業務操作は存在しない。よって入力は新規時のみ:
+ * - `select`: 新規追加（C3）・新規作成（C1）。白紙から選択する。
+ * - `fixed`: 複製（C3 duplicate）。複製元から引き継ぎ変更不可。disabled な select は FormData に
+ *   乗らないため、固定ラベル表示＋ hidden で値を運ぶ。
+ *
+ * 値の保持は単一（選択式は uncontrolled な select が conform 管理、固定は hidden 1 つ）。
+ */
+type SubmissionTypeFieldProps = {
+  field: FieldMetadata<string>;
+} & ({ mode: "select"; disabled?: boolean } | { mode: "fixed"; value: string });
+
+export function SubmissionTypeField(props: SubmissionTypeFieldProps) {
+  const { field } = props;
+  const error = field.errors?.[0];
+  return (
+    <div className="mb-6">
+      {props.mode === "fixed" ? (
+        <>
+          <label className="block text-sm font-bold text-gray-700 mb-1">提出区分</label>
+          <p className="border rounded px-3 py-2 bg-gray-50 text-gray-700">
+            {SUBMISSION_TYPE_LABELS[props.value] ?? props.value}
+            <span className="ml-2 text-xs text-gray-500">（複製元から引き継ぎ・変更不可）</span>
+          </p>
+          <input type="hidden" name={field.name} value={props.value} />
+        </>
+      ) : (
+        <>
+          <label htmlFor={field.id} className="block text-sm font-bold text-gray-700 mb-1">
+            提出区分
+          </label>
+          <select
+            {...getSelectProps(field)}
+            disabled={props.disabled}
+            className="border rounded px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-400"
+          >
+            {Object.entries(SUBMISSION_TYPE_LABELS).map(([code, label]) => (
+              <option key={code} value={code}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </>
+      )}
+      {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/(features)/estimates/_shared/tax-rate-actions.ts
+++ b/src/app/(features)/estimates/_shared/tax-rate-actions.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { resolveEffectiveTaxRateQueryFactory } from "@subdomains/estimate/application/factories/estimateQueryFactory";
+import { fromDateInputValue } from "./date";
+
+/**
+ * 見積年月日（"yyyy-mm-dd"）に有効な消費税率をライブ解決する Server Action（C1 作成画面）。
+ *
+ * 作成中はまだ税率が確定しないため、見積年月日の変更に追従してマスタから有効税率を引き、
+ * ヘッダーの read-only 表示と明細プレビューの税率に供給する（編集画面と同じ `findEffectiveAt`）。
+ * 日付は JST 固定でパースし、UTC 解釈による暦日ずれ（§8.7 era 誤判定）を避ける。該当税率が
+ * 無い場合は `null` を返し、UI で「税率未設定」を扱う。確定値は submit 時に §8.7 で再確定する。
+ */
+export async function resolveEffectiveTaxRate(estimateDate: string): Promise<number | null> {
+  await verifySession();
+
+  if (!estimateDate) {
+    return null;
+  }
+
+  return await resolveEffectiveTaxRateQueryFactory().execute({
+    date: fromDateInputValue(estimateDate),
+  });
+}

--- a/src/app/(features)/estimates/estimates-create.e2e.ts
+++ b/src/app/(features)/estimates/estimates-create.e2e.ts
@@ -1,0 +1,124 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 見積新規作成画面 S1（C1）の E2E。seed-e2e の決定的マスタ（得意先・納品先・部署・商品・税率
+ * 8%/10% 境界）に対し、(1) NEW 作成→詳細遷移、(2) 自動展開セット群を含む作成、(3) 区分別情報
+ * （修理）入力での作成、(4) §8.7 税率不一致のフォーム警告を検証する（ADR-0017/0020）。
+ *
+ * 単一フォーム＋単一アクションで原子的に作成し、成功時は詳細画面へ遷移する。作成系のため各テストは
+ * 独立に1見積を作る（採番は再シードで決定的・厳密な採番値は assert しない）。
+ */
+
+/** 得意先（山田製作所）と納品先（東京倉庫）をモーダルで選ぶ。 */
+async function selectCustomerAndDelivery(page: Page) {
+  await page.getByRole("button", { name: "得意先を選択" }).click();
+  await page.getByLabel("名称").fill("山田製作所");
+  await page.getByRole("button", { name: "検索" }).click();
+  await page
+    .getByRole("row", { name: /株式会社山田製作所/ })
+    .getByRole("checkbox")
+    .click();
+  await page.getByRole("button", { name: /件を追加/ }).click();
+
+  await page.getByRole("button", { name: "納品先を選択" }).click();
+  await page.getByLabel("名称").fill("東京倉庫");
+  await page.getByRole("button", { name: "検索" }).click();
+  await page
+    .getByRole("row", { name: /山田製作所 東京倉庫/ })
+    .getByRole("checkbox")
+    .click();
+  await page.getByRole("button", { name: /件を追加/ }).click();
+}
+
+/** 明細追加モーダルで指定商品を選ぶ。 */
+async function addProductLine(page: Page, productName: string) {
+  await page.getByRole("button", { name: "明細追加" }).click();
+  await page.locator("#modal-search-name").fill(productName);
+  await page.getByRole("button", { name: "検索" }).click();
+  await page
+    .getByRole("row", { name: new RegExp(productName) })
+    .getByRole("checkbox")
+    .click();
+  await page.getByRole("button", { name: /件を追加/ }).click();
+}
+
+test.describe("見積新規作成（C1）", () => {
+  test("NEW を作成すると詳細画面へ遷移し登録トーストが出る", async ({ page }) => {
+    await page.goto("/estimates/new");
+
+    await selectCustomerAndDelivery(page);
+    await page.getByLabel("部署").selectOption({ label: "営業部" });
+    await addProductLine(page, "標準デスク");
+
+    await page.getByRole("button", { name: "作成", exact: true }).click();
+
+    await expect(page.getByText("見積を登録しました。")).toBeVisible();
+    // 詳細画面（閲覧）へ遷移し、選んだ得意先が反映される。
+    await expect(page).toHaveURL(/\/estimates\/[A-Za-z0-9]+/);
+    await expect(page.getByText(/株式会社山田製作所/)).toBeVisible();
+  });
+
+  test("セット商品を選ぶと構成が自動展開され、その見積を作成できる", async ({ page }) => {
+    await page.goto("/estimates/new");
+
+    await selectCustomerAndDelivery(page);
+    await page.getByLabel("部署").selectOption({ label: "営業部" });
+
+    // セット商品（デスクセット一式）→ 構成（標準デスク・オフィスチェア）が自動展開される。
+    await addProductLine(page, "デスクセット一式");
+    await expect(page.getByRole("button", { name: "明細を削除（標準デスク）" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "明細を削除（オフィスチェア）" })).toBeVisible();
+
+    await page.getByRole("button", { name: "作成", exact: true }).click();
+
+    await expect(page.getByText("見積を登録しました。")).toBeVisible();
+    await expect(page.locator("table tbody tr", { hasText: "標準デスク" })).toBeVisible();
+    await expect(page.locator("table tbody tr", { hasText: "オフィスチェア" })).toBeVisible();
+  });
+
+  test("修理区分を選び修理情報を入力して作成できる", async ({ page }) => {
+    await page.goto("/estimates/new");
+
+    // 見積区分=修理 → 修理情報セクションが現れる。
+    await page.getByLabel("見積区分").selectOption({ label: "修理" });
+    await expect(page.getByText("修理情報", { exact: true })).toBeVisible();
+
+    await selectCustomerAndDelivery(page);
+    await page.getByLabel("部署").selectOption({ label: "営業部" });
+
+    // 修理対象機器（標準デスク）・修理予定日・故障内容を埋める（区分別必須）。
+    await page.getByRole("button", { name: "修理対象機器を選択" }).click();
+    await page.locator("#modal-search-name").fill("標準デスク");
+    await page.getByRole("button", { name: "検索" }).click();
+    await page
+      .getByRole("row", { name: /標準デスク/ })
+      .getByRole("checkbox")
+      .click();
+    await page.getByRole("button", { name: /件を追加/ }).click();
+
+    await page.getByLabel("修理予定日").fill("2026-07-01");
+    await page.getByLabel("故障内容").fill("天板の歪み");
+
+    await page.getByRole("button", { name: "作成", exact: true }).click();
+
+    await expect(page.getByText("見積を登録しました。")).toBeVisible();
+    await expect(page.getByText(/株式会社山田製作所/)).toBeVisible();
+  });
+
+  test("見積年月日と締切日で税率が異なると §8.7 警告が出て作成されない", async ({ page }) => {
+    await page.goto("/estimates/new");
+
+    await selectCustomerAndDelivery(page);
+    await page.getByLabel("部署").selectOption({ label: "営業部" });
+
+    // 8%(〜2019-09-30) と 10%(2019-10-01〜) の境界をまたぐ。
+    await page.getByLabel("見積日").fill("2019-09-30");
+    await page.getByLabel("締切日").fill("2019-10-01");
+
+    await page.getByRole("button", { name: "作成", exact: true }).click();
+
+    // 不一致は作成されずフォームエラーで提示される（詳細へは遷移しない）。
+    await expect(page.getByText(/税率が異なります/)).toBeVisible();
+    await expect(page).toHaveURL(/\/estimates\/new$/);
+  });
+});

--- a/src/app/(features)/estimates/new/CreateEstimateForm.tsx
+++ b/src/app/(features)/estimates/new/CreateEstimateForm.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import { getFormProps, getInputProps, getSelectProps } from "@conform-to/react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { useServerForm } from "@/app/_hooks/useServerForm";
+import { SelectionModal } from "@/app/_components/shared/SelectionModal";
+import type { SearchFieldDef } from "@/app/_components/shared/SearchForm";
+import { AfterRepairDetailFields } from "../_shared/AfterRepairDetailFields";
+import { FkSelectionField } from "../_shared/FkSelectionField";
+import { inputClassDisabled } from "../_shared/formStyles";
+import { ESTIMATE_TYPE_LABELS, TAX_ROUNDING_TYPE_LABELS } from "../_shared/labels";
+import { productSearchFields } from "../_shared/productSearch";
+import { RepairDetailFields } from "../_shared/RepairDetailFields";
+import {
+  companySelectionColumns,
+  productSelectionColumns,
+  type CompanyRow,
+  type ProductSelectionRow,
+} from "../_shared/selectionColumns";
+import {
+  searchCustomersForSelection,
+  searchDeliveryLocationsForSelection,
+  searchProductsForSelection,
+} from "../_shared/selection-actions";
+import { SubmissionTypeField } from "../_shared/SubmissionTypeField";
+import { resolveEffectiveTaxRate } from "../_shared/tax-rate-actions";
+import {
+  VariationLineEditor,
+  VariationLineEditorOverlays,
+} from "../[estimateNumber]/components/VariationLineEditor";
+import { useVariationLineEditor } from "../[estimateNumber]/useVariationLineEditor";
+import { createEstimate } from "./actions";
+import { createEstimateSchema } from "./schema";
+
+type DepartmentOption = { id: string; name: string };
+
+type Props = {
+  /** 作成者（認証セッションの employeeId から解決・read-only）。 */
+  creatorName: string;
+  creatorCode: string;
+  departments: DepartmentOption[];
+  /** 既定の見積年月日 "yyyy-mm-dd"（今日・JST）。 */
+  defaultEstimateDate: string;
+  /** 既定の締切日 "yyyy-mm-dd"。 */
+  defaultDeadline: string;
+  /** 既定見積年月日に対する解決済み有効税率（マスタ該当なしは null）。 */
+  initialTaxRate: number | null;
+};
+
+const companySearchFields: SearchFieldDef[] = [
+  { type: "text", key: "code", label: "コード", placeholder: "部分一致" },
+  { type: "text", key: "name", label: "名称", placeholder: "部分一致" },
+];
+
+/**
+ * 見積新規作成の統合フォーム（C1）。
+ *
+ * ヘッダー（見積区分セレクタで NEW/REPAIR/AFTER_REPAIR を選びサブタイプ欄を切替）と初期バリ1件
+ * （提出区分・明細・全体値引・メモ）を 1 フォーム・1 アクションで原子的に保存する。編集画面と
+ * 部品・ロジックを共有する: FK 選択は FkSelectionField、サブタイプ詳細は Repair/AfterRepairDetailFields、
+ * 提出区分は SubmissionTypeField、明細は useVariationLineEditor＋VariationLineEditor（ADR-0047/0050）。
+ *
+ * 作成固有の差分: (1) 税率はフォーム入力でなく見積年月日からライブ解決し read-only 表示＆プレビューに
+ * 供給（submit で §8.7 再確定・ADR-0056）、(2) estimateType を選択する（編集は固定）、(3) version を
+ * 持たない（新規採番）。税率の確定値は Server Action 側で導出するためフォームには税率欄を置かない。
+ */
+export function CreateEstimateForm({
+  creatorName,
+  creatorCode,
+  departments,
+  defaultEstimateDate,
+  defaultDeadline,
+  initialTaxRate,
+}: Props) {
+  const router = useRouter();
+
+  const { form, fields, isPending } = useServerForm({
+    action: createEstimate,
+    schema: createEstimateSchema,
+    defaultValue: {
+      submissionType: "CUSTOMER",
+      customerMemo: "",
+      internalMemo: "",
+    },
+  });
+
+  // 見積区分・見積年月日・税端数区分・税率は表示連動のためローカル state で持つ（プレビュー・
+  // サブタイプ切替に効く）。FK はモーダル駆動のため hidden で送る。
+  const [estimateType, setEstimateType] = useState("NEW");
+  const [estimateDate, setEstimateDate] = useState(defaultEstimateDate);
+  const [taxRoundingType, setTaxRoundingType] = useState("ROUND_DOWN");
+  const [taxRate, setTaxRate] = useState<number | null>(initialTaxRate);
+  const [, startTaxResolve] = useTransition();
+
+  const [customer, setCustomer] = useState({ id: "", code: "", name: "" });
+  const [deliveryLocation, setDeliveryLocation] = useState({ id: "", code: "", name: "" });
+  const [targetProduct, setTargetProduct] = useState({ id: "", code: "", name: "" });
+
+  const [customerModalOpen, setCustomerModalOpen] = useState(false);
+  const [deliveryModalOpen, setDeliveryModalOpen] = useState(false);
+  const [productModalOpen, setProductModalOpen] = useState(false);
+
+  // 見積年月日の変更に追従して有効税率をライブ解決する（編集画面と同じ findEffectiveAt・§A.1）。
+  const handleEstimateDateChange = (value: string) => {
+    setEstimateDate(value);
+    startTaxResolve(async () => {
+      setTaxRate(await resolveEffectiveTaxRate(value));
+    });
+  };
+
+  const handleCustomerSelect = (rows: CompanyRow[]) => {
+    const picked = rows[0];
+    if (!picked) return;
+    setCustomer({ id: picked.id, code: picked.code, name: picked.name });
+    // 得意先を変えたら納品先は不整合になるためクリアして再選択させる（集約をまたぐ整合）。
+    setDeliveryLocation({ id: "", code: "", name: "" });
+  };
+
+  const handleDeliverySelect = (rows: CompanyRow[]) => {
+    const picked = rows[0];
+    if (!picked) return;
+    setDeliveryLocation({ id: picked.id, code: picked.code, name: picked.name });
+  };
+
+  const handleProductSelect = (rows: ProductSelectionRow[]) => {
+    const picked = rows[0];
+    if (!picked) return;
+    setTargetProduct({ id: picked.id, code: picked.code, name: picked.name });
+  };
+
+  // 明細編集器（新規作成は白紙＝空ノード・全体値引0で開始）。プレビュー税率はライブ解決値。
+  const editor = useVariationLineEditor({
+    initialNodes: [],
+    initialOverallDiscount: 0,
+    taxRate: taxRate ?? 0,
+    taxRoundingType,
+  });
+
+  const isRepair = estimateType === "REPAIR";
+  const isAfterRepair = estimateType === "AFTER_REPAIR";
+  const targetProductLabel = targetProduct.id
+    ? `${targetProduct.name}（${targetProduct.code}）`
+    : null;
+
+  return (
+    <>
+      {form.errors && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+          role="alert"
+        >
+          <p className="font-bold">エラー</p>
+          {form.errors.map((e) => (
+            <p key={e}>{e}</p>
+          ))}
+        </div>
+      )}
+
+      <form {...getFormProps(form)} noValidate>
+        {/* モーダル駆動 FK は state を hidden で送る。 */}
+        <input type="hidden" name={fields.customerId.name} value={customer.id} />
+        <input type="hidden" name={fields.deliveryLocationId.name} value={deliveryLocation.id} />
+
+        <section className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+          <h2 className="text-xl font-semibold mb-4 text-gray-500">基本情報</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {/* 見積区分（サブタイプ欄の表示を切り替える） */}
+            <div>
+              <label
+                htmlFor={fields.estimateType.id}
+                className="block text-gray-700 text-sm font-bold mb-2"
+              >
+                見積区分
+              </label>
+              <select
+                id={fields.estimateType.id}
+                name={fields.estimateType.name}
+                value={estimateType}
+                onChange={(e) => setEstimateType(e.target.value)}
+                disabled={isPending}
+                className={inputClassDisabled}
+              >
+                {Object.entries(ESTIMATE_TYPE_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              {fields.estimateType.errors && (
+                <p className="text-red-500 text-xs mt-1">{fields.estimateType.errors[0]}</p>
+              )}
+            </div>
+
+            {/* 作成者（read-only） */}
+            <div>
+              <span className="block text-gray-700 text-sm font-bold mb-2">作成者</span>
+              <p className="text-gray-900 py-2">
+                {creatorName}（{creatorCode}）
+              </p>
+            </div>
+
+            {/* 得意先（SelectionModal） */}
+            <FkSelectionField
+              label="得意先"
+              selectedLabel={customer.id ? `${customer.name}（${customer.code}）` : null}
+              onSelect={() => setCustomerModalOpen(true)}
+              disabled={isPending}
+              selectAriaLabel="得意先を選択"
+              error={fields.customerId.errors?.[0]}
+            />
+
+            {/* 納品先（選択中得意先で絞り込み） */}
+            <FkSelectionField
+              label="納品先"
+              selectedLabel={
+                deliveryLocation.id ? `${deliveryLocation.name}（${deliveryLocation.code}）` : null
+              }
+              onSelect={() => setDeliveryModalOpen(true)}
+              disabled={isPending || !customer.id}
+              selectAriaLabel="納品先を選択"
+              error={fields.deliveryLocationId.errors?.[0]}
+            />
+
+            {/* 部署（プレースホルダ必須選択。自動解決は後続 #374） */}
+            <div>
+              <label
+                htmlFor={fields.departmentId.id}
+                className="block text-gray-700 text-sm font-bold mb-2"
+              >
+                部署
+              </label>
+              <select
+                {...getSelectProps(fields.departmentId)}
+                defaultValue=""
+                disabled={isPending}
+                className={inputClassDisabled}
+              >
+                <option value="" disabled>
+                  選択してください
+                </option>
+                {departments.map((d) => (
+                  <option key={d.id} value={d.id}>
+                    {d.name}
+                  </option>
+                ))}
+              </select>
+              {fields.departmentId.errors && (
+                <p className="text-red-500 text-xs mt-1">{fields.departmentId.errors[0]}</p>
+              )}
+            </div>
+
+            {/* 見積日（変更で税率をライブ解決） */}
+            <div>
+              <label htmlFor="estimateDate" className="block text-gray-700 text-sm font-bold mb-2">
+                見積日
+              </label>
+              <input
+                type="date"
+                id="estimateDate"
+                name={fields.estimateDate.name}
+                value={estimateDate}
+                onChange={(e) => handleEstimateDateChange(e.target.value)}
+                disabled={isPending}
+                className={inputClassDisabled}
+              />
+              {fields.estimateDate.errors && (
+                <p className="text-red-500 text-xs mt-1">{fields.estimateDate.errors[0]}</p>
+              )}
+            </div>
+
+            {/* 締切日 */}
+            <div>
+              <label
+                htmlFor={fields.deadline.id}
+                className="block text-gray-700 text-sm font-bold mb-2"
+              >
+                締切日
+              </label>
+              <input
+                {...getInputProps(fields.deadline, { type: "date" })}
+                defaultValue={defaultDeadline}
+                disabled={isPending}
+                className={inputClassDisabled}
+              />
+              {fields.deadline.errors && (
+                <p className="text-red-500 text-xs mt-1">{fields.deadline.errors[0]}</p>
+              )}
+            </div>
+
+            {/* 消費税率（read-only・見積年月日からライブ導出） */}
+            <div>
+              <span className="block text-gray-700 text-sm font-bold mb-2">消費税率</span>
+              <p className="text-gray-900 py-2">
+                {taxRate != null ? `${Math.round(taxRate * 100)}%` : "未設定"}
+              </p>
+              <p className="text-gray-600 text-xs mt-1">税率は見積年月日から自動決定されます</p>
+            </div>
+
+            {/* 税端数区分（プレビューに効くため controlled） */}
+            <div>
+              <label
+                htmlFor="taxRoundingType"
+                className="block text-gray-700 text-sm font-bold mb-2"
+              >
+                税端数区分
+              </label>
+              <select
+                id="taxRoundingType"
+                name={fields.taxRoundingType.name}
+                value={taxRoundingType}
+                onChange={(e) => setTaxRoundingType(e.target.value)}
+                disabled={isPending}
+                className={inputClassDisabled}
+              >
+                {Object.entries(TAX_ROUNDING_TYPE_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              {fields.taxRoundingType.errors && (
+                <p className="text-red-500 text-xs mt-1">{fields.taxRoundingType.errors[0]}</p>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* 修理情報（REPAIR） */}
+        {isRepair && (
+          <RepairDetailFields
+            targetProductIdName={fields.repairTargetProductId.name}
+            targetProductId={targetProduct.id}
+            targetProductLabel={targetProductLabel}
+            onSelectProduct={() => setProductModalOpen(true)}
+            scheduledRepairDateField={fields.repairScheduledRepairDate}
+            faultDescriptionField={fields.repairFaultDescription}
+            disabled={isPending}
+          />
+        )}
+
+        {/* 事後修理情報（AFTER_REPAIR） */}
+        {isAfterRepair && (
+          <AfterRepairDetailFields
+            targetProductIdName={fields.afterRepairTargetProductId.name}
+            targetProductId={targetProduct.id}
+            targetProductLabel={targetProductLabel}
+            onSelectProduct={() => setProductModalOpen(true)}
+            actualRepairDateField={fields.afterRepairActualRepairDate}
+            emergencyReasonField={fields.afterRepairEmergencyReason}
+            faultDescriptionField={fields.afterRepairFaultDescription}
+            disabled={isPending}
+          />
+        )}
+
+        {/* 初期バリエーション（1件・提出区分＋明細） */}
+        <section className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+          <h2 className="text-xl font-semibold mb-4 text-gray-500">バリエーション</h2>
+          <SubmissionTypeField field={fields.submissionType} mode="select" disabled={isPending} />
+          <VariationLineEditor
+            editor={editor}
+            nodesField={fields.nodes}
+            overallDiscountField={fields.overallDiscount}
+            customerMemoField={fields.customerMemo}
+            internalMemoField={fields.internalMemo}
+            isPending={isPending}
+          />
+        </section>
+
+        <div className="flex gap-4">
+          <button
+            type="submit"
+            disabled={isPending}
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            {isPending ? "作成中..." : "作成"}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push("/estimates")}
+            disabled={isPending}
+            className="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:cursor-not-allowed"
+          >
+            キャンセル
+          </button>
+        </div>
+      </form>
+
+      {/* FK 選択モーダル（単一選択） */}
+      <SelectionModal<CompanyRow>
+        isOpen={customerModalOpen}
+        onClose={() => setCustomerModalOpen(false)}
+        title="得意先を選択"
+        searchFields={companySearchFields}
+        searchAction={searchCustomersForSelection}
+        columns={companySelectionColumns}
+        onConfirm={handleCustomerSelect}
+        getRowId={(row) => row.id}
+        emptyMessage="該当する得意先が見つかりません"
+      />
+      <SelectionModal<CompanyRow>
+        isOpen={deliveryModalOpen}
+        onClose={() => setDeliveryModalOpen(false)}
+        title="納品先を選択"
+        searchFields={companySearchFields}
+        searchAction={searchDeliveryLocationsForSelection.bind(null, customer.id)}
+        columns={companySelectionColumns}
+        onConfirm={handleDeliverySelect}
+        getRowId={(row) => row.id}
+        emptyMessage="該当する納品先が見つかりません"
+      />
+      <SelectionModal<ProductSelectionRow>
+        isOpen={productModalOpen}
+        onClose={() => setProductModalOpen(false)}
+        title="修理対象機器を選択"
+        searchFields={productSearchFields}
+        searchAction={searchProductsForSelection}
+        columns={productSelectionColumns}
+        onConfirm={handleProductSelect}
+        getRowId={(row) => row.id}
+        emptyMessage="該当する商品が見つかりません"
+      />
+
+      <VariationLineEditorOverlays editor={editor} />
+    </>
+  );
+}

--- a/src/app/(features)/estimates/new/__tests__/schema.conform.test.ts
+++ b/src/app/(features)/estimates/new/__tests__/schema.conform.test.ts
@@ -1,0 +1,101 @@
+import { parseWithZod } from "@conform-to/zod/v4";
+import { describe, expect, it } from "vitest";
+import { createEstimateSchema } from "../schema";
+
+/**
+ * C1 作成フォームの createEstimateSchema を conform parseWithZod 経路で固定するテスト。
+ *
+ * 検証する契約:
+ * - 区分別サブタイプ必須（NEW=不要 / REPAIR=修理3項目 / AFTER_REPAIR=事後修理4項目）を superRefine で担保
+ * - 空メモは conform が undefined 化しても success（optional 契約・編集側と同じ）
+ * - ノード配列が JSON からパースされて value.nodes に載る（ADR-0050・nodesField 共有）
+ */
+
+const ONE_LINE_NODE = JSON.stringify([
+  {
+    kind: "line",
+    productId: "p1",
+    itemName: "明細",
+    unit: "個",
+    quantity: 1,
+    unitPrice: 1000,
+    discountRate: 1,
+    itemDiscount: 0,
+    customerMemo: "",
+    internalMemo: "",
+  },
+]);
+
+/** ヘッダー共通項目＋初期バリ1件の最小 FormData。overrides で個別フィールドを差し替える。 */
+function buildFormData(overrides: Record<string, string> = {}): FormData {
+  const base: Record<string, string> = {
+    estimateType: "NEW",
+    estimateDate: "2026-06-17",
+    deadline: "2026-06-30",
+    customerId: "cust-1",
+    deliveryLocationId: "loc-1",
+    departmentId: "dept-1",
+    taxRoundingType: "ROUND_DOWN",
+    submissionType: "CUSTOMER",
+    overallDiscount: "0",
+    customerMemo: "",
+    internalMemo: "",
+    nodes: ONE_LINE_NODE,
+  };
+  const merged = { ...base, ...overrides };
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(merged)) {
+    fd.set(k, v);
+  }
+  return fd;
+}
+
+describe("createEstimateSchema の conform parseWithZod 経路", () => {
+  it("NEW は修理情報なしで success（空メモも undefined 化に耐える）", () => {
+    const submission = parseWithZod(buildFormData(), { schema: createEstimateSchema });
+
+    if (submission.status !== "success") {
+      throw new Error(`status=${submission.status} reply=${JSON.stringify(submission.reply())}`);
+    }
+    expect(submission.value.estimateType).toBe("NEW");
+    expect(submission.value.nodes).toHaveLength(1);
+  });
+
+  it("REPAIR で修理3項目が空だと、各フィールドパスへエラーが付き失敗する", () => {
+    const submission = parseWithZod(buildFormData({ estimateType: "REPAIR" }), {
+      schema: createEstimateSchema,
+    });
+
+    expect(submission.status).toBe("error");
+    const reply = submission.reply();
+    expect(reply.error).toHaveProperty("repairTargetProductId");
+    expect(reply.error).toHaveProperty("repairFaultDescription");
+    expect(reply.error).toHaveProperty("repairScheduledRepairDate");
+  });
+
+  it("REPAIR で修理3項目が揃えば success", () => {
+    const submission = parseWithZod(
+      buildFormData({
+        estimateType: "REPAIR",
+        repairTargetProductId: "prod-9",
+        repairFaultDescription: "異音",
+        repairScheduledRepairDate: "2026-07-01",
+      }),
+      { schema: createEstimateSchema }
+    );
+
+    if (submission.status !== "success") {
+      throw new Error(`status=${submission.status} reply=${JSON.stringify(submission.reply())}`);
+    }
+    expect(submission.value.estimateType).toBe("REPAIR");
+  });
+
+  it("AFTER_REPAIR で事後修理4項目が空だと失敗する（緊急理由含む）", () => {
+    const submission = parseWithZod(buildFormData({ estimateType: "AFTER_REPAIR" }), {
+      schema: createEstimateSchema,
+    });
+
+    expect(submission.status).toBe("error");
+    expect(submission.reply().error).toHaveProperty("afterRepairEmergencyReason");
+  });
+});

--- a/src/app/(features)/estimates/new/actions.ts
+++ b/src/app/(features)/estimates/new/actions.ts
@@ -1,0 +1,107 @@
+"use server";
+
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { REDIRECT_REASON } from "@shared/constants/redirect-reasons";
+import { checkTaxRateThenCreate } from "@subdomains/estimate/application/shared/checkTaxRateThenCreate";
+import { checkTaxRateThenCreateDepsFactory } from "@subdomains/estimate/application/factories/checkTaxRateThenCreateDepsFactory";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { handleCommandError } from "../../_shared/error-handler";
+import { fromDateInputValue } from "../_shared/date";
+import { toVariationContentInputFromNodes } from "../[estimateNumber]/variationContentMapping";
+import { createEstimateSchema } from "./schema";
+
+/**
+ * 見積新規作成（C1）の Server Action。
+ *
+ * 単一統合フォーム（ヘッダー＋初期バリ1件）を 1 アクションでまとめて保存し、空見積を構造的に
+ * 排除する（≥1 バリの原子的作成）。作成者は session.user.employeeId（null は作成不可）。税率は
+ * フォームから受け取らず、見積年月日から app-shared `checkTaxRateThenCreate` が導出する（§A.1 /
+ * ADR-0056）。§8.7 税率不一致は例外でなく Result のためフォームエラーで提示し入力を維持する。
+ * その他例外は handleCommandError 経由でフォームエラー化する。成功時のみ詳細画面へ redirect。
+ * 日付は JST 固定パース（z.coerce.date() は暦日がずれるため使わない）。
+ */
+export async function createEstimate(_prevState: unknown, formData: FormData) {
+  const session = await verifySession();
+
+  const submission = parseWithZod(formData, { schema: createEstimateSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+  const value = submission.value;
+
+  // 作成者は認証セッションの employeeId に固定する（フォーム改ざん不可・null は作成不可）。
+  const createdBy = session.user.employeeId;
+  if (!createdBy) {
+    return submission.reply({
+      formErrors: ["作成者の従業員情報が取得できないため、見積を作成できません。"],
+    });
+  }
+
+  const content = toVariationContentInputFromNodes(value);
+
+  const input = {
+    estimateType: value.estimateType,
+    estimateDate: fromDateInputValue(value.estimateDate),
+    deadline: fromDateInputValue(value.deadline),
+    customerId: value.customerId,
+    deliveryLocationId: value.deliveryLocationId,
+    taxRoundingType: value.taxRoundingType,
+    createdBy,
+    departmentId: value.departmentId,
+    // 初期バリエーションは正確に1件（variationNumber=1）。2件目以降は詳細画面の C3 で足す。
+    variations: [
+      {
+        variationNumber: 1,
+        submissionType: value.submissionType,
+        items: content.items,
+        setGroups: content.setGroups,
+        overallDiscount: content.overallDiscount,
+        customerMemo: content.customerMemo,
+        internalMemo: content.internalMemo,
+      },
+    ],
+    repairDetail:
+      value.estimateType === "REPAIR"
+        ? {
+            targetProductId: value.repairTargetProductId ?? "",
+            faultDescription: value.repairFaultDescription ?? "",
+            scheduledRepairDate: fromDateInputValue(value.repairScheduledRepairDate ?? ""),
+          }
+        : null,
+    afterRepairDetail:
+      value.estimateType === "AFTER_REPAIR"
+        ? {
+            targetProductId: value.afterRepairTargetProductId ?? "",
+            faultDescription: value.afterRepairFaultDescription ?? "",
+            actualRepairDate: fromDateInputValue(value.afterRepairActualRepairDate ?? ""),
+            emergencyReason: value.afterRepairEmergencyReason ?? "",
+          }
+        : null,
+  };
+
+  let result;
+  try {
+    result = await checkTaxRateThenCreate(input, checkTaxRateThenCreateDepsFactory());
+  } catch (error) {
+    const errorResult = handleCommandError(error);
+    const errorMessage = !errorResult.success && errorResult.error ? errorResult.error : undefined;
+    return submission.reply({ formErrors: errorMessage ? [errorMessage] : [] });
+  }
+
+  // 税率不一致（§8.7）は作成されない。両税率を提示して入力を維持する。
+  if (result.kind === "taxRateMismatch") {
+    const estimateDatePct = Math.round(result.estimateDateRate.value * 100);
+    const deadlinePct = Math.round(result.deadlineRate.value * 100);
+    return submission.reply({
+      formErrors: [
+        `見積年月日（${estimateDatePct}%）と締切日（${deadlinePct}%）で税率が異なります。日付を確認してください（§8.7）。`,
+      ],
+    });
+  }
+
+  const estimateNumber = result.estimate.estimateNumber.value;
+  revalidatePath(`/estimates/${estimateNumber}`);
+  redirect(`/estimates/${estimateNumber}?reason=${REDIRECT_REASON.ESTIMATE_CREATED}`);
+}

--- a/src/app/(features)/estimates/new/page.tsx
+++ b/src/app/(features)/estimates/new/page.tsx
@@ -1,0 +1,59 @@
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { getActiveDepartmentsQueryFactory } from "@subdomains/department/application/factories/departmentQueryFactory";
+import { getEmployeeByIdQueryFactory } from "@subdomains/employee/application/factories/employeeQueryFactory";
+import { resolveEffectiveTaxRateQueryFactory } from "@subdomains/estimate/application/factories/estimateQueryFactory";
+import { fromDateInputValue, toDateInputValue } from "../_shared/date";
+import { CreateEstimateForm } from "./CreateEstimateForm";
+
+/**
+ * 見積新規作成画面 S1（C1）。
+ *
+ * RSC（本ファイル）が作成者（認証セッションの employeeId から解決）・有効部署一覧・既定日付の
+ * 有効税率を取得し、クライアントアイランド CreateEstimateForm へ渡す。作成者の従業員情報が
+ * 引けない場合は作成不可とし、フォームを出さずに案内する（createdBy 必須・null は作成不可）。
+ */
+export default async function NewEstimatePage() {
+  const session = await verifySession();
+
+  const employeeId = session.user.employeeId;
+  const creator = employeeId
+    ? await getEmployeeByIdQueryFactory().execute({ id: employeeId })
+    : null;
+
+  if (!creator) {
+    return (
+      <div className="container mx-auto p-8">
+        <h1 className="text-2xl font-bold mb-4">見積新規作成</h1>
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded"
+          role="alert"
+        >
+          作成者の従業員情報が取得できないため、見積を作成できません。管理者にお問い合わせください。
+        </div>
+      </div>
+    );
+  }
+
+  // 有効部署のみ（GetActiveDepartmentsQuery・Q6）。部署の自動解決は後続 #374。
+  const departments = await getActiveDepartmentsQueryFactory().execute({});
+
+  // 既定の見積年月日・締切日は今日（JST）。既定日付の有効税率を read-only 表示の初期値とする。
+  const today = toDateInputValue(new Date());
+  const initialTaxRate = await resolveEffectiveTaxRateQueryFactory().execute({
+    date: fromDateInputValue(today),
+  });
+
+  return (
+    <div className="container mx-auto p-8">
+      <h1 className="text-3xl font-bold mb-8">見積新規作成</h1>
+      <CreateEstimateForm
+        creatorName={creator.name}
+        creatorCode={creator.employeeCd}
+        departments={departments.map((d) => ({ id: d.id, name: d.name }))}
+        defaultEstimateDate={today}
+        defaultDeadline={today}
+        initialTaxRate={initialTaxRate}
+      />
+    </div>
+  );
+}

--- a/src/app/(features)/estimates/new/schema.ts
+++ b/src/app/(features)/estimates/new/schema.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { dateInput } from "../[estimateNumber]/schema";
+import { nodesField } from "../[estimateNumber]/variationSchema";
+
+/**
+ * 見積新規作成フォーム（C1）のバリデーションスキーマ。
+ *
+ * 編集系（updateEstimateHeaderSchema / addVariationNodeSchema）と原子を共有しつつ、作成固有の
+ * 差分を持つ:
+ * - `version` を持たない（新規採番のため楽観ロックトークン不要・ADR-0039）
+ * - `taxRate` を持たない（見積年月日からマスタ導出し read-only・§A.1 / ADR-0056）
+ * - `estimateType` を submit に持つ（編集は estimate から固定だが作成は選択する）
+ * - 初期バリ1件分の `submissionType`（不変属性・ADR-0045）と内容（nodes/全体値引/メモ）を含む
+ *
+ * 日付は "yyyy-mm-dd" のまま受け Server Action で JST 固定パースする（z.coerce.date() は不可）。
+ * 区分別サブタイプの必須性は estimateType を submit に持つ作成側でのみ schema で担保できるため、
+ * superRefine で条件必須化する（編集はアクション側＋ドメイン VO 担保からの意図的乖離）。
+ */
+export const createEstimateSchema = z
+  .object({
+    estimateType: z.enum(["NEW", "REPAIR", "AFTER_REPAIR"], {
+      message: "見積区分を選択してください",
+    }),
+    estimateDate: dateInput,
+    deadline: dateInput,
+    customerId: z.string().min(1, "得意先を選択してください"),
+    deliveryLocationId: z.string().min(1, "納品先を選択してください"),
+    departmentId: z.string().min(1, "部署を選択してください"),
+    taxRoundingType: z.enum(["ROUND_DOWN", "ROUND_UP", "ROUND"]),
+
+    // 初期バリエーション（1件）。提出区分は不変属性（ADR-0045）。
+    submissionType: z.enum(["CUSTOMER", "DELIVERY_LOCATION"], {
+      message: "提出区分を選択してください",
+    }),
+    overallDiscount: z.coerce.number().min(0, "全体値引は0以上で入力してください"),
+    customerMemo: z.string().optional(),
+    internalMemo: z.string().optional(),
+    nodes: nodesField,
+
+    // 修理情報（REPAIR）。表示は区分依存のため optional で受け、superRefine で必須化する。
+    repairTargetProductId: z.string().optional(),
+    repairFaultDescription: z.string().optional(),
+    repairScheduledRepairDate: z.string().optional(),
+
+    // 事後修理情報（AFTER_REPAIR）。同上。
+    afterRepairTargetProductId: z.string().optional(),
+    afterRepairFaultDescription: z.string().optional(),
+    afterRepairActualRepairDate: z.string().optional(),
+    afterRepairEmergencyReason: z.string().optional(),
+  })
+  .superRefine((value, ctx) => {
+    /** 空文字／undefined を「未入力」として、指定パスへ必須エラーを付与する。 */
+    const requireField = (field: string, message: string) => {
+      const v = value[field as keyof typeof value];
+      if (typeof v !== "string" || v.trim() === "") {
+        ctx.addIssue({ code: "custom", message, path: [field] });
+      }
+    };
+
+    if (value.estimateType === "REPAIR") {
+      requireField("repairTargetProductId", "修理対象製品を選択してください");
+      requireField("repairFaultDescription", "故障内容を入力してください");
+      requireField("repairScheduledRepairDate", "修理予定日を入力してください");
+    }
+
+    if (value.estimateType === "AFTER_REPAIR") {
+      requireField("afterRepairTargetProductId", "修理対象製品を選択してください");
+      requireField("afterRepairFaultDescription", "故障内容を入力してください");
+      requireField("afterRepairActualRepairDate", "修理実施日を入力してください");
+      requireField("afterRepairEmergencyReason", "緊急理由を入力してください");
+    }
+  });
+
+export type CreateEstimateFormInput = z.infer<typeof createEstimateSchema>;

--- a/src/app/_components/redirect-reason-toast.tsx
+++ b/src/app/_components/redirect-reason-toast.tsx
@@ -117,6 +117,10 @@ const FLASH_MESSAGES: Record<RedirectReason, FlashMessage> = {
     type: FLASH_MESSAGE_TYPE.SUCCESS,
     message: "納品先を無効化しました。",
   },
+  [REDIRECT_REASON.ESTIMATE_CREATED]: {
+    type: FLASH_MESSAGE_TYPE.SUCCESS,
+    message: "見積を登録しました。",
+  },
   [REDIRECT_REASON.ESTIMATE_UPDATED]: {
     type: FLASH_MESSAGE_TYPE.SUCCESS,
     message: "見積を更新しました。",

--- a/src/server/subdomains/employee/application/factories/employeeQueryFactory.ts
+++ b/src/server/subdomains/employee/application/factories/employeeQueryFactory.ts
@@ -1,0 +1,7 @@
+import { GetEmployeeByIdQuery } from "../queries/GetEmployeeByIdQuery";
+import { PrismaEmployeeQueryService } from "../../infrastructure/queries/PrismaEmployeeQueryService";
+
+/** ID で従業員を取得するクエリの Composition Root。 */
+export function getEmployeeByIdQueryFactory(): GetEmployeeByIdQuery {
+  return new GetEmployeeByIdQuery(new PrismaEmployeeQueryService());
+}

--- a/src/server/subdomains/employee/application/factories/index.ts
+++ b/src/server/subdomains/employee/application/factories/index.ts
@@ -1,3 +1,4 @@
 export { createEmployeeCommandFactory } from "./createEmployeeCommandFactory";
 export { updateEmployeeCommandFactory } from "./updateEmployeeCommandFactory";
 export { deleteEmployeeCommandFactory } from "./deleteEmployeeCommandFactory";
+export { getEmployeeByIdQueryFactory } from "./employeeQueryFactory";

--- a/src/server/subdomains/estimate/application/factories/checkTaxRateThenCreateDepsFactory.ts
+++ b/src/server/subdomains/estimate/application/factories/checkTaxRateThenCreateDepsFactory.ts
@@ -1,0 +1,19 @@
+import { TaxRateConsistencyCheckDomainService } from "../../domain/services/TaxRateConsistencyCheckDomainService";
+import { PrismaTaxRateRepository } from "../../infrastructure/prisma/PrismaTaxRateRepository";
+import { createEstimateCommandFactory } from "./createEstimateCommandFactory";
+
+/**
+ * app-shared `checkTaxRateThenCreate`（ADR-0056）に渡す依存の Composition Root。
+ *
+ * 税率導出＋§8.7 整合チェックの {@link TaxRateConsistencyCheckDomainService}（編集画面と
+ * 同じ `findEffectiveAt` を共有）と、純粋な組立器 {@link CreateEstimateCommand} を解決する。
+ * 後者はセット検証用に `PrismaProductQueryService` 注入済み（ADR-0052）。
+ */
+export function checkTaxRateThenCreateDepsFactory() {
+  return {
+    taxRateConsistencyCheck: new TaxRateConsistencyCheckDomainService(
+      new PrismaTaxRateRepository()
+    ),
+    createCommand: createEstimateCommandFactory(),
+  };
+}

--- a/src/server/subdomains/estimate/application/factories/createEstimateCommandFactory.ts
+++ b/src/server/subdomains/estimate/application/factories/createEstimateCommandFactory.ts
@@ -1,3 +1,4 @@
+import { PrismaProductQueryService } from "@subdomains/product/infrastructure/queries/PrismaProductQueryService";
 import { CreateEstimateCommand } from "../commands/CreateEstimateCommand";
 import { PrismaEstimateNumberIssuer } from "../../infrastructure/prisma/PrismaEstimateNumberIssuer";
 import { PrismaEstimateRepository } from "../../infrastructure/prisma/PrismaEstimateRepository";
@@ -7,9 +8,12 @@ import { PrismaEstimateRepository } from "../../infrastructure/prisma/PrismaEsti
  *
  * ドメインインターフェース（EstimateRepository / EstimateNumberIssuer）に対する
  * Prisma 実装を解決して注入する。コマンド自身は具象実装に依存しない。
+ *
+ * セット構成のライブ区分・有効性検証（ADR-0052）に商品クエリを注入する。C4 と同型で、
+ * 作成画面（#351）から渡るセット群ペイロードを防御する。
  */
 export function createEstimateCommandFactory(): CreateEstimateCommand {
   const repository = new PrismaEstimateRepository();
   const numberIssuer = new PrismaEstimateNumberIssuer();
-  return new CreateEstimateCommand(repository, numberIssuer);
+  return new CreateEstimateCommand(repository, numberIssuer, new PrismaProductQueryService());
 }

--- a/src/server/subdomains/estimate/application/factories/estimateQueryFactory.ts
+++ b/src/server/subdomains/estimate/application/factories/estimateQueryFactory.ts
@@ -1,6 +1,8 @@
 import { GetEstimateDetailQuery } from "../queries/GetEstimateDetailQuery";
+import { ResolveEffectiveTaxRateQuery } from "../queries/ResolveEffectiveTaxRateQuery";
 import { SearchEstimatesQuery } from "../queries/SearchEstimatesQuery";
 import { PrismaEstimateQueryService } from "../../infrastructure/queries/PrismaEstimateQueryService";
+import { PrismaTaxRateRepository } from "../../infrastructure/prisma/PrismaTaxRateRepository";
 
 /** 見積詳細取得クエリ（Q1）を組み立てる。読み取りは PrismaEstimateQueryService 実装に閉じる。 */
 export function getEstimateDetailQueryFactory(): GetEstimateDetailQuery {
@@ -10,4 +12,9 @@ export function getEstimateDetailQueryFactory(): GetEstimateDetailQuery {
 /** 見積一覧取得クエリを組み立てる。代表選択・名前解決は PrismaEstimateQueryService に閉じる（ADR-0051）。 */
 export function searchEstimatesQueryFactory(): SearchEstimatesQuery {
   return new SearchEstimatesQuery(new PrismaEstimateQueryService());
+}
+
+/** 基準日の有効税率を解決するクエリ（C1 作成画面プレビュー用）。マスタ読み取りに閉じる。 */
+export function resolveEffectiveTaxRateQueryFactory(): ResolveEffectiveTaxRateQuery {
+  return new ResolveEffectiveTaxRateQuery(new PrismaTaxRateRepository());
 }

--- a/src/server/subdomains/estimate/application/factories/index.ts
+++ b/src/server/subdomains/estimate/application/factories/index.ts
@@ -1,4 +1,5 @@
 export { createEstimateCommandFactory } from "./createEstimateCommandFactory";
+export { checkTaxRateThenCreateDepsFactory } from "./checkTaxRateThenCreateDepsFactory";
 export { updateEstimateCommandFactory } from "./updateEstimateCommandFactory";
 export { addVariationCommandFactory } from "./addVariationCommandFactory";
 export { updateVariationCommandFactory } from "./updateVariationCommandFactory";

--- a/src/server/subdomains/estimate/application/queries/ResolveEffectiveTaxRateQuery.ts
+++ b/src/server/subdomains/estimate/application/queries/ResolveEffectiveTaxRateQuery.ts
@@ -1,0 +1,22 @@
+import type { TaxRateRepository } from "../../domain/repositories/TaxRateRepository";
+
+export type ResolveEffectiveTaxRateInput = {
+  /** 有効税率を解決する基準日（JST 固定パース済みの Date）。 */
+  date: Date;
+};
+
+/**
+ * 基準日に有効な消費税率を解決する読み取りクエリ（C1 作成画面のプレビュー用）。
+ *
+ * 見積年月日の変更に追従して税率を read-only 表示／明細プレビューに供給する。マスタ最古行
+ * より前など該当が無い場合は `null` を返し（想定内の表示不能）、UI 側で「税率未設定」を扱う。
+ * 編集画面と同じ `findEffectiveAt` を共有し、表示ロジックを統一する。
+ */
+export class ResolveEffectiveTaxRateQuery {
+  constructor(private readonly taxRateRepository: TaxRateRepository) {}
+
+  async execute(input: ResolveEffectiveTaxRateInput): Promise<number | null> {
+    const master = await this.taxRateRepository.findEffectiveAt(input.date);
+    return master?.rate.value ?? null;
+  }
+}

--- a/src/server/subdomains/estimate/application/queries/__tests__/ResolveEffectiveTaxRateQuery.test.ts
+++ b/src/server/subdomains/estimate/application/queries/__tests__/ResolveEffectiveTaxRateQuery.test.ts
@@ -1,0 +1,39 @@
+import { TaxRateMaster } from "@subdomains/estimate/domain/entities/TaxRateMaster";
+import type { TaxRateRepository } from "@subdomains/estimate/domain/repositories/TaxRateRepository";
+import { TaxRate } from "@subdomains/estimate/domain/values/TaxRate";
+import { TaxRateMasterId } from "@subdomains/estimate/domain/values/TaxRateMasterId";
+import { describe, expect, it, vi } from "vitest";
+import { ResolveEffectiveTaxRateQuery } from "../ResolveEffectiveTaxRateQuery";
+
+const MASTER_ID = "00000000-0000-7000-8000-0000000000f1";
+
+describe("ResolveEffectiveTaxRateQuery", () => {
+  it("有効税率が見つかれば税率値（number）を返す", async () => {
+    const master = TaxRateMaster.reconstruct(
+      new TaxRateMasterId(MASTER_ID),
+      new TaxRate(0.1),
+      new Date("2019-10-01T00:00:00+09:00")
+    );
+    const repository = {
+      findEffectiveAt: vi.fn().mockResolvedValue(master),
+    } as unknown as TaxRateRepository;
+
+    const result = await new ResolveEffectiveTaxRateQuery(repository).execute({
+      date: new Date("2026-06-17T00:00:00+09:00"),
+    });
+
+    expect(result).toBe(0.1);
+  });
+
+  it("有効税率が無ければ null を返す（マスタ最古行より前など）", async () => {
+    const repository = {
+      findEffectiveAt: vi.fn().mockResolvedValue(null),
+    } as unknown as TaxRateRepository;
+
+    const result = await new ResolveEffectiveTaxRateQuery(repository).execute({
+      date: new Date("2000-01-01T00:00:00+09:00"),
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/server/subdomains/estimate/application/shared/__tests__/checkTaxRateThenCreate.test.ts
+++ b/src/server/subdomains/estimate/application/shared/__tests__/checkTaxRateThenCreate.test.ts
@@ -1,0 +1,52 @@
+import type { Estimate } from "@subdomains/estimate/domain/entities";
+import type { CreateEstimateCommand } from "@subdomains/estimate/application/commands/CreateEstimateCommand";
+import type { TaxRateConsistencyCheckDomainService } from "@subdomains/estimate/domain/services/TaxRateConsistencyCheckDomainService";
+import { TaxRate } from "@subdomains/estimate/domain/values/TaxRate";
+import { describe, expect, it, vi } from "vitest";
+import { checkTaxRateThenCreate } from "../checkTaxRateThenCreate";
+
+/** taxRate を除いた作成入力の最小フィクスチャ（関数は中身を検証せず委譲するだけ）。 */
+function inputFixture() {
+  return {
+    estimateType: "NEW",
+    estimateDate: new Date("2019-09-30T00:00:00+09:00"),
+    deadline: new Date("2019-10-31T00:00:00+09:00"),
+    customerId: "00000000-0000-7000-8000-000000000001",
+    deliveryLocationId: "00000000-0000-7000-8000-000000000002",
+    taxRoundingType: "ROUND_DOWN",
+    createdBy: "00000000-0000-7000-8000-000000000003",
+    departmentId: "00000000-0000-7000-8000-000000000004",
+    variations: [],
+  };
+}
+
+describe("checkTaxRateThenCreate", () => {
+  it("税率が一致するとき、解決税率をコマンドへ注入して作成し created を返す", async () => {
+    const sentinel = { id: "estimate" } as unknown as Estimate;
+    const execute = vi.fn().mockResolvedValue(sentinel);
+    const check = vi.fn().mockResolvedValue({ kind: "consistent", rate: new TaxRate(0.1) });
+
+    const result = await checkTaxRateThenCreate(inputFixture(), {
+      taxRateConsistencyCheck: { check } as unknown as TaxRateConsistencyCheckDomainService,
+      createCommand: { execute } as unknown as CreateEstimateCommand,
+    });
+
+    expect(result).toEqual({ kind: "created", estimate: sentinel });
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({ taxRate: 0.1 }));
+  });
+
+  it("税率が不一致のとき、作成せず両税率を載せた taxRateMismatch を返す", async () => {
+    const execute = vi.fn();
+    const estimateDateRate = new TaxRate(0.08);
+    const deadlineRate = new TaxRate(0.1);
+    const check = vi.fn().mockResolvedValue({ kind: "mismatch", estimateDateRate, deadlineRate });
+
+    const result = await checkTaxRateThenCreate(inputFixture(), {
+      taxRateConsistencyCheck: { check } as unknown as TaxRateConsistencyCheckDomainService,
+      createCommand: { execute } as unknown as CreateEstimateCommand,
+    });
+
+    expect(result).toEqual({ kind: "taxRateMismatch", estimateDateRate, deadlineRate });
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/subdomains/estimate/application/shared/checkTaxRateThenCreate.ts
+++ b/src/server/subdomains/estimate/application/shared/checkTaxRateThenCreate.ts
@@ -1,0 +1,54 @@
+import type { Estimate } from "@subdomains/estimate/domain/entities";
+import type { TaxRateConsistencyCheckDomainService } from "@subdomains/estimate/domain/services/TaxRateConsistencyCheckDomainService";
+import type { TaxRate } from "@subdomains/estimate/domain/values/TaxRate";
+import type { CreateEstimateCommand, CreateEstimateInput } from "../commands/CreateEstimateCommand";
+
+/**
+ * 税率チェック→作成の結果（C1 専用・ADR-0056）。
+ *
+ * 予測可能な業務分岐（税率不一致）は Result で返し、想定外（適用税率なし・採番衝突・
+ * VO 検証失敗）は呼び出し側へ throw で抜ける（ADR-0037/0038）。更新系の
+ * {@link import("./checkTaxRateThenSave").TaxCheckedSaveResult} と app-shared 層で対称をなす。
+ */
+export type TaxCheckedCreateResult =
+  | { kind: "created"; estimate: Estimate }
+  | { kind: "taxRateMismatch"; estimateDateRate: TaxRate; deadlineRate: TaxRate };
+
+/**
+ * 見積作成時の税率「導出＋整合チェック」を 1 箇所に集約した app-shared ラッパ（ADR-0056）。
+ *
+ * 設計書 §8.7 の税率整合（見積年月日の税率＝締切日の税率）を検証し、不一致なら**作成せず**
+ * Result を返す（保存時＝その場で修正）。一致時はそのとき確定した単一税率を採用税率として
+ * {@link CreateEstimateCommand} へ注入し作成する。
+ *
+ * 更新系 `checkTaxRateThenSave`（チェックのみ）と異なり、作成系は税率を導出する。導出は
+ * 既存の {@link TaxRateConsistencyCheckDomainService}（編集画面と同じ `findEffectiveAt`）を
+ * 再利用するため、フォームに税率入力欄を持たせない。`CreateEstimateCommand` は純粋な
+ * 組立器のまま据え置き、税率関心はこのラッパが所有する（ADR-0056 の非対称）。
+ */
+export async function checkTaxRateThenCreate(
+  input: Omit<CreateEstimateInput, "taxRate">,
+  deps: {
+    taxRateConsistencyCheck: TaxRateConsistencyCheckDomainService;
+    createCommand: CreateEstimateCommand;
+  }
+): Promise<TaxCheckedCreateResult> {
+  const result = await deps.taxRateConsistencyCheck.check({
+    estimateDate: input.estimateDate,
+    deadline: input.deadline,
+  });
+
+  if (result.kind === "mismatch") {
+    return {
+      kind: "taxRateMismatch",
+      estimateDateRate: result.estimateDateRate,
+      deadlineRate: result.deadlineRate,
+    };
+  }
+
+  const estimate = await deps.createCommand.execute({
+    ...input,
+    taxRate: result.rate.value,
+  });
+  return { kind: "created", estimate };
+}

--- a/src/shared/constants/redirect-reasons.ts
+++ b/src/shared/constants/redirect-reasons.ts
@@ -29,6 +29,7 @@ export const REDIRECT_REASON = {
   DELIVERY_LOCATION_DELETED: "delivery_location_deleted",
   DELIVERY_LOCATION_ACTIVATED: "delivery_location_activated",
   DELIVERY_LOCATION_DEACTIVATED: "delivery_location_deactivated",
+  ESTIMATE_CREATED: "estimate_created",
   ESTIMATE_UPDATED: "estimate_updated",
 } as const;
 


### PR DESCRIPTION
## Summary

新規見積作成ルート `/estimates/new` と統合作成フォームを実装し、`CreateEstimateCommand` を1回駆動して見積（ヘッダー＋初期バリエーション1件）を原子的に新規作成、作成後に詳細画面（`[estimateNumber]`）へ遷移できるようにしました。税率は見積年月日からマスタ導出して read-only 表示し、§8.7 税率不一致は app-shared `checkTaxRateThenCreate`（ADR-0056）で検出してフォームエラーとして警告します。編集画面（#342/#346/#333）と部品・検証ロジックの原子を統一しました。

Closes #351

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### create-estimate-screen.md

#### 概要

新規見積作成ルート `/estimates/new` と作成フォームを実装し、`CreateEstimateCommand` を1回駆動して見積を原子的に新規作成、作成後に詳細画面（`[estimateNumber]`）へ遷移する。

- ヘッダー基本情報（見積年月日・締切日・得意先・納品先・部署・税端数区分・見積区分）＋ 区分別サブタイプ詳細（修理／事後修理）＋ 初期バリエーション1件（提出区分・通常明細・自動展開セット群・全体値引・メモ）を**単一の統合フォーム**で入力し、**単一の `createEstimate` Server Action** でまとめて保存する（空見積不可＝≥1バリの原子的作成）。
- 税率はユーザー入力にせず、見積年月日からマスタ導出して read-only 表示（編集画面と統一）。§8.7 税率不一致は保存せずフォームエラーで警告する。
- 編集画面（#342/#346/#333 で出荷済み）と**部品・ロジックを積極的に統一**する方針（不都合がない箇所のみ）。統一の単位はラッパフォーム丸ごとではなく、内側の dumb 部品と検証ロジックの原子。

#### 設計判断

- **税率の供給**: 見積年月日からマスタ導出・read-only を採用（編集画面の read-only 方針と一致、整合チェックが解決する税率を再利用）。
- **税率導出＋§8.7 チェックの配置（ADR-0056）**: `CreateEstimateCommand` 据え置き＋ app-shared `checkTaxRateThenCreate` を新設しアクションが使用。既存 `TaxRateConsistencyCheckDomainService` を再利用しコマンドを純粋な組立器に保つ。
- **フォーム骨格**: 単一統合フォーム＋単一アクションで原子的作成。空見積不可（≥1バリ必須）の原子性を構造的に担保。
- **ヘッダー部の統一手段**: 共有 dumb 部品（修理/事後修理塊・FK選択フィールド）を抽出し、出荷済み編集フォームも差し替え（重複を残さない）。
- **作成者・部署の解決**: 作成者＝`session.user.employeeId`（read-only・null は作成不可）。部署は有効部署の手動 select（自動解決は後続 #374）。
- **初期バリエーション件数**: 正確に1件。2件目以降は詳細画面の C3 で追加。
- **セット群対応**: 自動展開のみ（手動構成追加は #350 へ繰り延べ）。`assertSetComponentsValid`（ADR-0052）を C4 と同型で適用。
- **税率プレビュー**: 見積年月日変更時にサーバで有効税率をライブ解決し、ヘッダー read-only 表示＆プレビュー税率に使用。
- **作成スキーマ**: 専用 `createEstimateSchema` を共有原子から構成（version/taxRate は含めない）。サブタイプ必須性は `superRefine` で区分別に条件必須化。
- **テスト戦略**: 単体は各ステップ内で test-first（`checkTaxRateThenCreate`・`createEstimateSchema` の conform 経路）。UI は E2E を外側ループとして検証（ダブルループ）。

#### ステップ

1. app-shared `checkTaxRateThenCreate` ＋ 作成配線ファクトリ（test-first）
2. 税率ライブ解決の Server Action
3. 作成スキーマ `createEstimateSchema`（test-first）
4. ヘッダー共有部品の抽出と編集フォーム差し替え（案a）
5. 作成フォーム本体（統合フォーム）
6. `createEstimate` アクション ＋ ルート ＋ リダイレクト
7. E2E `estimates-create.e2e.ts`（受け入れ条件4本＝外側ループ）

</details>

## 計画からの逸脱

1. **Step 2 に専用クエリ `ResolveEffectiveTaxRateQuery` を新設**
   - 計画は「`TaxRateRepository.findEffectiveAt` で有効税率を返す薄い Server Action」だったが、Server Action はアプリ層クエリ `ResolveEffectiveTaxRateQuery` 経由で解決する形にした。
   - 理由: presentation がドメインリポジトリを直接握るのを避け DDD レイヤリングを保つため。単一日付の解決は 2 日付比較の `TaxRateConsistencyCheckDomainService` とは別関心。

2. **Step 5・6 を「コンパイル可能な意味単位」で3コミットに再分割**
   - 計画の2ステップを、(1) `SubmissionTypeField` の共有抽出、(2) `createEstimate` アクション＋`ESTIMATE_CREATED`、(3) `CreateEstimateForm` 本体＋ルート、の3コミットに再編。
   - 理由: フォームはアクションに依存するため Step 5 単独ではコンパイルできない。各コミットが tsc/lint を通る意味単位へ分割（設計内容自体は不変）。

3. **作成者氏名解決のため `getEmployeeByIdQueryFactory` を新設**
   - employee サブドメインに既存 `GetEmployeeByIdQuery` の Composition Root を追加し、RSC で作成者 DTO を解決。
   - 理由: 作成者表示名「氏名（コード）」の解決に既存クエリのファクトリが無かったため。

## Test Plan

- 単体テスト（test-first）
  - [ ] `checkTaxRateThenCreate.test.ts`: 8%/10% 境界で consistent→`created` / mismatch→`taxRateMismatch` union
  - [ ] `ResolveEffectiveTaxRateQuery.test.ts`: 見積年月日からの有効税率解決
  - [ ] `schema.conform.test.ts`: 区分別必須（NEW=不要 / REPAIR・AFTER_REPAIR=各3項目）・空メモの undefined 化・`nodesField` パース
- E2E（`estimates-create.e2e.ts`・受け入れ条件4本）
  - [ ] NEW 作成 → 詳細画面へ遷移
  - [ ] 自動展開セット群を含む作成
  - [ ] REPAIR / AFTER_REPAIR の区分別情報入力で作成
  - [ ] 税率不一致（見積年月日 2019-09-30／締切日 2019-10-01）でフォーム警告
- 回帰
  - [ ] Step 4 のヘッダー共有部品差し替えで編集画面の挙動が不変であること（既存テスト／E2E がガード）

---

Generated with [Claude Code](https://claude.ai/code)
