### PR TITLE
feat: 得意先別販売単価の書き込みユースケース（ドメイン編集操作 + commands/factories）

### DIFF
--- a/docs/claude-plans/issue-505/customer-selling-price-write-usecases.md
+++ b/docs/claude-plans/issue-505/customer-selling-price-write-usecases.md
@@ -1,0 +1,97 @@
+# Issue #505: 得意先別販売単価の書き込みユースケース（ドメイン編集操作 + commands/factories） — 実装計画
+
+## 概要
+
+得意先別販売単価（`CustomerSellingPrice`）の「書き込み」関心を実装する。**動作中の共通販売単価 BE（`CommonSellingPrice` 集約 + 5 コマンド + `loadCommonSellingPriceOrThrow` + factories + `PrismaCommonSellingPriceRepository`）を得意先別へ完全写像**する。得意先軸の差分は複合自然キー `(CustomerId, ProductId)` が identity である一点のみ（ADR-20260624-8tg）で、それ以外の業務ルール・永続化パターンは共通と同一。
+
+現状の得意先別は集約が `addPeriod`（過去ガード無し）のみ・コマンドゼロ。リポジトリは #460 時点の append-only 実装のまま。本計画で共通と同水準まで引き上げる。
+
+- **含む**: 集約の編集系ミューテータ（`editPeriod` / `endDatePeriod` / `deletePeriod` / `currentValidPeriod`、および `addPeriod` への参照日ガード）／application commands 5 種（Register / Edit / EndDate / Delete / Revise）＋共有ロードヘルパ／factories／リポジトリの差分 sync 化／テスト一式
+- **含まない**: 読みモデル（一覧・編集 QueryService / DTO）、FE 一切、納品先別（DeliveryLocation）への波及、E2E（いずれも別イシュー）
+
+## 設計判断
+
+### リポジトリの infra 変更をスコープに含めるか
+- A. 含める（`PrismaCommonSellingPriceRepository` を完全写像。insert=`appendPeriodRows`／update=`syncPeriodRows`）
+- B. 含めない（既存 append-only を温存）
+- **採用: A**。理由: 集約に `editPeriod`（既存 id の in-place 変更）・`deletePeriod`（行の除去）を足すと、現行 update の `appendPeriodRows`（`ON CONFLICT (id) DO NOTHING`）では編集が黙って握り潰され・削除が DB に残存し、コマンドが機能しない。#460 の古い実装は温存せず、動作中の共通リポジトリを写像する（既に共有ヘルパ `sellingPricePeriodPersistence` が存在するため新規ロジック無し）。
+
+### ドメインルールの写像度（得意先軸固有ルールの有無）
+- A. 共通の完全ミラー・得意先固有ルールを足さない
+- B. 得意先軸に固有ルール（跨集約の存在チェック等）を追加
+- **採用: A**。理由: 温度ガード（将来行=編集/削除可・現在有効行=適用終了のみ・失効行=不可／ADR-20260627-86b）、結果型（集約を返す・失敗は例外・union 不使用／ADR-0037-0038）、楽観ロック（Register は既存追加時のみ expectedVersion 必須／ADR-0039）、参照日注入（`referenceDate` を入力で受けサーバー生成は上流の別イシュー）はすべて共通と同一。跨集約チェック（対応する共通販売単価の存在・Customer 実在）は**入れない** — CONTEXT.md「適用終了」注記が「最低1期間の保証は跨集約ハード強制せず価格決定の安全弁で担保」と明言し #476 でハード強制は不採用。
+
+### 納品先別（DeliveryLocation）への同時波及
+- A. 触れない（得意先別のみ共通へ追いつかせる）
+- B. 同型2層として納品先別も同時にミューテータ補完
+- **採用: A**。理由: 親 #492 は得意先別保守の分割。ADR-20260624-8tg の「同型」は集約構造の同型であり全レイヤー機能の同時実装を約束しない（既に共通↔上書き2層で非対称は存在）。納品先別への写像は同型ゆえ後日ほぼ機械作業で追随できる。「1回1スコープ」方針にも沿う。
+
+### ADR 起票 / CONTEXT.md 更新
+- **不要**。本計画の判断はすべて既存 ADR の適用（8tg 同型／86b 温度ガード／0032 差分 upsert／0037-0038 結果型／0039 楽観ロック／0018 独立 EndDate／0067 daterange）であり、「反転しにくい・文脈なしに驚く・真のトレードオフ」の3条件を満たす新規判断が無い。用語集（得意先別販売単価/適用終了/単価改定/失効/適用期間）も完備。
+
+### 実装方式（TDD）
+- 依存の向き **ドメイン（純粋）→ リポジトリ（実DB往復）→ コマンド（実DB・実 Customer/Product 前提）** に従い red-green-refactor で進める。共通側コマンドテストが実 `Prisma*Repository` を直接注入し実 Product を FK 生成するため、リポジトリの sync 化をコマンド実装より前に置く。
+
+## ステップ
+
+### Step 1: ドメイン集約 CustomerSellingPrice のミューテータ補完（TDD・純粋ドメイン）
+- 対象ファイル:
+  - `src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts`
+  - `src/server/subdomains/pricing/domain/entities/__tests__/CustomerSellingPrice.test.ts`
+  - 署名変更で影響する既存テスト（コンパイル修復）: `application/queries/__tests__/ResolveCustomerSellingPriceQuery.test.ts` / `infrastructure/queries/__tests__/PrismaCustomerSellingPriceQueryService.test.ts` / `infrastructure/prisma/__tests__/PrismaCustomerSellingPriceRepository.test.ts` / `application/queries/__tests__/ResolveSellingPriceQuery.test.ts`
+- 作業内容:
+  - Red: `CommonSellingPrice.test.ts` を写し、`addPeriod` の過去開始拒否・`editPeriod`（将来行のみ・過去開始拒否・重複拒否）・`endDatePeriod`（現在有効行のみ・短縮限定・今日以前拒否・`assertNoOverlap`）・`deletePeriod`（未来行のみ）・`currentValidPeriod` のケースを追加
+  - Green: `addPeriod` に第3引数 `referenceDate` と `assertStartNotPast` を追加、`editPeriod` / `endDatePeriod` / `deletePeriod` / `currentValidPeriod` と private ヘルパ（`requireRow` / `isFuture` / `assertStartNotPast` / `assertNoOverlap`）を実装
+  - 署名変更で壊れる既存テストの `addPeriod(...)` 呼び出しに `referenceDate`（＝開始日）を機械付与してコンパイル復旧
+- コミットメッセージ: `feat: 得意先別販売単価 集約の編集系ミューテータを補完`
+  - body: 共通販売単価集約の完全ミラー。addPeriod に参照日注入の過去不変ガードを追加し editPeriod/endDatePeriod/deletePeriod/currentValidPeriod を実装（ADR-20260624-8tg / 20260627-86b）。
+
+### Step 2: リポジトリを共通実装へ写像（TDD・実DB往復）
+- 対象ファイル:
+  - `src/server/subdomains/pricing/infrastructure/prisma/PrismaCustomerSellingPriceRepository.ts`
+  - `src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCustomerSellingPriceRepository.test.ts`
+- 作業内容:
+  - Red: 編集の in-place 反映（`updated_at` 挙動含む）・削除行の消滅・楽観ロック競合の往復テストを追加
+  - Green: `update()` を `syncPeriodRows` へ切り替え、`PERIOD_TABLE` 定数・`toWriteRows` を分離、`insert()` は `appendPeriodRows` 維持。クラスコメントを刷新（append-only 前提の旧根拠を差分 sync 前提へ）
+- コミットメッセージ: `feat: 得意先別販売単価リポジトリを差分sync同期へ`
+  - body: #460 の append-only 実装を PrismaCommonSellingPriceRepository へ写像。update は syncPeriodRows で編集・適用終了・削除を反映し無変更行の updated_at は据え置く（ADR-0032 / 0039）。
+
+### Step 3: 登録コマンド Register（TDD・実DB）
+- 対象ファイル:
+  - `src/server/subdomains/pricing/application/commands/RegisterCustomerSellingPricePeriodCommand.ts`（+ `__tests__`）
+  - `src/server/subdomains/pricing/application/factories/registerCustomerSellingPricePeriodCommandFactory.ts`
+- 作業内容:
+  - Red→Green: 未設定 (customer,product) は新規 insert（version 1）・既存は addPeriod + update（expectedVersion 必須、未指定は ValidationError）。実 Customer + Product を FK 生成する fixture でテスト
+  - factory で `PrismaCustomerSellingPriceRepository` を DI
+- コミットメッセージ: `feat: 得意先別販売単価 登録コマンド（Register）`
+
+### Step 4: 共有ロードヘルパ + 編集コマンド Edit（TDD・実DB）
+- 対象ファイル:
+  - `src/server/subdomains/pricing/application/commands/loadCustomerSellingPriceOrThrow.ts`
+  - `src/server/subdomains/pricing/application/commands/EditCustomerSellingPricePeriodCommand.ts`（+ `__tests__`）
+  - `src/server/subdomains/pricing/application/factories/editCustomerSellingPricePeriodCommandFactory.ts`
+- 作業内容:
+  - `loadCustomerSellingPriceOrThrow(repository, customerId, productId)`：`findByCustomerIdAndProductId` で取得し null なら `NotFoundEntityError`
+  - Red→Green: Edit は集約取得 → `editPeriod` → update（expectedVersion 必須）。状態違反は集約が BusinessRuleViolationError
+- コミットメッセージ: `feat: 得意先別販売単価 編集コマンド（Edit）と共有ロードヘルパ`
+
+### Step 5: 適用終了コマンド EndDate（TDD・実DB）
+- 対象ファイル:
+  - `src/server/subdomains/pricing/application/commands/EndDateCustomerSellingPricePeriodCommand.ts`（+ `__tests__`）
+  - `src/server/subdomains/pricing/application/factories/endDateCustomerSellingPricePeriodCommandFactory.ts`
+- 作業内容: 入力 `{ customerId, productId, periodId, endDate, referenceDate, expectedVersion }`。現在有効行を `endDatePeriod` で打ち切り update。独立コマンド（ADR-0018 / 86b 軸4）
+- コミットメッセージ: `feat: 得意先別販売単価 適用終了コマンド（EndDate）`
+
+### Step 6: 削除コマンド Delete（TDD・実DB）
+- 対象ファイル:
+  - `src/server/subdomains/pricing/application/commands/DeleteCustomerSellingPricePeriodCommand.ts`（+ `__tests__`）
+  - `src/server/subdomains/pricing/application/factories/deleteCustomerSellingPricePeriodCommandFactory.ts`
+- 作業内容: 未来開始行を `deletePeriod` で物理削除 update。現在有効・失効行の削除は BusinessRuleViolationError
+- コミットメッセージ: `feat: 得意先別販売単価 削除コマンド（Delete）`
+
+### Step 7: 単価改定コマンド Revise（TDD・実DB）
+- 対象ファイル:
+  - `src/server/subdomains/pricing/application/commands/ReviseCustomerSellingPricePeriodCommand.ts`（+ `__tests__`）
+  - `src/server/subdomains/pricing/application/factories/reviseCustomerSellingPricePeriodCommandFactory.ts`
+- 作業内容: `currentValidPeriod` が無ければ拒否。`endDatePeriod`（終了日=改定日）→ `addPeriod`（改定日開始・無期限）の順で1ロード1セーブ。単一集約 version でアトミック（合成糖衣・CONTEXT.md「単価改定」）
+- コミットメッセージ: `feat: 得意先別販売単価 単価改定コマンド（Revise）`

