### PR TITLE
refactor: メモ textarea 共通クラスを _shared/formStyles に集約

### DIFF
--- a/src/app/(features)/estimates/[estimateNumber]/VariationMemoEditForm.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationMemoEditForm.tsx
@@ -4,6 +4,7 @@ import { getFormProps, getInputProps } from "@conform-to/react";
 import { useState } from "react";
 import { useServerForm } from "@/app/_hooks/useServerForm";
 import type { VariationDTO } from "@subdomains/estimate/application/queries/dto/EstimateDetailDTO";
+import { memoInputClass } from "../_shared/formStyles";
 import { LineTable, type MemoPatch } from "./components/LineTable";
 import { updateVariationMemos } from "./actions";
 import { updateVariationMemosSchema } from "./variationMemoSchema";
@@ -144,7 +145,7 @@ export function VariationMemoEditForm({ estimateNumber, version, variation, onCa
               name={fields.customerMemo.name}
               defaultValue={variation.customerMemo}
               rows={3}
-              className="mt-1 w-full border rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400"
+              className={memoInputClass}
             />
           </div>
           <div>
@@ -156,7 +157,7 @@ export function VariationMemoEditForm({ estimateNumber, version, variation, onCa
               name={fields.internalMemo.name}
               defaultValue={variation.internalMemo}
               rows={3}
-              className="mt-1 w-full border rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400"
+              className={memoInputClass}
             />
           </div>
         </div>

--- a/src/app/(features)/estimates/[estimateNumber]/components/LineEditTable.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/components/LineEditTable.tsx
@@ -10,6 +10,7 @@ import {
 } from "@dnd-kit/core";
 import { restrictToParentElement, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { memoInputClass } from "../../_shared/formStyles";
 import { PRODUCT_CATEGORY_LABELS, formatYen } from "../../_shared/labels";
 import { previewGroupAmount, previewLineAmount } from "../previewAmounts";
 import type { WorkingLine, WorkingNode, WorkingSetGroup } from "../variationLines";
@@ -29,8 +30,6 @@ type Props = {
 
 const cellInputClass =
   "w-full border rounded px-2 py-1 text-right focus:outline-none focus:ring-1 focus:ring-blue-400";
-const memoInputClass =
-  "mt-1 w-full border rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400";
 
 const COLUMN_COUNT = 12;
 

--- a/src/app/(features)/estimates/[estimateNumber]/components/LineTable.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/components/LineTable.tsx
@@ -5,13 +5,11 @@ import type {
   LineDTO,
   SetGroupDTO,
 } from "@subdomains/estimate/application/queries/dto/EstimateDetailDTO";
+import { memoInputClass } from "../../_shared/formStyles";
 import { PRODUCT_CATEGORY_LABELS, formatYen } from "../../_shared/labels";
 
 /** 明細メモの編集パッチ（顧客/社内のいずれか一方ずつ）。 */
 export type MemoPatch = { customerMemo?: string; internalMemo?: string };
-
-const memoInputClass =
-  "mt-1 w-full border rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400";
 
 type Props = {
   lines: (LineDTO | SetGroupDTO)[];

--- a/src/app/(features)/estimates/_shared/formStyles.ts
+++ b/src/app/(features)/estimates/_shared/formStyles.ts
@@ -11,3 +11,10 @@ export const inputClass =
   "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline";
 
 export const inputClassDisabled = `${inputClass} disabled:bg-gray-100`;
+
+/**
+ * メモ textarea 共通クラス（明細メモセル・バリ単位メモ共用）。rows と aria-label は呼び出し側で付与する。
+ * 数量・単価などの数値入力用（text-right 系）とは用途が異なるため統合しない。
+ */
+export const memoInputClass =
+  "mt-1 w-full border rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400";


### PR DESCRIPTION
## Summary

メモ textarea に使われていた同一の Tailwind クラス文字列 (`mt-1 w-full border rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400`) が、`LineTable` / `LineEditTable` / `VariationMemoEditForm` の計4箇所にコピーされていたため、`_shared/formStyles.ts` の `memoInputClass` に一本化しました。マージ済み #391 のコードレビューで発見した重複の解消です。

数値入力用の `cellInputClass`（`text-right` 系）は用途が異なるため統合せず温存しています。

> 本 PR は特定の issue を close しません。重複は #391（マージ済み）のレビューで発見した後追いリファクタです。

## 計画からの逸脱

実装計画なしで実装を行いました（小規模なリファクタのため plan mode 未使用）。

## 設計判断

- **メモ用クラスは集約し、数値入力用クラスは温存**: `memoInputClass` は明細メモセル・バリ単位メモで完全一致する文字列のため集約。一方 `cellInputClass`（`text-right` を含む数値入力用）は見た目・用途が異なるため統合せず別定数として残した。判断理由は `formStyles.ts` の JSDoc にも明記。
- **`rows` / `aria-label` は呼び出し側で付与**: 行数やラベルは利用箇所ごとに異なるため共通クラスには含めず、className のみを共有する設計とした。

## Test Plan

クラス文字列の差し替えのみで、振る舞いの変更はなし。

- [x] `tsc --noEmit` 緑
- [x] 対象テスト 9/9 緑
- [ ] レビュアー確認: メモ欄（明細メモセル / バリ単位メモ）の見た目に変化がないこと

---

Generated with [Claude Code](https://claude.ai/code)
