### PR TITLE
fix: 一覧検索の ILIKE で LIKE メタ文字 (% _) が未エスケープ (pricing 4箇所)

### DIFF
--- a/docs/claude-plans/issue-518/escape-ilike-metacharacters.md
+++ b/docs/claude-plans/issue-518/escape-ilike-metacharacters.md
@@ -1,0 +1,67 @@
+# Issue #518: 一覧検索の ILIKE で LIKE メタ文字 (% _) が未エスケープ (pricing 4箇所) — 実装計画
+
+## 概要
+
+pricing の一覧検索 QueryService 2本（`PrismaCostPriceListQueryService` / `PrismaCommonSellingPriceListQueryService`）で、生 ILIKE のパターン `%${input.code}%` に含まれるユーザー入力の LIKE メタ文字 `%` `_` が未エスケープのまま渡り、意図しない広範囲がヒットする実バグを修正する（2ファイル×2列=4箇所）。
+
+他の一覧検索（customer/product/employee など）は Prisma の `contains:` を使い値が自動エスケープされるため無傷。この2本だけが `daterange @>` 演算子の都合で `$queryRaw` + 生 ILIKE を使わざるを得ず、手動エスケープが必要になっている。
+
+共有インフラ util としてエスケープ関数を新設し、両 QueryService に適用する。`/tdd`（red-green-refactor）で、各ステップともテスト先行で進める。
+
+## 設計判断
+
+### エスケープ機構
+- `\` `%` `_` の3文字を `\` でエスケープし、SQL 側に明示的な `ESCAPE '\'` 句を付与する。
+- 理由: `input.code = "50%"` → `50\%` → パターン `%50\%%` でリテラル `50%` にマッチ（正しい挙動）。デフォルトのエスケープ文字が `\` なので `ESCAPE '\'` は省略しても動くが、明示することで意図がクエリ上に残り `standard_conforming_strings` 等の設定に依存しなくなる。
+- `$queryRaw` はテンプレート変数をバインドパラメータとして渡すため、SQL文字列リテラルのエスケープ問題は絡まず、純粋にパターン文字列としての3文字だけを扱えばよい。
+
+### エスケープ関数の配置レイヤーと共通化
+- `src/server/shared/infrastructure/escapeLikePattern.ts` に共有 util として置く（`dateRange.ts` と同レイヤ）。
+- 理由: LIKE エスケープはドメイン知識ではなく ILIKE という技術詳細への対処なので domain 層ではなく infrastructure 層。呼び出し箇所が確実に2ファイル4箇所あり DRY の実益がある。pricing 固有の関心ではなく他サブドメインも再利用しうる純粋な技術関数のため pricing ローカルではなく shared。
+- 対立案（各ファイルにインライン複製 / pricing ローカル）は、同一ロジックの二重管理・関心の閉じ込めすぎのため退けた。
+
+### 関数の責務分割（プリミティブ + コンポジット）
+- `escapeLikePattern(s: string): string` — プリミティブ。`\` `%` `_` を `\` でエスケープのみ。
+- `containsPattern(s: string): string` — コンポジット。内部で `escapeLikePattern` を呼び、`` `%…%` `` で囲んで返す。
+- 呼び出し側: `` ILIKE ${containsPattern(input.code)} ESCAPE '\\' ``。
+- 理由: 関心を階層化することで、プリミティブは前方一致など別パターンでも再利用でき単体テストをエスケープ規則そのものに集中できる。コンポジットは「囲みが付くこと」だけ確認すればよく、呼び出し側から `%...%` の文字列連結が消えて囲み忘れ等の別バグの余地がなくなる。`ESCAPE` 句は SQL 構文要素なので SQL テンプレート側に残すのが正しい配置。
+- 実装メモ: エスケープは単一の正規表現1パス `s.replace(/[\\%_]/g, m => "\\" + m)` で書き、順序依存の二重エスケープ事故を原理的に回避する。
+
+### テスト方針（二層）
+- 単体テスト（網羅担当・DB不要の純関数）: `escapeLikePattern` / `containsPattern`。`%`→`\%`、`_`→`\_`、`\`→`\\`、複合（`a\_b`→`a\\\_b`）、メタ文字なし素通し、`containsPattern` の前後 `%` 付与。
+- 統合テスト（結線担当・実DB）: 各 QueryService テストに1ケース。`%`/`_` を含む実データを用意し、`%` 等を検索語に入れたとき「リテラルとしてマッチする1件のみ返り、全件マッチしない」ことを確認。エスケープ済みパターンが ILIKE に正しく届き `ESCAPE '\'` 句が効いていることのエンドツーエンド保証。
+- 理由: 単体だけだと SQL への結線（`ESCAPE` 句付与漏れ等）を捕捉できず、統合だけだとエスケープ規則の網羅コストが高い。網羅は単体に寄せ、統合は各ファイル1ケースに留める。
+
+### ドキュメント
+- ADR: 作らない。覆すコストが低く、非対称の理由（`daterange` は Prisma typed で扱えず `$queryRaw`）は既に両ファイルのヘッダコメントに明記済みで、素直な既定選択のため3条件を満たさない。
+- CONTEXT.md: 更新しない。用語集（ドメイン言語）であり `containsPattern`/LIKEエスケープは実装語彙のため対象外。
+- deviations.md: 逸脱発生時のみ記録。事前作成不要。
+
+## ステップ
+
+### Step 1: エスケープ関数 `escapeLikePattern` / `containsPattern` の実装（TDD）
+- 対象ファイル:
+  - `src/server/shared/infrastructure/__tests__/escapeLikePattern.test.ts`（新規）
+  - `src/server/shared/infrastructure/escapeLikePattern.ts`（新規）
+- 作業内容:
+  - RED: 純関数の単体テストを先に書く（`%`→`\%`、`_`→`\_`、`\`→`\\`、複合 `a\_b`→`a\\\_b`、メタ文字なし素通し、`containsPattern` の前後 `%` 付与）。
+  - GREEN: `escapeLikePattern`（正規表現1パス `s.replace(/[\\%_]/g, m => "\\" + m)`）と、それを内部利用する `containsPattern` を実装してテストを通す。
+- コミットメッセージ: `fix: LIKEメタ文字エスケープ用の共有util(escapeLikePattern/containsPattern)を追加 #518`
+
+### Step 2: `PrismaCostPriceListQueryService` への適用（TDD）
+- 対象ファイル:
+  - `src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCostPriceListQueryService.test.ts`
+  - `src/server/subdomains/pricing/infrastructure/queries/PrismaCostPriceListQueryService.ts`
+- 作業内容:
+  - RED: `%`/`_` を含む実データで「リテラルマッチ1件のみ／全件マッチしない」ことを検証する統合テスト1ケースを追加（現状は失敗する）。
+  - GREEN: `%${input.code}%` / `%${input.name}%` を `containsPattern(...)` に置換し、ILIKE 句に `ESCAPE '\\'` を付与して通す。
+- コミットメッセージ: `fix: 原価一覧検索のILIKEメタ文字を未エスケープから修正 #518`
+
+### Step 3: `PrismaCommonSellingPriceListQueryService` への適用（TDD）
+- 対象ファイル:
+  - `src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCommonSellingPriceListQueryService.test.ts`
+  - `src/server/subdomains/pricing/infrastructure/queries/PrismaCommonSellingPriceListQueryService.ts`
+- 作業内容:
+  - RED: 同型の統合テスト1ケースを追加（現状は失敗する）。
+  - GREEN: 同様に `containsPattern(...)` + `ESCAPE '\\'` へ置換して通す。
+- コミットメッセージ: `fix: 共通売価一覧検索のILIKEメタ文字を未エスケープから修正 #518`