--- a/src/server/subdomains/pricing/application/commands/DeleteCustomerSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/DeleteCustomerSellingPricePeriodCommand.ts
@@ -1,0 +1,38 @@
+import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
+import { CustomerSellingPriceRepository } from "@subdomains/pricing/domain/repositories/CustomerSellingPriceRepository";
+import { CustomerSellingPricePeriodId } from "@subdomains/pricing/domain/values/CustomerSellingPricePeriodId";
+import { loadCustomerSellingPriceOrThrow } from "./loadCustomerSellingPriceOrThrow";
+
+export type DeleteCustomerSellingPricePeriodInput = {
+  customerId: string;
+  productId: string;
+  periodId: string;
+  /** 参照日（今日・JST 暦日）。Server Action がサーバー生成して詰める。 */
+  referenceDate: string;
+  /** 編集画面表示時の version（楽観ロック・ADR-0039）。 */
+  expectedVersion: number;
+};
+
+/**
+ * 得意先別売単価の未来開始行を削除するコマンド（誤入力の訂正）。
+ *
+ * 現在有効・失効の行は過去そのもの／既発行見積が時点解決した履歴のため削除できない。状態違反は
+ * 集約の不変条件が `BusinessRuleViolationError` で弾く（参照日に依存・ADR-20260627-86b）。共通売単価
+ * の削除コマンドと同型で、identity が複合自然キー（得意先 × 商品）である点が異なる（ADR-20260624-8tg）。
+ */
+export class DeleteCustomerSellingPricePeriodCommand {
+  constructor(private readonly repository: CustomerSellingPriceRepository) {}
+
+  async execute(input: DeleteCustomerSellingPricePeriodInput): Promise<CustomerSellingPrice> {
+    const aggregate = await loadCustomerSellingPriceOrThrow(
+      this.repository,
+      input.customerId,
+      input.productId
+    );
+
+    aggregate.deletePeriod(new CustomerSellingPricePeriodId(input.periodId), input.referenceDate);
+
+    await this.repository.update(aggregate, input.expectedVersion);
+    return aggregate;
+  }
+}

--- a/src/server/subdomains/pricing/application/commands/EditCustomerSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/EditCustomerSellingPricePeriodCommand.ts
@@ -1,0 +1,52 @@
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { Money } from "@server/shared/domain/values/Money";
+import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
+import { CustomerSellingPriceRepository } from "@subdomains/pricing/domain/repositories/CustomerSellingPriceRepository";
+import { CustomerSellingPricePeriodId } from "@subdomains/pricing/domain/values/CustomerSellingPricePeriodId";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { loadCustomerSellingPriceOrThrow } from "./loadCustomerSellingPriceOrThrow";
+
+export type EditCustomerSellingPricePeriodInput = {
+  customerId: string;
+  productId: string;
+  periodId: string;
+  start: string;
+  end: string | null;
+  /** 通貨スケール固定の10進文字列。 */
+  price: string;
+  /** 参照日（今日・JST 暦日）。Server Action がサーバー生成して詰める。 */
+  referenceDate: string;
+  /** 編集画面表示時の version（楽観ロック・ADR-0039）。 */
+  expectedVersion: number;
+};
+
+/**
+ * 得意先別売単価の将来行を編集するコマンド（全項目）。
+ *
+ * 集約を取得し（無ければ NotFoundEntityError）、`editPeriod` で将来行のみ差し替える。現在有効・
+ * 失効の行への編集や開始日が今日より前の指定は集約の不変条件が `BusinessRuleViolationError` で弾く
+ * （参照日に依存・ADR-20260627-86b）。戻り値は編集後の集約。共通売単価の編集コマンドと同型で、
+ * identity が複合自然キー（得意先 × 商品）である点が異なる（ADR-20260624-8tg）。
+ */
+export class EditCustomerSellingPricePeriodCommand {
+  constructor(private readonly repository: CustomerSellingPriceRepository) {}
+
+  async execute(input: EditCustomerSellingPricePeriodInput): Promise<CustomerSellingPrice> {
+    const aggregate = await loadCustomerSellingPriceOrThrow(
+      this.repository,
+      input.customerId,
+      input.productId
+    );
+
+    const period = ApplicablePeriod.create({ start: input.start, end: input.end });
+    const price = SellingUnitPrice.fromMoney(Money.fromDecimalString(input.price));
+    aggregate.editPeriod(
+      new CustomerSellingPricePeriodId(input.periodId),
+      { period, price },
+      input.referenceDate
+    );
+
+    await this.repository.update(aggregate, input.expectedVersion);
+    return aggregate;
+  }
+}

--- a/src/server/subdomains/pricing/application/commands/EndDateCustomerSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/EndDateCustomerSellingPricePeriodCommand.ts
@@ -1,0 +1,45 @@
+import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
+import { CustomerSellingPriceRepository } from "@subdomains/pricing/domain/repositories/CustomerSellingPriceRepository";
+import { CustomerSellingPricePeriodId } from "@subdomains/pricing/domain/values/CustomerSellingPricePeriodId";
+import { loadCustomerSellingPriceOrThrow } from "./loadCustomerSellingPriceOrThrow";
+
+export type EndDateCustomerSellingPricePeriodInput = {
+  customerId: string;
+  productId: string;
+  periodId: string;
+  /** 適用終了日（今日より後・JST 暦日）。 */
+  endDate: string;
+  /** 参照日（今日・JST 暦日）。Server Action がサーバー生成して詰める。 */
+  referenceDate: string;
+  /** 編集画面表示時の version（楽観ロック・ADR-0039）。 */
+  expectedVersion: number;
+};
+
+/**
+ * 得意先別売単価の現在有効行を適用終了するコマンド（end-dating・独立コマンド）。
+ *
+ * 単価・開始日は変えず終了日のみ未来方向に確定する。入力が `{ periodId, endDate }` のみで将来行の
+ * 全項目編集とは形が異なるため独立コマンドにする（ADR-0018 流・ADR-20260627-86b 軸4）。現在有効行
+ * 以外への適用終了や今日以前の終了日は集約の不変条件が `BusinessRuleViolationError` で弾く。共通売単価
+ * の適用終了コマンドと同型で、identity が複合自然キー（得意先 × 商品）である点が異なる（ADR-20260624-8tg）。
+ */
+export class EndDateCustomerSellingPricePeriodCommand {
+  constructor(private readonly repository: CustomerSellingPriceRepository) {}
+
+  async execute(input: EndDateCustomerSellingPricePeriodInput): Promise<CustomerSellingPrice> {
+    const aggregate = await loadCustomerSellingPriceOrThrow(
+      this.repository,
+      input.customerId,
+      input.productId
+    );
+
+    aggregate.endDatePeriod(
+      new CustomerSellingPricePeriodId(input.periodId),
+      input.endDate,
+      input.referenceDate
+    );
+
+    await this.repository.update(aggregate, input.expectedVersion);
+    return aggregate;
+  }
+}

--- a/src/server/subdomains/pricing/application/commands/RegisterCustomerSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/RegisterCustomerSellingPricePeriodCommand.ts
@@ -1,0 +1,63 @@
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { Money } from "@server/shared/domain/values/Money";
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
+import { CustomerSellingPriceRepository } from "@subdomains/pricing/domain/repositories/CustomerSellingPriceRepository";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+
+export type RegisterCustomerSellingPricePeriodInput = {
+  customerId: string;
+  productId: string;
+  start: string;
+  end: string | null;
+  /** 通貨スケール固定の10進文字列（float を経由しない・ADR-0022）。 */
+  price: string;
+  /** 参照日（今日・JST 暦日）。Server Action がサーバー生成して詰める（ADR-20260627-86b）。 */
+  referenceDate: string;
+  /** 既存集約へ追加する場合の編集画面表示時 version（楽観ロック・ADR-0039）。未設定への初回登録では不要。 */
+  expectedVersion?: number;
+};
+
+/**
+ * 得意先別売単価の適用期間行を登録するコマンド。
+ *
+ * 母集合は得意先 × 商品で「未設定（集約が無い）」組み合わせが初期は多数を占める。集約が無ければ
+ * 新規作成して insert（version 1 始まり）、既に在れば期間を追加して update（expectedVersion で
+ * 楽観ロック）する。insert/update の選択はインフラ関心としてここで吸収する。開始日 ≥ 今日・重複禁止の
+ * 不変条件は集約の `addPeriod` が参照日を使って強制する。戻り値は登録後の集約（ADR-0038）。
+ * 共通売単価の登録コマンドと同型で、identity が複合自然キー（得意先 × 商品）である点が異なる
+ * （ADR-20260624-8tg）。
+ */
+export class RegisterCustomerSellingPricePeriodCommand {
+  constructor(private readonly repository: CustomerSellingPriceRepository) {}
+
+  async execute(input: RegisterCustomerSellingPricePeriodInput): Promise<CustomerSellingPrice> {
+    const customerId = new CustomerId(input.customerId);
+    const productId = new ProductId(input.productId);
+    const period = ApplicablePeriod.create({ start: input.start, end: input.end });
+    const price = SellingUnitPrice.fromMoney(Money.fromDecimalString(input.price));
+
+    const existing = await this.repository.findByCustomerIdAndProductId(customerId, productId);
+    if (existing === null) {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period, price, input.referenceDate);
+      await this.repository.insert(aggregate);
+      return aggregate;
+    }
+
+    // 既存集約への追加は version を渡した楽観ロックが必須。未指定を `?? 0` で吸収すると 1 始まりの
+    // 実 version と永久に一致せず必ず ConflictError（「他のユーザーが更新」の誤表示）になるため、
+    // 入力契約違反として ValidationError で早期に弾く（silent conflict を loud failure へ）。
+    if (input.expectedVersion === undefined) {
+      throw new ValidationError(
+        "既存の得意先別販売単価へ期間を追加するには expectedVersion（編集画面表示時の version）が必要です"
+      );
+    }
+
+    existing.addPeriod(period, price, input.referenceDate);
+    await this.repository.update(existing, input.expectedVersion);
+    return existing;
+  }
+}

--- a/src/server/subdomains/pricing/application/commands/ReviseCustomerSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/ReviseCustomerSellingPricePeriodCommand.ts
@@ -1,0 +1,64 @@
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { Money } from "@server/shared/domain/values/Money";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
+import { CustomerSellingPriceRepository } from "@subdomains/pricing/domain/repositories/CustomerSellingPriceRepository";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { loadCustomerSellingPriceOrThrow } from "./loadCustomerSellingPriceOrThrow";
+
+export type ReviseCustomerSellingPricePeriodInput = {
+  customerId: string;
+  productId: string;
+  /** 改定日（＝現在有効行の適用終了日＝新行の適用開始日。今日より後・JST 暦日）。 */
+  revisionDate: string;
+  /** 改定後の単価。通貨スケール固定の10進文字列（float を経由しない・ADR-0022）。 */
+  price: string;
+  /** 参照日（今日・JST 暦日）。Server Action がサーバー生成して詰める（ADR-20260627-86b）。 */
+  referenceDate: string;
+  /** 編集画面表示時の version（楽観ロック・ADR-0039）。 */
+  expectedVersion: number;
+};
+
+/**
+ * 得意先別売単価を改定日から新単価へ切り替えるコマンド（単価改定）。
+ *
+ * 改定は新しい原子操作ではなく「現在有効行の適用終了（終了日＝改定日）」＋「改定日開始の新規期間追加」
+ * の合成糖衣（CONTEXT.md `単価改定`）。1ロードした集約に両ミューテータを順適用し1セーブすることで、
+ * 単一集約 version の楽観ロックでアトミック性（部分適用なし）を担保する。各原子操作は ADR-20260627-86b
+ * の温度ガード（適用終了＝終了日>今日／追加＝開始≥今日）を持つため、過去日改定の遡及改竄は構造的に閉じる。
+ *
+ * 適用終了→追加の順で呼ぶ（逆順だと旧行が現在有効行のまま新行と接触判定され重複しうる）。
+ * 現在有効行が無い（未設定・失効のみ）は改定対象が無く {@link BusinessRuleViolationError} で拒否する。
+ * 共通売単価の改定コマンドと同型で、identity が複合自然キー（得意先 × 商品）である点が異なる
+ * （ADR-20260624-8tg）。
+ */
+export class ReviseCustomerSellingPricePeriodCommand {
+  constructor(private readonly repository: CustomerSellingPriceRepository) {}
+
+  async execute(input: ReviseCustomerSellingPricePeriodInput): Promise<CustomerSellingPrice> {
+    const aggregate = await loadCustomerSellingPriceOrThrow(
+      this.repository,
+      input.customerId,
+      input.productId
+    );
+
+    const current = aggregate.currentValidPeriod(input.referenceDate);
+    if (current === undefined) {
+      throw new BusinessRuleViolationError(
+        `${CustomerSellingPrice.ENTITY_NAME}の改定には現在有効な単価が必要です（未設定・失効の得意先×商品は新規登録から行ってください）`
+      );
+    }
+
+    const newPrice = SellingUnitPrice.fromMoney(Money.fromDecimalString(input.price));
+
+    aggregate.endDatePeriod(current.id, input.revisionDate, input.referenceDate);
+    aggregate.addPeriod(
+      ApplicablePeriod.create({ start: input.revisionDate, end: null }),
+      newPrice,
+      input.referenceDate
+    );
+
+    await this.repository.update(aggregate, input.expectedVersion);
+    return aggregate;
+  }
+}

