### PR TITLE
fix: 共通売単価 保守画面 — 一般ユーザーに編集系ボタンを表示しない（role 出し分け）

### DIFF
--- a/docs/claude-plans/issue-482/role-gate-mutation-buttons.md
+++ b/docs/claude-plans/issue-482/role-gate-mutation-buttons.md
@@ -1,0 +1,74 @@
+# Issue #482: 共通売単価 保守画面 — 一般ユーザーに編集系ボタンを表示しない（role 出し分け） — 実装計画
+
+## Context
+
+共通売単価 保守画面の詳細（`/common-selling-prices/[productCd]`）では、ミューテーション系ボタン
+（新規追加 / 編集 / 適用終了 / 削除）が **role に関係なく常時表示**されている。一般ユーザーが押すと
+サーバーアクションの `verifyAdmin()` が `redirect("/signin?reason=forbidden")` で弾くため操作自体は
+防げているが、「押せるのに弾かれる」UX になっている。
+
+ADR-0020 判断5 は「一般ユーザー用の閲覧画面でも編集系ボタンが表示されないこと」を必須としており、
+現状はこの要件を満たしていない。本 Issue でフロント側のボタン出し分けを追加し、要件を満たす。
+認可の正本はサーバー側 `verifyAdmin()`（変更しない＝二重防御の維持）、フロントの出し分けは UX 補助。
+
+関連: #481（E2E テスト）は本修正の完了を前提に書くため、本 Issue を先行させる。
+
+## 設計判断
+
+### isAdmin の導出と受け渡し方式
+- 既存パターン踏襲のため判断不要。`departments/[departmentCd]/page.tsx:12,22` と同様に
+  `const session = await verifySession();` → `isAdmin(session)` で導出し、
+  client wrapper（`PeriodDetailPanel`）に boolean prop として渡す。
+- `verifySession()` は `cache()` 済み（`src/app/_lib/verifyAuthentication.ts:15`）のため、
+  現状の `await verifySession()`（戻り値破棄）を「戻り値受け取り」に変えても追加コストなし。
+
+### 非管理者時の「操作」列の扱い
+- **列ごと非表示にする**（ユーザー確認済み）。
+- 非管理者では `操作` 列の `<th>` と各行の `<td>` を描画しない。全行が `—` になる列を残さず、
+  閲覧専用としてスッキリさせる。`新規追加` ボタン（パネルヘッダ）も非表示にする。
+
+### 下流コンポーネントへの role 伝播
+- 不要。`PeriodForm` / `PeriodDeleteConfirm` は `PeriodDetailPanel` 内のボタン経由でしか
+  `mode` が遷移せず開けない。ボタンを描画しなければフォームも到達不能。prop 追加は
+  `PeriodDetailPanel` のみで閉じる。
+
+## ステップ
+
+### Step 1: 詳細ページで isAdmin を導出し PeriodDetailPanel へ渡す
+- 対象ファイル: `src/app/(features)/common-selling-prices/[productCd]/page.tsx`
+- 作業内容:
+  - `import { isAdmin } from "@server/shared/auth";` を追加
+  - `await verifySession();` を `const session = await verifySession();` に変更
+  - `const admin = isAdmin(session);` を算出（関数名 `isAdmin` と衝突するため変数名は `admin`）
+  - `<PeriodDetailPanel detail={detail} />` を `<PeriodDetailPanel detail={detail} isAdmin={admin} />` に変更
+- コミットメッセージ: `fix: 共通売単価詳細ページで管理者判定を PeriodDetailPanel に渡す (#482)`
+
+### Step 2: PeriodDetailPanel で非管理者時にミューテーション UI を非表示
+- 対象ファイル: `src/app/(features)/common-selling-prices/[productCd]/PeriodDetailPanel.tsx`
+- 作業内容:
+  - `Props` に `isAdmin: boolean` を追加し、関数引数で受け取る
+  - パネルヘッダの `新規追加` ボタンを `isAdmin && (...)` で条件描画
+  - テーブルヘッダの `操作` `<th>` を `isAdmin && (...)` で条件描画
+  - 各行の `操作` `<td>`（`PeriodDeleteConfirm` 分岐・編集/適用終了/削除ボタン・`—` 表示を含む全体）を `isAdmin && (...)` で条件描画
+  - `auth = authorityFor(...)` や `mode` ロジックは温存（非管理者では UI が出ないため影響なし）
+- コミットメッセージ: `fix: 共通売単価 保守画面で一般ユーザーに編集系ボタンを表示しない (#482)`
+
+## 変更しないもの（明示）
+
+- `[productCd]/actions.ts` の各アクション冒頭 `verifyAdmin()` — 認可の正本として維持（二重防御）。
+- `PeriodForm.tsx` / `PeriodDeleteConfirm.tsx` — props 変更なし。
+- E2E / 単体テスト — 本 Issue では追加しない（「ボタン非表示」テストは #481 の範囲）。
+
+## 受け入れ条件との対応
+
+- [ ] 一般ユーザーで詳細画面 → `新規追加`・`操作` 列ごと非表示（閲覧のみ） … Step 1 + Step 2
+- [ ] 管理者では従来どおり全ボタンが状態別（`authorityFor`）に表示 … `isAdmin && (...)` 条件のみ追加で既存挙動温存
+- [ ] サーバー側 `verifyAdmin()` 維持 … 変更しない
+
+## 検証方法
+
+1. `pnpm lint` / `pnpm build`（型エラー確認: `isAdmin` prop の追加・必須化）
+2. dev server + Playwright MCP（`/verify-frontend` 手順）で実機確認:
+   - 管理者ログイン → `/common-selling-prices/{productCd}` → `新規追加`・各行の編集/適用終了/削除が状態別に表示
+   - 一般ユーザーログイン → 同画面 → `新規追加` ボタン・`操作` 列（ヘッダ＋セル）が一切非表示、商品情報・適用期間明細は閲覧可能
+3. （参考）一般ユーザーで万一サーバーアクションを直接叩いても `verifyAdmin()` の redirect が効くこと＝二重防御の維持