--- a/src/server/shared/infrastructure/__tests__/escapeLikePattern.test.ts
+++ b/src/server/shared/infrastructure/__tests__/escapeLikePattern.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { containsPattern, escapeLikePattern } from "../escapeLikePattern";
+
+describe("escapeLikePattern", () => {
+  it("% を \\% にエスケープしてリテラル化する", () => {
+    expect(escapeLikePattern("50%")).toBe("50\\%");
+  });
+
+  it("_ を \\_ にエスケープしてリテラル化する", () => {
+    expect(escapeLikePattern("a_b")).toBe("a\\_b");
+  });
+
+  it("エスケープ文字 \\ 自身も \\\\ にエスケープする", () => {
+    expect(escapeLikePattern("a\\b")).toBe("a\\\\b");
+  });
+
+  it("\\ と _ が混在しても各文字を独立にエスケープする（二重エスケープしない）", () => {
+    expect(escapeLikePattern("a\\_b")).toBe("a\\\\\\_b");
+  });
+
+  it("メタ文字を含まない入力はそのまま返す", () => {
+    expect(escapeLikePattern("PROD-001")).toBe("PROD-001");
+  });
+});
+
+describe("containsPattern", () => {
+  it("エスケープ済み本体を前後 % で囲んだ部分一致パターンを返す", () => {
+    expect(containsPattern("50%")).toBe("%50\\%%");
+  });
+
+  it("メタ文字を含まない入力も前後 % で囲む", () => {
+    expect(containsPattern("PROD")).toBe("%PROD%");
+  });
+});