--- a/src/server/subdomains/pricing/application/commands/__tests__/DeleteCustomerSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/DeleteCustomerSellingPricePeriodCommand.test.ts
@@ -1,0 +1,135 @@
+import prisma from "@server/prisma";
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
+import { CustomerSellingPricePeriodId } from "@subdomains/pricing/domain/values/CustomerSellingPricePeriodId";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaCustomerSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaCustomerSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DeleteCustomerSellingPricePeriodCommand } from "../DeleteCustomerSellingPricePeriodCommand";
+
+const TEST_PRODUCT_CODE = "CUSPCMD40";
+const TEST_CUSTOMER_CODE = "CUSPCMD41";
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+const period = (start: string, end: string | null) => ApplicablePeriod.create({ start, end });
+
+async function cleanup(): Promise<void> {
+  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.customer.deleteMany({ where: { code: TEST_CUSTOMER_CODE } });
+}
+
+describe("DeleteCustomerSellingPricePeriodCommand", () => {
+  let command: DeleteCustomerSellingPricePeriodCommand;
+  let repository: PrismaCustomerSellingPriceRepository;
+  let customerId: CustomerId;
+  let productId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    repository = new PrismaCustomerSellingPriceRepository();
+    command = new DeleteCustomerSellingPricePeriodCommand(repository);
+
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(
+        new CompanyCode(TEST_CUSTOMER_CODE),
+        new CompanyName("削除コマンドテスト得意先")
+      )
+    );
+    customerId = customer.id;
+
+    const product = await new PrismaProductRepository().insert(
+      Product.create(
+        new ProductCode(TEST_PRODUCT_CODE),
+        new ProductName("削除コマンドテスト商品"),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+  });
+
+  afterEach(cleanup);
+
+  it("将来行を削除できる", async () => {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2025-06-01");
+    aggregate.addPeriod(period("2030-06-01", null), price(1200), "2025-06-01");
+    await repository.insert(aggregate);
+    const firstId = (await repository.findByCustomerIdAndProductId(customerId, productId))!
+      .periods[0].id;
+
+    await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      periodId: firstId.value,
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    expect(found!.periods).toHaveLength(1);
+    expect(found!.periods[0].period.equals(period("2030-06-01", null))).toBe(true);
+  });
+
+  it("集約が無い得意先×商品では NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: CustomerSellingPricePeriodId.generate().value,
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(NotFoundEntityError);
+  });
+
+  it("現在有効行の削除は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+    await repository.insert(aggregate);
+    const periodId = (await repository.findByCustomerIdAndProductId(customerId, productId))!
+      .periods[0].id;
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+  });
+
+  it("expectedVersion が古いと ConflictError", async () => {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+    const periodId = (await repository.findByCustomerIdAndProductId(customerId, productId))!
+      .periods[0].id;
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        referenceDate: "2025-06-01",
+        expectedVersion: 999,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/src/server/subdomains/pricing/application/commands/__tests__/EditCustomerSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/EditCustomerSellingPricePeriodCommand.test.ts
@@ -1,0 +1,146 @@
+import prisma from "@server/prisma";
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
+import { CustomerSellingPricePeriodId } from "@subdomains/pricing/domain/values/CustomerSellingPricePeriodId";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaCustomerSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaCustomerSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EditCustomerSellingPricePeriodCommand } from "../EditCustomerSellingPricePeriodCommand";
+
+const TEST_PRODUCT_CODE = "CUSPCMD20";
+const TEST_CUSTOMER_CODE = "CUSPCMD21";
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+const period = (start: string, end: string | null) => ApplicablePeriod.create({ start, end });
+
+async function cleanup(): Promise<void> {
+  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.customer.deleteMany({ where: { code: TEST_CUSTOMER_CODE } });
+}
+
+describe("EditCustomerSellingPricePeriodCommand", () => {
+  let command: EditCustomerSellingPricePeriodCommand;
+  let repository: PrismaCustomerSellingPriceRepository;
+  let customerId: CustomerId;
+  let productId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    repository = new PrismaCustomerSellingPriceRepository();
+    command = new EditCustomerSellingPricePeriodCommand(repository);
+
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(
+        new CompanyCode(TEST_CUSTOMER_CODE),
+        new CompanyName("編集コマンドテスト得意先")
+      )
+    );
+    customerId = customer.id;
+
+    const product = await new PrismaProductRepository().insert(
+      Product.create(
+        new ProductCode(TEST_PRODUCT_CODE),
+        new ProductName("編集コマンドテスト商品"),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+  });
+
+  afterEach(cleanup);
+
+  /** 将来行を1本持つ集約を用意し、その periodId を返す。 */
+  async function seedFuturePeriod(): Promise<CustomerSellingPricePeriodId> {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+    return (await repository.findByCustomerIdAndProductId(customerId, productId))!.periods[0].id;
+  }
+
+  it("将来行の単価・期間を編集できる", async () => {
+    const periodId = await seedFuturePeriod();
+
+    await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      periodId: periodId.value,
+      start: "2030-02-01",
+      end: null,
+      price: "1500",
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    expect(found!.periods[0].price.equals(price(1500))).toBe(true);
+    expect(found!.periods[0].period.equals(period("2030-02-01", null))).toBe(true);
+  });
+
+  it("集約が無い得意先×商品では NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: CustomerSellingPricePeriodId.generate().value,
+        start: "2030-02-01",
+        end: null,
+        price: "1500",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(NotFoundEntityError);
+  });
+
+  it("現在有効行の編集は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2025-05-01", "2030-01-01"), price(1000), "2025-04-01");
+    await repository.insert(aggregate);
+    const periodId = (await repository.findByCustomerIdAndProductId(customerId, productId))!
+      .periods[0].id;
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        start: "2030-02-01",
+        end: null,
+        price: "1500",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+  });
+
+  it("expectedVersion が古いと ConflictError", async () => {
+    const periodId = await seedFuturePeriod();
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        start: "2030-02-01",
+        end: null,
+        price: "1500",
+        referenceDate: "2025-06-01",
+        expectedVersion: 999,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/src/server/subdomains/pricing/application/commands/__tests__/EndDateCustomerSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/EndDateCustomerSellingPricePeriodCommand.test.ts
@@ -1,0 +1,137 @@
+import prisma from "@server/prisma";
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
+import { CustomerSellingPricePeriodId } from "@subdomains/pricing/domain/values/CustomerSellingPricePeriodId";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaCustomerSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaCustomerSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EndDateCustomerSellingPricePeriodCommand } from "../EndDateCustomerSellingPricePeriodCommand";
+
+const TEST_PRODUCT_CODE = "CUSPCMD30";
+const TEST_CUSTOMER_CODE = "CUSPCMD31";
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+const period = (start: string, end: string | null) => ApplicablePeriod.create({ start, end });
+
+async function cleanup(): Promise<void> {
+  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.customer.deleteMany({ where: { code: TEST_CUSTOMER_CODE } });
+}
+
+describe("EndDateCustomerSellingPricePeriodCommand", () => {
+  let command: EndDateCustomerSellingPricePeriodCommand;
+  let repository: PrismaCustomerSellingPriceRepository;
+  let customerId: CustomerId;
+  let productId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    repository = new PrismaCustomerSellingPriceRepository();
+    command = new EndDateCustomerSellingPricePeriodCommand(repository);
+
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(
+        new CompanyCode(TEST_CUSTOMER_CODE),
+        new CompanyName("適用終了コマンドテスト得意先")
+      )
+    );
+    customerId = customer.id;
+
+    const product = await new PrismaProductRepository().insert(
+      Product.create(
+        new ProductCode(TEST_PRODUCT_CODE),
+        new ProductName("適用終了コマンドテスト商品"),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+  });
+
+  afterEach(cleanup);
+
+  /** 現在有効な無期限行を1本持つ集約を用意し、その periodId を返す。 */
+  async function seedActivePeriod(): Promise<CustomerSellingPricePeriodId> {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+    await repository.insert(aggregate);
+    return (await repository.findByCustomerIdAndProductId(customerId, productId))!.periods[0].id;
+  }
+
+  it("現在有効行に終了日を設定できる（適用終了）", async () => {
+    const periodId = await seedActivePeriod();
+
+    await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      periodId: periodId.value,
+      endDate: "2030-01-01",
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    expect(found!.periods[0].period.equals(period("2025-04-01", "2030-01-01"))).toBe(true);
+  });
+
+  it("集約が無い得意先×商品では NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: CustomerSellingPricePeriodId.generate().value,
+        endDate: "2030-01-01",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(NotFoundEntityError);
+  });
+
+  it("将来行への適用終了は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+    const periodId = (await repository.findByCustomerIdAndProductId(customerId, productId))!
+      .periods[0].id;
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        endDate: "2031-01-01",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+  });
+
+  it("expectedVersion が古いと ConflictError", async () => {
+    const periodId = await seedActivePeriod();
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        endDate: "2030-01-01",
+        referenceDate: "2025-06-01",
+        expectedVersion: 999,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/src/server/subdomains/pricing/application/commands/__tests__/RegisterCustomerSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/RegisterCustomerSellingPricePeriodCommand.test.ts
@@ -1,0 +1,160 @@
+import prisma from "@server/prisma";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaCustomerSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaCustomerSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RegisterCustomerSellingPricePeriodCommand } from "../RegisterCustomerSellingPricePeriodCommand";
+
+const TEST_PRODUCT_CODE = "CUSPCMD10";
+const TEST_CUSTOMER_CODE = "CUSPCMD11";
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+
+async function cleanup(): Promise<void> {
+  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.customer.deleteMany({ where: { code: TEST_CUSTOMER_CODE } });
+}
+
+describe("RegisterCustomerSellingPricePeriodCommand", () => {
+  let command: RegisterCustomerSellingPricePeriodCommand;
+  let repository: PrismaCustomerSellingPriceRepository;
+  let customerId: CustomerId;
+  let productId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    repository = new PrismaCustomerSellingPriceRepository();
+    command = new RegisterCustomerSellingPricePeriodCommand(repository);
+
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(
+        new CompanyCode(TEST_CUSTOMER_CODE),
+        new CompanyName("登録コマンドテスト得意先")
+      )
+    );
+    customerId = customer.id;
+
+    const product = await new PrismaProductRepository().insert(
+      Product.create(
+        new ProductCode(TEST_PRODUCT_CODE),
+        new ProductName("登録コマンドテスト商品"),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+  });
+
+  afterEach(cleanup);
+
+  it("未設定の得意先×商品に最初の期間を登録できる（新規 insert）", async () => {
+    const result = await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      start: "2030-01-01",
+      end: null,
+      price: "1000",
+      referenceDate: "2025-06-01",
+    });
+
+    expect(result.periods).toHaveLength(1);
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    expect(found!.periods).toHaveLength(1);
+    expect(found!.periods[0].price.equals(price(1000))).toBe(true);
+  });
+
+  it("既存集約へ2本目の期間を追加できる（expectedVersion での update）", async () => {
+    await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      start: "2030-01-01",
+      end: "2030-06-01",
+      price: "1000",
+      referenceDate: "2025-06-01",
+    });
+
+    await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      start: "2030-06-01",
+      end: null,
+      price: "1200",
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    expect(found!.periods).toHaveLength(2);
+  });
+
+  it("開始日が今日より前なら BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        start: "2025-05-31",
+        end: null,
+        price: "1000",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+  });
+
+  it("既存集約への追加で expectedVersion 未指定なら ValidationError（楽観ロック失敗ではなく入力契約違反）", async () => {
+    await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      start: "2030-01-01",
+      end: "2030-06-01",
+      price: "1000",
+      referenceDate: "2025-06-01",
+    });
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        start: "2030-06-01",
+        end: null,
+        price: "1200",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("既存集約への追加で expectedVersion が古いと ConflictError（expectedVersion が repo まで素通しされる）", async () => {
+    await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      start: "2030-01-01",
+      end: "2030-06-01",
+      price: "1000",
+      referenceDate: "2025-06-01",
+    });
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        start: "2030-06-01",
+        end: null,
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 999,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/src/server/subdomains/pricing/application/commands/__tests__/ReviseCustomerSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/ReviseCustomerSellingPricePeriodCommand.test.ts
@@ -1,0 +1,245 @@
+import prisma from "@server/prisma";
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaCustomerSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaCustomerSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EndDateCustomerSellingPricePeriodCommand } from "../EndDateCustomerSellingPricePeriodCommand";
+import { ReviseCustomerSellingPricePeriodCommand } from "../ReviseCustomerSellingPricePeriodCommand";
+
+const TEST_PRODUCT_CODE = "CUSPCMD50";
+const TEST_CUSTOMER_CODE = "CUSPCMD51";
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+const period = (start: string, end: string | null) => ApplicablePeriod.create({ start, end });
+
+async function cleanup(): Promise<void> {
+  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.customer.deleteMany({ where: { code: TEST_CUSTOMER_CODE } });
+}
+
+describe("ReviseCustomerSellingPricePeriodCommand", () => {
+  let command: ReviseCustomerSellingPricePeriodCommand;
+  let repository: PrismaCustomerSellingPriceRepository;
+  let customerId: CustomerId;
+  let productId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    repository = new PrismaCustomerSellingPriceRepository();
+    command = new ReviseCustomerSellingPricePeriodCommand(repository);
+
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(
+        new CompanyCode(TEST_CUSTOMER_CODE),
+        new CompanyName("単価改定コマンドテスト得意先")
+      )
+    );
+    customerId = customer.id;
+
+    const product = await new PrismaProductRepository().insert(
+      Product.create(
+        new ProductCode(TEST_PRODUCT_CODE),
+        new ProductName("単価改定コマンドテスト商品"),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+  });
+
+  afterEach(cleanup);
+
+  /** 現在有効な無期限行（2025-04-01〜・1000円）を1本持つ集約を用意する。 */
+  async function seedActivePeriod(): Promise<void> {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+    await repository.insert(aggregate);
+  }
+
+  it("現在有効行を改定日で終了し、改定日開始の新行を連続して追加する", async () => {
+    await seedActivePeriod();
+
+    await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      revisionDate: "2025-09-01",
+      price: "1200",
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    const rows = [...found!.periods].sort((a, b) => a.period.start.localeCompare(b.period.start));
+    expect(rows).toHaveLength(2);
+    // 旧行: 改定日で終了、単価据え置き
+    expect(rows[0].period.equals(period("2025-04-01", "2025-09-01"))).toBe(true);
+    expect(rows[0].price.equals(price(1000))).toBe(true);
+    // 新行: 改定日開始の無期限、新単価
+    expect(rows[1].period.equals(period("2025-09-01", null))).toBe(true);
+    expect(rows[1].price.equals(price(1200))).toBe(true);
+  });
+
+  it("現在有効行が無い得意先×商品（将来行のみ）は BusinessRuleViolationError", async () => {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2025-12-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        revisionDate: "2026-01-01",
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+  });
+
+  it("集約が無い得意先×商品（未設定）は NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        revisionDate: "2025-09-01",
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(NotFoundEntityError);
+  });
+
+  it("改定日が今日以前なら BusinessRuleViolationError（適用終了ガード由来・遡及改竄を閉じる）", async () => {
+    await seedActivePeriod();
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        revisionDate: "2025-06-01", // = referenceDate（今日）
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+
+    // 失敗時は集約が変わらない（部分適用なし）
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    expect(found!.periods).toHaveLength(1);
+    expect(found!.periods[0].period.equals(period("2025-04-01", null))).toBe(true);
+  });
+
+  it("据え置き（新単価＝現単価）も改定として成立する（拒否しない）", async () => {
+    await seedActivePeriod();
+
+    await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      revisionDate: "2025-09-01",
+      price: "1000", // 現単価と同一
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    const rows = [...found!.periods].sort((a, b) => a.period.start.localeCompare(b.period.start));
+    expect(rows).toHaveLength(2);
+    expect(rows[1].period.equals(period("2025-09-01", null))).toBe(true);
+    expect(rows[1].price.equals(price(1000))).toBe(true);
+  });
+
+  it("expectedVersion が古いと ConflictError（部分適用なし）", async () => {
+    await seedActivePeriod();
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        revisionDate: "2025-09-01",
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 999,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    expect(found!.periods).toHaveLength(1);
+  });
+
+  it("改定日開始の新行が既存の将来行と重複すると BusinessRuleViolationError", async () => {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2025-04-01", "2025-10-01"), price(1000), "2025-03-01");
+    aggregate.addPeriod(period("2025-10-01", null), price(1100), "2025-03-01");
+    await repository.insert(aggregate);
+
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        revisionDate: "2025-09-01",
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    expect(found!.periods).toHaveLength(2);
+  });
+
+  it("version は改定1回につき1度だけ上がる（後続操作が expectedVersion=2 で通り 1 で弾かれる）", async () => {
+    await seedActivePeriod();
+
+    await command.execute({
+      customerId: customerId.value,
+      productId: productId.value,
+      revisionDate: "2025-09-01",
+      price: "1200",
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const endDate = new EndDateCustomerSellingPricePeriodCommand(repository);
+    const currentId = (await repository.findByCustomerIdAndProductId(
+      customerId,
+      productId
+    ))!.periods.find((r) => r.period.contains("2025-06-01"))!.id.value;
+
+    await expect(
+      endDate.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: currentId,
+        endDate: "2025-08-01",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    await expect(
+      endDate.execute({
+        customerId: customerId.value,
+        productId: productId.value,
+        periodId: currentId,
+        endDate: "2025-08-01",
+        referenceDate: "2025-06-01",
+        expectedVersion: 2,
+      })
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/server/subdomains/pricing/application/commands/loadCustomerSellingPriceOrThrow.ts
+++ b/src/server/subdomains/pricing/application/commands/loadCustomerSellingPriceOrThrow.ts
@@ -1,0 +1,27 @@
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
+import { CustomerSellingPriceRepository } from "@subdomains/pricing/domain/repositories/CustomerSellingPriceRepository";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+
+/**
+ * 得意先ID×商品IDから得意先別売単価集約を取得し、無ければ {@link NotFoundEntityError} を投げる。
+ *
+ * 既存集約の存在を前提とする編集系コマンド（編集・適用終了・削除）が共有する定型。「無ければ NotFound」
+ * はアプリ層のユースケース上の関心であり、Repository は null を返す問い合わせに徹する（既存規約）。
+ * 登録コマンドは null を正常系（新規 insert）に分岐するため、このヘルパは使わない。
+ */
+export async function loadCustomerSellingPriceOrThrow(
+  repository: CustomerSellingPriceRepository,
+  customerId: string,
+  productId: string
+): Promise<CustomerSellingPrice> {
+  const aggregate = await repository.findByCustomerIdAndProductId(
+    new CustomerId(customerId),
+    new ProductId(productId)
+  );
+  if (aggregate === null) {
+    throw new NotFoundEntityError(CustomerSellingPrice, { customerId, productId });
+  }
+  return aggregate;
+}

--- a/src/server/subdomains/pricing/application/factories/deleteCustomerSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/deleteCustomerSellingPricePeriodCommandFactory.ts
@@ -1,0 +1,7 @@
+import { DeleteCustomerSellingPricePeriodCommand } from "../commands/DeleteCustomerSellingPricePeriodCommand";
+import { PrismaCustomerSellingPriceRepository } from "../../infrastructure/prisma/PrismaCustomerSellingPriceRepository";
+
+/** 得意先別売単価の未来開始行を削除するコマンド（#505）を Repository から構築する。 */
+export function deleteCustomerSellingPricePeriodCommandFactory(): DeleteCustomerSellingPricePeriodCommand {
+  return new DeleteCustomerSellingPricePeriodCommand(new PrismaCustomerSellingPriceRepository());
+}

--- a/src/server/subdomains/pricing/application/factories/editCustomerSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/editCustomerSellingPricePeriodCommandFactory.ts
@@ -1,0 +1,7 @@
+import { EditCustomerSellingPricePeriodCommand } from "../commands/EditCustomerSellingPricePeriodCommand";
+import { PrismaCustomerSellingPriceRepository } from "../../infrastructure/prisma/PrismaCustomerSellingPriceRepository";
+
+/** 得意先別売単価の将来行を編集するコマンド（#505）を Repository から構築する。 */
+export function editCustomerSellingPricePeriodCommandFactory(): EditCustomerSellingPricePeriodCommand {
+  return new EditCustomerSellingPricePeriodCommand(new PrismaCustomerSellingPriceRepository());
+}

--- a/src/server/subdomains/pricing/application/factories/endDateCustomerSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/endDateCustomerSellingPricePeriodCommandFactory.ts
@@ -1,0 +1,7 @@
+import { EndDateCustomerSellingPricePeriodCommand } from "../commands/EndDateCustomerSellingPricePeriodCommand";
+import { PrismaCustomerSellingPriceRepository } from "../../infrastructure/prisma/PrismaCustomerSellingPriceRepository";
+
+/** 得意先別売単価の現在有効行を適用終了するコマンド（#505）を Repository から構築する。 */
+export function endDateCustomerSellingPricePeriodCommandFactory(): EndDateCustomerSellingPricePeriodCommand {
+  return new EndDateCustomerSellingPricePeriodCommand(new PrismaCustomerSellingPriceRepository());
+}

--- a/src/server/subdomains/pricing/application/factories/registerCustomerSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/registerCustomerSellingPricePeriodCommandFactory.ts
@@ -1,0 +1,7 @@
+import { RegisterCustomerSellingPricePeriodCommand } from "../commands/RegisterCustomerSellingPricePeriodCommand";
+import { PrismaCustomerSellingPriceRepository } from "../../infrastructure/prisma/PrismaCustomerSellingPriceRepository";
+
+/** 得意先別売単価の適用期間行を登録するコマンド（#505）を Repository から構築する。 */
+export function registerCustomerSellingPricePeriodCommandFactory(): RegisterCustomerSellingPricePeriodCommand {
+  return new RegisterCustomerSellingPricePeriodCommand(new PrismaCustomerSellingPriceRepository());
+}

--- a/src/server/subdomains/pricing/application/factories/reviseCustomerSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/reviseCustomerSellingPricePeriodCommandFactory.ts
@@ -1,0 +1,7 @@
+import { ReviseCustomerSellingPricePeriodCommand } from "../commands/ReviseCustomerSellingPricePeriodCommand";
+import { PrismaCustomerSellingPriceRepository } from "../../infrastructure/prisma/PrismaCustomerSellingPriceRepository";
+
+/** 得意先別売単価を改定日から新単価へ切り替えるコマンド（#505）を Repository から構築する。 */
+export function reviseCustomerSellingPricePeriodCommandFactory(): ReviseCustomerSellingPricePeriodCommand {
+  return new ReviseCustomerSellingPricePeriodCommand(new PrismaCustomerSellingPriceRepository());
+}

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveCustomerSellingPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveCustomerSellingPriceQuery.test.ts
@@ -70,7 +70,7 @@ describe("ResolveCustomerSellingPriceQuery", () => {
 
   it("基準暦日に有効な得意先別販売単価を解決する", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     const result = await query.execute({

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveSellingPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveSellingPriceQuery.test.ts
@@ -109,7 +109,7 @@ describe("ResolveSellingPriceQuery", () => {
     await commonRepository.insert(common);
 
     const customerPrice = CustomerSellingPrice.create(customerId, productId);
-    customerPrice.addPeriod(period("2025-07-01", null), price(800));
+    customerPrice.addPeriod(period("2025-07-01", null), price(800), "2025-07-01");
     await customerRepo.insert(customerPrice);
 
     const resolved = await query.execute({

--- a/src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts
+++ b/src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts
@@ -52,17 +52,151 @@ export class CustomerSellingPrice {
   }
 
   /**
-   * 適用期間行を追加する。既存のどの期間とも重ならない場合のみ許す。
-   * 重なる場合は不変条件違反として {@link BusinessRuleViolationError} を投げ、集約は変更しない。
+   * 適用期間行を追加する。既存のどの期間とも重ならず、かつ開始日が参照日（今日）以降の場合のみ許す。
+   *
+   * 過去にさかのぼった行の後付け登録は「過去不変」を破るため禁止する（ADR-20260627-86b）。
+   * 過去日データの投入は移行用の {@link reconstruct} 経路に限定し、業務操作からは閉じる。
+   * 重複・過去開始は不変条件違反として {@link BusinessRuleViolationError} を投げ、集約は変更しない。
+   *
+   * @param referenceDate 参照日（今日・JST 暦日 `"YYYY-MM-DD"`）。保存実行時にサーバー生成して注入する。
    */
-  addPeriod(period: ApplicablePeriod, price: SellingUnitPrice): void {
-    const overlapping = this._periods.find((row) => row.period.overlaps(period));
+  addPeriod(period: ApplicablePeriod, price: SellingUnitPrice, referenceDate: string): void {
+    this.assertStartNotPast(period.start, referenceDate);
+    this.assertNoOverlap(period);
+    this._periods.push(CustomerSellingPricePeriod.create(period, price));
+  }
+
+  /**
+   * 将来行（今日 < 開始）の期間・単価を差し替える。将来行はまだどの見積も時点解決していないため
+   * 全項目訂正できる（ADR-20260627-86b 軸1）。現在有効・失効の行は編集できない。
+   * 新しい開始日も今日以降であり、他の行と重ならない必要がある。
+   *
+   * @param referenceDate 参照日（今日・JST 暦日 `"YYYY-MM-DD"`）。
+   */
+  editPeriod(
+    periodId: CustomerSellingPricePeriodId,
+    changes: { period: ApplicablePeriod; price: SellingUnitPrice },
+    referenceDate: string
+  ): void {
+    const row = this.requireRow(periodId);
+    if (!this.isFuture(row.period, referenceDate)) {
+      throw new BusinessRuleViolationError(
+        `${CustomerSellingPrice.ENTITY_NAME}は将来行のみ編集できます（現在有効・失効の行は変更不可）`
+      );
+    }
+    this.assertStartNotPast(changes.period.start, referenceDate);
+    this.assertNoOverlap(changes.period, row);
+    row.changeTo(changes.period, changes.price);
+  }
+
+  /**
+   * 現在有効行（開始 ≤ 今日 < 終了）に終了日を設定して打ち切る（適用終了・end-dating）。
+   * 単価・開始日は変えず、終了日のみを未来方向に確定する（現在有効行に許される唯一の編集）。
+   * 単価改定は「適用終了＋新規期間追加」で表現し、各行を不変の履歴として残す（ADR-20260627-86b）。
+   *
+   * 終了日は今日より後でなければならない（半開区間 `[開始, 終了)` ゆえ終了日=今日は今日を被覆外にし
+   * 遡及削除になるため）。また「適用終了」は打ち切り＝短縮であり延長ではないため、既存終了日が有界なら
+   * 新しい終了日はそれより手前でなければならない（延長は本来失効すべき単価を生かし未来見積の単価判定を
+   * 誤らせる）。既存が無期限（end=null）なら任意の未来日が正当な短縮として許される。
+   *
+   * @param referenceDate 参照日（今日・JST 暦日 `"YYYY-MM-DD"`）。
+   */
+  endDatePeriod(
+    periodId: CustomerSellingPricePeriodId,
+    endDate: string,
+    referenceDate: string
+  ): void {
+    const row = this.requireRow(periodId);
+    if (!row.period.contains(referenceDate)) {
+      throw new BusinessRuleViolationError(
+        `${CustomerSellingPrice.ENTITY_NAME}は現在有効行のみ適用終了できます`
+      );
+    }
+    // 業務ルール（今日比較・短縮限定）の前に endDate の形式・実在性を検証する。後回しにすると
+    // 不正値が文字列比較で「短縮のみ」「今日より後」などの無関係なメッセージへ誤って落ちるため、
+    // ここで ApplicablePeriod を生成して形式エラー（ValidationError）を前倒しする。
+    const ended = ApplicablePeriod.create({ start: row.period.start, end: endDate });
+    if (endDate <= referenceDate) {
+      throw new BusinessRuleViolationError(
+        `${CustomerSellingPrice.ENTITY_NAME}の適用終了日は今日より後である必要があります: ${endDate} <= ${referenceDate}`
+      );
+    }
+    if (row.period.end !== null && endDate >= row.period.end) {
+      throw new BusinessRuleViolationError(
+        `${CustomerSellingPrice.ENTITY_NAME}の適用終了は短縮のみ可能です（既存終了日より後へは延長できません）: ${endDate} >= ${row.period.end}`
+      );
+    }
+    this.assertNoOverlap(ended, row);
+    row.endDateOn(endDate);
+  }
+
+  /**
+   * 未来開始行（今日 < 開始）を削除する（誤入力の訂正）。現在有効・失効の行は過去そのもの／
+   * 既発行見積が時点解決した履歴のため削除できない（ADR-20260627-86b 軸1）。
+   *
+   * @param referenceDate 参照日（今日・JST 暦日 `"YYYY-MM-DD"`）。
+   */
+  deletePeriod(periodId: CustomerSellingPricePeriodId, referenceDate: string): void {
+    const row = this.requireRow(periodId);
+    if (!this.isFuture(row.period, referenceDate)) {
+      throw new BusinessRuleViolationError(
+        `${CustomerSellingPrice.ENTITY_NAME}は未来開始行のみ削除できます（現在有効・失効の行は削除不可）`
+      );
+    }
+    this._periods.splice(this._periods.indexOf(row), 1);
+  }
+
+  /**
+   * 参照日（今日）時点で現在有効な期間行（開始 ≤ 今日 < 終了）を返す。無ければ undefined。
+   *
+   * 「現在有効」という述語を集約に集約するクエリ（read-only）。単価改定はこの行を `endDatePeriod`
+   * の対象として特定するために使う。半開区間の被覆判定はそのまま `ApplicablePeriod.contains` に委ねる。
+   * 集約内の重複ゼロ不変条件（`addPeriod`）により、被覆する行は高々1つに定まる。
+   *
+   * @param referenceDate 参照日（今日・JST 暦日 `"YYYY-MM-DD"`）。
+   */
+  currentValidPeriod(referenceDate: string): CustomerSellingPricePeriod | undefined {
+    return this._periods.find((row) => row.period.contains(referenceDate));
+  }
+
+  /** identity で期間行を引く。存在しなければ不変条件違反として投げる。 */
+  private requireRow(periodId: CustomerSellingPricePeriodId): CustomerSellingPricePeriod {
+    const row = this._periods.find((r) => r.id.equals(periodId));
+    if (row === undefined) {
+      throw new BusinessRuleViolationError(
+        `${CustomerSellingPrice.ENTITY_NAME}に指定された適用期間行が存在しません`
+      );
+    }
+    return row;
+  }
+
+  /** 将来行か（今日 < 開始）。 */
+  private isFuture(period: ApplicablePeriod, referenceDate: string): boolean {
+    return referenceDate < period.start;
+  }
+
+  /** 適用開始日が参照日（今日）より前なら過去不変違反として投げる（ADR-20260627-86b）。 */
+  private assertStartNotPast(start: string, referenceDate: string): void {
+    if (start < referenceDate) {
+      throw new BusinessRuleViolationError(
+        `${CustomerSellingPrice.ENTITY_NAME}の適用開始日は今日以降である必要があります: ${start} < ${referenceDate}`
+      );
+    }
+  }
+
+  /**
+   * 指定期間が既存のどの行とも重ならないことを保証する。重なれば不変条件違反として投げる。
+   * `excludeRow` を渡すと自分自身（編集・適用終了の対象行）を比較から除外する。
+   */
+  private assertNoOverlap(period: ApplicablePeriod, excludeRow?: CustomerSellingPricePeriod): void {
+    const overlapping = this._periods.find(
+      (row) => row !== excludeRow && row.period.overlaps(period)
+    );
     if (overlapping !== undefined) {
       throw new BusinessRuleViolationError(
         `${CustomerSellingPrice.ENTITY_NAME}の適用期間が既存の期間と重複しています`
       );
     }
-    this._periods.push(CustomerSellingPricePeriod.create(period, price));
   }
 
   get customerId(): CustomerId {

--- a/src/server/subdomains/pricing/domain/entities/CustomerSellingPricePeriod.ts
+++ b/src/server/subdomains/pricing/domain/entities/CustomerSellingPricePeriod.ts
@@ -12,8 +12,8 @@ import { SellingUnitPrice } from "../values/SellingUnitPrice";
 export class CustomerSellingPricePeriod {
   private constructor(
     private readonly _id: CustomerSellingPricePeriodId,
-    private readonly _period: ApplicablePeriod,
-    private readonly _price: SellingUnitPrice
+    private _period: ApplicablePeriod,
+    private _price: SellingUnitPrice
   ) {}
 
   /** 新規の期間行を生成する（identity を採番）。 */
@@ -28,6 +28,23 @@ export class CustomerSellingPricePeriod {
     price: SellingUnitPrice
   ): CustomerSellingPricePeriod {
     return new CustomerSellingPricePeriod(id, period, price);
+  }
+
+  /**
+   * 期間と単価を差し替える（将来行の編集用・集約ルートからのみ呼ぶ）。
+   * 行状態ガード（将来行限定）は集約ルート側の不変条件で守るため、ここでは状態を見ない。
+   */
+  changeTo(period: ApplicablePeriod, price: SellingUnitPrice): void {
+    this._period = period;
+    this._price = price;
+  }
+
+  /**
+   * 終了日のみを差し替える（適用終了用・集約ルートからのみ呼ぶ）。
+   * 開始日・単価は変えない。状態ガード（現在有効行限定）は集約ルート側で守る。
+   */
+  endDateOn(endDate: string): void {
+    this._period = ApplicablePeriod.create({ start: this._period.start, end: endDate });
   }
 
   get id(): CustomerSellingPricePeriodId {

--- a/src/server/subdomains/pricing/domain/entities/__tests__/CustomerSellingPrice.test.ts
+++ b/src/server/subdomains/pricing/domain/entities/__tests__/CustomerSellingPrice.test.ts
@@ -1,6 +1,6 @@
 import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
 import { Money } from "@server/shared/domain/values/Money";
-import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
 import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { describe, expect, it } from "vitest";
@@ -24,9 +24,11 @@ describe("CustomerSellingPrice 集約", () => {
   });
 
   describe("addPeriod — 適用期間行の追加", () => {
+    const today = "2025-06-01";
+
     it("期間行を追加でき、期間と単価が保持される", () => {
       const aggregate = CustomerSellingPrice.create(customerId, productId);
-      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
 
       expect(aggregate.periods).toHaveLength(1);
       const row = aggregate.periods[0];
@@ -36,8 +38,8 @@ describe("CustomerSellingPrice 集約", () => {
 
     it("採番された identity が各行に付与される", () => {
       const aggregate = CustomerSellingPrice.create(customerId, productId);
-      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
-      aggregate.addPeriod(period("2025-10-01", null), price(1200));
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
+      aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
 
       const [a, b] = aggregate.periods;
       expect(a.id.equals(b.id)).toBe(false);
@@ -45,30 +47,276 @@ describe("CustomerSellingPrice 集約", () => {
 
     it("重ならない期間は複数追加できる（隣接含む）", () => {
       const aggregate = CustomerSellingPrice.create(customerId, productId);
-      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
-      aggregate.addPeriod(period("2025-10-01", null), price(1200));
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
+      aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
 
       expect(aggregate.periods).toHaveLength(2);
     });
 
     it("既存期間と重複する期間は BusinessRuleViolationError", () => {
       const aggregate = CustomerSellingPrice.create(customerId, productId);
-      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
 
-      expect(() => aggregate.addPeriod(period("2025-09-01", "2025-12-01"), price(1100))).toThrow(
-        BusinessRuleViolationError
-      );
+      expect(() =>
+        aggregate.addPeriod(period("2025-09-01", "2025-12-01"), price(1100), today)
+      ).toThrow(BusinessRuleViolationError);
       // 失敗時は追加されない
       expect(aggregate.periods).toHaveLength(1);
     });
 
     it("無期限行があるとき、その開始日以降に重なる期間は弾く", () => {
       const aggregate = CustomerSellingPrice.create(customerId, productId);
-      aggregate.addPeriod(period("2025-07-01", null), price(1000));
+      aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
 
-      expect(() => aggregate.addPeriod(period("2030-01-01", "2030-02-01"), price(1100))).toThrow(
+      expect(() =>
+        aggregate.addPeriod(period("2030-01-01", "2030-02-01"), price(1100), today)
+      ).toThrow(BusinessRuleViolationError);
+    });
+
+    it("開始日が今日と同じなら追加できる（境界・以上）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period(today, null), price(1000), today);
+
+      expect(aggregate.periods).toHaveLength(1);
+    });
+
+    it("開始日が今日より前なら BusinessRuleViolationError（過去への後付け登録を禁止）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+
+      expect(() => aggregate.addPeriod(period("2025-05-31", null), price(1000), today)).toThrow(
         BusinessRuleViolationError
       );
+      expect(aggregate.periods).toHaveLength(0);
+    });
+  });
+
+  describe("editPeriod — 将来行の全項目編集", () => {
+    const today = "2025-06-01";
+
+    it("将来行の期間と単価を差し替えられる（identity は保持）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
+      const id = aggregate.periods[0].id;
+
+      aggregate.editPeriod(
+        id,
+        { period: period("2025-08-01", "2025-11-01"), price: price(1500) },
+        today
+      );
+
+      const row = aggregate.periods[0];
+      expect(row.id.equals(id)).toBe(true);
+      expect(row.period.equals(period("2025-08-01", "2025-11-01"))).toBe(true);
+      expect(row.price.equals(price(1500))).toBe(true);
+    });
+
+    it("現在有効行は編集できない（BusinessRuleViolationError・単価ロック）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      // 開始 ≤ 今日 < 終了 = 現在有効
+      aggregate.addPeriod(period("2025-05-01", "2025-12-01"), price(1000), "2025-04-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() =>
+        aggregate.editPeriod(id, { period: period("2025-07-01", null), price: price(1500) }, today)
+      ).toThrow(BusinessRuleViolationError);
+      // 失敗時は元のまま
+      expect(aggregate.periods[0].period.equals(period("2025-05-01", "2025-12-01"))).toBe(true);
+      expect(aggregate.periods[0].price.equals(price(1000))).toBe(true);
+    });
+
+    it("失効行は編集できない（BusinessRuleViolationError）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      // 今日 ≥ 終了 = 失効
+      aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() =>
+        aggregate.editPeriod(id, { period: period("2025-07-01", null), price: price(1500) }, today)
+      ).toThrow(BusinessRuleViolationError);
+    });
+
+    it("存在しない periodId は BusinessRuleViolationError", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
+
+      expect(() =>
+        aggregate.editPeriod(
+          CustomerSellingPricePeriodId.generate(),
+          { period: period("2025-08-01", null), price: price(1500) },
+          today
+        )
+      ).toThrow(BusinessRuleViolationError);
+    });
+  });
+
+  describe("endDatePeriod — 現在有効行の適用終了", () => {
+    const today = "2025-06-01";
+
+    it("現在有効行に終了日を設定でき、開始日・単価は変わらない", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      aggregate.endDatePeriod(id, "2025-09-01", today);
+
+      const row = aggregate.periods[0];
+      expect(row.period.equals(period("2025-04-01", "2025-09-01"))).toBe(true);
+      expect(row.price.equals(price(1000))).toBe(true);
+      expect(row.id.equals(id)).toBe(true);
+    });
+
+    it("終了日が今日以前なら不可（過去の被覆を遡及削除させない）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, today, today)).toThrow(BusinessRuleViolationError);
+    });
+
+    it("将来行には適用終了できない（編集で対応する）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "2025-12-01", today)).toThrow(
+        BusinessRuleViolationError
+      );
+    });
+
+    it("失効行には適用終了できない", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "2025-12-01", today)).toThrow(
+        BusinessRuleViolationError
+      );
+    });
+
+    it("有界の現在有効行を既存終了日より後へは延長できない（短縮のみ許可）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "2025-12-01", today)).toThrow(
+        BusinessRuleViolationError
+      );
+    });
+
+    it("有界の現在有効行で既存終了日と同一の終了日は不可（短縮になっていない）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "2025-07-01", today)).toThrow(
+        BusinessRuleViolationError
+      );
+    });
+
+    it("有界の現在有効行を既存終了日より手前へは短縮できる", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      aggregate.endDatePeriod(id, "2025-06-15", today);
+
+      expect(aggregate.periods[0].period.equals(period("2025-04-01", "2025-06-15"))).toBe(true);
+    });
+
+    it("実在しない日付の終了日は形式エラー（短縮判定より前に弾く）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "9999-99-99", today)).toThrow(ValidationError);
+    });
+
+    it("空文字の終了日は形式エラー（今日比較より前に弾く）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "", today)).toThrow(ValidationError);
+    });
+  });
+
+  describe("deletePeriod — 未来開始行の削除", () => {
+    const today = "2025-06-01";
+
+    it("将来行を削除できる（誤入力訂正）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
+      aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
+      const id = aggregate.periods[0].id;
+
+      aggregate.deletePeriod(id, today);
+
+      expect(aggregate.periods).toHaveLength(1);
+      expect(aggregate.periods[0].period.equals(period("2025-10-01", null))).toBe(true);
+    });
+
+    it("現在有効行は削除できない（BusinessRuleViolationError）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.deletePeriod(id, today)).toThrow(BusinessRuleViolationError);
+      expect(aggregate.periods).toHaveLength(1);
+    });
+
+    it("失効行は削除できない（BusinessRuleViolationError）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.deletePeriod(id, today)).toThrow(BusinessRuleViolationError);
+      expect(aggregate.periods).toHaveLength(1);
+    });
+
+    it("存在しない periodId は BusinessRuleViolationError", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
+
+      expect(() => aggregate.deletePeriod(CustomerSellingPricePeriodId.generate(), today)).toThrow(
+        BusinessRuleViolationError
+      );
+    });
+  });
+
+  describe("currentValidPeriod — 現在有効行の照会", () => {
+    const today = "2025-06-01";
+
+    it("現在有効行（開始 ≤ 今日 < 終了）を返す", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-04-01", "2025-12-01"), price(1000), "2025-03-01");
+
+      const row = aggregate.currentValidPeriod(today);
+
+      expect(row).toBeDefined();
+      expect(row?.period.equals(period("2025-04-01", "2025-12-01"))).toBe(true);
+      expect(row?.price.equals(price(1000))).toBe(true);
+    });
+
+    it("無期限の現在有効行（開始 ≤ 今日・終了なし）を返す", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+
+      const row = aggregate.currentValidPeriod(today);
+
+      expect(row?.period.equals(period("2025-04-01", null))).toBe(true);
+    });
+
+    it("現在有効行が無ければ undefined（将来行・失効行のみ）", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01"); // 失効
+      aggregate.addPeriod(period("2025-07-01", null), price(1200), today); // 将来
+
+      expect(aggregate.currentValidPeriod(today)).toBeUndefined();
+    });
+
+    it("空集約では undefined", () => {
+      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      expect(aggregate.currentValidPeriod(today)).toBeUndefined();
     });
   });
 

