### PR TITLE
feat: 見積申請・承認免除リポジトリの Prisma 実装（Mapper・統合テスト）

### DIFF
--- a/docs/claude-plans/issue-407/implement-approval-prisma-repositories.md
+++ b/docs/claude-plans/issue-407/implement-approval-prisma-repositories.md
@@ -1,0 +1,87 @@
+# Issue #407: 見積申請・承認免除リポジトリの Prisma 実装（Mapper・統合テスト） — 実装計画
+
+## 概要
+
+#386 で実装した承認系ドメイン層（`EstimateApplication` / `EstimateApprovalStep` / `EstimateApprovalExemption` 集約・終端イベント VO・`ApprovalChainPlan`）の上に、インフラ層を実装する。具体的には承認免除・見積申請リポジトリの Prisma 実装、Domain⇔Prisma の Mapper、TDD による統合テストを行う。
+
+**スコープは Mapper + リポジトリ Prisma 実装 2 本 + 統合テストの 3 点に縮退**している。Issue 起票時の未決事項に挙がっていた「§3.7 逆参照リレーション追加」「migration の切り方」は、調査の結果 **#384（commit da032b0）で承認系 6 テーブル・全 FK・CHECK・index・§3.7 逆参照リレーションがすべて作成済み**であることが判明したため、本 issue の対象外とする（新規 migration 不要）。
+
+**本 issue 外の境界**: 承認 Inbox 等の QueryService、楽観ロック `version` を読み出す read model は別 issue。本リポジトリ interface は集約の保存・再構築に必要な最小操作のみを提供する。
+
+## 設計判断
+
+### スコープ縮退（§3.7・migration は #384 で完了済み）
+- 逆参照リレーションは Prisma の仮想リレーション（SQL カラムを生まない）で、FK が #384 で張られていれば schema 記載のみで完結し新規 migration は不要。
+- 判断: §3.7 / migration を本 issue から外し、Mapper + リポジトリ実装 + 統合テストに集中する。
+
+### ファイル配置
+- A. 既存 `infrastructure/mappers/`・`infrastructure/prisma/` の flat 配置に合わせる
+- B. ドメイン層の `approval/` 区画化（commit `b5f0c94`）を鏡写しに `infrastructure/mappers/approval/`・`infrastructure/prisma/approval/` を新設する
+- 推奨: **B**（承認系を区画化する確立済み規約に揃える。flat 配置は承認系導入前の名残）
+
+### `update()` の終端イベント永続化方式
+- A. version ガード＋終端イベントを自然キーで idempotent upsert＋ステップ骨格は不触＋`created_at` は DB 既定＋`refetch`
+- B. DB のイベント行を読んで差分の不足分だけ create（読み込み 1 往復増・利得なし）
+- C. イベント全削除→再作成（追記専用・不変原則に反し `created_at` を壊す）
+- 推奨: **A**。理由: 終端イベントは追記専用・1ステップ1決定でドメインが `isDecided()` ガード済み、`stepId`/`applicationId` が `@id` 自然キーのため upsert が冪等になり FK 安全。並行性は `version` ガード（ADR-0039/0058）、冪等性は自然キーが担保し、読み込み差分も削除再作成も不要。`occurredAt` は reload 後の DB `created_at` で確定する（ADR-0058「occurredAt = イベント行 createdAt」と一致、in-memory の `new Date()` は捨てる）。
+
+### `insert()` の形
+- 既存パターン踏襲（ルート＋ステップ骨格のネスト create。生成時点でイベントは無し）のため判断不要。
+
+### Mapper の責務分割
+- 集約ルートごとに 1 Mapper（`*_FULL_INCLUDE` 定数＋`toDomain`＋create-input ビルダ、子の `reconstruct()` 直呼び）。eslint override（ADR-0031）は各 mapper ファイルに限定。既存 `EstimateMapper` と同型のため判断不要。
+
+### ユニーク制約衝突の例外翻訳
+- 推奨: `estimate_applications(variationId, attempt)` 衝突・`estimate_approval_exemptions.variationId` 衝突（Prisma P2002）を `ConflictError` に翻訳する。理由: いずれも「アプリ層チェックをすり抜けた並行レースを DB の最後の砦が捕捉」したケースで、`attempt` は §6.3 の楽観採番（MAX+1）、免除は二重確定レース。既存 `estimate_number` 翻訳の先例と一貫した再試行 UX に落とす。FK 違反（P2003）は翻訳せず生のまま（テストで別途確認）。
+
+### 統合テストのデータ準備方式
+- A. テスト専用に予約コードで組織（役職・役割・従業員）を全て自前生成
+- B. 役職・役割はシードを code 引きで再利用、従業員のみ予約コードで upsert
+- 推奨: **B**。理由: 既存の組織グラフ依存テスト（`SuperiorRoleValidationDomainService.test.ts`）がシード組織を `positionCd` で code 引きする確立済み流儀があり、`Position.name`/`positionCd` の `@unique` がテスト専用役職の生成を阻む。役職・役割は固定の正準マスタなのでシード再利用、従業員はシードを mutate せず隔離するため予約コードで upsert。対象 variation は実 estimate insert で本物の FK を用意。
+
+### テスト戦略（申請集約の構築）
+- 推奨: 申請集約は `EstimateApplication.create` ＋ **`ApprovalChainPlan` 手組み**で生成し、`ApprovalChainBuilder` は通さない。理由: リポジトリテストの主題は永続化往復＋ADR-0058 状態導出であり、チェーン構築（組織トラバース）は #386 ドメインテストで担保済み。混ぜると関心が二重化する。
+
+### ドキュメント更新
+- CONTEXT.md: 今回の決定は全て実装方式で新規業務用語なし → 追記不要（glossary は実装詳細を持たない）。
+- 新規 ADR: 既存 ADR（0058/0039/0032/0054・estimate_number 翻訳先例）に従うのみで「不可逆×文脈なしでは驚く×真のトレードオフ」を満たさない → 起票見送り。
+
+## ステップ
+
+TDD（red → green → refactor）で進める。各ステップは 1 つの red-green サイクルで動作する意味的まとまりを成し、green に達した時点で 1 コミットする（failing-test の単独コミットは作らない）。
+
+### Step 1: 承認免除リポジトリを TDD で実装（＋ensureApprovalFixtures 土台）
+- 対象ファイル:
+  - `src/server/__tests__/helpers/ensureApprovalFixtures.ts`（新規・テスト helper）
+  - `src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApprovalExemptionRepository.test.ts`（新規）
+  - `src/server/subdomains/estimate/infrastructure/mappers/approval/EstimateApprovalExemptionMapper.ts`（新規）
+  - `src/server/subdomains/estimate/infrastructure/prisma/approval/PrismaEstimateApprovalExemptionRepository.ts`（新規）
+- 作業内容:
+  - Red: `ensureApprovalFixtures`（役職・役割はシード code 引き、従業員は予約コード upsert、対象 variation は実 estimate insert）を整え、免除の統合テストを書く（insert → `findByVariationId` 往復、同一 variation 二重 insert → `ConflictError`）。
+  - Green: `EstimateApprovalExemptionMapper`（`*_FULL_INCLUDE`・`toDomain`・create-input）と `PrismaEstimateApprovalExemptionRepository`（`insert`/`findByVariationId`、P2002→`ConflictError` 翻訳）を実装。mapper ファイルに eslint override（ADR-0031）を限定付与。
+  - Refactor: 予約コード namespace・cleanup を既存 `ensureEstimateFixtures` 流儀に整える。
+- コミットメッセージ: `feat: 承認免除リポジトリのPrisma実装とテストフィクスチャ土台を追加`
+  - body 記載: 承認系インフラを approval/ サブフォルダに区画化（理由: ドメイン層の approval/ 区画化と鏡写し）。免除の variationId unique 衝突を ConflictError に翻訳（理由: 二重確定レースを再試行可能な競合として表面化、estimate_number 先例に一貫）。
+
+### Step 2: 見積申請リポジトリの insert / 検索を TDD で実装
+- 対象ファイル:
+  - `src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApplicationRepository.test.ts`（新規）
+  - `src/server/subdomains/estimate/infrastructure/mappers/approval/EstimateApplicationMapper.ts`（新規）
+  - `src/server/subdomains/estimate/infrastructure/prisma/approval/PrismaEstimateApplicationRepository.ts`（新規）
+- 作業内容:
+  - Red: `EstimateApplication.create` ＋手組み `ApprovalChainPlan`（例 goalPosition=部長、step 役割 ROLE009→ROLE004 の 2 段）で申請を構築し、`insert` → `findById`/`findByStepId`/`findByVariationId` の往復テストを書く。検証の核は **PENDING 状態の導出が往復を生き残ること**（`applicationStatus===PENDING`・先頭ステップ `AWAITING`・以降 `NOT_STARTED`）。`findByVariationId` は attempt 複数件で履歴が返ることを確認。(variationId, attempt) 二重 insert → `ConflictError`。
+  - Green: `EstimateApplicationMapper`（steps を traverse する `*_FULL_INCLUDE`・`toDomain`・ステップ骨格ネスト create を含む insert create-input）と `PrismaEstimateApplicationRepository` の `insert`/`findById`/`findByStepId`/`findByVariationId` を実装。P2002→`ConflictError` 翻訳。
+- コミットメッセージ: `feat: 見積申請リポジトリのinsert・検索系をPrismaで実装`
+  - body 記載: insert はルート＋ステップ骨格のネスト create でイベントは持たない（理由: 生成時点で決定は無く、状態は行の存在から導出する ADR-0058）。
+
+### Step 3: 申請の update（承認・差戻・取下＋楽観ロック）を TDD で実装
+- 対象ファイル:
+  - `.../prisma/approval/__tests__/PrismaEstimateApplicationRepository.test.ts`（追記）
+  - `.../mappers/approval/EstimateApplicationMapper.ts`（イベント upsert input を追記）
+  - `.../prisma/approval/PrismaEstimateApplicationRepository.ts`（`update` を追記）
+- 作業内容:
+  - Red: ドメインの `approve`/`reject`/`withdraw` を経た申請を `update(application, expectedVersion)` で永続化し、reload で **ADR-0058 状態導出が往復を生き残ること**を検証（approve 連鎖で順次 `APPROVED`・次が `AWAITING`、最終承認で申請 `APPROVED` ／ reject で `REJECTED` ／ withdraw で `WITHDRAWN`）。stale `expectedVersion` で `ConflictError`。`created_at`（occurredAt）が DB 既定で確定し refetch 後に復元されることを確認。
+  - Green: `EstimateApplicationMapper` に終端イベントの自然キー create/upsert input を追加。`PrismaEstimateApplicationRepository.update` を方式 A で実装（`updateMany({where:{id,version}})`→`count===0` で `ConflictError`、non-null イベントを自然キー idempotent upsert、ステップ骨格は不触、`created_at` は DB 既定、末尾 `refetch`）。
+  - Refactor: 既存 `PrismaEstimateRepository.update` と共通するロック/翻訳の型を見直し、重複があれば整理。
+- コミットメッセージ: `feat: 見積申請のupdate（承認・差戻・取下）を楽観ロック付きで実装`
+  - body 記載: update は終端イベントを自然キーで idempotent upsert しステップ骨格は触らない（理由: イベントは追記専用・不変で 1ステップ1決定。並行性は version、冪等性は @id 自然キーが担保。ADR-0058/0039）。occurredAt は in-memory 値を捨て DB created_at で確定（ADR-0058）。

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -162,6 +162,17 @@ const eslintConfig = defineConfig([
       "no-restricted-imports": "off",
     },
   },
