### PR TITLE
agent: フックコマンドを相対パスから $CLAUDE_PROJECT_DIR
  絶対パスに変更する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -113,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/stop-notify-completion.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop-notify-completion.sh"
           }
         ]
       }
@@ -124,7 +124,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre-enter-plan-mode-reminder.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-enter-plan-mode-reminder.sh"
           }
         ]
       },
@@ -133,7 +133,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre-ask-notify-question.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-ask-notify-question.sh"
           }
         ]
       },
@@ -142,7 +142,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre-bash-branch-safety.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-bash-branch-safety.sh"
           }
         ]
       },
@@ -151,7 +151,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre-bash-plan-reminder.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-bash-plan-reminder.sh"
           }
         ]
       },
@@ -160,7 +160,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre-bash-plan-file-check.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-bash-plan-file-check.sh"
           }
         ]
       },
@@ -169,7 +169,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pipe-stage-permissions.sh",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pipe-stage-permissions.sh",
             "timeout": 5
           }
         ]
@@ -181,7 +181,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/notify-permission-prompt.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/notify-permission-prompt.sh"
           }
         ]
       }
@@ -192,7 +192,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/post-bash-commit-fail-check.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-bash-commit-fail-check.sh"
           }
         ]
       },
@@ -201,7 +201,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/post-exit-plan-mode-reminder.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-exit-plan-mode-reminder.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

PreToolUse / PostToolUse / Stop / Notification の全フック10本の起動コマンドを、相対パス `bash .claude/hooks/X.sh` から `bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/X.sh`（絶対パス）に変更する。

## 背景・真因

相対パスはフック実行時の CWD がプロジェクトルートのときしか解決しない。エージェントが `cd <サブディレクトリ> && <command>` を実行すると CWD が移り、相対 `.claude/hooks/X.sh` が **exit 127（No such file or directory）** で失敗していた。

非ブロッキング失敗のため作業自体は止まらないが、全 Bash 結果にエラー行が混入し、エージェントに「出力が混線している」と誤認させていた。その結果、全コマンド出力を `/tmp/*.txt` に書いて読み直す遠回り運用を誘発し、「処理が詰まる」「/tmp が散らかる」という体感不調につながっていた。

Claude Code がフック実行時に必ずセットする `$CLAUDE_PROJECT_DIR`（プロジェクトルート絶対パス）を使えば、CWD に依存せず解決する。

## 変更したフック（10本）

- Stop: `stop-notify-completion.sh`
- PreToolUse: `pre-enter-plan-mode-reminder.sh` / `pre-ask-notify-question.sh` / `pre-bash-branch-safety.sh` / `pre-bash-plan-reminder.sh` / `pre-bash-plan-file-check.sh` / `pipe-stage-permissions.sh`
- Notification: `notify-permission-prompt.sh`
- PostToolUse: `post-bash-commit-fail-check.sh` / `post-exit-plan-mode-reminder.sh`

## 実装計画

issue なし・計画ディレクトリなしのツール設定修正のため、計画ファイルなし。

## Test Plan

- [x] JSON 妥当性確認（`JSON.parse` 成功）
- [x] 置換数 10、旧相対形の残存 0 を確認
- [x] サブディレクトリ（`src/server`）から新形式で実行し **exit 0**（従来は exit 127）を再現確認
- [x] メインリポでの本コミット自体がフックエラー 0 で完走

🤖 Generated with [Claude Code](https://claude.com/claude-code)