--- a/src/app/(features)/common-selling-prices/[productCd]/PeriodDetailPanel.tsx
+++ b/src/app/(features)/common-selling-prices/[productCd]/PeriodDetailPanel.tsx
@@ -34,6 +34,8 @@ type PanelMode =
 
 type Props = {
   detail: CommonSellingPriceEditDTO;
+  /** 管理者のみミューテーション系UI（新規追加・編集・適用終了・削除）を描画する。認可の正本はサーバー側 verifyAdmin。 */
+  isAdmin: boolean;
 };
 
 /**
@@ -43,7 +45,7 @@ type Props = {
  * （use-cases.md §7・authorityFor）、登録/編集/適用終了は単一 PeriodForm をモードで
  * 切り替えて下部パネルに表示する。削除は行内2段階確認（決定5）。
  */
-export function PeriodDetailPanel({ detail }: Props) {
+export function PeriodDetailPanel({ detail, isAdmin }: Props) {
   const [mode, setMode] = useState<PanelMode>({ kind: "closed" });
   const close = useCallback(() => setMode({ kind: "closed" }), []);
 
@@ -59,13 +61,15 @@ export function PeriodDetailPanel({ detail }: Props) {
     <div className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-xl font-semibold text-gray-500">適用期間</h2>
-        <button
-          type="button"
-          onClick={() => setMode({ kind: "new" })}
-          className="bg-blue-500 hover:bg-blue-700 text-white text-sm font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-        >
-          新規追加
-        </button>
+        {isAdmin && (
+          <button
+            type="button"
+            onClick={() => setMode({ kind: "new" })}
+            className="bg-blue-500 hover:bg-blue-700 text-white text-sm font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          >
+            新規追加
+          </button>
+        )}
       </div>
 
       {detail.periods.length > 0 ? (
@@ -76,7 +80,7 @@ export function PeriodDetailPanel({ detail }: Props) {
               <th className="py-2 text-sm font-bold text-gray-700">適用終了日</th>
               <th className="py-2 text-sm font-bold text-gray-700 text-right">共通売単価</th>
               <th className="py-2 text-sm font-bold text-gray-700">状態</th>
-              <th className="py-2 text-sm font-bold text-gray-700 text-right">操作</th>
+              {isAdmin && <th className="py-2 text-sm font-bold text-gray-700 text-right">操作</th>}
             </tr>
           </thead>
           <tbody>
@@ -96,51 +100,55 @@ export function PeriodDetailPanel({ detail }: Props) {
                   <td className="py-2">
                     <Badge variant={badge.variant}>{badge.label}</Badge>
                   </td>
-                  <td className="py-2">
-                    {isDeleting ? (
-                      <PeriodDeleteConfirm
-                        productId={detail.productId}
-                        productCode={detail.productCode}
-                        periodId={period.periodId}
-                        version={detail.version ?? 0}
-                        onSuccess={close}
-                        onCancel={close}
-                      />
-                    ) : (
-                      <div className="flex gap-2 justify-end">
-                        {auth.editable && (
-                          <button
-                            type="button"
-                            onClick={() => setMode({ kind: "edit", periodId: period.periodId })}
-                            className="text-blue-600 hover:text-blue-800 hover:underline text-sm"
-                          >
-                            編集
-                          </button>
-                        )}
-                        {auth.endDatable && (
-                          <button
-                            type="button"
-                            onClick={() => setMode({ kind: "endDate", periodId: period.periodId })}
-                            className="text-blue-600 hover:text-blue-800 hover:underline text-sm"
-                          >
-                            適用終了
-                          </button>
-                        )}
-                        {auth.deletable && (
-                          <button
-                            type="button"
-                            onClick={() => setMode({ kind: "delete", periodId: period.periodId })}
-                            className="text-red-600 hover:text-red-800 hover:underline text-sm"
-                          >
-                            削除
-                          </button>
-                        )}
-                        {!auth.editable && !auth.endDatable && !auth.deletable && (
-                          <span className="text-gray-400 text-sm">—</span>
-                        )}
-                      </div>
-                    )}
-                  </td>
+                  {isAdmin && (
+                    <td className="py-2">
+                      {isDeleting ? (
+                        <PeriodDeleteConfirm
+                          productId={detail.productId}
+                          productCode={detail.productCode}
+                          periodId={period.periodId}
+                          version={detail.version ?? 0}
+                          onSuccess={close}
+                          onCancel={close}
+                        />
+                      ) : (
+                        <div className="flex gap-2 justify-end">
+                          {auth.editable && (
+                            <button
+                              type="button"
+                              onClick={() => setMode({ kind: "edit", periodId: period.periodId })}
+                              className="text-blue-600 hover:text-blue-800 hover:underline text-sm"
+                            >
+                              編集
+                            </button>
+                          )}
+                          {auth.endDatable && (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setMode({ kind: "endDate", periodId: period.periodId })
+                              }
+                              className="text-blue-600 hover:text-blue-800 hover:underline text-sm"
+                            >
+                              適用終了
+                            </button>
+                          )}
+                          {auth.deletable && (
+                            <button
+                              type="button"
+                              onClick={() => setMode({ kind: "delete", periodId: period.periodId })}
+                              className="text-red-600 hover:text-red-800 hover:underline text-sm"
+                            >
+                              削除
+                            </button>
+                          )}
+                          {!auth.editable && !auth.endDatable && !auth.deletable && (
+                            <span className="text-gray-400 text-sm">—</span>
+                          )}
+                        </div>
+                      )}
+                    </td>
+                  )}
                 </tr>
               );
             })}

--- a/src/app/(features)/common-selling-prices/[productCd]/page.tsx
+++ b/src/app/(features)/common-selling-prices/[productCd]/page.tsx
@@ -1,4 +1,5 @@
 import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { isAdmin } from "@server/shared/auth";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { commonSellingPriceEditQueryFactory } from "@subdomains/pricing/application/factories/pricingQueryFactory";
@@ -11,7 +12,8 @@ export default async function CommonSellingPriceDetailPage({
 }: {
   params: Promise<{ productCd: string }>;
 }) {
-  await verifySession();
+  const session = await verifySession();
+  const admin = isAdmin(session);
   const { productCd } = await params;
 
   const detail = await commonSellingPriceEditQueryFactory().find({
@@ -56,7 +58,7 @@ export default async function CommonSellingPriceDetailPage({
       </div>
 
       {/* 適用期間明細＋操作（UC-2/3/4/5）。表示・操作はクライアント wrapper に委譲。 */}
-      <PeriodDetailPanel detail={detail} />
+      <PeriodDetailPanel detail={detail} isAdmin={admin} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

共通売単価 保守画面の詳細（`/common-selling-prices/[productCd]`）で、ミューテーション系ボタン（新規追加 / 編集 / 適用終了 / 削除）が role に関係なく常時表示されていた問題を修正。詳細ページで管理者判定を導出し `PeriodDetailPanel` に `isAdmin` を渡して、非管理者では `新規追加` ボタンと `操作` 列（ヘッダ＋セル）を非表示にした。サーバー側 `verifyAdmin()` は認可の正本として維持（二重防御）。

Closes #482

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### role-gate-mutation-buttons.md

#### Context

共通売単価 保守画面の詳細では、ミューテーション系ボタンが role に関係なく常時表示されている。一般ユーザーが押すとサーバーアクションの `verifyAdmin()` が `redirect("/signin?reason=forbidden")` で弾くため操作自体は防げているが、「押せるのに弾かれる」UX になっている。ADR-0020 判断5 は「一般ユーザー用の閲覧画面でも編集系ボタンが表示されないこと」を必須としており、本 Issue でフロント側のボタン出し分けを追加して要件を満たす。認可の正本はサーバー側 `verifyAdmin()`（変更しない＝二重防御の維持）。

#### 設計判断

- **isAdmin の導出と受け渡し方式**: 既存パターン踏襲（`departments/[departmentCd]/page.tsx` と同様）。`const session = await verifySession();` → `isAdmin(session)` で導出し、client wrapper に boolean prop として渡す。`verifySession()` は `cache()` 済みのため追加コストなし。
- **非管理者時の「操作」列の扱い**: 列ごと非表示（ユーザー確認済み）。`<th>` と各行の `<td>` を描画せず、閲覧専用としてスッキリさせる。`新規追加` ボタンも非表示。
- **下流コンポーネントへの role 伝播**: 不要。`PeriodForm` / `PeriodDeleteConfirm` は `PeriodDetailPanel` 内のボタン経由でしか開けず、ボタンを描画しなければ到達不能。prop 追加は `PeriodDetailPanel` のみで閉じる。

#### ステップ

- **Step 1**: 詳細ページ（`page.tsx`）で `isAdmin` を導出し `PeriodDetailPanel` へ渡す。
- **Step 2**: `PeriodDetailPanel` で非管理者時にミューテーション UI（`新規追加` ボタン・`操作` 列のヘッダとセル）を非表示。`authorityFor` / `mode` ロジックは温存。

#### 変更しないもの

- `actions.ts` の各アクション冒頭 `verifyAdmin()` — 認可の正本として維持（二重防御）。
- `PeriodForm.tsx` / `PeriodDeleteConfirm.tsx` — props 変更なし。
- E2E / 単体テスト — 本 Issue では追加しない（「ボタン非表示」テストは #481 の範囲）。

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

本 Issue は自動テストを追加しない方針（「ボタン非表示」E2E テストは #481 の範囲）。下記を手動で確認する。

- [ ] 管理者ログイン → `/common-selling-prices/{productCd}` → `新規追加`・各行の編集 / 適用終了 / 削除が状態別（`authorityFor`）に表示される
- [ ] 一般ユーザーログイン → 同画面 → `新規追加` ボタン・`操作` 列（ヘッダ＋セル）が一切非表示、商品情報・適用期間明細は閲覧可能
- [ ] 一般ユーザーでサーバーアクションを直接叩いても `verifyAdmin()` の redirect が効く（二重防御の維持）
- [ ] `pnpm lint` / `pnpm build` が通る

---

Generated with [Claude Code](https://claude.ai/code)