+  // EstimateApplicationMapper も同様に永続化からの集約再構築のため、子エンティティ
+  // EstimateApprovalStep の reconstruct() を直接呼ぶ。承認免除（EstimateApprovalExemptionMapper）は
+  // 子を持たない薄い集約のため override 不要で、本ファイルのみに穴を限定する。
+  {
+    files: [
+      "src/server/subdomains/estimate/infrastructure/mappers/approval/EstimateApplicationMapper.ts",
+    ],
+    rules: {
+      "no-restricted-imports": "off",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/src/server/__tests__/helpers/ensureApprovalFixtures.ts
+++ b/src/server/__tests__/helpers/ensureApprovalFixtures.ts
@@ -18,6 +18,8 @@ export type ApprovalFixtureIds = {
   exempterEmployeeId: string;
   /** 申請者（予約コードで隔離）。 */
   applicantEmployeeId: string;
+  /** 承認・差戻を実施する従業員（予約コードで隔離）。 */
+  approverEmployeeId: string;
   /** 承認チェーンのゴール役職（部長 = POS002・シード再利用）。 */
   goalPositionId: string;
   /** 承認ステップの順序付き役割列（営業一課長 → 営業部長・シード再利用）。 */
@@ -26,6 +28,7 @@ export type ApprovalFixtureIds = {
 
 const EXEMPTER_EMPLOYEE_CD = "EMP999092";
 const APPLICANT_EMPLOYEE_CD = "EMP999093";
+const APPROVER_EMPLOYEE_CD = "EMP999094";
 
 // 承認チェーンに使うシードの正準組織（code 引きで再利用）。
 const GOAL_POSITION_CD = "POS002"; // 部長
@@ -58,6 +61,18 @@ export async function ensureApprovalFixtures(): Promise<ApprovalFixtureIds> {
     },
   });
 
+  const approver = await prisma.employee.upsert({
+    where: { employeeCd: APPROVER_EMPLOYEE_CD },
+    update: { name: "承認者" },
+    create: {
+      id: generateId(),
+      employeeCd: APPROVER_EMPLOYEE_CD,
+      email: "approval-approver@example.com",
+      name: "承認者",
+      departmentId: estimate.departmentId,
+    },
+  });
+
   // 役職・役割はシードの固定マスタを code 引きで再利用する（@unique がテスト専用生成を阻むため）。
   const goalPosition = await prisma.position.findUniqueOrThrow({
     where: { positionCd: GOAL_POSITION_CD },
@@ -70,6 +85,7 @@ export async function ensureApprovalFixtures(): Promise<ApprovalFixtureIds> {
     estimate,
     exempterEmployeeId: exempter.id,
     applicantEmployeeId: applicant.id,
+    approverEmployeeId: approver.id,
     goalPositionId: goalPosition.id,
     stepRoleIds: stepRoles.map((r) => r.id),
   };

--- a/src/server/__tests__/helpers/ensureApprovalFixtures.ts
+++ b/src/server/__tests__/helpers/ensureApprovalFixtures.ts
@@ -1,0 +1,42 @@
+import prisma from "@server/prisma";
+import { generateId } from "@server/shared/generateId";
+
+import { ensureEstimateFixtures, type EstimateFixtureIds } from "./ensureEstimateFixtures";
+
+/**
+ * 承認系集約（承認免除・見積申請）の永続化テストに必要な FK マスタを確実に用意し、その ID を返す。
+ *
+ * 見積集約のマスタ（部署・得意先・商品など）は {@link ensureEstimateFixtures} に委譲し、
+ * その上に承認系専用の従業員（免除実施者など）を予約コードで冪等 upsert して積み増す。
+ * 役職・役割はシードの正準マスタ（POS / ROLE 系コード）を code 引きで再利用する方針のため、ここでは
+ * 生成しない（テスト側で都度引く）。対象バリエーションは実 estimate insert で本物の FK を用意する。
+ */
+export type ApprovalFixtureIds = {
+  /** 見積集約のマスタ ID 群（対象バリエーションを作る estimate insert に使う）。 */
+  estimate: EstimateFixtureIds;
+  /** 承認免除を実施する従業員（予約コードで隔離）。 */
+  exempterEmployeeId: string;
+};
+
+const EXEMPTER_EMPLOYEE_CD = "EMP999092";
+
+export async function ensureApprovalFixtures(): Promise<ApprovalFixtureIds> {
+  const estimate = await ensureEstimateFixtures();
+
+  const exempter = await prisma.employee.upsert({
+    where: { employeeCd: EXEMPTER_EMPLOYEE_CD },
+    update: { name: "承認免除実施者" },
+    create: {
+      id: generateId(),
+      employeeCd: EXEMPTER_EMPLOYEE_CD,
+      email: "approval-exempter@example.com",
+      name: "承認免除実施者",
+      departmentId: estimate.departmentId,
+    },
+  });
+
+  return {
+    estimate,
+    exempterEmployeeId: exempter.id,
+  };
+}

--- a/src/server/__tests__/helpers/ensureApprovalFixtures.ts
+++ b/src/server/__tests__/helpers/ensureApprovalFixtures.ts
@@ -90,3 +90,50 @@ export async function ensureApprovalFixtures(): Promise<ApprovalFixtureIds> {
     stepRoleIds: stepRoles.map((r) => r.id),
   };
 }
+
+/**
+ * 指定見積番号に紐づく承認系テストデータを FK 安全な順序で削除する（免除・申請テスト共有）。
+ *
+ * 承認系の各表はすべて Restrict FK のため、内側（イベント → ステップ → 申請／免除）から
+ * estimate へ向けて削除する。免除・申請のどちらか一方しか作っていないケースでも、各 deleteMany は
+ * 対象ゼロなら no-op で安全に通る（上位集合として両系統を網羅する）。
+ */
+export async function cleanupApprovalFixtures(estimateNumbers: readonly string[]): Promise<void> {
+  const numbers = [...estimateNumbers];
+  const estimates = await prisma.estimate.findMany({
+    where: { estimateNumber: { in: numbers } },
+    select: { variations: { select: { id: true } } },
+  });
+  const variationIds = estimates.flatMap((e) => e.variations.map((v) => v.id));
+
+  if (variationIds.length > 0) {
+    // 承認免除（variation を Restrict FK 参照）。
+    await prisma.estimateApprovalExemption.deleteMany({
+      where: { variationId: { in: variationIds } },
+    });
+
+    // 申請 → ステップ → 各イベント（すべて Restrict FK のため内側から削除する）。
+    const applications = await prisma.estimateApplication.findMany({
+      where: { variationId: { in: variationIds } },
+      select: { id: true, steps: { select: { id: true } } },
+    });
+    const applicationIds = applications.map((a) => a.id);
+    const stepIds = applications.flatMap((a) => a.steps.map((s) => s.id));
+
+    if (stepIds.length > 0) {
+      await prisma.estimateStepApproval.deleteMany({ where: { stepId: { in: stepIds } } });
+      await prisma.estimateStepRejection.deleteMany({ where: { stepId: { in: stepIds } } });
+    }
+    if (applicationIds.length > 0) {
+      await prisma.estimateApplicationWithdrawal.deleteMany({
+        where: { applicationId: { in: applicationIds } },
+      });
+      await prisma.estimateApprovalStep.deleteMany({
+        where: { applicationId: { in: applicationIds } },
+      });
+      await prisma.estimateApplication.deleteMany({ where: { id: { in: applicationIds } } });
+    }
+  }
+
+  await prisma.estimate.deleteMany({ where: { estimateNumber: { in: numbers } } });
+}

--- a/src/server/__tests__/helpers/ensureApprovalFixtures.ts
+++ b/src/server/__tests__/helpers/ensureApprovalFixtures.ts
@@ -16,9 +16,20 @@ export type ApprovalFixtureIds = {
   estimate: EstimateFixtureIds;
   /** 承認免除を実施する従業員（予約コードで隔離）。 */
   exempterEmployeeId: string;
+  /** 申請者（予約コードで隔離）。 */
+  applicantEmployeeId: string;
+  /** 承認チェーンのゴール役職（部長 = POS002・シード再利用）。 */
+  goalPositionId: string;
+  /** 承認ステップの順序付き役割列（営業一課長 → 営業部長・シード再利用）。 */
+  stepRoleIds: string[];
 };
 
 const EXEMPTER_EMPLOYEE_CD = "EMP999092";
+const APPLICANT_EMPLOYEE_CD = "EMP999093";
+
+// 承認チェーンに使うシードの正準組織（code 引きで再利用）。
+const GOAL_POSITION_CD = "POS002"; // 部長
+const STEP_ROLE_CDS = ["ROLE009", "ROLE004"] as const; // 営業一課長 → 営業部長
 
 export async function ensureApprovalFixtures(): Promise<ApprovalFixtureIds> {
   const estimate = await ensureEstimateFixtures();
@@ -35,8 +46,31 @@ export async function ensureApprovalFixtures(): Promise<ApprovalFixtureIds> {
     },
   });
 
+  const applicant = await prisma.employee.upsert({
+    where: { employeeCd: APPLICANT_EMPLOYEE_CD },
+    update: { name: "申請者" },
+    create: {
+      id: generateId(),
+      employeeCd: APPLICANT_EMPLOYEE_CD,
+      email: "approval-applicant@example.com",
+      name: "申請者",
+      departmentId: estimate.departmentId,
+    },
+  });
+
+  // 役職・役割はシードの固定マスタを code 引きで再利用する（@unique がテスト専用生成を阻むため）。
+  const goalPosition = await prisma.position.findUniqueOrThrow({
+    where: { positionCd: GOAL_POSITION_CD },
+  });
+  const stepRoles = await Promise.all(
+    STEP_ROLE_CDS.map((roleCd) => prisma.role.findUniqueOrThrow({ where: { roleCd } }))
+  );
+
   return {
     estimate,
     exempterEmployeeId: exempter.id,
+    applicantEmployeeId: applicant.id,
+    goalPositionId: goalPosition.id,
+    stepRoleIds: stepRoles.map((r) => r.id),
   };
 }

--- a/src/server/subdomains/estimate/infrastructure/mappers/approval/EstimateApplicationMapper.ts
+++ b/src/server/subdomains/estimate/infrastructure/mappers/approval/EstimateApplicationMapper.ts
@@ -113,4 +113,54 @@ export class EstimateApplicationMapper {
       },
     };
   }