--- a/src/server/subdomains/pricing/domain/repositories/CustomerSellingPriceRepository.ts
+++ b/src/server/subdomains/pricing/domain/repositories/CustomerSellingPriceRepository.ts
@@ -8,8 +8,8 @@ import { CustomerSellingPrice } from "../entities";
  * 時点解決（見積年月日で有効な売単価を引く）は read 関心として価格決定フェーズの
  * QueryService に置くため、本リポジトリは集約単位の取得・永続化に限定する（ADR-0066 /
  * 20260624-8tg）。集約の identity は複合自然キー（得意先 × 商品）のため取得 API も両キーを
- * 受ける。永続化は親 version＋期間行の append-only 同期で行い、楽観ロックは insert/update
- * 分割で扱う（ADR-0039）。
+ * 受ける。insert は append-only、update は差分 sync（編集・適用終了・削除を反映）で永続化し、
+ * 楽観ロックは親 version の条件付き更新を insert/update 分割で扱う（ADR-0032 / 0039）。
  */
 export interface CustomerSellingPriceRepository {
   /** 得意先ID×商品IDで集約を取得する。未登録なら null。 */
@@ -24,7 +24,8 @@ export interface CustomerSellingPriceRepository {
   /**
    * 既存の得意先別販売単価集約を更新する（楽観ロック / ADR-0039）。
    *
-   * 期間行は append-only で同期し、親 version を条件に更新する。
+   * 期間行は差分 sync（編集の in-place 更新・適用終了・削除を反映）で集約の現在状態へ収束させ、
+   * 親 version を条件に更新する（ADR-0032）。
    *
    * @param expectedVersion 編集画面表示時に取得した version（フォーム往復で持ち回るトークン）。
    *   保存時点の version と一致しない場合は ConflictError を throw し、後勝ちの変更喪失を防ぐ。

--- a/src/server/subdomains/pricing/infrastructure/prisma/PrismaCustomerSellingPriceRepository.ts
+++ b/src/server/subdomains/pricing/infrastructure/prisma/PrismaCustomerSellingPriceRepository.ts
@@ -10,6 +10,7 @@ import {
 import {
   appendPeriodRows,
   assertVersionBumped,
+  syncPeriodRows,
   translateInsertConflict,
   type Tx,
 } from "@subdomains/pricing/infrastructure/prisma/sellingPricePeriodPersistence";
@@ -20,12 +21,14 @@ import { ProductId } from "@subdomains/product/domain/values/ProductId";
  *
  * 共通販売単価リポジトリと同型で、宛先が得意先（複合自然キー identity）である点だけが異なる
  * （ADR-20260624-8tg）。適用期間（daterange）は Prisma typed では扱えないため、期間行の読み出しは
- * `$queryRaw`・境界展開は `applicablePeriodBounds` に委ねる（ADR-0067）。期間行の書き込み（append-only
- * INSERT）・P2002 の ConflictError 翻訳・楽観ロックの version 判定は、3層で共通の永続化ヘルパ
- * `sellingPricePeriodPersistence` に委譲する（#458）。期間行の同期は append-only で、新規 id のみを
- * 挿入し既存行には触れない（`ON CONFLICT (id) DO NOTHING`）。ドメインの変更操作が addPeriod（追加）
- * のみ・子が id 単位で内容不変ゆえ削除分岐は到達不能で、既存行を触らないため改定時に updated_at を
- * 保持できる（監査保持）。楽観ロックは親 version の条件付き更新で行う（ADR-0039）。
+ * `$queryRaw`・境界展開は `applicablePeriodBounds` に委ねる（ADR-0067）。期間行の書き込み・P2002 の
+ * ConflictError 翻訳・楽観ロックの version 判定は、3層で共通の永続化ヘルパ
+ * `sellingPricePeriodPersistence` に委譲する（#458）。
+ *
+ * insert は新規作成ゆえ衝突が無く append-only（`ON CONFLICT (id) DO NOTHING`）で足りる。update は
+ * 編集・適用終了・削除を伴うため差分 sync（`syncPeriodRows`）で DB を集約の現在状態へ収束させる:
+ * 既存 id は値が変わった行だけ in-place 更新し（無変更行は `updated_at` 据え置き＝監査保持）、
+ * 集約から消えた id の行は削除する（ADR-0032）。楽観ロックは親 version の条件付き更新（ADR-0039）。
  */
 export class PrismaCustomerSellingPriceRepository implements CustomerSellingPriceRepository {
   async findByCustomerIdAndProductId(
@@ -88,30 +91,40 @@ export class PrismaCustomerSellingPriceRepository implements CustomerSellingPric
       });
       assertVersionBumped(result.count);
 
-      // 期間行は append-only で同期する。ドメインの変更操作は addPeriod（追加）のみで子は
-      // id 単位で内容不変ゆえ、集約は常に DB の id を包含し「DB にあって集約に無い id（=削除）」
-      // は発生しない。よって既存行に触れず新規 id のみ挿入すればよく、既存行の updated_at は
-      // まったく動かない（監査保持）。
-      await this.writePeriods(tx, aggregate);
+      // 期間行は差分 sync で集約の現在状態へ収束させる（編集の in-place 更新・適用終了・削除を反映）。
+      // 値が変わった行だけ updated_at が前進し、無変更行は据え置かれる（監査保持）。
+      await syncPeriodRows(
+        tx,
+        PrismaCustomerSellingPriceRepository.PERIOD_TABLE,
+        [aggregate.customerId.value, aggregate.productId.value],
+        this.toWriteRows(aggregate)
+      );
     });
   }
 
