### PR TITLE
feat: 見積詳細画面 得意先改訂（C7）の UI 配線

### DIFF
--- a/docs/business/estimate/ユースケース一覧(見積).md
+++ b/docs/business/estimate/ユースケース一覧(見積).md
@@ -38,7 +38,7 @@
 | C4 | `UpdateVariation` | estimate | variationId + メモ/明細/全体値引 | 無効状態は編集不可(§3.4) / 保存時 再計算 | 間接 |
 | C5 | `DeactivateVariation` / `ActivateVariation` | estimate | variationId | 申請中・承認済は無効化不可 / 無効→有効は無条件(§3.4) | **直接** |
 | C6 | `DuplicateEstimate`（複製・集約またぎ） | estimate | sourceEstimateId + 選択 variationId[]（複数可・順序保持） | 選択順保持・連番振り直し / 単価クリア / 申請レコード作らない(§5) / `EstimateVariationCopy` 生成 / 新見積を新採番 | – |
-| C7 | `ReviseForCustomer`（得意先改訂・集約内） | estimate | estimateId + sourceVariationId | 同一見積内に新バリエーション生成 / 改訂元を凍結(§7.2) / `deliveryPrice` スナップショット(§8.4) / `EstimateVariationRevision` 生成 / 採番なし | – |
+| C7 | `ReviseForCustomer`（得意先改訂・集約内） | estimate | estimateId + sourceVariationId + version | 同一見積内に新バリエーション生成 / 改訂元を凍結(§7.2) / `deliveryPrice` スナップショット(§8.4) / `EstimateVariationRevision` 生成 / 採番なし / **改訂先の内容はドメインが改訂元から全複写で決定する**ため UI は内容入力を取らない純粋確認ゲート（version は楽観ロックトークン・ADR-0039） / 初回改訂でヘッダーロック発火(ADR-0049) | – |
 | C8 | `CreateOrder` | order | variationId | 承認済 or 承認不要(事後)から(§4.3) / 納品先見積は不可(§7.2) / 税率チェック(§8.6) / `Order` 行生成 | **直接** |
 | C9 | `UpdateOrderNote` | order | orderId + メモ | メモのみ編集(§4.4) | – |
 | C10 | `ConfirmOrder` | order | orderId + 納期 | 納期必須(§4.5) → `OrderConfirmation` 生成 / 税率チェック | – |

--- a/docs/claude-plans/issue-359/deviations.md
+++ b/docs/claude-plans/issue-359/deviations.md
@@ -1,0 +1,49 @@
+# Issue #359 実装計画からの逸脱記録
+
+`docs/claude-plans/issue-359/revise-for-customer-c7-ui.md` の計画に対し、実装中に生じた逸脱を記録する。
+
+## 1. ファイルパスの相違（Step 3）
+
+- **元の計画**: リダイレクト理由を `src/server/shared/constants/redirect-reasons.ts`、フラッシュ文言を
+  `flash-message-handler.tsx` に追記する。
+- **実際の実装**: 実体は `src/shared/constants/redirect-reasons.ts`（`server/` 配下ではない）と
+  `src/app/_components/redirect-reason-toast.tsx`。両ファイルに `ESTIMATE_REVISED` とトーストを追記した。
+- **理由**: 計画策定時のパス記憶違い。`FLASH_MESSAGES` が `Record<RedirectReason, FlashMessage>` 型で
+  網羅を型強制するため、定数追加とメッセージ追加は同一コミットで揃える必要があった（計画どおり1コミット）。
+
+## 2. ステップ順序の入れ替え（Step 2 と Step 3）
+
+- **元の計画**: Step 2（Server Action）→ Step 3（リダイレクト理由）。
+- **実際の実装**: Step 3 → Step 2 の順でコミットした。
+- **理由**: Server Action が `REDIRECT_REASON.ESTIMATE_REVISED` を参照するため、定数を先に入れないと
+  Step 2 のコミットが型エラーで壊れる。各コミットがビルド可能であることを優先した。
+
+## 3. Step 4 を TDD で実装（実装先行 → ユニットTDD）
+
+- **元の計画**: 適格ゲート `isVariationRevisableForCustomer` は「実装先行」。
+- **実際の実装**: co-located `variationEditable.test.ts` に RED→GREEN で追加した（純粋述語のため）。
+- **理由**: 対象が副作用のない純粋述語で、既存の co-located テストがあり TDD が自然だったため。複製適格との
+  差（凍結判定を持たない＝再改訂許可）をテストで明示でき、回帰ガードとして有効。
+
+## 4. 専用シード見積 N9905006 の追加（Step 7）
+
+- **元の計画**: E2E は `estimates-revise-for-customer.e2e.ts`（新設）のみ。シード変更は明記なし。
+- **実際の実装**: `prisma/seed-estimates.ts` に C7 専用の見積 `N9905006`（改訂前・hasRevision=false／
+  納品先宛 V1＝改訂元適格・得意先宛 V2＝適格外）を追加した。
+- **理由**: 改訂は必ず集約を破壊的に変更する。共有見積（N9905001 等）を改訂操作の対象にすると他テスト
+  ファイルと状態が結合し脆くなる。各シナリオが専用見積を持つ既存パターン（editable/revised/setGroup）に
+  そろえ、初回改訂→ヘッダーロック発火の遷移を観測できる clean な起点を用意した。
+
+## 5. Step 7 ② の検証内容の変更（凍結の UI 観測は不可能）★重要
+
+- **元の計画**: 改訂実行後「改訂元タブに『内容を編集』が出ない＝凍結を UI 観測」する。
+- **実際の実装**: その検証は行わず、代わりに UI 観測可能な結果（改訂先 V3 タブの出現・得意先向けバッジ・
+  専用フラッシュ「得意先改訂しました」・初回改訂後のヘッダーロック）を検証した。
+- **理由**: 現実装では改訂元の凍結を UI から観測できない。
+  - `VariationDTO` は per-variation の凍結フラグを持たない（系譜ラベルは S6 送り・DTO コメント参照）。
+  - 改訂元の凍結はドメイン `editableVariationOrThrow`（集約横断ガード）で強制され、改訂元の明細自体には
+    `revisedDeliveryPrice` が付かない（スナップショットは改訂先の明細に複写される）。
+  - 結果として `isVariationEditable(改訂元)` は改訂後も `true`（ACTIVE かつ自分の明細に改訂価格なし）で、
+    改訂元タブの「内容を編集」ボタンは残る。クリックして保存するとドメインが例外を投げる二重防御の内側。
+  - よって「編集ボタン消失」は起こらず、計画の前提が現実装と矛盾していた。ADR-0012（テストで Prisma 直接
+    利用禁止）もありフラグの DB 直接確認もしないため、凍結はユニットテスト済みとして扱い E2E からは外した。