+
+  // ========================================
+  // update パス（終端イベントの自然キー create-input。upsert の create 側に渡す）
+  // 各イベント行は stepId / applicationId を @id 自然キーに持つため idempotent upsert が安全。
+  // occurredAt は DB の created_at（@default(now())）に委ねるため含めない（ADR-0058）。
+  // ========================================
+
+  /** 承認イベントの create-input 群（承認済ステップのみ）。 */
+  static toStepApprovalCreateInputs(
+    application: EstimateApplication
+  ): Prisma.EstimateStepApprovalUncheckedCreateInput[] {
+    return application.steps.flatMap((step) => {
+      const approval = step.approval;
+      return approval
+        ? [{ stepId: step.id.value, approverEmployeeId: approval.approverEmployeeId.value }]
+        : [];
+    });
+  }
+
+  /** 差戻イベントの create-input 群（差戻済ステップのみ）。 */
+  static toStepRejectionCreateInputs(
+    application: EstimateApplication
+  ): Prisma.EstimateStepRejectionUncheckedCreateInput[] {
+    return application.steps.flatMap((step) => {
+      const rejection = step.rejection;
+      return rejection
+        ? [
+            {
+              stepId: step.id.value,
+              rejectedByEmployeeId: rejection.rejectedByEmployeeId.value,
+              comment: rejection.comment.value,
+            },
+          ]
+        : [];
+    });
+  }
+
+  /** 取下イベントの create-input（未取下なら null）。 */
+  static toWithdrawalCreateInput(
+    application: EstimateApplication
+  ): Prisma.EstimateApplicationWithdrawalUncheckedCreateInput | null {
+    const withdrawal = application.withdrawal;
+    if (!withdrawal) {
+      return null;
+    }
+    return {
+      applicationId: application.id.value,
+      withdrawnByEmployeeId: withdrawal.withdrawnByEmployeeId.value,
+    };
+  }
 }

--- a/src/server/subdomains/estimate/infrastructure/mappers/approval/EstimateApplicationMapper.ts
+++ b/src/server/subdomains/estimate/infrastructure/mappers/approval/EstimateApplicationMapper.ts
@@ -1,0 +1,116 @@
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
+import { RoleId } from "@subdomains/role/domain/values/RoleId";
+
+import { EstimateApplication } from "@subdomains/estimate/domain/entities";
+// 集約境界規約の正当な例外（eslint.config.mjs の本ファイル限定 override）:
+// 永続化からの集約再構築のため、子エンティティ EstimateApprovalStep の reconstruct() を直接呼ぶ。
+import { EstimateApprovalStep } from "@subdomains/estimate/domain/entities/approval/EstimateApprovalStep";
+
+import { ApplicationWithdrawal } from "@subdomains/estimate/domain/values/approval/ApplicationWithdrawal";
+import { EstimateApplicationId } from "@subdomains/estimate/domain/values/approval/EstimateApplicationId";
+import { EstimateApprovalStepId } from "@subdomains/estimate/domain/values/approval/EstimateApprovalStepId";
+import { RejectionComment } from "@subdomains/estimate/domain/values/approval/RejectionComment";
+import { StepApproval } from "@subdomains/estimate/domain/values/approval/StepApproval";
+import { StepRejection } from "@subdomains/estimate/domain/values/approval/StepRejection";
+import { EstimateVariationId } from "@subdomains/estimate/domain/values/EstimateVariationId";
+
+import { Prisma } from "@generated/prisma/client";
+
+/**
+ * findById / findByStepId / findByVariationId で申請集約を再構築するための include 定義。
+ * ステップは stepOrder 昇順で固定し、各ステップの終端イベント（承認/差戻）と申請レベルの
+ * 取下イベントを併せて読む。状態（§3.6）はこれらの行の存在から導出する（ADR-0058）。
+ */
+export const ESTIMATE_APPLICATION_FULL_INCLUDE = {
+  steps: {
+    orderBy: { stepOrder: "asc" },
+    include: { approval: true, rejection: true },
+  },
+  withdrawal: true,
+} satisfies Prisma.EstimateApplicationInclude;
+
+export type PrismaEstimateApplicationFull = Prisma.EstimateApplicationGetPayload<{
+  include: typeof ESTIMATE_APPLICATION_FULL_INCLUDE;
+}>;
+
+type PrismaStepFull = PrismaEstimateApplicationFull["steps"][number];
+
+/**
+ * EstimateApplicationMapper
+ *
+ * 見積申請集約（EstimateApplication → EstimateApprovalStep ＋ 終端イベント VO）と Prisma
+ * レコードを相互変換する。集約境界規約の正当な例外として、子エンティティ EstimateApprovalStep の
+ * reconstruct() を直接呼ぶ（eslint override は本ファイルに限定）。
+ *
+ * 終端イベント VO（StepApproval / StepRejection / ApplicationWithdrawal）は独自 identity を
+ * 持たないイベント payload のため、occurredAt にはイベント行の createdAt を充てる（ADR-0058）。
+ */
+export class EstimateApplicationMapper {
+  // ========================================
+  // toDomain（読み取り）
+  // ========================================
+
+  static toDomain(row: PrismaEstimateApplicationFull): EstimateApplication {
+    return EstimateApplication.reconstruct({
+      id: new EstimateApplicationId(row.id),
+      variationId: new EstimateVariationId(row.variationId),
+      attempt: row.attempt,
+      applicantEmployeeId: new EmployeeId(row.applicantEmployeeId),
+      finalApprovalPositionId: new PositionId(row.finalApprovalPositionId),
+      steps: row.steps.map((s) => EstimateApplicationMapper.stepToDomain(s)),
+      withdrawal: row.withdrawal
+        ? ApplicationWithdrawal.create(
+            new EmployeeId(row.withdrawal.withdrawnByEmployeeId),
+            row.withdrawal.createdAt
+          )
+        : null,
+    });
+  }
+
+  private static stepToDomain(s: PrismaStepFull): EstimateApprovalStep {
+    return EstimateApprovalStep.reconstruct({
+      id: new EstimateApprovalStepId(s.id),
+      stepOrder: s.stepOrder,
+      roleId: new RoleId(s.roleId),
+      approval: s.approval
+        ? StepApproval.create(new EmployeeId(s.approval.approverEmployeeId), s.approval.createdAt)
+        : null,
+      rejection: s.rejection
+        ? StepRejection.create(
+            new EmployeeId(s.rejection.rejectedByEmployeeId),
+            new RejectionComment(s.rejection.comment),
+            s.rejection.createdAt
+          )
+        : null,
+    });
+  }
+
+  // ========================================
+  // create パス（ルート＋ステップ骨格のネスト create。生成時点でイベントは無い）
+  // ========================================
+
+  /**
+   * 新規申請の create-input へ変換する。ステップは骨格（役割・順序）のみをネスト create し、
+   * 終端イベントは持たない（生成時点で決定は無く、状態は行の存在から導出する・ADR-0058）。
+   * version（@default(1)）・createdAt（@default(now())）は DB 既定に委ねるため含めない。
+   */
+  static toCreateInput(
+    application: EstimateApplication
+  ): Prisma.EstimateApplicationUncheckedCreateInput {
+    return {
+      id: application.id.value,
+      variationId: application.variationId.value,
+      attempt: application.attempt,
+      applicantEmployeeId: application.applicantEmployeeId.value,
+      finalApprovalPositionId: application.finalApprovalPositionId.value,
+      steps: {
+        create: application.steps.map((step) => ({
+          id: step.id.value,
+          stepOrder: step.stepOrder,
+          roleId: step.roleId.value,
+        })),
+      },
+    };
+  }
+}