-  /** 集約の全期間行を append-only で同期する（共通ヘルパへ委譲）。 */
+  private static readonly PERIOD_TABLE = {
+    table: "customer_selling_price_periods",
+    keyColumns: ["customer_id", "product_id"],
+    valueColumn: "selling_price",
+  } as const;
+
+  /** 集約の全期間行を append-only で挿入する（新規作成専用・共通ヘルパへ委譲）。 */
   private async writePeriods(tx: Tx, aggregate: CustomerSellingPrice): Promise<void> {
     await appendPeriodRows(
       tx,
-      {
-        table: "customer_selling_price_periods",
-        keyColumns: ["customer_id", "product_id"],
-        valueColumn: "selling_price",
-      },
-      CustomerSellingPriceMapper.toPeriodWriteRows(aggregate).map((row) => ({
-        id: row.id,
-        keyValues: [row.customerId, row.productId],
-        value: row.sellingPrice,
-        start: row.start,
-        end: row.end,
-      }))
+      PrismaCustomerSellingPriceRepository.PERIOD_TABLE,
+      this.toWriteRows(aggregate)
     );
+  }
+
+  /** 集約の期間行を永続化ヘルパの行形式へ変換する。 */
+  private toWriteRows(aggregate: CustomerSellingPrice) {
+    return CustomerSellingPriceMapper.toPeriodWriteRows(aggregate).map((row) => ({
+      id: row.id,
+      keyValues: [row.customerId, row.productId],
+      value: row.sellingPrice,
+      start: row.start,
+      end: row.end,
+    }));
   }
 }