--- a/docs/claude-plans/issue-359/revise-for-customer-c7-ui.md
+++ b/docs/claude-plans/issue-359/revise-for-customer-c7-ui.md
@@ -1,0 +1,160 @@
+# Issue #359: 見積詳細画面 得意先改訂（C7）の UI 配線 — 実装計画
+
+> 本計画は `/grill-with-docs` セッション（2026-06-18）で合意した内容の結晶化。
+> #359 はドメイン `Estimate.reviseForCustomer` ／ アプリ `ReviseForCustomerCommand` が
+> 実装済み・ユニットテスト完備で、欠けているプレゼン層配線のみを対象とするスライス。
+> 用語は CONTEXT.md「得意先改訂 / 改訂元 / 凍結 / 改訂先 / 改訂系譜 / 行構成固定」で既に網羅されており、
+> 本セッションで新語・語義衝突・鋭利化すべき曖昧語は生じなかった（CONTEXT.md 変更不要）。
+
+## 概要
+
+見積詳細画面に得意先改訂（C7 `ReviseForCustomer`）の UI を実装し、既存コマンドへ配線する。
+納品先宛バリエーションを改訂元として、同一見積内に得意先宛の改訂先バリエーションを生成する操作。
+
+調査で確定した本質的前提:
+
+- ドメイン `Estimate.reviseForCustomer(sourceVariationId)` は **内容入力を一切取らない**。改訂先の
+  明細・メモ・全体値引は改訂元からの全複写でドメインが決定し、`finalAmount` を改訂後納品単価
+  （`RevisedEstimateItemDetail`）としてスナップショットする（`Estimate.ts:209`）。
+- したがって C3 バリエーション複製のような「プリフィルした作成フォームを開く」UX は不要。
+  入力は `sourceVariationId + version` の 2 つだけで、UI は実質「ボタン → 確認モーダル → 純粋コマンド送信」。
+- C7 の設計が C3/C6 より小さいのは、入力面積がコマンド署名で規定されるため（偶然ではなく
+  ドメインがプレゼンを規定した結果）。スキーマ・写像・金額プレビューはいずれも不要。
+
+## 設計判断
+
+### 改訂元ボタンの適格条件
+- A. 「納品先宛（DELIVERY_LOCATION）かつ 有効（ACTIVE）」のみ＝ドメイン2ガードの写し。再改訂を許す。
+- B. A に加えて「既に改訂元になった（凍結済み）バリは除外」＝再改訂禁止。
+- **採用: A**。理由:
+  - 二重防御の原則。UI ゲートはドメインガード（`isDeliveryLocation() && isActive()`）の外側の写しであるべきで、
+    ドメインに無い「2回目禁止」を UI だけで発明すると整合性ルールが乖離する。
+  - スコープ最小。「凍結済みか」の UI 判定には DTO への per-variation 凍結フラグ追加が必要だが、
+    現状 `VariationDTO` は持たない（系譜ラベルは S6 送り）。本 issue は配線のみのスライス。
+  - 業務的に無害。改訂は改訂元を変更しないため、同一納品先ベースから複数の得意先向け提案を作るのは
+    自然な操作。再改訂禁止が必要ならドメイン不変条件として実装すべき別関心事。
+
+### 確認ダイアログの実装方式とエラー表示先
+- A. `window.confirm`（既存タブ切替破棄と同方式）。
+- B. `dialog.tsx`（shadcn Dialog）モーダル。
+- **採用: B**。理由:
+  - 不可逆性（改訂系譜生成＋改訂元凍結）に見合う説明責任。汎用 OK/Cancel では「凍結」を説明しきれない。
+  - 税率不一致（§8.7）・楽観ロック競合（ADR-0039）の `formErrors` をモーダル内インラインに置ける。
+    C7 には C4 のような常設編集フォームが無く、`window.confirm` 経路だとエラーの描画先が宙に浮く。
+  - C6 がモーダル駆動コマンド（ADR-0057）にした前例にそろう。
+
+### 確認モーダルの警告文
+- A. issue 通り「改訂元の凍結」のみ告知。
+- B. 凍結は常時告知し、**初回改訂時（`hasRevision === false`）のみ**「以後この見積の見積年月日・税率・
+     税端数・得意先・納品先が変更不可になる」を追記。
+- **採用: B**。理由:
+  - 不可逆な結果の完全開示。最初の改訂はヘッダーロック（CONTEXT.md「得意先改訂」定義の本質的帰結）を
+    発火させる。凍結だけ告げてロックを伏せるのは片手落ち。
+  - 既存の top-level `hasRevision`（C2 の disabled 出し分け用）で「初回か」を正確に判定でき、2 回目以降は
+    既にロック済みなので冗長な文言を出さない精密制御が可能。締切日・部署は改訂後も可変なので列挙から除く。
+
+### 成功後フィードバック
+- A. `ESTIMATE_UPDATED` 再利用（フラッシュ「更新しました」）。
+- B. 専用 `REDIRECT_REASON.ESTIMATE_REVISED` ＋静的フラッシュ「得意先改訂しました」。タブ自動フォーカス無し。
+- C. B に加えて改訂先タブを自動フォーカス。
+- **採用: B**。理由:
+  - 改訂は新バリを生む不可逆操作で「更新しました」では結果を取り違える。固有フィードバックが要る
+    （C6 の `ESTIMATE_DUPLICATED` 前例にそろう）。
+  - AC「改訂後、得意先宛の新バリが詳細画面に表示される」はタブ一覧出現で充足。自動フォーカスは未要求。
+  - C は改訂先 variationId 導出（`TaxCheckedSaveResult.saved` は集約全体しか返さない）＋クエリ受け渡し＋
+    `VariationPanel` の初期タブ上書きを伴い「配線のみ」を超える。望むなら別 polish/issue が素直。
+
+### ADR の要否
+- **新規 ADR は作らない**（ユーザー判断で確定）。理由:
+  - 唯一の候補「改訂モーダル＝編集要素ゼロの純粋確認ゲート（C3 プリフィル／C6 ヘッダー入力と対照）」は、
+    コマンド署名が内容を取らないことの直接の帰結で、その大元は ADR-0044（改訂系譜は集約内）/
+    ADR-0045（提出区分不変）/ ADR-0046（改訂済みは粒度調整のみ）＋ CONTEXT.md（行構成固定・凍結）に記録済み。
+    「再現困難＋驚き＋真のトレードオフ」を 3 つとも満たす新決定ではない。
+  - モーダル駆動コマンドは ADR-0057（C6）が既出。C3 配線スライスも「新規 ADR 不要」と判断済みで、本スライスは
+    さらに導出的。
+
+### CONTEXT.md の要否
+- **変更不要**。C7 の語彙（得意先改訂・改訂元・凍結・改訂先・改訂系譜・行構成固定）は既存定義で正確かつ網羅的。
+
+### 実装方式（/tdd）
+- 純粋モジュール（入力スキーマ）は co-located `*.test.ts` で behavior ごとに RED→GREEN（test+impl 同一コミット）。
+  ただし C3/C6 と異なり写像・プレビューが無いため TDD 対象は実質スキーマのみで小さい。
+- 配線層（Server Action・モーダル・Panel）はユニット不可（conform+FormData／プレゼン）のため実装先行。
+  コアロジックはドメイン／アプリのユニットで検証済み・規約により E2E のみで配線を検証する（`actions.ts` に倣う）。
+- E2E は配線後の統合受け入れ。bulk author せず 1 ケースずつ追加・実行する。
+- `PanelMode` 判別共用体は body モード（閲覧／編集／新規追加／複製）用なので触らない。確認モーダルは body を
+  置換しないオーバーレイのため、モーダル開閉は `PanelMode` と直交した別 state で管理する。
+
+## ステップ
+
+> **TDD 構成**: 純粋ロジック（入力スキーマ）のユニットを実装スライスへ畳み込み（RED→GREEN）、E2E のみ
+> 配線後の受け入れに残す（C3/#334 計画を踏襲）。各 Step の `[ ]` は実装方式。
+
+### Step 1: 得意先改訂の入力スキーマ ［ユニットTDD: RED→GREEN］
+- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/reviseForCustomerSchema.ts`（新設）／`reviseForCustomerSchema.test.ts`
+- 作業内容（behavior ごとに RED→GREEN、test+impl 同一コミット）:
+  - `reviseForCustomerSchema` を定義（`version: number` ＋ `sourceVariationId: string`）。
+  - behavior: ①有効入力（tracer）②`version` 数値強制 ③`sourceVariationId` 必須（回帰ガード）。
+  - 内容フィールドは無い（ドメインが全複写で決定）ため明細系の検証は持たせない。
+- コミットメッセージ: `feat: 得意先改訂（C7）の入力スキーマを追加する`
+
+### Step 2: Server Action（C7 配線）［実装先行］
+- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/actions.ts`
+- 作業内容:
+  - `reviseForCustomer` を追加。C2/C4 同型（`verifySession` → `parseWithZod`(`reviseForCustomerSchema`) →
+    DTO で `estimateId` 解決 → `ReviseForCustomerInput`{estimateId, sourceVariationId, version} →
+    `reviseForCustomerCommandFactory().execute()`）。
+  - 税率不一致（§8.7・`taxRateMismatch`）は `taxRateMismatchFormErrors` でモーダル維持、競合・その他例外は
+    `handleCommandError` 経由でフォームエラー化。成功で `revalidatePath`＋`redirect(ESTIMATE_REVISED)`。
+  - テストなし（規約・コアは Step1＋ドメイン/アプリのユニットで検証済み）。
+- コミットメッセージ: `feat: 得意先改訂の Server Action（C7配線）を追加する`
+
+### Step 3: リダイレクト理由とフラッシュ ［実装先行］
+- 対象ファイル: `src/server/shared/constants/redirect-reasons.ts`、`flash-message-handler.tsx`（フラッシュ文言の所在）
+- 作業内容:
+  - `REDIRECT_REASON.ESTIMATE_REVISED = "estimate_revised"` を追加。
+  - フラッシュハンドラに静的メッセージ「得意先改訂しました」（SUCCESS）を追記。
+- コミットメッセージ: `feat: 得意先改訂成功のリダイレクト理由とフラッシュを追加する`
+
+### Step 4: 適格ゲート ［実装先行］
+- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/variationEditable.ts`
+- 作業内容:
+  - `isVariationRevisableForCustomer(v)` を追加。条件は `submissionType==="DELIVERY_LOCATION"` かつ
+    `status==="ACTIVE"`（ドメイン `reviseForCustomer` の 2 ガードの写し・再改訂許可で凍結判定は持たない）。
+- コミットメッセージ: `feat: 得意先改訂の改訂元適格ゲートを追加する`
+
+### Step 5: 確認モーダル ［実装先行］
+- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/ReviseForCustomerDialog.tsx`（新設）
+- 作業内容:
+  - `dialog.tsx` ベースのモーダルに `useActionState` フォームを内包。隠しフィールドは `version`（prop）＋
+    `sourceVariationId`（active バリの `variationId`）。
+  - 警告文: 凍結は常時告知。`hasRevision === false` のときのみヘッダーロック告知を追記（締切日・部署は除外）。
+  - `formErrors`（税率不一致・競合）をモーダル内インライン描画。送信中は二重送信抑止。
+- コミットメッセージ: `feat: 得意先改訂の確認モーダルを実装する`
+
+### Step 6: VariationPanel 配線 ［実装先行］
+- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx`、詳細ページ（`hasRevision` の引き回し元）
+- 作業内容:
+  - 操作行(⑤) にゲート付き「得意先改訂」ボタン（`isVariationRevisableForCustomer(active)` のときのみ表示）。
+  - ボタン押下で確認モーダルを開く（`PanelMode` と直交した別 state）。`hasRevision` を page → `VariationPanel`
+    → モーダルへ prop で通す。
+- コミットメッセージ: `feat: 見積詳細画面に得意先改訂の操作を配線する`
+
+### Step 7: E2E 統合受け入れ（1 ケースずつ追加・実行）［統合受け入れ］
+- 対象ファイル: `estimates-revise-for-customer.e2e.ts`（新設）
+- 作業内容（bulk author せず 1 ケース追加→`pnpm e2e`→次、を反復）:
+  - ①納品先宛・ACTIVE バリの操作行にのみ「得意先改訂」ボタンが出る（得意先宛・無効では非表示）。
+  - ②ボタン → 確認モーダル → 実行で、同一見積内に得意先宛の改訂先バリが出現し、改訂元が凍結される
+    （改訂元タブに「内容を編集」が出ない＝凍結を UI 観測）。
+  - ③初回改訂後、ヘッダー編集（C2）の見積年月日・税率・税端数・得意先・納品先が disabled になる
+    （ヘッダーロックを UI 観測）。
+  - 系譜・凍結の DB アサートはしない（ADR-0012: テストで Prisma 直接利用禁止）。ドメイン保証は
+    ユニットテスト済みとして扱い、E2E は UI 観測可能な結果のみ検証する。
+- コミットメッセージ: `test: 得意先改訂（C7）の E2E を追加する`
+
+### Step 8: ドキュメント整合
+- 対象ファイル: `docs/business/estimate/ユースケース一覧(見積).md`、（逸脱があれば）`docs/claude-plans/issue-359/deviations.md`
+- 作業内容:
+  - ユースケース一覧の C7 行の入力粒度を `estimateId + sourceVariationId + version` に更新し、UI が純粋確認
+    ゲート（内容入力なし）である旨を注記する。
+- コミットメッセージ: `docs: 得意先改訂（C7）のユースケースを反映する`

--- a/prisma/seed-estimates.ts
+++ b/prisma/seed-estimates.ts
@@ -48,6 +48,8 @@ export const SEED_ESTIMATE_NUMBERS = {
   revised: "N9905004",
   /** S5 セット群編集の E2E 用（セット群1＋通常明細1・非改訂 ACTIVE＝編集対象）。 */
   setGroup: "N9905005",
+  /** C7 得意先改訂の E2E 用（改訂前・hasRevision=false の起点。納品先宛 V1＝改訂元適格）。 */
+  reviseSource: "N9905006",
 } as const;
 
 /** 見積が参照する FK マスタ（呼び出し側 seed の作成済みデータから解決した ID）。 */
@@ -195,6 +197,31 @@ function buildRevisedEstimate(fk: EstimateSeedFk) {
   return estimate;
 }
 
+/**
+ * C7 得意先改訂 E2E 用の見積（改訂前・hasRevision=false）。改訂操作の起点。
+ * V1 は納品先宛・ACTIVE（改訂元適格＝得意先改訂ボタンが出る）、V2 は得意先宛・ACTIVE
+ * （適格外＝ボタンが出ない）。系譜は張らず、改訂操作そのもので改訂先 V3 を生成させ
+ * 初回改訂→ヘッダーロック発火の遷移を観測できるようにする。
+ */
+function buildReviseSourceEstimate(fk: EstimateSeedFk) {
+  return EstimateFactory.create({
+    ...header(fk),
+    estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.reviseSource),
+    variations: [
+      {
+        variationNumber: 1,
+        submissionType: SubmissionType.DELIVERY_LOCATION,
+        items: [mkItem(fk.productAId, 1, "改訂元明細(納品先)", 1, 5000)],
+      },
+      {
+        variationNumber: 2,
+        submissionType: SubmissionType.CUSTOMER,
+        items: [mkItem(fk.productBId, 1, "得意先明細", 1, 6000)],
+      },
+    ],
+  });
+}
+
 /** 全バリエーション無効の見積（全無効警告の確認用）。 */
 function buildAllInactiveEstimate(fk: EstimateSeedFk) {
   const estimate = EstimateFactory.create({
@@ -288,6 +315,7 @@ export async function seedEstimates(prisma: PrismaClient): Promise<number> {
     buildAllInactiveEstimate(fk),
     buildEditableEstimate(fk),
     buildRepairSeedEstimate(fk),
+    buildReviseSourceEstimate(fk),
   ];
   for (const estimate of estimates) {
     // 上記はセット群なし → 所属交差表の createMany は不要。
@@ -314,6 +342,6 @@ export async function seedEstimates(prisma: PrismaClient): Promise<number> {
     });
   }
 
-  // estimates（4）＋ セット群付き（1）＋ 改訂済み（1）。
+  // estimates（5）＋ セット群付き（1）＋ 改訂済み（1）。
   return estimates.length + 2;
 }

--- a/src/app/(features)/estimates/[estimateNumber]/ReviseForCustomerDialog.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/ReviseForCustomerDialog.tsx
@@ -54,7 +54,7 @@ export function ReviseForCustomerDialog({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="bg-white hover:bg-gray-100 text-gray-700 font-bold py-2 px-4 rounded border border-gray-300 focus:outline-none focus:shadow-outline"
+        className="bg-orange-500 hover:bg-orange-700 text-white text-sm font-bold py-1 px-4 rounded focus:outline-none focus:shadow-outline"
       >
         得意先改訂
       </button>

--- a/src/app/(features)/estimates/[estimateNumber]/ReviseForCustomerDialog.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/ReviseForCustomerDialog.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { getFormProps, getInputProps } from "@conform-to/react";
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/app/_components/shadcnui/dialog";
+import { useServerForm } from "@/app/_hooks/useServerForm";
+import { reviseForCustomer } from "./actions";
+import { reviseForCustomerSchema } from "./reviseForCustomerSchema";
+
+type Props = {
+  /** 見積番号（Server Action の束縛・成功時 redirect の戻り先に使う）。 */
+  estimateNumber: string;
+  /** 親集約の楽観ロックトークン（ADR-0039）。hidden で往復する。 */
+  version: number;
+  /** 改訂元（納品先宛・ACTIVE）のバリエーション ID。hidden で往復する。 */
+  sourceVariationId: string;
+  /** 改訂元の案番号（確認文の表示用）。 */
+  sourceVariationNumber: number;
+  /**
+   * この見積に既に改訂系譜が存在するか（top-level・ADR-0049）。初回改訂（false）のときのみ
+   * ヘッダーロックの告知を出す（2 回目以降は既にロック済みで冗長なため）。
+   */
+  hasRevision: boolean;
+};
+
+/**
+ * 得意先改訂の確認モーダル（C7）。
+ *
+ * 操作行の「得意先改訂」ボタン（トリガー）とモーダルを内包する自己完結コンポーネント。改訂先の
+ * 内容はドメインが改訂元から全複写で決定するため利用者の入力面は無く、UI は「ボタン → 確認 →
+ * 純粋コマンド送信」に徹する（hidden は version と sourceVariationId のみ）。確認に `dialog.tsx`
+ * モーダルを使うのは、不可逆な結果（改訂系譜生成・改訂元凍結・初回はヘッダーロック）の説明責任と、
+ * 税率不一致（§8.7）・楽観ロック競合（ADR-0039）の formErrors をモーダル内インラインに置くため
+ * （window.confirm 経路だとエラーの描画先が宙に浮く・判断B）。開閉 state は PanelMode（body の
+ * 閲覧／編集／新規／複製）と直交した別 state でこのコンポーネント内に閉じる。
+ */
+export function ReviseForCustomerDialog({
+  estimateNumber,
+  version,
+  sourceVariationId,
+  sourceVariationNumber,
+  hasRevision,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="bg-white hover:bg-gray-100 text-gray-700 font-bold py-2 px-4 rounded border border-gray-300 focus:outline-none focus:shadow-outline"
+      >
+        得意先改訂
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>得意先改訂</DialogTitle>
+            <DialogDescription>
+              第{sourceVariationNumber}
+              案（納品先宛）を改訂元として、得意先宛の改訂先バリエーションを
+              この見積内に作成します。改訂先の内容は改訂元から引き継がれます。
+            </DialogDescription>
+          </DialogHeader>
+
+          {open && (
+            <ReviseForm
+              estimateNumber={estimateNumber}
+              version={version}
+              sourceVariationId={sourceVariationId}
+              sourceVariationNumber={sourceVariationNumber}
+              hasRevision={hasRevision}
+              onCancel={() => setOpen(false)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+/**
+ * モーダル内の改訂フォーム本体。`open` 時のみマウントして conform の状態を開閉ごとにリセットする。
+ */
+function ReviseForm({
+  estimateNumber,
+  version,
+  sourceVariationId,
+  sourceVariationNumber,
+  hasRevision,
+  onCancel,
+}: Props & { onCancel: () => void }) {
+  const action = reviseForCustomer.bind(null, estimateNumber);
+  const { form, fields, isPending } = useServerForm({
+    action,
+    schema: reviseForCustomerSchema,
+    defaultValue: {
+      version: String(version),
+      sourceVariationId,
+    },
+  });
+
+  return (
+    <form {...getFormProps(form)} noValidate>
+      <input {...getInputProps(fields.version, { type: "hidden" })} />
+      <input {...getInputProps(fields.sourceVariationId, { type: "hidden" })} />
+
+      {form.errors && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded mb-4 text-sm"
+          role="alert"
+        >
+          {form.errors.map((e) => (
+            <p key={e}>{e}</p>
+          ))}
+        </div>
+      )}
+
+      {/* 不可逆な結果の告知。凍結は常時、ヘッダーロックは初回改訂のときのみ。 */}
+      <div className="bg-amber-50 border border-amber-300 text-amber-800 text-sm px-3 py-2 rounded mb-4 space-y-2">
+        <p>
+          改訂すると、改訂元の第{sourceVariationNumber}
+          案はメモ以外を編集できなくなります（凍結）。
+        </p>
+        {!hasRevision && (
+          <p>
+            また、この見積で最初の改訂のため、以後この見積の見積年月日・税率・税端数・得意先・納品先が
+            変更できなくなります。
+          </p>
+        )}
+      </div>
+
+      <div className="flex gap-3 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPending}
+          className="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:cursor-not-allowed"
+        >
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+        >
+          {isPending ? "改訂中..." : "得意先改訂する"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(features)/estimates/[estimateNumber]/VariationPanel.test.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationPanel.test.tsx
@@ -70,6 +70,7 @@ function renderPanel(variations: VariationDTO[]) {
       variations={variations}
       taxRate={0.1}
       taxRoundingType="ROUND_DOWN"
+      hasRevision={false}
     />
   );
 }

--- a/src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx
@@ -5,9 +5,14 @@ import { Badge } from "@/app/_components/shadcnui/badge";
 import type { VariationDTO } from "@subdomains/estimate/application/queries/dto/EstimateDetailDTO";
 import { SUBMISSION_TYPE_LABELS, formatYen } from "../_shared/labels";
 import { LineTable } from "./components/LineTable";
-import { isVariationDuplicatable, isVariationEditable } from "./variationEditable";
+import {
+  isVariationDuplicatable,
+  isVariationEditable,
+  isVariationRevisableForCustomer,
+} from "./variationEditable";
 import { VariationEditForm } from "./VariationEditForm";
 import { VariationCreateForm } from "./VariationCreateForm";
+import { ReviseForCustomerDialog } from "./ReviseForCustomerDialog";
 import {
   toCreateInitialValuesFromVariation,
   type VariationCreateInitialValues,
@@ -22,6 +27,11 @@ type Props = {
   taxRate: number;
   /** 税端数区分（金額プレビュー用）。 */
   taxRoundingType: string;
+  /**
+   * この見積に既に改訂系譜が存在するか（top-level・ADR-0049）。得意先改訂の確認モーダルが
+   * 初回改訂か（＝ヘッダーロック告知の要否）を判断するために引き回す。
+   */
+  hasRevision: boolean;
 };
 
 /**
@@ -50,6 +60,7 @@ export function VariationPanel({
   variations,
   taxRate,
   taxRoundingType,
+  hasRevision,
 }: Props) {
   // 既定タブ＝最小番号の ACTIVE バリ（全 INACTIVE なら最小番号）。variations は番号昇順。
   const firstActive = variations.findIndex((v) => v.status === "ACTIVE");
@@ -159,6 +170,17 @@ export function VariationPanel({
                   >
                     複製
                   </button>
+                )}
+                {/* 得意先改訂は「納品先宛・有効」バリのみ（C7・ドメイン2ガードの写し）。確認モーダルは
+                    PanelMode と直交した自己完結コンポーネント（開閉 state はダイアログ内に閉じる）。 */}
+                {isVariationRevisableForCustomer(active) && (
+                  <ReviseForCustomerDialog
+                    estimateNumber={estimateNumber}
+                    version={version}
+                    sourceVariationId={active.variationId}
+                    sourceVariationNumber={active.variationNumber}
+                    hasRevision={hasRevision}
+                  />
                 )}
                 <button
                   type="button"

--- a/src/app/(features)/estimates/[estimateNumber]/actions.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/actions.ts
@@ -9,9 +9,11 @@ import { updateVariationCommandFactory } from "@subdomains/estimate/application/
 import { addVariationCommandFactory } from "@subdomains/estimate/application/factories/addVariationCommandFactory";
 import { checkTaxRateThenDuplicateDepsFactory } from "@subdomains/estimate/application/factories/checkTaxRateThenDuplicateDepsFactory";
 import { checkTaxRateThenDuplicate } from "@subdomains/estimate/application/shared/checkTaxRateThenDuplicate";
+import { reviseForCustomerCommandFactory } from "@subdomains/estimate/application/factories/reviseForCustomerCommandFactory";
 import type { UpdateEstimateInput } from "@subdomains/estimate/application/commands/UpdateEstimateCommand";
 import type { UpdateVariationInput } from "@subdomains/estimate/application/commands/UpdateVariationCommand";
 import type { AddVariationInput } from "@subdomains/estimate/application/commands/AddVariationCommand";
+import type { ReviseForCustomerInput } from "@subdomains/estimate/application/commands/ReviseForCustomerCommand";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { handleCommandError } from "../../_shared/error-handler";
@@ -20,6 +22,7 @@ import { taxRateMismatchFormErrors } from "../_shared/tax-rate-format";
 import { duplicateEstimateSchema } from "./duplicateSchema";
 import { updateEstimateHeaderSchema } from "./schema";
 import { addVariationNodeSchema, updateVariationContentNodeSchema } from "./variationSchema";
+import { reviseForCustomerSchema } from "./reviseForCustomerSchema";
 import { toVariationContentInputFromNodes } from "./variationContentMapping";
 
 /**
@@ -157,6 +160,63 @@ export async function addVariation(
 
   revalidatePath(`/estimates/${estimateNumber}`);
   redirect(`/estimates/${estimateNumber}?reason=${REDIRECT_REASON.ESTIMATE_UPDATED}`);
+}
+
+/**
+ * 得意先改訂（C7・集約内の縦スライス）の Server Action。
+ *
+ * 改訂先の内容は改訂元からの全複写でドメインが決定するため、入力は改訂元の sourceVariationId と
+ * 楽観ロックトークン version のみ（reviseForCustomerSchema）。estimateId は estimateNumber から DTO
+ * 解決する。明細・金額の写像は不要（C4 と異なり content を組み立てない）。税率不一致（§8.7）は
+ * 例外でなく Result のためフォームエラーで提示しモーダルを維持する（文言は作成・複製と共有）。
+ * 競合・その他例外は handleCommandError 経由でフォームエラー化する。成功時は同一見積の詳細へ
+ * 改訂先タブ出現済みで戻り、専用フラッシュで結果を伝える（ESTIMATE_REVISED）。
+ */
+export async function reviseForCustomer(
+  estimateNumber: string,
+  _prevState: unknown,
+  formData: FormData
+) {
+  await verifySession();
+
+  const submission = parseWithZod(formData, { schema: reviseForCustomerSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+  const value = submission.value;
+
+  const dto = await getEstimateDetailQueryFactory().execute({ estimateNumber });
+  if (!dto) {
+    return submission.reply({ formErrors: ["見積が見つかりません"] });
+  }
+
+  const input: ReviseForCustomerInput = {
+    estimateId: dto.estimateId,
+    sourceVariationId: value.sourceVariationId,
+    version: value.version,
+  };
+
+  let result;
+  try {
+    result = await reviseForCustomerCommandFactory().execute(input);
+  } catch (error) {
+    const errorResult = handleCommandError(error);
+    const errorMessage = !errorResult.success && errorResult.error ? errorResult.error : undefined;
+    return submission.reply({ formErrors: errorMessage ? [errorMessage] : [] });
+  }
+
+  // 税率不一致（§8.7）は改訂されない。両税率を提示してモーダルを維持する（文言は作成・複製と共有）。
+  if (result.kind === "taxRateMismatch") {
+    return submission.reply({
+      formErrors: taxRateMismatchFormErrors(
+        result.estimateDateRate.value,
+        result.deadlineRate.value
+      ),
+    });
+  }
+
+  revalidatePath(`/estimates/${estimateNumber}`);
+  redirect(`/estimates/${estimateNumber}?reason=${REDIRECT_REASON.ESTIMATE_REVISED}`);
 }
 
 /**

--- a/src/app/(features)/estimates/[estimateNumber]/page.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/page.tsx
@@ -67,6 +67,7 @@ export default async function EstimateDetailPage({
         variations={estimate.variations}
         taxRate={estimate.taxRate}
         taxRoundingType={estimate.taxRoundingType}
+        hasRevision={estimate.hasRevision}
       />
     </div>
   );

--- a/src/app/(features)/estimates/[estimateNumber]/reviseForCustomerSchema.test.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/reviseForCustomerSchema.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { reviseForCustomerSchema } from "./reviseForCustomerSchema";
+
+describe("reviseForCustomerSchema（得意先改訂・C7）", () => {
+  function parse(overrides: Record<string, unknown> = {}) {
+    return reviseForCustomerSchema.safeParse({
+      version: "1",
+      sourceVariationId: "v1",
+      ...overrides,
+    });
+  }
+
+  it("version と sourceVariationId だけの有効入力を通す（tracer bullet）", () => {
+    expect(parse().success).toBe(true);
+  });
+
+  it("FormData 由来の version 文字列を数値へ強制する（楽観ロックトークン・ADR-0039）", () => {
+    const result = parse({ version: "7" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.version).toBe(7);
+    }
+  });
+
+  it("sourceVariationId 空を拒否する（改訂元の同定必須・回帰ガード）", () => {
+    expect(parse({ sourceVariationId: "" }).success).toBe(false);
+  });
+});

--- a/src/app/(features)/estimates/[estimateNumber]/reviseForCustomerSchema.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/reviseForCustomerSchema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+/**
+ * 得意先改訂フォーム（C7 / ReviseForCustomer）のバリデーションスキーマ。
+ *
+ * 改訂はドメイン `Estimate.reviseForCustomer(sourceVariationId)` が改訂元から明細・メモ・全体値引を
+ * **全複写**で決定する（内容入力を一切取らない・Estimate.ts）。よって利用者の入力面は「どの改訂元を
+ * 改訂するか（sourceVariationId）」と楽観ロックトークン（version）の 2 つだけで、C3/C6 のような明細・
+ * 日付・部署の入力は持たない（スキーマ・写像・金額プレビュー不要）。
+ *
+ * - version: 集約ルートの楽観ロックトークン（ADR-0039）。hidden で往復し coerce で数値化（C2/C4 と同型）。
+ * - sourceVariationId: 改訂元バリエーションの同定。estimateId は estimateNumber から DTO 解決する。
+ */
+export const reviseForCustomerSchema = z.object({
+  version: z.coerce.number().int(),
+  sourceVariationId: z.string().min(1, "改訂元バリエーションが特定できません"),
+});
+
+export type ReviseForCustomerFormInput = z.infer<typeof reviseForCustomerSchema>;

--- a/src/app/(features)/estimates/[estimateNumber]/variationEditable.test.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/variationEditable.test.ts
@@ -4,7 +4,11 @@ import type {
   SetGroupDTO,
   VariationDTO,
 } from "@subdomains/estimate/application/queries/dto/EstimateDetailDTO";
-import { isVariationDuplicatable, isVariationEditable } from "./variationEditable";
+import {
+  isVariationDuplicatable,
+  isVariationEditable,
+  isVariationRevisableForCustomer,
+} from "./variationEditable";
 
 /** テスト用の最小 LineDTO（必要なフィールドのみ上書き）。 */
 function line(overrides: Partial<LineDTO> = {}): LineDTO {
@@ -112,5 +116,31 @@ describe("isVariationDuplicatable（複製元の適格性・C3）", () => {
 
   it("無効(INACTIVE)でも改訂明細を含まなければ複製元にできる（状態を問わない・編集可否との差）", () => {
     expect(isVariationDuplicatable(variation({ status: "INACTIVE", lines: [line()] }))).toBe(true);
+  });
+});
+
+describe("isVariationRevisableForCustomer（改訂元の適格性・C7）", () => {
+  it("納品先宛(DELIVERY_LOCATION)かつ ACTIVE のバリは改訂元にできる（tracer bullet）", () => {
+    const v = variation({ submissionType: "DELIVERY_LOCATION", status: "ACTIVE" });
+    expect(isVariationRevisableForCustomer(v)).toBe(true);
+  });
+
+  it("得意先宛(CUSTOMER)のバリは改訂元にできない（ドメイン isDeliveryLocation ガードの写し）", () => {
+    const v = variation({ submissionType: "CUSTOMER", status: "ACTIVE" });
+    expect(isVariationRevisableForCustomer(v)).toBe(false);
+  });
+
+  it("無効(INACTIVE)の納品先宛バリは改訂元にできない（ドメイン isActive ガードの写し）", () => {
+    const v = variation({ submissionType: "DELIVERY_LOCATION", status: "INACTIVE" });
+    expect(isVariationRevisableForCustomer(v)).toBe(false);
+  });
+
+  it("既に改訂明細を含む納品先宛 ACTIVE バリも改訂元にできる（再改訂許可・凍結判定は持たない）", () => {
+    const v = variation({
+      submissionType: "DELIVERY_LOCATION",
+      status: "ACTIVE",
+      lines: [line({ revisedDeliveryPrice: 800 })],
+    });
+    expect(isVariationRevisableForCustomer(v)).toBe(true);
   });
 });

--- a/src/app/(features)/estimates/[estimateNumber]/variationEditable.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/variationEditable.ts
@@ -34,3 +34,15 @@ export function isVariationEditable(variation: VariationDTO): boolean {
 export function isVariationDuplicatable(variation: VariationDTO): boolean {
   return !containsRevisedLine(variation);
 }
+
+/**
+ * 得意先改訂の改訂元にできるバリか判定する（C7・UI 抑止・二重防御の外側）。
+ *
+ * 条件はドメイン `Estimate.reviseForCustomer` の 2 ガード「納品先宛(DELIVERY_LOCATION)」かつ
+ * 「有効(ACTIVE)」の写しのみ。ドメインは「既に改訂元か（凍結済みか）」を改訂禁止条件にしていない
+ * （再改訂を許す）ため、UI ゲートも凍結判定を持たない。同一納品先ベースから複数の得意先向け提案を
+ * 作るのは自然な操作で、改訂は改訂元を変更しない。最終強制はドメインが担う。
+ */
+export function isVariationRevisableForCustomer(variation: VariationDTO): boolean {
+  return variation.submissionType === "DELIVERY_LOCATION" && variation.status === "ACTIVE";
+}

--- a/src/app/(features)/estimates/estimates-revise-for-customer.e2e.ts
+++ b/src/app/(features)/estimates/estimates-revise-for-customer.e2e.ts
@@ -1,0 +1,86 @@
+import { type Page, expect, test } from "@playwright/test";
+
+/**
+ * 得意先改訂（C7・§7.2）の E2E。納品先宛 ACTIVE バリの操作行「得意先改訂」から確認モーダルを開き、
+ * 同一見積内に得意先宛の改訂先バリエーションを生成する。改訂先の内容はドメインが改訂元から全複写で
+ * 決定するため利用者の入力面はなく、UI は「ボタン → 確認 → 純粋コマンド送信」に徹する。
+ *
+ * 検証範囲（ADR-0017/0020・UI 観測可能な範囲）:
+ * - (1) 操作行の「得意先改訂」は納品先宛 ACTIVE バリにのみ出る（得意先宛では出ない）
+ * - (2) ボタン → 確認モーダル → 実行で、同一見積内に得意先宛の改訂先バリが出現する＋専用フラッシュ
+ * - (3) 初回改訂後、ヘッダー編集（C2）の見積日・税端数・得意先が disabled になる（ヘッダーロック）
+ *
+ * 「改訂系譜の記録」「改訂元の凍結（編集不可）」は Prisma 直接参照なしでは UI 観測できない
+ * （VariationDTO は per-variation 凍結フラグを持たず、改訂元の「内容を編集」ボタンは残る＝凍結は
+ * ドメイン assertEditable が強制する二重防御の内側）。ADR-0012 によりここでは検証せず、ドメイン/
+ * アプリのユニットテスト済みとして扱い、E2E は UI 観測可能な結果（改訂先の出現・ヘッダーロック・
+ * フラッシュ）のみを検証する。
+ */
+const SOURCE = "N9905006"; // 改訂前・hasRevision=false（V1=納品先宛 ACTIVE・V2=得意先宛 ACTIVE）
+
+async function waitForDetailReady(page: Page, estimateNumber: string) {
+  await expect(page.getByRole("heading", { level: 1, name: estimateNumber })).toBeVisible();
+}
+
+async function selectVariationTab(page: Page, variationNumber: number) {
+  await page.getByRole("tab", { name: `バリエーション${variationNumber}` }).click();
+}
+
+test.describe.serial("得意先改訂（C7 / N9905006）", () => {
+  test("「得意先改訂」は納品先宛 ACTIVE バリにのみ出る（得意先宛では出ない）", async ({ page }) => {
+    await page.goto(`/estimates/${SOURCE}`);
+    await waitForDetailReady(page, SOURCE);
+
+    // V1（納品先宛・ACTIVE）= 改訂元適格 → ボタンが出る。
+    await selectVariationTab(page, 1);
+    await expect(page.getByRole("button", { name: "得意先改訂" })).toBeVisible();
+
+    // V2（得意先宛・ACTIVE）= 適格外 → ボタンが出ない。
+    await selectVariationTab(page, 2);
+    await expect(page.getByRole("button", { name: "得意先改訂" })).toHaveCount(0);
+  });
+
+  test("ボタン → 確認モーダル → 実行で得意先宛の改訂先バリが出現する", async ({ page }) => {
+    await page.goto(`/estimates/${SOURCE}`);
+    await waitForDetailReady(page, SOURCE);
+
+    // 改訂前は V1・V2 の 2 タブのみ（V3 はまだ無い）。
+    await expect(page.getByRole("tab", { name: "バリエーション3" })).toHaveCount(0);
+
+    // V1（改訂元）の操作行から確認モーダルを開く。
+    await selectVariationTab(page, 1);
+    await page.getByRole("button", { name: "得意先改訂" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    // モーダル内の実行ボタンで改訂を確定する（入力面は無く確認のみ）。
+    await page.getByRole("button", { name: "得意先改訂する" }).click();
+
+    // 専用フラッシュ（ESTIMATE_REVISED）。
+    await expect(page.getByText("得意先改訂しました。")).toBeVisible({ timeout: 10000 });
+    // 同一見積内に改訂先 V3（得意先宛）が出現する。
+    await expect(page.getByRole("tab", { name: "バリエーション3" })).toBeVisible();
+    await selectVariationTab(page, 3);
+    await expect(page.getByText("得意先向け", { exact: true })).toBeVisible();
+  });
+
+  test("初回改訂後、ヘッダー編集の見積日・税端数・得意先が disabled になる（ヘッダーロック）", async ({
+    page,
+  }) => {
+    // 直前のテストで N9905006 は初回改訂済み（hasRevision=true）。
+    await page.goto(`/estimates/${SOURCE}`);
+    await waitForDetailReady(page, SOURCE);
+
+    // 閲覧モードに「改訂あり」バッジが出る（ADR-0049）。
+    await expect(page.getByText("改訂あり", { exact: true })).toBeVisible();
+
+    await page.getByRole("button", { name: "編集", exact: true }).click();
+
+    // ロック対象（§7.2）: 見積日・税端数区分・得意先選択は不可。
+    await expect(page.getByLabel("見積日")).toBeDisabled();
+    await expect(page.getByLabel("税端数区分")).toBeDisabled();
+    await expect(page.getByRole("button", { name: "得意先を選択" })).toBeDisabled();
+    // 締切日・部署は改訂後も編集可。
+    await expect(page.getByLabel("締切日")).toBeEnabled();
+    await expect(page.getByLabel("部署")).toBeEnabled();
+  });
+});

--- a/src/app/_components/redirect-reason-toast.tsx
+++ b/src/app/_components/redirect-reason-toast.tsx
@@ -130,6 +130,10 @@ const FLASH_MESSAGES: Record<RedirectReason, FlashMessage> = {
     message:
       "見積を複製しました。複製先の見積単価はクリアされています。各バリエーションで再入力してください。",
   },
+  [REDIRECT_REASON.ESTIMATE_REVISED]: {
+    type: FLASH_MESSAGE_TYPE.SUCCESS,
+    message: "得意先改訂しました。",
+  },
 };
 
 function RedirectReasonToastInner() {

--- a/src/shared/constants/redirect-reasons.ts
+++ b/src/shared/constants/redirect-reasons.ts
@@ -32,6 +32,7 @@ export const REDIRECT_REASON = {
   ESTIMATE_CREATED: "estimate_created",
   ESTIMATE_UPDATED: "estimate_updated",
   ESTIMATE_DUPLICATED: "estimate_duplicated",
+  ESTIMATE_REVISED: "estimate_revised",
 } as const;
 
 export type RedirectReason = (typeof REDIRECT_REASON)[keyof typeof REDIRECT_REASON];


### PR DESCRIPTION
## Summary

見積詳細画面に得意先改訂（C7 `ReviseForCustomer`）の UI を配線した。実装済み・ユニット完備のドメイン/アプリ層（`Estimate.reviseForCustomer` / `ReviseForCustomerCommand`）に対し、欠けていたプレゼン層（入力スキーマ・Server Action・確認モーダル・適格ゲート・操作行ボタン）を追加し E2E で受け入れた。改訂先は内容入力を取らずドメインが改訂元から全複写するため、UI は「ボタン → 確認モーダル → 純粋コマンド送信」の構成。

Closes #359

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### revise-for-customer-c7-ui.md

見積詳細画面に得意先改訂（C7 `ReviseForCustomer`）の UI を実装し、既存コマンドへ配線する。納品先宛バリエーションを改訂元として、同一見積内に得意先宛の改訂先バリエーションを生成する操作。

**主な設計判断:**
- **改訂元ボタンの適格条件**: 「納品先宛（DELIVERY_LOCATION）かつ有効（ACTIVE）」のみ＝ドメイン2ガードの写し（再改訂を許す）。二重防御の原則と配線スライスのスコープ最小化のため、UI 独自の「2回目禁止」は発明しない。
- **確認ダイアログ**: `dialog.tsx`（shadcn Dialog）モーダルを採用。不可逆性（改訂系譜生成＋改訂元凍結）の説明責任と、税率不一致・楽観ロック競合の `formErrors` をモーダル内インラインに置けるため。C6（ADR-0057）の前例にそろう。
- **警告文**: 凍結は常時告知。初回改訂時（`hasRevision === false`）のみヘッダーロック（見積年月日・税率・税端数・得意先・納品先が変更不可）を追記。
- **成功後フィードバック**: 専用 `REDIRECT_REASON.ESTIMATE_REVISED` ＋静的フラッシュ「得意先改訂しました」（C6 の `ESTIMATE_DUPLICATED` 前例にそろう）。改訂先タブの自動フォーカスは未要求のため行わない。
- **新規 ADR は作らない**（ユーザー判断で確定）: 唯一の候補「改訂モーダル＝純粋確認ゲート」はコマンド署名が内容を取らないことの直接の帰結で、大元は ADR-0044/0045/0046 ＋ CONTEXT.md に記録済み。
- **CONTEXT.md 変更不要**: C7 の語彙は既存定義で網羅的。

**ステップ:**
1. 入力スキーマ `reviseForCustomerSchema`（`version` + `sourceVariationId`）［ユニットTDD］
2. Server Action `reviseForCustomer`（C2/C4 同型）［実装先行］
3. リダイレクト理由 `ESTIMATE_REVISED` とフラッシュ
4. 適格ゲート `isVariationRevisableForCustomer`
5. 確認モーダル `ReviseForCustomerDialog`
6. `VariationPanel` 操作行への配線（`hasRevision` を page → Panel → モーダルへ引き回し）
7. E2E 統合受け入れ（1 ケースずつ）
8. ユースケース一覧の C7 行を `estimateId + sourceVariationId + version` に更新

</details>

## 計画からの逸脱

1. **ファイルパスの相違（Step 3）**: リダイレクト理由の実体は `src/shared/constants/redirect-reasons.ts`（`server/` 配下ではない）、フラッシュは `src/app/_components/redirect-reason-toast.tsx`。計画策定時のパス記憶違い。`FLASH_MESSAGES` が網羅を型強制するため定数追加とメッセージ追加は同一コミットで揃えた。

2. **ステップ順序の入れ替え（Step 2 ↔ Step 3）**: Server Action が `ESTIMATE_REVISED` を参照するため、定数を先に入れないと型エラーになる。各コミットがビルド可能であることを優先し Step 3 → Step 2 の順でコミットした。

3. **Step 4 を TDD で実装**: 適格ゲートは「実装先行」予定だったが、副作用のない純粋述語かつ既存 co-located テストがあるため `variationEditable.test.ts` に RED→GREEN で追加。複製適格との差（凍結判定なし＝再改訂許可）を回帰ガードとして明示できる。

4. **専用シード見積 N9905006 の追加（Step 7）**: 改訂は集約を破壊的に変更するため、共有見積を対象にすると他テストと状態結合し脆くなる。C7 専用見積（改訂前・納品先宛 V1 適格／得意先宛 V2 適格外）を `seed-estimates.ts` に追加し、初回改訂→ヘッダーロック発火を観測できる clean な起点を用意した。

5. **★重要: Step 7 ② の検証内容の変更（凍結の UI 観測は不可能）**: 計画は「改訂元タブに『内容を編集』が出ない＝凍結を UI 観測」だったが、現実装では改訂元の凍結を UI から観測できない。`VariationDTO` は per-variation 凍結フラグを持たず、凍結はドメイン `editableVariationOrThrow`（集約横断ガード）で強制されるため `isVariationEditable(改訂元)` は改訂後も `true` のまま編集ボタンが残る（クリック保存時に二重防御の内側でドメインが例外を投げる）。よって代わりに UI 観測可能な結果（改訂先タブの出現・得意先向けバッジ・専用フラッシュ・初回改訂後のヘッダーロック）を検証した。

## Test Plan

- 入力スキーマ `reviseForCustomerSchema` のユニットテスト（有効入力・`version` 数値強制・`sourceVariationId` 必須）
- 適格ゲート `isVariationRevisableForCustomer` のユニットテスト（納品先宛×ACTIVE のみ true・複製適格との差を明示）
- E2E `estimates-revise-for-customer.e2e.ts`:
  - [ ] 納品先宛・ACTIVE バリの操作行にのみ「得意先改訂」ボタンが出る（得意先宛・無効では非表示）
  - [ ] ボタン → 確認モーダル → 実行で、同一見積内に得意先宛の改訂先バリが出現・得意先向けバッジ・専用フラッシュ「得意先改訂しました」
  - [ ] 初回改訂後、ヘッダー編集（C2）の見積年月日・税率・税端数・得意先・納品先が disabled（ヘッダーロック）
- 系譜・凍結の DB アサートはしない（ADR-0012: テストで Prisma 直接利用禁止）。ドメイン保証はユニットテスト済みとして扱う

---

Generated with [Claude Code](https://claude.ai/code)