--- a/src/server/subdomains/estimate/infrastructure/mappers/approval/EstimateApprovalExemptionMapper.ts
+++ b/src/server/subdomains/estimate/infrastructure/mappers/approval/EstimateApprovalExemptionMapper.ts
@@ -1,0 +1,49 @@
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
+import { EstimateApprovalExemption } from "@subdomains/estimate/domain/entities";
+import { EstimateApprovalExemptionId } from "@subdomains/estimate/domain/values/approval/EstimateApprovalExemptionId";
+import { EstimateExemptionReason } from "@subdomains/estimate/domain/values/approval/EstimateExemptionReason";
+import { EstimateVariationId } from "@subdomains/estimate/domain/values/EstimateVariationId";
+import { Prisma } from "@generated/prisma/client";
+import type { EstimateExemptionReason as PrismaEstimateExemptionReason } from "@generated/prisma/enums";
+
+/**
+ * findByVariationId で集約を再構築するための型。承認免除は子エンティティを持たない薄い集約
+ * （ADR-0054）のため include 定義は不要で、フラットなレコード型をそのまま使う。
+ */
+export type PrismaEstimateApprovalExemption = Prisma.EstimateApprovalExemptionGetPayload<
+  Record<string, never>
+>;
+
+/**
+ * EstimateApprovalExemptionMapper
+ *
+ * 承認免除集約（EstimateApprovalExemption）と Prisma レコードを相互変換する。集約ルートのみで
+ * 子エンティティを持たないため、ルートの reconstruct() をバレル経由で呼ぶ（子の直 import は無く、
+ * EstimateMapper のような eslint override は不要）。
+ */
+export class EstimateApprovalExemptionMapper {
+  static toDomain(row: PrismaEstimateApprovalExemption): EstimateApprovalExemption {
+    return EstimateApprovalExemption.reconstruct({
+      id: new EstimateApprovalExemptionId(row.id),
+      variationId: new EstimateVariationId(row.variationId),
+      reason: EstimateExemptionReason.from(row.reason),
+      exemptedByEmployeeId: new EmployeeId(row.exemptedByEmployeeId),
+      createdAt: row.createdAt,
+    });
+  }
+
+  /**
+   * 新規作成の create-input へ変換する。免除日時（createdAt）は DB 既定（@default(now())）に
+   * 委ねるため含めない（in-memory の値は捨て、refetch で確定する・§3.5）。
+   */
+  static toCreateInput(
+    exemption: EstimateApprovalExemption
+  ): Prisma.EstimateApprovalExemptionUncheckedCreateInput {
+    return {
+      id: exemption.id.value,
+      variationId: exemption.variationId.value,
+      reason: exemption.reason.value as PrismaEstimateExemptionReason,
+      exemptedByEmployeeId: exemption.exemptedByEmployeeId.value,
+    };
+  }
+}

--- a/src/server/subdomains/estimate/infrastructure/prisma/approval/PrismaEstimateApplicationRepository.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/approval/PrismaEstimateApplicationRepository.ts
@@ -1,0 +1,108 @@
+import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { EstimateApplication } from "@subdomains/estimate/domain/entities";
+import { EstimateApplicationRepository } from "@subdomains/estimate/domain/repositories/approval/EstimateApplicationRepository";
+import { EstimateApplicationId } from "@subdomains/estimate/domain/values/approval/EstimateApplicationId";
+import { EstimateApprovalStepId } from "@subdomains/estimate/domain/values/approval/EstimateApprovalStepId";
+import { EstimateVariationId } from "@subdomains/estimate/domain/values/EstimateVariationId";
+import {
+  ESTIMATE_APPLICATION_FULL_INCLUDE,
+  EstimateApplicationMapper,
+} from "@subdomains/estimate/infrastructure/mappers/approval/EstimateApplicationMapper";
+import { Prisma } from "@generated/prisma/client";
+
+/**
+ * PrismaEstimateApplicationRepository
+ *
+ * 見積申請集約（EstimateApplication → EstimateApprovalStep ＋ 終端イベント）の永続化を担う
+ * EstimateApplicationRepository の Prisma 実装（ADR-0039/0058）。集約ルート単位でのみ永続化し、
+ * ステップ骨格・終端イベントは集約経由で書く。状態は保存せず行の存在から導出する。
+ */
+export class PrismaEstimateApplicationRepository implements EstimateApplicationRepository {
+  /**
+   * 申請を新規作成する（ルート＋ステップ骨格をネスト create で同一トランザクション保存）。
+   * 生成時点でイベントは無い。(variationId, attempt) の unique 衝突（並行採番レース・§6.3）は
+   * P2002 を ConflictError へ翻訳して再試行可能な競合として表面化する。
+   */
+  async insert(application: EstimateApplication): Promise<EstimateApplication> {
+    try {
+      await prisma.estimateApplication.create({
+        data: EstimateApplicationMapper.toCreateInput(application),
+      });
+    } catch (error) {
+      PrismaEstimateApplicationRepository.translateInsertConflict(error, application);
+    }
+
+    return this.refetch(application.id.value);
+  }
+
+  /**
+   * 申請アグリゲートを楽観ロック付きで更新する（承認・差戻・取下）。
+   * 本実装は Step 3 で追加する（現時点では未実装）。
+   */
+  async update(
+    _application: EstimateApplication,
+    _expectedVersion: number
+  ): Promise<EstimateApplication> {
+    throw new Error("PrismaEstimateApplicationRepository.update は未実装です（Step 3 で実装）");
+  }
+
+  async findById(id: EstimateApplicationId): Promise<EstimateApplication | null> {
+    const row = await prisma.estimateApplication.findUnique({
+      where: { id: id.value },
+      include: ESTIMATE_APPLICATION_FULL_INCLUDE,
+    });
+
+    return row ? EstimateApplicationMapper.toDomain(row) : null;
+  }
+
+  /**
+   * 承認ステップ ID から、それを含む申請ルートを取得する（§7.1/§7.2）。
+   * まずステップ行から所属 applicationId を引き、申請ルートをアグリゲート単位で読み直す。
+   */
+  async findByStepId(stepId: EstimateApprovalStepId): Promise<EstimateApplication | null> {
+    const step = await prisma.estimateApprovalStep.findUnique({
+      where: { id: stepId.value },
+      select: { applicationId: true },
+    });
+    if (!step) {
+      return null;
+    }
+    return this.findById(new EstimateApplicationId(step.applicationId));
+  }
+
+  /**
+   * バリエーション ID から申請を取得する（attempt 通番の履歴・§3.2/§6.3）。
+   * 差戻→再申請で複数 attempt を持ちうるため全件を attempt 昇順で返す。
+   */
+  async findByVariationId(variationId: EstimateVariationId): Promise<EstimateApplication[]> {
+    const rows = await prisma.estimateApplication.findMany({
+      where: { variationId: variationId.value },
+      include: ESTIMATE_APPLICATION_FULL_INCLUDE,
+      orderBy: { attempt: "asc" },
+    });
+
+    return rows.map((row) => EstimateApplicationMapper.toDomain(row));
+  }
+
+  /** 保存後の集約を完全な include で読み直して返す（イベント createdAt を DB 既定で確定させる）。 */
+  private async refetch(id: string): Promise<EstimateApplication> {
+    const row = await prisma.estimateApplication.findUnique({
+      where: { id },
+      include: ESTIMATE_APPLICATION_FULL_INCLUDE,
+    });
+    if (!row) {
+      throw new Error(`保存した見積申請の再取得に失敗しました: ${id}`);
+    }
+    return EstimateApplicationMapper.toDomain(row);
+  }
+
+  private static translateInsertConflict(error: unknown, application: EstimateApplication): never {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      throw new ConflictError(
+        `バリエーション ${application.variationId.value} の ${application.attempt} 回目の申請は既に存在します。画面を再読み込みしてください。`
+      );
+    }
+    throw error;
+  }
+}

