### PR TITLE
fix: 申請プレビューがINACTIVEバリエーションを弾かずSubmitと可否が食い違う (#442)

### DIFF
--- a/docs/claude-plans/issue-442/preview-rejects-inactive-variation.md
+++ b/docs/claude-plans/issue-442/preview-rejects-inactive-variation.md
@@ -1,0 +1,70 @@
+# Issue #442: 申請プレビューが INACTIVE バリエーションを弾かず Submit と可否が食い違う — 実装計画
+
+## Context
+
+PR #437（#417）レビュー指摘 #4。`loadApprovalChainInputs` は越境ローダーとして
+`targetVariationIsActive` という「バリエーションが有効か」の事実を集めているが、これを
+「申請可否」へ変換しているのは `SubmitApplicationCommand` だけ。`PreviewApplicationQuery` は
+同じローダーを使いながらこの事実を読まず、judge＋チェーン組立てをそのまま走らせている。
+
+結果、確認モーダル（Preview）は INACTIVE バリエーションでも EXEMPT/REQUIRED を返し
+「申請できる」かのように承認チェーンを見せるが、実行（Submit）で初めて
+「無効なバリエーションには申請できません」で弾かれる。Preview/Submit が同一事実から異なる
+可否を答えており、共有ローダーの目的（ドリフト防止）に対し最も基本的な可否要因が
+消費から漏れている。本修正はこの漏れを Preview 側で閉じ、両者の可否を一致させる。
+
+## 設計判断
+
+### INACTIVE の DTO 表現 — 専用 kind を追加（ユーザー確認済み）
+- A. `PreviewApplicationResultDTO` に専用 `{ kind: "INACTIVE" }` を新設 ← **採用**
+- B. `BLOCKED.reason` を `ApprovalChainBlockedReason | "INACTIVE"` に拡張
+- 採用理由: `ApprovalChainBlockedReason`（`NO_SUPERIOR_ROLE` 等）はドメインサービス
+  `ApprovalChainBuilder` の語彙＝「承認チェーンが組めない理由」。INACTIVE は
+  チェーン構築以前の「バリエーション状態」の問題で原因が異なる。専用 kind に分けることで
+  ドメインサービスの語彙を汚さず、UI 分岐も意味論的に明確になる。
+
+### 判定の配置順 — ローダー直後・assembleApprovalChain の前（判断不要）
+- Submit と同じく `targetVariationIsActive` を判定の起点に置く（Issue 明記）。
+  Preview でもローダー直後・組立て前で早期 return し、INACTIVE 時は judge/チェーン構築を
+  走らせない。Submit の順序（INACTIVE → 兄弟 → judge）と整合。
+
+### スコープ — INACTIVE のみ（ユーザー確認済み）
+- 兄弟前進チェック（1見積1前進）の Preview/Submit 食い違いは同種の問題だが本Issueの
+  スコープ外。今回は `targetVariationIsActive` の消費漏れだけを閉じる。
+
+## ステップ
+
+### Step 1: Preview 結果 DTO に INACTIVE kind を追加し Query で早期 return（TDD: RED→GREEN）
+- 対象ファイル:
+  - `src/server/subdomains/estimate/application/queries/__tests__/PreviewApplicationQuery.test.ts`
+  - `src/server/subdomains/estimate/application/queries/dto/PreviewApplicationResultDTO.ts`
+  - `src/server/subdomains/estimate/application/queries/PreviewApplicationQuery.ts`
+- 作業内容:
+  - RED: `SubmitApplicationCommand.test.ts:177-194` を参考に、
+    `buildNewEstimate(ids.estimate, EN.inactive, { variationNumbers: [1, 2] })` で
+    複数バリエーションを作り `built.deactivateVariation(targetVariationId)` で対象を無効化。
+    Preview 結果が `{ kind: "INACTIVE" }` であること、副作用（申請行・免除行）が無いことを検証。
+  - GREEN: DTO の判別共用体に `| { kind: "INACTIVE" }` を追加。
+    `PreviewApplicationQuery.execute` で `loadApprovalChainInputs` 直後・
+    `assembleApprovalChain` の前に
+    `if (!loaded.targetVariationIsActive) return { kind: "INACTIVE" };` を置く。
+- コミットメッセージ: `fix: 申請プレビューがINACTIVEバリエーションを弾かずSubmitと可否が食い違う (#442)`
+
+## 影響範囲の確認
+
+- `PreviewApplicationResultDTO` / `PreviewApplicationQuery` の利用箇所は factory とテストのみで、
+  プレゼンテーション層（API route / server action / UI モーダル）には未接続。よって UI 側の
+  網羅的 switch などの破壊は無く、変更はアプリ層内で完結する。
+- DDD レイヤリング: 変更はアプリ層（queries/dto）のみ。ドメイン層・ドメインサービスの型
+  （`ApprovalChainBlockedReason`）には一切手を入れない。
+
+## 検証
+
+```bash
+pnpm test src/server/subdomains/estimate/application/queries/__tests__/PreviewApplicationQuery.test.ts
+pnpm lint
+```
+
+- 新規 INACTIVE テストが green になること。
+- 既存4ケース（EXEMPT / REQUIRED / BLOCKED(NO_SUPERIOR_ROLE) / 副作用なし）が回帰しないこと。
+- 型チェックで DTO の判別共用体追加が破綻しないこと。

--- a/src/server/subdomains/estimate/application/queries/PreviewApplicationQuery.ts
+++ b/src/server/subdomains/estimate/application/queries/PreviewApplicationQuery.ts
@@ -45,6 +45,13 @@ export class PreviewApplicationQuery {
       roleQueryService: this.roleQueryService,
     });
 