--- a/src/server/shared/infrastructure/escapeLikePattern.ts
+++ b/src/server/shared/infrastructure/escapeLikePattern.ts
@@ -1,0 +1,31 @@
+/**
+ * PostgreSQL `LIKE`/`ILIKE` パターンのメタ文字エスケープを担う共有 SQL ヘルパ（#518）。
+ *
+ * Prisma typed の `contains:` は値を自動エスケープするが、`daterange @>` の都合で `$queryRaw` +
+ * 生 ILIKE を使う一覧検索（pricing の原価/共通売価）ではユーザー入力の `%` `_` がパターンとして
+ * 解釈され、意図しない広範囲がヒットする。`escapeLikePattern` で `\` `%` `_` を `\` でエスケープし、
+ * 呼び出し側の ILIKE 句に `ESCAPE '\'` を付けてリテラル一致を保証する。
+ */
+
+/**
+ * `LIKE`/`ILIKE` のメタ文字 `\` `%` `_` を `\` でエスケープする。
+ *
+ * 単一の正規表現1パス置換で各マッチを独立処理し、`\` を先に処理しないと二重エスケープになる
+ * 順序依存を原理的に回避する。`$queryRaw` はパターンをバインドパラメータとして渡すため、
+ * SQL文字列リテラルのエスケープは絡まず、純粋にパターン文字列としての3文字だけを扱えばよい。
+ */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+/**
+ * 部分一致（contains）用の `LIKE`/`ILIKE` パターンを組み立てる。
+ *
+ * `escapeLikePattern` でメタ文字をリテラル化した本体を前後 `%` で囲む。呼び出し側の ILIKE 句には
+ * `ESCAPE '\'` を付ける前提。囲みをここへ集約することで、呼び出し側での `%...%` 文字列連結（囲み
+ * 忘れ・片側 `%` 等の別バグ）を防ぐ。他サブドメインが Prisma の `contains:` で表す部分一致検索と
+ * 語彙を揃える。
+ */
+export function containsPattern(value: string): string {
+  return `%${escapeLikePattern(value)}%`;
+}

--- a/src/server/subdomains/pricing/infrastructure/queries/PrismaCommonSellingPriceListQueryService.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/PrismaCommonSellingPriceListQueryService.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@generated/prisma/client";
 import prisma from "@server/prisma";