--- a/src/server/subdomains/estimate/infrastructure/prisma/approval/PrismaEstimateApplicationRepository.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/approval/PrismaEstimateApplicationRepository.ts
@@ -37,14 +37,63 @@ export class PrismaEstimateApplicationRepository implements EstimateApplicationR
   }
 
   /**
-   * 申請アグリゲートを楽観ロック付きで更新する（承認・差戻・取下）。
-   * 本実装は Step 3 で追加する（現時点では未実装）。
+   * 申請アグリゲートを楽観ロック付きで更新する（承認・差戻・取下／方式 A・ADR-0039/0058）。
+   *
+   * ステップ骨格は不変なので一切触れず、終端イベント行のみを自然キー（stepId / applicationId =
+   * @id）で idempotent upsert する。並行性は version ガード（WHERE id AND version の条件付き
+   * UPDATE → count 0 で競合）が担い、冪等性は自然キーが担う。occurredAt はイベント行の
+   * created_at（@default(now())）で確定するため書き込まず、末尾の refetch で復元する。
    */
   async update(
-    _application: EstimateApplication,
-    _expectedVersion: number
+    application: EstimateApplication,
+    expectedVersion: number
   ): Promise<EstimateApplication> {
-    throw new Error("PrismaEstimateApplicationRepository.update は未実装です（Step 3 で実装）");
+    const applicationId = application.id.value;
+
+    await prisma.$transaction(async (tx) => {
+      // 1. ルートの version を条件付きインクリメント（楽観ロックのチェック地点）。
+      //    count 0 は version 不一致（先行更新）／行消失の両方を含むため競合として扱い、
+      //    throw で $transaction 全体（イベント upsert 含む）をロールバックする。
+      const rootUpdate = await tx.estimateApplication.updateMany({
+        where: { id: applicationId, version: expectedVersion },
+        data: { version: { increment: 1 } },
+      });
+      if (rootUpdate.count === 0) {
+        throw new ConflictError(
+          "他のユーザーによって更新されています。画面を再読み込みして最新の内容を確認してください。"
+        );
+      }
+
+      // 2. 承認イベントを自然キーで idempotent upsert（既存は update:{} で no-op = created_at 保持）。
+      for (const input of EstimateApplicationMapper.toStepApprovalCreateInputs(application)) {
+        await tx.estimateStepApproval.upsert({
+          where: { stepId: input.stepId },
+          create: input,
+          update: {},
+        });
+      }
+
+      // 3. 差戻イベントを自然キーで idempotent upsert。
+      for (const input of EstimateApplicationMapper.toStepRejectionCreateInputs(application)) {
+        await tx.estimateStepRejection.upsert({
+          where: { stepId: input.stepId },
+          create: input,
+          update: {},
+        });
+      }
+
+      // 4. 取下イベント（申請レベル・高々 1）を自然キーで idempotent upsert。
+      const withdrawal = EstimateApplicationMapper.toWithdrawalCreateInput(application);
+      if (withdrawal) {
+        await tx.estimateApplicationWithdrawal.upsert({
+          where: { applicationId: withdrawal.applicationId },
+          create: withdrawal,
+          update: {},
+        });
+      }
+    });
+
+    return this.refetch(applicationId);
   }
 
   async findById(id: EstimateApplicationId): Promise<EstimateApplication | null> {

--- a/src/server/subdomains/estimate/infrastructure/prisma/approval/PrismaEstimateApplicationRepository.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/approval/PrismaEstimateApplicationRepository.ts
@@ -40,9 +40,11 @@ export class PrismaEstimateApplicationRepository implements EstimateApplicationR
    * 申請アグリゲートを楽観ロック付きで更新する（承認・差戻・取下／方式 A・ADR-0039/0058）。
    *
    * ステップ骨格は不変なので一切触れず、終端イベント行のみを自然キー（stepId / applicationId =
-   * @id）で idempotent upsert する。並行性は version ガード（WHERE id AND version の条件付き
-   * UPDATE → count 0 で競合）が担い、冪等性は自然キーが担う。occurredAt はイベント行の
-   * created_at（@default(now())）で確定するため書き込まず、末尾の refetch で復元する。
+   * @id）で追記する。並行性は version ガード（WHERE id AND version の条件付き UPDATE →
+   * count 0 で競合）が担い、冪等性は `createMany({ skipDuplicates: true })` が担う（既決イベントは
+   * @id 衝突でスキップされ created_at を保持する）。テーブル毎に 1 往復へ畳み、version ロック
+   * 保持中の往復数を抑える。occurredAt はイベント行の created_at（@default(now())）で確定する
+   * ため書き込まず、末尾の refetch で復元する。
    */
   async update(
     application: EstimateApplication,
@@ -52,8 +54,8 @@ export class PrismaEstimateApplicationRepository implements EstimateApplicationR
 
     await prisma.$transaction(async (tx) => {
       // 1. ルートの version を条件付きインクリメント（楽観ロックのチェック地点）。
-      //    count 0 は version 不一致（先行更新）／行消失の両方を含むため競合として扱い、
-      //    throw で $transaction 全体（イベント upsert 含む）をロールバックする。
+      //    count 0 は version 不一致（先行更新あり）を意味する。申請は delete を持たない
+      //    append-only 集約のため行消失は通常起きない。throw で $transaction 全体をロールバックする。
       const rootUpdate = await tx.estimateApplication.updateMany({
         where: { id: applicationId, version: expectedVersion },
         data: { version: { increment: 1 } },
@@ -64,31 +66,22 @@ export class PrismaEstimateApplicationRepository implements EstimateApplicationR
         );
       }
 
-      // 2. 承認イベントを自然キーで idempotent upsert（既存は update:{} で no-op = created_at 保持）。
-      for (const input of EstimateApplicationMapper.toStepApprovalCreateInputs(application)) {
-        await tx.estimateStepApproval.upsert({
-          where: { stepId: input.stepId },
-          create: input,
-          update: {},
-        });
+      // 2. 承認・差戻イベントを自然キーで一括追記（既決は skipDuplicates でスキップ = created_at 保持）。
+      const approvals = EstimateApplicationMapper.toStepApprovalCreateInputs(application);
+      if (approvals.length > 0) {
+        await tx.estimateStepApproval.createMany({ data: approvals, skipDuplicates: true });
+      }
+      const rejections = EstimateApplicationMapper.toStepRejectionCreateInputs(application);
+      if (rejections.length > 0) {
+        await tx.estimateStepRejection.createMany({ data: rejections, skipDuplicates: true });
       }
 
-      // 3. 差戻イベントを自然キーで idempotent upsert。
-      for (const input of EstimateApplicationMapper.toStepRejectionCreateInputs(application)) {
-        await tx.estimateStepRejection.upsert({
-          where: { stepId: input.stepId },
-          create: input,
-          update: {},
-        });
-      }
-
-      // 4. 取下イベント（申請レベル・高々 1）を自然キーで idempotent upsert。
+      // 3. 取下イベント（申請レベル・高々 1）も同じく自然キーで冪等追記する。
       const withdrawal = EstimateApplicationMapper.toWithdrawalCreateInput(application);
       if (withdrawal) {
-        await tx.estimateApplicationWithdrawal.upsert({
-          where: { applicationId: withdrawal.applicationId },
-          create: withdrawal,
-          update: {},
+        await tx.estimateApplicationWithdrawal.createMany({
+          data: [withdrawal],
+          skipDuplicates: true,
         });
       }
     });
@@ -107,17 +100,15 @@ export class PrismaEstimateApplicationRepository implements EstimateApplicationR
 
   /**
    * 承認ステップ ID から、それを含む申請ルートを取得する（§7.1/§7.2）。
-   * まずステップ行から所属 applicationId を引き、申請ルートをアグリゲート単位で読み直す。
+   * ステップの `application` リレーションを辿り、親集約を 1 クエリで読む（承認 Inbox の
+   * 「このステップを承認」導線は最頻読取のため往復を 1 回に抑える）。
    */
   async findByStepId(stepId: EstimateApprovalStepId): Promise<EstimateApplication | null> {
     const step = await prisma.estimateApprovalStep.findUnique({
       where: { id: stepId.value },
-      select: { applicationId: true },
+      select: { application: { include: ESTIMATE_APPLICATION_FULL_INCLUDE } },
     });
-    if (!step) {
-      return null;
-    }
-    return this.findById(new EstimateApplicationId(step.applicationId));
+    return step ? EstimateApplicationMapper.toDomain(step.application) : null;
   }
 
   /**
@@ -146,6 +137,14 @@ export class PrismaEstimateApplicationRepository implements EstimateApplicationR
     return EstimateApplicationMapper.toDomain(row);
   }
 
+  /**
+   * 新規作成系の P2002（一意制約違反）を ConflictError へ翻訳する。
+   *
+   * 本 insert で発火しうる P2002 は実質 `@@unique([variationId, attempt])` のみ。ネスト create する
+   * steps の `@@unique([applicationId, stepOrder])` は新規 applicationId 配下かつ stepOrder が
+   * 1 始まり連番のため衝突不能、id は UUIDv7 で衝突不能。よって制約名で絞らず一律翻訳しても
+   * メッセージは (variationId, attempt) 競合に対応する（並行採番レース・§6.3 を再試行可能化）。
+   */
   private static translateInsertConflict(error: unknown, application: EstimateApplication): never {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
       throw new ConflictError(

--- a/src/server/subdomains/estimate/infrastructure/prisma/approval/PrismaEstimateApprovalExemptionRepository.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/approval/PrismaEstimateApprovalExemptionRepository.ts
@@ -1,0 +1,63 @@
+import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { EstimateApprovalExemption } from "@subdomains/estimate/domain/entities";
+import { EstimateApprovalExemptionRepository } from "@subdomains/estimate/domain/repositories/approval/EstimateApprovalExemptionRepository";
+import { EstimateVariationId } from "@subdomains/estimate/domain/values/EstimateVariationId";
+import { EstimateApprovalExemptionMapper } from "@subdomains/estimate/infrastructure/mappers/approval/EstimateApprovalExemptionMapper";
+import { Prisma } from "@generated/prisma/client";
+
+/**
+ * PrismaEstimateApprovalExemptionRepository
+ *
+ * 承認免除集約（EstimateApprovalExemption）の永続化を担う Prisma 実装（ADR-0054）。
+ * 免除は生成後に状態が変わらない不変レコードのため、update / 楽観ロック / delete は提供しない。
+ */
+export class PrismaEstimateApprovalExemptionRepository implements EstimateApprovalExemptionRepository {
+  /**
+   * 承認免除を新規作成する（1バリエーション1免除・variation_id @unique）。
+   * アプリ層チェックをすり抜けた二重確定レースは DB の unique 制約が最後の砦として捕捉するため、
+   * P2002 を ConflictError へ翻訳して再試行可能な競合として表面化する（estimate_number 翻訳と一貫）。
+   */
+  async insert(exemption: EstimateApprovalExemption): Promise<EstimateApprovalExemption> {
+    try {
+      await prisma.estimateApprovalExemption.create({
+        data: EstimateApprovalExemptionMapper.toCreateInput(exemption),
+      });
+    } catch (error) {
+      PrismaEstimateApprovalExemptionRepository.translateInsertConflict(error, exemption);
+    }
+
+    return this.refetch(exemption.variationId);
+  }
+
+  async findByVariationId(
+    variationId: EstimateVariationId
+  ): Promise<EstimateApprovalExemption | null> {
+    const row = await prisma.estimateApprovalExemption.findUnique({
+      where: { variationId: variationId.value },
+    });
+
+    return row ? EstimateApprovalExemptionMapper.toDomain(row) : null;
+  }
+
+  /** 保存後の集約を読み直して返す（createdAt を DB 既定で確定させるため）。 */
+  private async refetch(variationId: EstimateVariationId): Promise<EstimateApprovalExemption> {
+    const found = await this.findByVariationId(variationId);
+    if (!found) {
+      throw new Error(`保存した承認免除の再取得に失敗しました: ${variationId.value}`);
+    }
+    return found;
+  }
+
+  private static translateInsertConflict(
+    error: unknown,
+    exemption: EstimateApprovalExemption
+  ): never {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      throw new ConflictError(
+        `バリエーション ${exemption.variationId.value} は既に承認免除されています。もう一度確認してください。`
+      );
+    }
+    throw error;
+  }
+}

--- a/src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApplicationRepository.test.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApplicationRepository.test.ts
@@ -10,6 +10,7 @@ import { RoleId } from "@subdomains/role/domain/values/RoleId";
 import { EstimateApplication } from "@subdomains/estimate/domain/entities";
 import { buildNewEstimate } from "@subdomains/estimate/domain/entities/__tests__/estimateAggregateBuilder";
 import { ApprovalChainPlan } from "@subdomains/estimate/domain/values/approval/ApprovalChainPlan";
+import { RejectionComment } from "@subdomains/estimate/domain/values/approval/RejectionComment";
 import { EstimateVariationId } from "@subdomains/estimate/domain/values/EstimateVariationId";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -22,6 +23,10 @@ const EN = {
   byStep: "N9907011",
   history: "N9907012",
   conflict: "N9907013",
+  approve: "N9907014",
+  reject: "N9907015",
+  withdraw: "N9907016",
+  stale: "N9907017",
 } as const;
 const ALL_NUMBERS = Object.values(EN);
 
@@ -162,5 +167,74 @@ describe("PrismaEstimateApplicationRepository", () => {
     await expect(repository.insert(buildApplication(variationId, 1))).rejects.toBeInstanceOf(
       ConflictError
     );
+  });
+
+  describe("update（承認・差戻・取下＋楽観ロック）", () => {
+    it("approve 連鎖で順次 APPROVED になり、最終承認で申請 APPROVED（往復生存）", async () => {
+      const variationId = await createVariationId(EN.approve);
+      const saved = await repository.insert(buildApplication(variationId));
+      const approver = new EmployeeId(ids.approverEmployeeId);
+
+      // step1 承認 → version 1 で更新（成功後 DB version は 2）
+      saved.approve(saved.steps[0].id, approver);
+      const afterStep1 = await repository.update(saved, 1);
+
+      expect(afterStep1.applicationStatus.value).toBe("PENDING");
+      expect(afterStep1.stepStatus(afterStep1.steps[0].id).value).toBe("APPROVED");
+      expect(afterStep1.stepStatus(afterStep1.steps[1].id).value).toBe("AWAITING");
+      // occurredAt は DB の created_at で確定し、refetch 後に復元される（ADR-0058）
+      expect(afterStep1.steps[0].approval).not.toBeNull();
+      expect(afterStep1.steps[0].approval?.occurredAt).toBeInstanceOf(Date);
+
+      // step2 承認（最終）→ version 2 で更新
+      afterStep1.approve(afterStep1.steps[1].id, approver);
+      const afterStep2 = await repository.update(afterStep1, 2);
+
+      expect(afterStep2.applicationStatus.value).toBe("APPROVED");
+      expect(afterStep2.stepStatus(afterStep2.steps[1].id).value).toBe("APPROVED");
+    });
+
+    it("reject で申請 REJECTED（往復生存）", async () => {
+      const variationId = await createVariationId(EN.reject);
+      const saved = await repository.insert(buildApplication(variationId));
+
+      saved.reject(
+        saved.steps[0].id,
+        new EmployeeId(ids.approverEmployeeId),
+        new RejectionComment("金額の根拠が不足しています")
+      );
+      const updated = await repository.update(saved, 1);
+
+      expect(updated.applicationStatus.value).toBe("REJECTED");
+      expect(updated.stepStatus(updated.steps[0].id).value).toBe("REJECTED");
+      expect(updated.steps[0].rejection?.comment.value).toBe("金額の根拠が不足しています");
+      expect(updated.steps[0].rejection?.occurredAt).toBeInstanceOf(Date);
+    });
+
+    it("withdraw で申請 WITHDRAWN（往復生存）", async () => {
+      const variationId = await createVariationId(EN.withdraw);
+      const saved = await repository.insert(buildApplication(variationId));
+
+      saved.withdraw(new EmployeeId(ids.applicantEmployeeId));
+      const updated = await repository.update(saved, 1);
+
+      expect(updated.applicationStatus.value).toBe("WITHDRAWN");
+      expect(updated.withdrawal).not.toBeNull();
+      expect(updated.withdrawal?.occurredAt).toBeInstanceOf(Date);
+    });
+
+    it("stale な expectedVersion での update は ConflictError", async () => {
+      const variationId = await createVariationId(EN.stale);
+      const saved = await repository.insert(buildApplication(variationId));
+      const approver = new EmployeeId(ids.approverEmployeeId);
+
+      // 先行更新で DB version を 2 に進める
+      saved.approve(saved.steps[0].id, approver);
+      const advanced = await repository.update(saved, 1);
+
+      // 進んだアグリゲートに次の変更を載せ、古い version 1 で更新を試みる
+      advanced.approve(advanced.steps[1].id, approver);
+      await expect(repository.update(advanced, 1)).rejects.toBeInstanceOf(ConflictError);
+    });
   });
 });

--- a/src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApplicationRepository.test.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApplicationRepository.test.ts
@@ -1,0 +1,166 @@
+import {
+  ensureApprovalFixtures,
+  type ApprovalFixtureIds,
+} from "@server/__tests__/helpers/ensureApprovalFixtures";
+import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
+import { PositionId } from "@subdomains/position/domain/values/PositionId";
+import { RoleId } from "@subdomains/role/domain/values/RoleId";
+import { EstimateApplication } from "@subdomains/estimate/domain/entities";
+import { buildNewEstimate } from "@subdomains/estimate/domain/entities/__tests__/estimateAggregateBuilder";
+import { ApprovalChainPlan } from "@subdomains/estimate/domain/values/approval/ApprovalChainPlan";
+import { EstimateVariationId } from "@subdomains/estimate/domain/values/EstimateVariationId";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { PrismaEstimateRepository } from "../../PrismaEstimateRepository";
+import { PrismaEstimateApplicationRepository } from "../PrismaEstimateApplicationRepository";
+
+// 承認系テスト見積番号（N9907xxx 帯。免除テストの 001/002 と分けて 01x を使う）。
+const EN = {
+  roundtrip: "N9907010",
+  byStep: "N9907011",
+  history: "N9907012",
+  conflict: "N9907013",
+} as const;
+const ALL_NUMBERS = Object.values(EN);
+
+async function cleanup(): Promise<void> {
+  const estimates = await prisma.estimate.findMany({
+    where: { estimateNumber: { in: [...ALL_NUMBERS] } },
+    select: { variations: { select: { id: true } } },
+  });
+  const variationIds = estimates.flatMap((e) => e.variations.map((v) => v.id));
+  if (variationIds.length > 0) {
+    // 申請（→ステップ→各イベント）を estimate 削除前に先に消す（variation FK は Restrict）。
+    const applications = await prisma.estimateApplication.findMany({
+      where: { variationId: { in: variationIds } },
+      select: { id: true, steps: { select: { id: true } } },
+    });
+    const applicationIds = applications.map((a) => a.id);
+    const stepIds = applications.flatMap((a) => a.steps.map((s) => s.id));
+    if (stepIds.length > 0) {
+      await prisma.estimateStepApproval.deleteMany({ where: { stepId: { in: stepIds } } });
+      await prisma.estimateStepRejection.deleteMany({ where: { stepId: { in: stepIds } } });
+    }
+    if (applicationIds.length > 0) {
+      await prisma.estimateApplicationWithdrawal.deleteMany({
+        where: { applicationId: { in: applicationIds } },
+      });
+      await prisma.estimateApprovalStep.deleteMany({
+        where: { applicationId: { in: applicationIds } },
+      });
+      await prisma.estimateApplication.deleteMany({ where: { id: { in: applicationIds } } });
+    }
+  }
+  await prisma.estimate.deleteMany({ where: { estimateNumber: { in: [...ALL_NUMBERS] } } });
+}
+
+describe("PrismaEstimateApplicationRepository", () => {
+  let repository: PrismaEstimateApplicationRepository;
+  let estimateRepository: PrismaEstimateRepository;
+  let ids: ApprovalFixtureIds;
+
+  beforeAll(async () => {
+    ids = await ensureApprovalFixtures();
+  });
+
+  beforeEach(async () => {
+    repository = new PrismaEstimateApplicationRepository();
+    estimateRepository = new PrismaEstimateRepository();
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  /** 実 estimate を insert して本物の FK を持つバリエーション ID を得る。 */
+  async function createVariationId(estimateNumber: string): Promise<EstimateVariationId> {
+    const estimate = await estimateRepository.insert(
+      buildNewEstimate(ids.estimate, estimateNumber)
+    );
+    return estimate.variations[0].id;
+  }
+
+  /** 部長ゴール・2段（営業一課長 → 営業部長）の手組みチェーン計画。 */
+  function buildPlan(): ApprovalChainPlan {
+    return ApprovalChainPlan.create(
+      new PositionId(ids.goalPositionId),
+      ids.stepRoleIds.map((id) => new RoleId(id))
+    );
+  }
+
+  /** PENDING な新規申請を組み立てる。 */
+  function buildApplication(variationId: EstimateVariationId, attempt = 1): EstimateApplication {
+    return EstimateApplication.create({
+      variationId,
+      attempt,
+      applicantEmployeeId: new EmployeeId(ids.applicantEmployeeId),
+      plan: buildPlan(),
+    });
+  }
+
+  it("insert → findById で PENDING 状態の導出が往復を生き残る", async () => {
+    const variationId = await createVariationId(EN.roundtrip);
+    const application = buildApplication(variationId);
+
+    const saved = await repository.insert(application);
+    const found = await repository.findById(saved.id);
+
+    expect(found).not.toBeNull();
+    if (!found) return;
+    expect(found.id.value).toBe(saved.id.value);
+    expect(found.variationId.value).toBe(variationId.value);
+    expect(found.attempt).toBe(1);
+    expect(found.applicantEmployeeId.value).toBe(ids.applicantEmployeeId);
+    expect(found.finalApprovalPositionId.value).toBe(ids.goalPositionId);
+
+    // 状態は保存せず行の存在から導出する（ADR-0058）。生成直後は申請 PENDING。
+    expect(found.applicationStatus.value).toBe("PENDING");
+
+    // ステップ骨格（順序・役割）が往復で保たれる。
+    expect(found.steps).toHaveLength(2);
+    expect(found.steps[0].stepOrder).toBe(1);
+    expect(found.steps[0].roleId.value).toBe(ids.stepRoleIds[0]);
+    expect(found.steps[1].stepOrder).toBe(2);
+    expect(found.steps[1].roleId.value).toBe(ids.stepRoleIds[1]);
+
+    // 先頭ステップが AWAITING、以降は NOT_STARTED（§3.6 導出）。
+    expect(found.stepStatus(found.steps[0].id).value).toBe("AWAITING");
+    expect(found.stepStatus(found.steps[1].id).value).toBe("NOT_STARTED");
+  });
+
+  it("findByStepId で当該ステップを含む申請ルートを取得できる", async () => {
+    const variationId = await createVariationId(EN.byStep);
+    const saved = await repository.insert(buildApplication(variationId));
+    const targetStepId = saved.steps[1].id;
+
+    const found = await repository.findByStepId(targetStepId);
+
+    expect(found).not.toBeNull();
+    if (!found) return;
+    expect(found.id.value).toBe(saved.id.value);
+    expect(found.steps.some((s) => s.id.value === targetStepId.value)).toBe(true);
+  });
+
+  it("findByVariationId は attempt 複数件の履歴を返す", async () => {
+    const variationId = await createVariationId(EN.history);
+    await repository.insert(buildApplication(variationId, 1));
+    await repository.insert(buildApplication(variationId, 2));
+
+    const found = await repository.findByVariationId(variationId);
+
+    expect(found).toHaveLength(2);
+    expect(found.map((a) => a.attempt).sort()).toEqual([1, 2]);
+  });
+
+  it("(variationId, attempt) の二重 insert は ConflictError", async () => {
+    const variationId = await createVariationId(EN.conflict);
+    await repository.insert(buildApplication(variationId, 1));
+
+    await expect(repository.insert(buildApplication(variationId, 1))).rejects.toBeInstanceOf(
+      ConflictError
+    );
+  });
+});

--- a/src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApplicationRepository.test.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApplicationRepository.test.ts
@@ -1,8 +1,8 @@
 import {
+  cleanupApprovalFixtures,
   ensureApprovalFixtures,
   type ApprovalFixtureIds,
 } from "@server/__tests__/helpers/ensureApprovalFixtures";
-import prisma from "@server/prisma";
 import { ConflictError } from "@server/shared/errors/ApplicationError";
 import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import { PositionId } from "@subdomains/position/domain/values/PositionId";
@@ -30,37 +30,6 @@ const EN = {
 } as const;
 const ALL_NUMBERS = Object.values(EN);
 
-async function cleanup(): Promise<void> {
-  const estimates = await prisma.estimate.findMany({
-    where: { estimateNumber: { in: [...ALL_NUMBERS] } },
-    select: { variations: { select: { id: true } } },
-  });
-  const variationIds = estimates.flatMap((e) => e.variations.map((v) => v.id));
-  if (variationIds.length > 0) {
-    // 申請（→ステップ→各イベント）を estimate 削除前に先に消す（variation FK は Restrict）。
-    const applications = await prisma.estimateApplication.findMany({
-      where: { variationId: { in: variationIds } },
-      select: { id: true, steps: { select: { id: true } } },
-    });
-    const applicationIds = applications.map((a) => a.id);
-    const stepIds = applications.flatMap((a) => a.steps.map((s) => s.id));
-    if (stepIds.length > 0) {
-      await prisma.estimateStepApproval.deleteMany({ where: { stepId: { in: stepIds } } });
-      await prisma.estimateStepRejection.deleteMany({ where: { stepId: { in: stepIds } } });
-    }
-    if (applicationIds.length > 0) {
-      await prisma.estimateApplicationWithdrawal.deleteMany({
-        where: { applicationId: { in: applicationIds } },
-      });
-      await prisma.estimateApprovalStep.deleteMany({
-        where: { applicationId: { in: applicationIds } },
-      });
-      await prisma.estimateApplication.deleteMany({ where: { id: { in: applicationIds } } });
-    }
-  }
-  await prisma.estimate.deleteMany({ where: { estimateNumber: { in: [...ALL_NUMBERS] } } });
-}
-
 describe("PrismaEstimateApplicationRepository", () => {
   let repository: PrismaEstimateApplicationRepository;
   let estimateRepository: PrismaEstimateRepository;
@@ -73,11 +42,11 @@ describe("PrismaEstimateApplicationRepository", () => {
   beforeEach(async () => {
     repository = new PrismaEstimateApplicationRepository();
     estimateRepository = new PrismaEstimateRepository();
-    await cleanup();
+    await cleanupApprovalFixtures(ALL_NUMBERS);
   });
 
   afterAll(async () => {
-    await cleanup();
+    await cleanupApprovalFixtures(ALL_NUMBERS);
   });
 
   /** 実 estimate を insert して本物の FK を持つバリエーション ID を得る。 */

--- a/src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApprovalExemptionRepository.test.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApprovalExemptionRepository.test.ts
@@ -1,8 +1,8 @@
 import {
+  cleanupApprovalFixtures,
   ensureApprovalFixtures,
   type ApprovalFixtureIds,
 } from "@server/__tests__/helpers/ensureApprovalFixtures";
-import prisma from "@server/prisma";
 import { ConflictError } from "@server/shared/errors/ApplicationError";
 import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
 import { EstimateApprovalExemption } from "@subdomains/estimate/domain/entities";
@@ -21,21 +21,6 @@ const EN = {
 } as const;
 const ALL_NUMBERS = Object.values(EN);
 
-async function cleanup(): Promise<void> {
-  const estimates = await prisma.estimate.findMany({
-    where: { estimateNumber: { in: [...ALL_NUMBERS] } },
-    select: { variations: { select: { id: true } } },
-  });
-  const variationIds = estimates.flatMap((e) => e.variations.map((v) => v.id));
-  if (variationIds.length > 0) {
-    // 免除は variation を FK 参照（onDelete Restrict）するため、estimate 削除前に先に消す。
-    await prisma.estimateApprovalExemption.deleteMany({
-      where: { variationId: { in: variationIds } },
-    });
-  }
-  await prisma.estimate.deleteMany({ where: { estimateNumber: { in: [...ALL_NUMBERS] } } });
-}
-
 describe("PrismaEstimateApprovalExemptionRepository", () => {
   let repository: PrismaEstimateApprovalExemptionRepository;
   let estimateRepository: PrismaEstimateRepository;
@@ -48,11 +33,11 @@ describe("PrismaEstimateApprovalExemptionRepository", () => {
   beforeEach(async () => {
     repository = new PrismaEstimateApprovalExemptionRepository();
     estimateRepository = new PrismaEstimateRepository();
-    await cleanup();
+    await cleanupApprovalFixtures(ALL_NUMBERS);
   });
 
   afterAll(async () => {
-    await cleanup();
+    await cleanupApprovalFixtures(ALL_NUMBERS);
   });
 
   /** 実 estimate を insert して本物の FK を持つバリエーション ID を得る。 */

--- a/src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApprovalExemptionRepository.test.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/approval/__tests__/PrismaEstimateApprovalExemptionRepository.test.ts
@@ -1,0 +1,112 @@
+import {
+  ensureApprovalFixtures,
+  type ApprovalFixtureIds,
+} from "@server/__tests__/helpers/ensureApprovalFixtures";
+import prisma from "@server/prisma";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { EmployeeId } from "@subdomains/employee/domain/values/EmployeeId";
+import { EstimateApprovalExemption } from "@subdomains/estimate/domain/entities";
+import { buildNewEstimate } from "@subdomains/estimate/domain/entities/__tests__/estimateAggregateBuilder";
+import { EstimateExemptionReason } from "@subdomains/estimate/domain/values/approval/EstimateExemptionReason";
+import { EstimateVariationId } from "@subdomains/estimate/domain/values/EstimateVariationId";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { PrismaEstimateRepository } from "../../PrismaEstimateRepository";
+import { PrismaEstimateApprovalExemptionRepository } from "../PrismaEstimateApprovalExemptionRepository";
+
+// 予約済みテスト見積番号（承認系は N9907xxx を使用。既存リポジトリテストの N9900xxx と衝突しない）。
+const EN = {
+  roundtrip: "N9907001",
+  conflict: "N9907002",
+} as const;
+const ALL_NUMBERS = Object.values(EN);
+
+async function cleanup(): Promise<void> {
+  const estimates = await prisma.estimate.findMany({
+    where: { estimateNumber: { in: [...ALL_NUMBERS] } },
+    select: { variations: { select: { id: true } } },
+  });
+  const variationIds = estimates.flatMap((e) => e.variations.map((v) => v.id));
+  if (variationIds.length > 0) {
+    // 免除は variation を FK 参照（onDelete Restrict）するため、estimate 削除前に先に消す。
+    await prisma.estimateApprovalExemption.deleteMany({
+      where: { variationId: { in: variationIds } },
+    });
+  }
+  await prisma.estimate.deleteMany({ where: { estimateNumber: { in: [...ALL_NUMBERS] } } });
+}
+
+describe("PrismaEstimateApprovalExemptionRepository", () => {
+  let repository: PrismaEstimateApprovalExemptionRepository;
+  let estimateRepository: PrismaEstimateRepository;
+  let ids: ApprovalFixtureIds;
+
+  beforeAll(async () => {
+    ids = await ensureApprovalFixtures();
+  });
+
+  beforeEach(async () => {
+    repository = new PrismaEstimateApprovalExemptionRepository();
+    estimateRepository = new PrismaEstimateRepository();
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  /** 実 estimate を insert して本物の FK を持つバリエーション ID を得る。 */
+  async function createVariationId(estimateNumber: string): Promise<EstimateVariationId> {
+    const estimate = await estimateRepository.insert(
+      buildNewEstimate(ids.estimate, estimateNumber)
+    );
+    return estimate.variations[0].id;
+  }
+
+  it("insert → findByVariationId で免除を等価に再構築できる", async () => {
+    const variationId = await createVariationId(EN.roundtrip);
+    const exemption = EstimateApprovalExemption.create(
+      variationId,
+      EstimateExemptionReason.BELOW_THRESHOLD,
+      new EmployeeId(ids.exempterEmployeeId)
+    );
+
+    const saved = await repository.insert(exemption);
+
+    const found = await repository.findByVariationId(variationId);
+    expect(found).not.toBeNull();
+    if (!found) return;
+    expect(found.id.value).toBe(saved.id.value);
+    expect(found.variationId.value).toBe(variationId.value);
+    expect(found.reason.value).toBe("BELOW_THRESHOLD");
+    expect(found.exemptedByEmployeeId.value).toBe(ids.exempterEmployeeId);
+    // 免除日時は DB 既定（@default(now())）で確定し、refetch で復元される
+    expect(found.createdAt).toBeInstanceOf(Date);
+  });
+
+  it("免除が無いバリエーションは findByVariationId で null", async () => {
+    const variationId = await createVariationId(EN.roundtrip);
+
+    const found = await repository.findByVariationId(variationId);
+
+    expect(found).toBeNull();
+  });
+
+  it("同一バリエーションへの二重 insert は ConflictError", async () => {
+    const variationId = await createVariationId(EN.conflict);
+    const first = EstimateApprovalExemption.create(
+      variationId,
+      EstimateExemptionReason.CONSUMABLE_ONLY,
+      new EmployeeId(ids.exempterEmployeeId)
+    );
+    await repository.insert(first);
+
+    const second = EstimateApprovalExemption.create(
+      variationId,
+      EstimateExemptionReason.AFTER_REPAIR,
+      new EmployeeId(ids.exempterEmployeeId)
+    );
+
+    await expect(repository.insert(second)).rejects.toBeInstanceOf(ConflictError);
+  });
+});


### PR DESCRIPTION
## Summary

#386 で実装した承認系ドメイン層（EstimateApplication / EstimateApprovalStep / EstimateApprovalExemption）の上にインフラ層を実装。承認免除・見積申請リポジトリの Prisma 実装、Domain⇔Prisma の Mapper、TDD による統合テストを追加した。insert/検索系に加え、申請の update（承認・差戻・取下）を楽観ロック付きで永続化し、ADR-0058 の状態導出が永続化往復を生き残ることを検証している。

Closes #407

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### implement-approval-prisma-repositories.md

#### 概要

#386 で実装した承認系ドメイン層（`EstimateApplication` / `EstimateApprovalStep` / `EstimateApprovalExemption` 集約・終端イベント VO・`ApprovalChainPlan`）の上に、インフラ層を実装する。承認免除・見積申請リポジトリの Prisma 実装、Domain⇔Prisma の Mapper、TDD による統合テストを行う。

スコープは Mapper + リポジトリ Prisma 実装 2 本 + 統合テストの 3 点に縮退。Issue 起票時の未決事項に挙がっていた「§3.7 逆参照リレーション追加」「migration の切り方」は、調査の結果 #384（commit da032b0）で承認系 6 テーブル・全 FK・CHECK・index・§3.7 逆参照リレーションがすべて作成済みであることが判明したため対象外（新規 migration 不要）。

本 issue 外の境界: 承認 Inbox 等の QueryService、楽観ロック `version` を読み出す read model は別 issue。

#### 設計判断

- **スコープ縮退（§3.7・migration は #384 で完了済み）**: 逆参照リレーションは Prisma の仮想リレーション（SQL カラムを生まない）で、FK が #384 で張られていれば schema 記載のみで完結し新規 migration は不要。§3.7 / migration を本 issue から外し、Mapper + リポジトリ実装 + 統合テストに集中する。
- **ファイル配置**: ドメイン層の `approval/` 区画化（commit b5f0c94）を鏡写しに `infrastructure/mappers/approval/`・`infrastructure/prisma/approval/` を新設する（確立済み規約に揃える）。
- **`update()` の終端イベント永続化方式**: version ガード＋終端イベントを自然キーで idempotent upsert＋ステップ骨格は不触＋`created_at` は DB 既定＋`refetch`。終端イベントは追記専用・1ステップ1決定でドメインが `isDecided()` ガード済み、`stepId`/`applicationId` が `@id` 自然キーのため upsert が冪等で FK 安全。並行性は version ガード（ADR-0039/0058）、冪等性は自然キーが担保。`occurredAt` は reload 後の DB `created_at` で確定（ADR-0058）。
- **`insert()` の形**: 既存パターン踏襲（ルート＋ステップ骨格のネスト create。生成時点でイベント無し）。
- **Mapper の責務分割**: 集約ルートごとに 1 Mapper（`*_FULL_INCLUDE` 定数＋`toDomain`＋create-input ビルダ、子の `reconstruct()` 直呼び）。eslint override（ADR-0031）は各 mapper ファイルに限定。
- **ユニーク制約衝突の例外翻訳**: `estimate_applications(variationId, attempt)` 衝突・`estimate_approval_exemptions.variationId` 衝突（P2002）を `ConflictError` に翻訳。FK 違反（P2003）は翻訳せず生のまま。
- **統合テストのデータ準備方式**: 役職・役割はシードを code 引きで再利用、従業員のみ予約コードで upsert。対象 variation は実 estimate insert で本物の FK を用意。
- **テスト戦略（申請集約の構築）**: 申請集約は `EstimateApplication.create` ＋ `ApprovalChainPlan` 手組みで生成し、`ApprovalChainBuilder` は通さない（チェーン構築は #386 ドメインテストで担保済み）。
- **ドキュメント更新**: CONTEXT.md は新規業務用語なしで追記不要。新規 ADR は既存 ADR（0058/0039/0032/0054・estimate_number 翻訳先例）に従うのみで起票見送り。

#### ステップ（TDD: red → green → refactor）

1. **承認免除リポジトリを TDD で実装（＋ensureApprovalFixtures 土台）**: `ensureApprovalFixtures` を整え、免除の統合テスト（insert → `findByVariationId` 往復、二重 insert → `ConflictError`）を書き、`EstimateApprovalExemptionMapper` と `PrismaEstimateApprovalExemptionRepository` を実装。
2. **見積申請リポジトリの insert / 検索を TDD で実装**: `EstimateApplication.create` ＋手組み `ApprovalChainPlan` で申請を構築し、`insert` → `findById`/`findByStepId`/`findByVariationId` の往復テスト。検証の核は PENDING 状態の導出が往復を生き残ること。`EstimateApplicationMapper` と `PrismaEstimateApplicationRepository` を実装。
3. **申請の update（承認・差戻・取下＋楽観ロック）を TDD で実装**: `approve`/`reject`/`withdraw` を経た申請を `update(application, expectedVersion)` で永続化し、reload で ADR-0058 状態導出が往復を生き残ることを検証。stale `expectedVersion` で `ConflictError`。`update` を方式 A で実装。

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

（補足: 計画ディレクトリに `deviations.md` は存在しません。コミット構成・ファイル配置・設計判断はいずれも計画書の Step 1〜3 と一致しています。）

## Test Plan

統合テストを TDD（red → green → refactor）で追加。Prisma 実 DB に対するリポジトリ往復テストで、ADR-0058 の状態導出が永続化を生き残ることを検証する。

- [ ] `PrismaEstimateApprovalExemptionRepository.test.ts`: insert → `findByVariationId` 往復 / 同一 variation 二重 insert → `ConflictError`
- [ ] `PrismaEstimateApplicationRepository.test.ts`（insert/検索）: insert → `findById`/`findByStepId`/`findByVariationId` 往復、PENDING 状態導出（先頭 `AWAITING`・以降 `NOT_STARTED`）、attempt 複数件の履歴、(variationId, attempt) 二重 insert → `ConflictError`
- [ ] `PrismaEstimateApplicationRepository.test.ts`（update）: approve 連鎖で順次 `APPROVED`・次が `AWAITING`、最終承認で `APPROVED` / reject で `REJECTED` / withdraw で `WITHDRAWN`、stale version で `ConflictError`、`occurredAt` が DB `created_at` で確定
- [ ] `pnpm test` がグリーン
- [ ] `pnpm lint` がグリーン

---

Generated with [Claude Code](https://claude.ai/code)