+    // INACTIVE バリエーションは申請不可（§3.4/§12）。Submit（SubmitApplicationCommand）と同じく
+    // `targetVariationIsActive` を判定の起点に置き、judge＋チェーン組立ての前に弾く。これを
+    // 怠ると Preview だけが INACTIVE でも EXEMPT/REQUIRED を見せ、Submit と可否が食い違う（#442）。
+    if (!loaded.targetVariationIsActive) {
+      return { kind: "INACTIVE" };
+    }
+
     const result = assembleApprovalChain(loaded.assemblerInput);
 
     if (result.kind === "EXEMPT") {

--- a/src/server/subdomains/estimate/application/queries/__tests__/PreviewApplicationQuery.test.ts
+++ b/src/server/subdomains/estimate/application/queries/__tests__/PreviewApplicationQuery.test.ts
@@ -28,6 +28,7 @@ describe("PreviewApplicationQuery", () => {
     required: "N9908002",
     noSuperior: "N9908003",
     sideEffect: "N9908004",
+    inactive: "N9908005",
   } as const;
   const ALL_NUMBERS = Object.values(EN);
   const OPERATOR_CD = "EMP999096";
@@ -131,6 +132,31 @@ describe("PreviewApplicationQuery", () => {
     });
 
     expect(result).toEqual({ kind: "BLOCKED", reason: "NO_SUPERIOR_ROLE" });
+  });
+
+  it("INACTIVE バリエーションは judge を走らせず INACTIVE を返す（Submit と可否一致）", async () => {
+    // 複数バリエーションで対象を無効化する（Submit テストと同じ手順）。
+    // INACTIVE 判定は judge より前で弾くため金額は不問。
+    const built = buildNewEstimate(ids.estimate, EN.inactive, { variationNumbers: [1, 2] });
+    const targetVariation = built.variations[1];
+    built.deactivateVariation(targetVariation.id);
+    const estimate = await estimateRepository.insert(built);
+    const variationId = targetVariation.id.value;
+
+    const result = await query.execute({
+      estimateId: estimate.id.value,
+      variationId,
+      operatorEmployeeId: operatorId,
+    });
+
+    // Submit（無効なバリエーションには申請できない）と可否が一致する。
+    expect(result).toEqual({ kind: "INACTIVE" });
+
+    // 副作用なし（クエリのため申請行・免除行を作らない）。
+    const applications = await prisma.estimateApplication.count({ where: { variationId } });
+    const exemptions = await prisma.estimateApprovalExemption.count({ where: { variationId } });
+    expect(applications).toBe(0);
+    expect(exemptions).toBe(0);
   });
 
   it("プレビューは副作用を持たない（申請行・免除行を作らない）", async () => {

--- a/src/server/subdomains/estimate/application/queries/dto/PreviewApplicationResultDTO.ts
+++ b/src/server/subdomains/estimate/application/queries/dto/PreviewApplicationResultDTO.ts
@@ -13,8 +13,13 @@ export type PreviewApplicationStepDTO = {
 /**
  * 申請プレビューの結果（確認モーダル用・§6.2）。
  *
- * 免除（理由）／承認必要（ゴール役職＋ステップ列）／申請不可（業務理由）の判別共用体。
- * 副作用は無く、`SubmitApplication` と同じ judge＋組立てロジックを共有して得る（#417）。
+ * 免除（理由）／承認必要（ゴール役職＋ステップ列）／申請不可（業務理由）／対象バリエーションが
+ * 無効（INACTIVE）の判別共用体。副作用は無く、`SubmitApplication` と同じ judge＋組立てロジックを
+ * 共有して得る（#417）。
+ *
+ * `INACTIVE` はチェーン構築以前の「バリエーション状態」の事実で、`BLOCKED`（承認チェーンが
+ * 組めない業務理由）とは原因が異なるため専用 kind に分ける。Submit が `targetVariationIsActive`
+ * を判定の起点に置くのと同じく、Preview も judge を走らせる前にこれを返す（#442）。
  */
 export type PreviewApplicationResultDTO =
   | { kind: "EXEMPT"; reason: string; reasonLabel: string }
@@ -24,4 +29,5 @@ export type PreviewApplicationResultDTO =
       goalPositionName: string;
       steps: PreviewApplicationStepDTO[];
     }
-  | { kind: "BLOCKED"; reason: ApprovalChainBlockedReason };
+  | { kind: "BLOCKED"; reason: ApprovalChainBlockedReason }
+  | { kind: "INACTIVE" };


### PR DESCRIPTION
## 概要

確認モーダル（Preview）が INACTIVE バリエーションを弾かず、Submit と申請可否が食い違う不具合を修正します（PR #437 / #417 レビュー指摘 #4）。

Closes #442

## 問題

`loadApprovalChainInputs`（Preview/Submit 共有の越境ローダー）は `targetVariationIsActive` を集めるが、これを申請可否へ変換しているのは `SubmitApplicationCommand` だけ。`PreviewApplicationQuery` は同じ事実を読まず judge＋チェーン組立てを走らせていた。

その結果、Preview は INACTIVE バリエーションでも `EXEMPT`/`REQUIRED` を返して「申請できる」かのように承認チェーンを見せ、実行（Submit）で初めて「無効なバリエーションには申請できません」で弾かれる。**同一事実から Preview/Submit が異なる可否を答え、共有ローダーの目的（ドリフト防止）に対し最も基本的な可否要因が消費から漏れていた。**

## 変更内容

- `PreviewApplicationResultDTO` に専用 `{ kind: "INACTIVE" }` を新設
- `PreviewApplicationQuery.execute` で `assembleApprovalChain` の前に `targetVariationIsActive` を判定し早期 return（Submit と同じ「判定の起点」に整合）

## 設計判断

### INACTIVE の DTO 表現 — 専用 kind を採用
- 採用: `{ kind: "INACTIVE" }` を新設
- 退けた案: `BLOCKED.reason` を `ApprovalChainBlockedReason | "INACTIVE"` に拡張
- 理由: `ApprovalChainBlockedReason`（`NO_SUPERIOR_ROLE` 等）はドメインサービス `ApprovalChainBuilder` の語彙＝「承認チェーンが組めない理由」。INACTIVE はチェーン構築以前の「バリエーション状態」の問題で原因が異なる。専用 kind に分けることでドメインサービスの語彙を汚さず、UI 分岐の意味論も明確になる。

### スコープ
- 本 PR は INACTIVE の消費漏れのみを閉じる。兄弟前進チェック（1見積1前進）の Preview/Submit 食い違いは同種の構造だが本 Issue のスコープ外。

## テスト

- `PreviewApplicationQuery.test.ts` に INACTIVE ケースを追加（`{ kind: "INACTIVE" }` を返すこと＋副作用なしを検証）
- 既存4ケース（EXEMPT / REQUIRED / BLOCKED(NO_SUPERIOR_ROLE) / 副作用なし）は回帰なし
- `pnpm lint` / `pnpm exec tsc --noEmit` クリーン

## 影響範囲

- 変更はアプリ層（queries/dto）に閉じ、ドメイン層・ドメインサービスの型には一切手を入れていない
- `PreviewApplicationResultDTO` / `PreviewApplicationQuery` の利用箇所は factory とテストのみで、プレゼンテーション層には未接続。UI 側の破壊なし

## 関連

- PR #437 レビュー #4 / ADR-0066 / #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)