--- a/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCustomerSellingPriceRepository.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCustomerSellingPriceRepository.test.ts
@@ -106,7 +106,7 @@ describe("PrismaCustomerSellingPriceRepository", () => {
     expect(found.periods[1].price.equals(price(1200))).toBe(true);
   });
 
-  it("update は既存期間行の updated_at を変更しない（append-only・監査保持）", async () => {
+  it("update は無変更の既存行の updated_at を変更しない（監査保持）", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
@@ -136,6 +136,75 @@ describe("PrismaCustomerSellingPriceRepository", () => {
     expect(rows[0].updatedAt.toISOString()).toBe(frozen.toISOString());
     // 追加行（2025-10-01 始まり）は今回の挿入なので過去値ではない。
     expect(rows[1].updatedAt.getTime()).toBeGreaterThan(frozen.getTime());
+  });
+
+  it("update で将来行の単価改定が in-place 反映され、改定行の updated_at が進む（編集の永続化）", async () => {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+
+    // 改定前の updated_at を既知の過去値へ固定し、in-place 更新で前進したことを検出可能にする。
+    const frozen = new Date("2020-01-01T00:00:00.000Z");
+    await prisma.$executeRaw`
+      UPDATE customer_selling_price_periods
+      SET updated_at = ${frozen}
+      WHERE customer_id = ${customerId.value}::uuid AND product_id = ${productId.value}::uuid
+    `;
+
+    const reloaded = (await repository.findByCustomerIdAndProductId(customerId, productId))!;
+    const id = reloaded.periods[0].id;
+    reloaded.editPeriod(
+      id,
+      { period: period("2030-01-01", null), price: price(1500) },
+      "2025-06-01"
+    );
+    await repository.update(reloaded, 1);
+
+    const found = (await repository.findByCustomerIdAndProductId(customerId, productId))!;
+    expect(found.periods).toHaveLength(1);
+    // id を保ったまま（差分 upsert・新規行を作らない）単価が改定される。
+    expect(found.periods[0].id.equals(id)).toBe(true);
+    expect(found.periods[0].price.equals(price(1500))).toBe(true);
+
+    const rows = await prisma.$queryRaw<{ updatedAt: Date }[]>`
+      SELECT updated_at AS "updatedAt"
+      FROM customer_selling_price_periods
+      WHERE customer_id = ${customerId.value}::uuid AND product_id = ${productId.value}::uuid
+    `;
+    // 改定した行は updated_at が前進する（監査）。
+    expect(rows[0].updatedAt.getTime()).toBeGreaterThan(frozen.getTime());
+  });
+
+  it("update で集約から消えた将来行は DB からも削除される（削除の永続化）", async () => {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2025-06-01");
+    aggregate.addPeriod(period("2030-06-01", null), price(1200), "2025-06-01");
+    await repository.insert(aggregate);
+
+    const reloaded = (await repository.findByCustomerIdAndProductId(customerId, productId))!;
+    const firstId = reloaded.periods[0].id;
+    reloaded.deletePeriod(firstId, "2025-06-01");
+    await repository.update(reloaded, 1);
+
+    const found = (await repository.findByCustomerIdAndProductId(customerId, productId))!;
+    expect(found.periods).toHaveLength(1);
+    expect(found.periods[0].period.equals(period("2030-06-01", null))).toBe(true);
+  });
+
+  it("update で最後の将来行を削除すると期間行が0件になる（空集約 delete・空配列バインド）", async () => {
+    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+
+    // 唯一の将来行を削除 → syncPeriodRows が rows=[] で DELETE ... ANY('{}'::uuid[]) を走らせる経路。
+    const reloaded = (await repository.findByCustomerIdAndProductId(customerId, productId))!;
+    reloaded.deletePeriod(reloaded.periods[0].id, "2025-06-01");
+    await repository.update(reloaded, 1);
+
+    // 親（customer_selling_prices）は残り、期間行だけ0件＝空集約として往復する（例外なく完了）。
+    const found = await repository.findByCustomerIdAndProductId(customerId, productId);
+    expect(found).not.toBeNull();
+    expect(found!.periods).toHaveLength(0);
   });
 
   it("古い expectedVersion での update は ConflictError", async () => {

--- a/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCustomerSellingPriceRepository.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCustomerSellingPriceRepository.test.ts
@@ -73,8 +73,8 @@ describe("PrismaCustomerSellingPriceRepository", () => {
 
   it("insert して findByCustomerIdAndProductId で往復できる（有界＋無期限・銭精度）", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
-    aggregate.addPeriod(period("2025-10-01", null), price(1234.56));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
+    aggregate.addPeriod(period("2025-10-01", null), price(1234.56), "2025-10-01");
     await repository.insert(aggregate);
 
     const found = await repository.findByCustomerIdAndProductId(customerId, productId);
@@ -93,12 +93,12 @@ describe("PrismaCustomerSellingPriceRepository", () => {
 
   it("update で期間行を追加同期できる（version 一致時・append-only）", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     // 画面表示時の version=1 を持ち回って改定（期間を1本追加）
     const reloaded = (await repository.findByCustomerIdAndProductId(customerId, productId))!;
-    reloaded.addPeriod(period("2025-10-01", null), price(1200));
+    reloaded.addPeriod(period("2025-10-01", null), price(1200), "2025-10-01");
     await repository.update(reloaded, 1);
 
     const found = (await repository.findByCustomerIdAndProductId(customerId, productId))!;
@@ -108,7 +108,7 @@ describe("PrismaCustomerSellingPriceRepository", () => {
 
   it("update は既存期間行の updated_at を変更しない（append-only・監査保持）", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     // 既存行の updated_at を既知の過去値に固定し、偶発的な現在時刻一致を排除する。
@@ -121,7 +121,7 @@ describe("PrismaCustomerSellingPriceRepository", () => {
 
     // version=1 を持ち回り、期間を1本追加して改定する。
     const reloaded = (await repository.findByCustomerIdAndProductId(customerId, productId))!;
-    reloaded.addPeriod(period("2025-10-01", null), price(1200));
+    reloaded.addPeriod(period("2025-10-01", null), price(1200), "2025-10-01");
     await repository.update(reloaded, 1);
 
     const rows = await prisma.$queryRaw<{ updatedAt: Date; start: string }[]>`
@@ -140,7 +140,7 @@ describe("PrismaCustomerSellingPriceRepository", () => {
 
   it("古い expectedVersion での update は ConflictError", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
-    aggregate.addPeriod(period("2025-07-01", null), price(1000));
+    aggregate.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     await expect(repository.update(aggregate, 999)).rejects.toBeInstanceOf(ConflictError);
@@ -148,18 +148,18 @@ describe("PrismaCustomerSellingPriceRepository", () => {
 
   it("同一の得意先×商品への二重 insert は ConflictError（親 複合PK 衝突の翻訳）", async () => {
     const first = CustomerSellingPrice.create(customerId, productId);
-    first.addPeriod(period("2025-07-01", null), price(1000));
+    first.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await repository.insert(first);
 
     // アプリ層の存在チェックをすり抜けた二重作成レースを模す。
     const second = CustomerSellingPrice.create(customerId, productId);
-    second.addPeriod(period("2025-07-01", null), price(2000));
+    second.addPeriod(period("2025-07-01", null), price(2000), "2025-07-01");
     await expect(repository.insert(second)).rejects.toBeInstanceOf(ConflictError);
   });
 
   it("同一の得意先×商品で適用期間が重複する行は EXCLUDE 制約で弾かれる", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     // 並行 stale 書き込みを模して、ドメインのガードを迂回し重なる期間を直接 INSERT する。

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCustomerSellingPriceQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCustomerSellingPriceQueryService.test.ts
@@ -96,7 +96,7 @@ describe("PrismaCustomerSellingPriceQueryService", () => {
 
   it("区間内の暦日で有効な得意先別単価を引く", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     const result = await queryService.resolve({
@@ -110,7 +110,7 @@ describe("PrismaCustomerSellingPriceQueryService", () => {
 
   it("同じ商品でも別の得意先では引かない（得意先キーの隔離）", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     const result = await queryService.resolve({
@@ -124,7 +124,7 @@ describe("PrismaCustomerSellingPriceQueryService", () => {
 
   it("同じ得意先でも別の商品では引かない（商品キーの隔離）", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     const result = await queryService.resolve({
@@ -154,7 +154,7 @@ describe("PrismaCustomerSellingPriceQueryService", () => {
 
   it("どの適用期間にも覆われない暦日では null を返す", async () => {
     const aggregate = CustomerSellingPrice.create(customerId, productId);
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     const result = await queryService.resolve({


### PR DESCRIPTION
## Summary

得意先別販売単価（`CustomerSellingPrice`）の「書き込み」関心を実装。動作中の共通販売単価 BE を得意先別へ完全写像し、集約に編集系ミューテータ（editPeriod / endDatePeriod / deletePeriod / currentValidPeriod と addPeriod への参照日ガード）を補完、application commands 5 種（Register / Edit / EndDate / Delete / Revise）＋共有ロードヘルパ＋factories を追加、リポジトリを差分 sync 同期化した。

Closes #505

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

# Issue #505: 得意先別販売単価の書き込みユースケース（ドメイン編集操作 + commands/factories） — 実装計画

## 概要

得意先別販売単価（`CustomerSellingPrice`）の「書き込み」関心を実装する。**動作中の共通販売単価 BE（`CommonSellingPrice` 集約 + 5 コマンド + `loadCommonSellingPriceOrThrow` + factories + `PrismaCommonSellingPriceRepository`）を得意先別へ完全写像**する。得意先軸の差分は複合自然キー `(CustomerId, ProductId)` が identity である一点のみ（ADR-20260624-8tg）で、それ以外の業務ルール・永続化パターンは共通と同一。

現状の得意先別は集約が `addPeriod`（過去ガード無し）のみ・コマンドゼロ。リポジトリは #460 時点の append-only 実装のまま。本計画で共通と同水準まで引き上げる。

- **含む**: 集約の編集系ミューテータ（`editPeriod` / `endDatePeriod` / `deletePeriod` / `currentValidPeriod`、および `addPeriod` への参照日ガード）／application commands 5 種（Register / Edit / EndDate / Delete / Revise）＋共有ロードヘルパ／factories／リポジトリの差分 sync 化／テスト一式
- **含まない**: 読みモデル（一覧・編集 QueryService / DTO）、FE 一切、納品先別（DeliveryLocation）への波及、E2E（いずれも別イシュー）

## 設計判断

### リポジトリの infra 変更をスコープに含めるか
- A. 含める（`PrismaCommonSellingPriceRepository` を完全写像。insert=`appendPeriodRows`／update=`syncPeriodRows`）
- B. 含めない（既存 append-only を温存）
- **採用: A**。理由: 集約に `editPeriod`（既存 id の in-place 変更）・`deletePeriod`（行の除去）を足すと、現行 update の `appendPeriodRows`（`ON CONFLICT (id) DO NOTHING`）では編集が黙って握り潰され・削除が DB に残存し、コマンドが機能しない。#460 の古い実装は温存せず、動作中の共通リポジトリを写像する（既に共有ヘルパ `sellingPricePeriodPersistence` が存在するため新規ロジック無し）。

### ドメインルールの写像度（得意先軸固有ルールの有無）
- A. 共通の完全ミラー・得意先固有ルールを足さない
- B. 得意先軸に固有ルール（跨集約の存在チェック等）を追加
- **採用: A**。理由: 温度ガード（将来行=編集/削除可・現在有効行=適用終了のみ・失効行=不可／ADR-20260627-86b）、結果型（集約を返す・失敗は例外・union 不使用／ADR-0037-0038）、楽観ロック（Register は既存追加時のみ expectedVersion 必須／ADR-0039）、参照日注入（`referenceDate` を入力で受けサーバー生成は上流の別イシュー）はすべて共通と同一。跨集約チェック（対応する共通販売単価の存在・Customer 実在）は**入れない** — CONTEXT.md「適用終了」注記が「最低1期間の保証は跨集約ハード強制せず価格決定の安全弁で担保」と明言し #476 でハード強制は不採用。

### 納品先別（DeliveryLocation）への同時波及
- A. 触れない（得意先別のみ共通へ追いつかせる）
- B. 同型2層として納品先別も同時にミューテータ補完
- **採用: A**。理由: 親 #492 は得意先別保守の分割。ADR-20260624-8tg の「同型」は集約構造の同型であり全レイヤー機能の同時実装を約束しない（既に共通↔上書き2層で非対称は存在）。納品先別への写像は同型ゆえ後日ほぼ機械作業で追随できる。「1回1スコープ」方針にも沿う。

### ADR 起票 / CONTEXT.md 更新
- **不要**。本計画の判断はすべて既存 ADR の適用（8tg 同型／86b 温度ガード／0032 差分 upsert／0037-0038 結果型／0039 楽観ロック／0018 独立 EndDate／0067 daterange）であり、「反転しにくい・文脈なしに驚く・真のトレードオフ」の3条件を満たす新規判断が無い。用語集（得意先別販売単価/適用終了/単価改定/失効/適用期間）も完備。

### 実装方式（TDD）
- 依存の向き **ドメイン（純粋）→ リポジトリ（実DB往復）→ コマンド（実DB・実 Customer/Product 前提）** に従い red-green-refactor で進める。共通側コマンドテストが実 `Prisma*Repository` を直接注入し実 Product を FK 生成するため、リポジトリの sync 化をコマンド実装より前に置く。

## ステップ

### Step 1: ドメイン集約 CustomerSellingPrice のミューテータ補完（TDD・純粋ドメイン）
- 対象ファイル:
  - `src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts`
  - `src/server/subdomains/pricing/domain/entities/__tests__/CustomerSellingPrice.test.ts`
  - 署名変更で影響する既存テスト（コンパイル修復）: `application/queries/__tests__/ResolveCustomerSellingPriceQuery.test.ts` / `infrastructure/queries/__tests__/PrismaCustomerSellingPriceQueryService.test.ts` / `infrastructure/prisma/__tests__/PrismaCustomerSellingPriceRepository.test.ts` / `application/queries/__tests__/ResolveSellingPriceQuery.test.ts`
- 作業内容:
  - Red: `CommonSellingPrice.test.ts` を写し、`addPeriod` の過去開始拒否・`editPeriod`（将来行のみ・過去開始拒否・重複拒否）・`endDatePeriod`（現在有効行のみ・短縮限定・今日以前拒否・`assertNoOverlap`）・`deletePeriod`（未来行のみ）・`currentValidPeriod` のケースを追加
  - Green: `addPeriod` に第3引数 `referenceDate` と `assertStartNotPast` を追加、`editPeriod` / `endDatePeriod` / `deletePeriod` / `currentValidPeriod` と private ヘルパ（`requireRow` / `isFuture` / `assertStartNotPast` / `assertNoOverlap`）を実装
  - 署名変更で壊れる既存テストの `addPeriod(...)` 呼び出しに `referenceDate`（＝開始日）を機械付与してコンパイル復旧
- コミットメッセージ: `feat: 得意先別販売単価 集約の編集系ミューテータを補完`
  - body: 共通販売単価集約の完全ミラー。addPeriod に参照日注入の過去不変ガードを追加し editPeriod/endDatePeriod/deletePeriod/currentValidPeriod を実装（ADR-20260624-8tg / 20260627-86b）。

### Step 2: リポジトリを共通実装へ写像（TDD・実DB往復）
- 対象ファイル:
  - `src/server/subdomains/pricing/infrastructure/prisma/PrismaCustomerSellingPriceRepository.ts`
  - `src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCustomerSellingPriceRepository.test.ts`
- 作業内容:
  - Red: 編集の in-place 反映（`updated_at` 挙動含む）・削除行の消滅・楽観ロック競合の往復テストを追加
  - Green: `update()` を `syncPeriodRows` へ切り替え、`PERIOD_TABLE` 定数・`toWriteRows` を分離、`insert()` は `appendPeriodRows` 維持。クラスコメントを刷新（append-only 前提の旧根拠を差分 sync 前提へ）
- コミットメッセージ: `feat: 得意先別販売単価リポジトリを差分sync同期へ`
  - body: #460 の append-only 実装を PrismaCommonSellingPriceRepository へ写像。update は syncPeriodRows で編集・適用終了・削除を反映し無変更行の updated_at は据え置く（ADR-0032 / 0039）。

### Step 3: 登録コマンド Register（TDD・実DB）
- 対象ファイル:
  - `src/server/subdomains/pricing/application/commands/RegisterCustomerSellingPricePeriodCommand.ts`（+ `__tests__`）
  - `src/server/subdomains/pricing/application/factories/registerCustomerSellingPricePeriodCommandFactory.ts`
- 作業内容:
  - Red→Green: 未設定 (customer,product) は新規 insert（version 1）・既存は addPeriod + update（expectedVersion 必須、未指定は ValidationError）。実 Customer + Product を FK 生成する fixture でテスト
  - factory で `PrismaCustomerSellingPriceRepository` を DI
- コミットメッセージ: `feat: 得意先別販売単価 登録コマンド（Register）`

### Step 4: 共有ロードヘルパ + 編集コマンド Edit（TDD・実DB）
- 対象ファイル:
  - `src/server/subdomains/pricing/application/commands/loadCustomerSellingPriceOrThrow.ts`
  - `src/server/subdomains/pricing/application/commands/EditCustomerSellingPricePeriodCommand.ts`（+ `__tests__`）
  - `src/server/subdomains/pricing/application/factories/editCustomerSellingPricePeriodCommandFactory.ts`
- 作業内容:
  - `loadCustomerSellingPriceOrThrow(repository, customerId, productId)`：`findByCustomerIdAndProductId` で取得し null なら `NotFoundEntityError`
  - Red→Green: Edit は集約取得 → `editPeriod` → update（expectedVersion 必須）。状態違反は集約が BusinessRuleViolationError
- コミットメッセージ: `feat: 得意先別販売単価 編集コマンド（Edit）と共有ロードヘルパ`

### Step 5: 適用終了コマンド EndDate（TDD・実DB）
- 対象ファイル:
  - `src/server/subdomains/pricing/application/commands/EndDateCustomerSellingPricePeriodCommand.ts`（+ `__tests__`）
  - `src/server/subdomains/pricing/application/factories/endDateCustomerSellingPricePeriodCommandFactory.ts`
- 作業内容: 入力 `{ customerId, productId, periodId, endDate, referenceDate, expectedVersion }`。現在有効行を `endDatePeriod` で打ち切り update。独立コマンド（ADR-0018 / 86b 軸4）
- コミットメッセージ: `feat: 得意先別販売単価 適用終了コマンド（EndDate）`

### Step 6: 削除コマンド Delete（TDD・実DB）
- 対象ファイル:
  - `src/server/subdomains/pricing/application/commands/DeleteCustomerSellingPricePeriodCommand.ts`（+ `__tests__`）
  - `src/server/subdomains/pricing/application/factories/deleteCustomerSellingPricePeriodCommandFactory.ts`
- 作業内容: 未来開始行を `deletePeriod` で物理削除 update。現在有効・失効行の削除は BusinessRuleViolationError
- コミットメッセージ: `feat: 得意先別販売単価 削除コマンド（Delete）`

### Step 7: 単価改定コマンド Revise（TDD・実DB）
- 対象ファイル:
  - `src/server/subdomains/pricing/application/commands/ReviseCustomerSellingPricePeriodCommand.ts`（+ `__tests__`）
  - `src/server/subdomains/pricing/application/factories/reviseCustomerSellingPricePeriodCommandFactory.ts`
- 作業内容: `currentValidPeriod` が無ければ拒否。`endDatePeriod`（終了日=改定日）→ `addPeriod`（改定日開始・無期限）の順で1ロード1セーブ。単一集約 version でアトミック（合成糖衣・CONTEXT.md「単価改定」）
- コミットメッセージ: `feat: 得意先別販売単価 単価改定コマンド（Revise）`

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

## Test Plan

TDD（red-green-refactor）で実装。ドメイン（純粋）→ リポジトリ（実DB往復）→ コマンド（実DB・実 Customer/Product 前提）の順で各層にテストを追加した。

- [ ] ドメイン集約: `CustomerSellingPrice.test.ts`（addPeriod 過去開始拒否 / editPeriod・endDatePeriod・deletePeriod の温度ガード / currentValidPeriod）
- [ ] リポジトリ: `PrismaCustomerSellingPriceRepository.test.ts`（編集の in-place 反映・削除行の消滅・楽観ロック競合・無変更行 updated_at 据え置き）
- [ ] コマンド: Register / Edit / EndDate / Delete / Revise の各 `*.test.ts`（実 Customer + Product FK 生成 fixture、expectedVersion 楽観ロック、状態別権限）
- [ ] 署名変更で影響する既存クエリテストのコンパイル復旧確認
- [ ] `pnpm test` / `pnpm lint` 通過確認

---

Generated with [Claude Code](https://claude.ai/code)