+import { containsPattern } from "@server/shared/infrastructure/escapeLikePattern";
 import { CommonSellingPriceListQueryService } from "@subdomains/pricing/application/queries/CommonSellingPriceListQueryService";
 import {
   CommonSellingPriceListItemDTO,
@@ -32,10 +33,10 @@ export class PrismaCommonSellingPriceListQueryService implements CommonSellingPr
   }): Promise<CommonSellingPriceListItemDTO[]> {
     const conditions: Prisma.Sql[] = [];
     if (input.code) {
-      conditions.push(Prisma.sql`t."productCode" ILIKE ${`%${input.code}%`}`);
+      conditions.push(Prisma.sql`t."productCode" ILIKE ${containsPattern(input.code)} ESCAPE '\\'`);
     }
     if (input.name) {
-      conditions.push(Prisma.sql`t."productName" ILIKE ${`%${input.name}%`}`);
+      conditions.push(Prisma.sql`t."productName" ILIKE ${containsPattern(input.name)} ESCAPE '\\'`);
     }
     if (input.priceStatus) {
       conditions.push(Prisma.sql`t."priceStatus" = ${input.priceStatus}`);

--- a/src/server/subdomains/pricing/infrastructure/queries/PrismaCostPriceListQueryService.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/PrismaCostPriceListQueryService.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@generated/prisma/client";
 import prisma from "@server/prisma";
+import { containsPattern } from "@server/shared/infrastructure/escapeLikePattern";
 import { CostPriceListQueryService } from "@subdomains/pricing/application/queries/CostPriceListQueryService";
 import {
   CostPriceListItemDTO,
@@ -32,10 +33,10 @@ export class PrismaCostPriceListQueryService implements CostPriceListQueryServic
   }): Promise<CostPriceListItemDTO[]> {
     const conditions: Prisma.Sql[] = [];
     if (input.code) {
-      conditions.push(Prisma.sql`t."productCode" ILIKE ${`%${input.code}%`}`);
+      conditions.push(Prisma.sql`t."productCode" ILIKE ${containsPattern(input.code)} ESCAPE '\\'`);
     }
     if (input.name) {
-      conditions.push(Prisma.sql`t."productName" ILIKE ${`%${input.name}%`}`);
+      conditions.push(Prisma.sql`t."productName" ILIKE ${containsPattern(input.name)} ESCAPE '\\'`);
     }
     if (input.priceStatus) {
       conditions.push(Prisma.sql`t."priceStatus" = ${input.priceStatus}`);

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCommonSellingPriceListQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCommonSellingPriceListQueryService.test.ts
@@ -164,6 +164,22 @@ describe("PrismaCommonSellingPriceListQueryService", () => {
       expect(codes).not.toContain(CODES.active);
     });
 
+    it("name の LIKE メタ文字 _ はリテラルとして扱い、ワイルドカード解釈しない（#518）", async () => {
+      // 検索語 "SPECIAL_ITEM" の _ を ILIKE がワイルドカード解釈すると、任意1文字の
+      // "SPECIALXITEM" もヒットしてしまう。エスケープ済みならリテラル _ のみに一致する。
+      await makeProduct(CODES.active, "SPECIAL_ITEM"); // リテラル _ を含む→一致すべき
+      await makeProduct(CODES.unset, "SPECIALXITEM"); // _ をワイルドカード化した時のみ一致するデコイ
+
+      const items = await queryService.list({
+        referenceDate: "2025-06-15",
+        name: "SPECIAL_ITEM",
+      });
+      const codes = items.map((i) => i.productCode);
+
+      expect(codes).toContain(CODES.active);
+      expect(codes).not.toContain(CODES.unset);
+    });
+
     it("priceStatus=unset は未設定のみへ絞り込む", async () => {
       const activeId = await makeProduct(CODES.active, "現在有効商品");
       const aggregate = CommonSellingPrice.create(activeId);

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCostPriceListQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCostPriceListQueryService.test.ts
@@ -164,6 +164,22 @@ describe("PrismaCostPriceListQueryService", () => {
       expect(codes).not.toContain(CODES.active);
     });
 
+    it("name の LIKE メタ文字 _ はリテラルとして扱い、ワイルドカード解釈しない（#518）", async () => {
+      // 検索語 "SPECIAL_ITEM" の _ を ILIKE がワイルドカード解釈すると、任意1文字の
+      // "SPECIALXITEM" もヒットしてしまう。エスケープ済みならリテラル _ のみに一致する。
+      await makeProduct(CODES.active, "SPECIAL_ITEM"); // リテラル _ を含む→一致すべき
+      await makeProduct(CODES.unset, "SPECIALXITEM"); // _ をワイルドカード化した時のみ一致するデコイ
+
+      const items = await queryService.list({
+        referenceDate: "2025-06-15",
+        name: "SPECIAL_ITEM",
+      });
+      const codes = items.map((i) => i.productCode);
+
+      expect(codes).toContain(CODES.active);
+      expect(codes).not.toContain(CODES.unset);
+    });
+
     it("priceStatus=unset は未設定のみへ絞り込む", async () => {
       const activeId = await makeProduct(CODES.active, "現在有効商品");
       const aggregate = CostPrice.create(activeId);


### PR DESCRIPTION
## Summary

pricing の一覧検索 QueryService 2本（`PrismaCostPriceListQueryService` / `PrismaCommonSellingPriceListQueryService`）で、生 ILIKE のパターンに含まれるユーザー入力の LIKE メタ文字 `%` `_` が未エスケープのまま渡り、意図しない広範囲がヒットする実バグを修正しました。共有 util（`escapeLikePattern` / `containsPattern`）を新設し、両 QueryService に `ESCAPE '\'` 句付きで適用しています。

Closes #518

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### escape-ilike-metacharacters.md

pricing の一覧検索 QueryService 2本で、生 ILIKE のパターン `%${input.code}%` に含まれるユーザー入力の LIKE メタ文字 `%` `_` が未エスケープのまま渡る実バグを修正する（2ファイル×2列=4箇所）。

他の一覧検索（customer/product/employee など）は Prisma の `contains:` を使い値が自動エスケープされるため無傷。この2本だけが `daterange @>` 演算子の都合で `$queryRaw` + 生 ILIKE を使わざるを得ず、手動エスケープが必要になっている。

**設計判断**

- **エスケープ機構**: `\` `%` `_` の3文字を `\` でエスケープし、SQL 側に明示的な `ESCAPE '\'` 句を付与する。デフォルトのエスケープ文字が `\` なので省略しても動くが、明示することで意図がクエリ上に残り設定依存を排除する。
- **配置レイヤーと共通化**: `src/server/shared/infrastructure/escapeLikePattern.ts` に共有 util として置く。LIKE エスケープはドメイン知識ではなく ILIKE という技術詳細への対処のため infrastructure 層。他サブドメインも再利用しうる純粋な技術関数のため shared。
- **責務分割（プリミティブ + コンポジット）**: `escapeLikePattern`（3文字をエスケープのみ）と、それを内部利用し `%…%` で囲む `containsPattern` に分割。エスケープは正規表現1パス `s.replace(/[\\%_]/g, m => "\\" + m)` で二重エスケープ事故を回避。
- **テスト方針（二層）**: 網羅は DB 不要の純関数単体テストに寄せ、統合テストは各 QueryService に1ケースずつ（`%`/`_` を含む実データで「リテラルマッチ1件のみ／全件マッチしない」を確認し `ESCAPE` 句の結線を保証）。
- **ドキュメント**: ADR は作らない。非対称の理由（`daterange` は Prisma typed で扱えず `$queryRaw`）は両ファイルのヘッダコメントに明記済みで、素直な既定選択のため ADR 3条件を満たさない。CONTEXT.md も実装語彙のため更新しない。

**ステップ**

1. エスケープ関数 `escapeLikePattern` / `containsPattern` の実装（TDD）
2. `PrismaCostPriceListQueryService` への適用（TDD）
3. `PrismaCommonSellingPriceListQueryService` への適用（TDD）

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません（`deviations.md` なし）。

## Test Plan

TDD（red-green-refactor）で各ステップともテスト先行で実装しました。

- [x] 単体テスト: `escapeLikePattern` / `containsPattern`（`%`→`\%`、`_`→`\_`、`\`→`\\`、複合、メタ文字なし素通し、前後 `%` 付与）
- [x] 統合テスト: `PrismaCostPriceListQueryService` に `%`/`_` を含む検索のリテラルマッチ1ケース
- [x] 統合テスト: `PrismaCommonSellingPriceListQueryService` に同型の1ケース
- [ ] `pnpm test` がグリーンであることを確認

---

Generated with [Claude Code](https://claude.ai/code)
