### PR TITLE
feat: #515 セット商品への単価・原価登録をファクトリガードで一律拒否（4集約横断）

### DIFF
--- a/docs/claude-plans/issue-515/deviations.md
+++ b/docs/claude-plans/issue-515/deviations.md
@@ -1,0 +1,27 @@
+# Issue #515 実装計画からの逸脱記録
+
+計画: `docs/claude-plans/issue-515/set-product-price-cost-guard.md`
+
+## 逸脱1: `ProductCategory.isSet()` を新規追加（計画未記載の前提追加）
+
+- **元の計画**: 3ファクトリで `category.isSet()` を呼ぶ前提だったが、`isSet()` メソッドの追加自体はステップに明記されていなかった。
+- **実際の実装**: `ProductCategory` VO に `isSet()`（`this._value === "SET"`）を既存の `canBe*`/`canHave*` 述語群と並べて追加し、専用テスト3件と共に独立コミット（`bf30e23`）した。
+- **逸脱の理由**: 既存 VO には `canHaveComponents()`（=SET判定）はあったが、価格ガードの意図を表す命名として `isSet()` が読み手に明快。計画本文（Step 2〜4の作業内容）が `category.isSet()` を前提にしていたため、その前提を満たす最小追加として先行実装した。
+
+## 逸脱2: コマンドテストは「スタブ注入」ではなく「実サービス＋実SET商品」
+
+- **元の計画**: 「既存テストの constructor に非セットを返す `ProductQueryService` スタブを追加。セット商品 `productId` の登録が throw するケースを追加」。
+- **実際の実装**: 既存の Register コマンドテストは実 Prisma リポジトリで実商品を insert する統合テストであるため、スタブではなく実 `PrismaProductQueryService` を注入した。セット商品ケースは `ProductCategory.SET` の実商品を別コードで insert して検証する。あわせて「存在しない商品ID → `ValidationError`」ケース（計画の category 取得タイミング節に記載の `findById === null` 分岐）もテスト追加した。
+- **逸脱の理由**: 既存テストの統合スタイルにスタブを混ぜると二重管理になり、`findById` の実クエリ経路も検証できない。実サービス＋実データの方が既存慣行と一貫し、ガードの実挙動をエンドツーエンドで確認できる。
+
+## 逸脱3: `create` シグネチャ変更に伴うテストフィクスチャの一括改修（波及範囲）
+
+- **元の計画**: Step 2〜4の対象ファイルとして各集約の「domain / command テスト2ファイル」のみを列挙。
+- **実際の実装**: `CostPrice.create` / `CommonSellingPrice.create` / `CustomerSellingPrice.create` の引数に `category` を必須追加したため、当該集約を組む**全テストフィクスチャ**（infra repository / query / list / edit テスト、他コマンドの Revise/Edit/EndDate/Delete テスト、`ResolveSellingPriceQuery` など横断テスト）の生成呼び出しに `ProductCategory.INDIVIDUAL` を補った（各集約コミットに同梱）。
+- **逸脱の理由**: 生成入口の構造的不変条件として `category` を必須引数にする設計（計画採用の案①）を選ぶと、コンパイル維持のため全生成箇所の更新が不可避。これらは非セット商品のフィクスチャであり `ProductCategory.INDIVIDUAL` 補完で意味的にも正しい。計画のファイル列挙が生成入口の呼び出し側までは網羅していなかったための機械的追補。
+
+## 逸脱4: 各ドメインテストに「消耗品でも生成できる」ケースを追加
+
+- **元の計画**: ドメインテストは「セット商品区分で `create` が throw / 非セットで成功」。
+- **実際の実装**: 非セット成功ケースを個別商品（INDIVIDUAL）に加え消耗品（CONSUMABLE）でも明示。
+- **逸脱の理由**: #514 グロッサリの「価格保守対象商品＝個別商品・消耗品」を明文化し、ガードが SET のみを弾き CONSUMABLE を通すことをテストで固定するため。

--- a/docs/claude-plans/issue-515/set-product-price-cost-guard.md
+++ b/docs/claude-plans/issue-515/set-product-price-cost-guard.md
@@ -1,0 +1,107 @@
+# Issue #515: セット商品への単価・原価登録をファクトリガードで一律拒否する（4集約横断） — 実装計画
+
+## Context
+
+価格系の4集約（共通売単価 `CommonSellingPrice` / 原価 `CostPrice` / 得意先別販売単価 `CustomerSellingPrice` / 納品先別販売単価 `DeliveryLocationSellingPrice`）の write 系コマンドは `ProductCategory` を参照しておらず、セット商品（`ProductCategory.SET`）の `productId` を指定しても期間登録できてしまう（ガードなし）。#502（原価 BE write系）のグリル中に出た論点だが、原価単独ではなく4集約横断の方針決定になるため本 issue に先送りされていた。
+
+### グリルで確定した業務ルール（ユーザー確認済み）
+
+**セット商品は売単価・原価とも自前の値を持たず、常に構成商品から導出される。** 見積機構はセット商品を構成明細に自動展開し、各構成明細は構成商品自身のマスタ価格・原価を解決するため、セット商品 `productId` のマスタ価格・原価はどの機構からも参照されない（＝登録は常にデッドデータになる）。この理解は #514 が導入したグロッサリ（後述）と整合する。
+
+### #514 グロッサリとの連携（別ブランチで先行編集）
+
+#514 が CONTEXT.md に以下を導入済み。#515 はこの語彙に整合させる。
+
+- **価格保守対象商品 (Priceable Product)**: 共通販売単価・原価を保守する対象。個別商品・消耗品が該当し、**セット商品は含まない**。原価一覧・共通販売単価一覧の母集合はこの区分に一致する（「全商品」ではない）。
+- **未設定 (Unset)**: 期間行を1件も持たない派生状態。**母集合に含まないセット商品を「未設定」とは呼ばない**。
+- **セット商品 (Set Product)**: それ自体は価格（単価・原価）を持たない（→価格保守対象商品ではない）。
+
+### 調査で確定した事実
+
+- **区分は不変**: `Product._category` は `private readonly`、`UpdateProductCommand` も「category は変更不可（B011）」。個別商品が後からセット商品になることはない。
+- **ガードは生成入口のみで十分**: 区分不変ゆえセット商品は永久に価格集約を1つも持てない。`addPeriod`/`revise`/`editPeriod`/`endDate`/`delete` は既存集約のロードを前提とするため、セット商品では自然に「見つからない」で弾かれ到達不能。明示ガードが要るのは唯一の生成入口＝Register系コマンドの新規作成分岐（`existing === null → create`）だけ。ADR-0052 と同じ「ペイロード防御」の位置づけ。
+- **read 側の母集合変更は #514 が担う**: 共通層2一覧の `FROM products p`（全商品）→ セット除外は #514 のスコープ。#515 は read 側コードを追加しない。
+- **得意先別・納品先別は画面が未存在**: 価格保守UI・商品セレクタが無く、現時点でデッドエンドは発生しない。納品先別は write 系コマンド自体も未実装。
+- **既存データは移行不要（監査済み）**: セット商品（`PRD005`/`PRD015–018`）と価格・原価対象（`PRD810/811/820–826`・`PRD840–847`）は重複ゼロ。得意先別・納品先別の価格 seed は存在しない。原価 backfill は既に `category === "SET"` を除外。
+
+## 設計判断
+
+### ガード対象範囲（Issue 未決事項）
+- 案A: ガード不要（現状維持） / 案B: 4集約一律 / 案C: 集約ごと個別
+- **採用: 案B（4集約一律）**（ユーザー確認済み）。業務ルールが集約横断で一様（売単価・原価とも構成品から導出）なため、案Cは根拠を欠く。上書き2層でセット商品を許すと「上書き対象の共通価格が存在しない上書き」という論理的に空虚なレコードを生む。
+- 実装は write 系のある3集約（共通売単価・原価・得意先別）に施す。**納品先別は write 系未実装のため前方ポリシー**（後述）として記録。
+
+### ガードの配置・実装方式（Issue 未決事項）
+- 案①: ドメインのファクトリ `create(productId, category)` に不変条件として置く / 案②: アプリ層で `ValidationError` を投げる
+- **採用: 案①（ファクトリガード）**（ユーザー確認済み）。「セット商品の価格集約は生成不能」を集約の構造的不変条件にでき、4集約で表現が統一され、将来コード・テストがうっかりセット商品の価格集約を作る事故も構造的に防げる。ADR-0052 の「ルール判定はドメインの純粋関数」に最も忠実。
+- category は ADR-0030（集約越えの事実はアプリ層が集めメソッド引数で渡す）に従い、アプリ層が `ProductQueryService` でライブ取得して `create` に渡す。ドメインの純粋性を保つ。
+- `ProductCategory` の pricing/domain への import は、既に全 pricing エンティティが `ProductId`（product/domain の VO）を import している越境と同性質（eslint 集約境界ルールが禁じるのは子エンティティの越境のみで VO は対象外）。
+
+### category 取得のタイミング
+- **`existing === null`（新規作成分岐）到達時のみ** `ProductQueryService.findById` を呼ぶ。区分不変性により既存集約は必ず非セットのため、更新経路では取得不要。無駄なクエリを増やさない。
+- `findById` が `null`（商品不在）の場合は `ValidationError`（入力契約違反）で早期に弾く。
+
+### インライン vs 共有ルール
+- 3ファクトリの `if (category.isSet()) throw` は各1行の自明な重複。共有ヘルパ抽出は over-engineering のため**インライン**とする。
+
+### read/UI 側の扱い（Issue 未決事項）
+- **#515 では read 側コードを追加しない**（ユーザー確認済み）。共通層2一覧のセット除外は #514、得意先別・納品先別のセレクタは未存在。
+
+### ADR 起票
+- **不要**（ユーザー判断）。ファクトリガードは実装詳細であり、独立した ADR を要するアーキテクチャ判断ではない。既存の ADR-0030/0052（メソッド引数での文脈渡し・集約越え検証）の適用に閉じる。
+
+## 前方ポリシー（将来 issue への申し送り）
+
+1. **納品先別販売単価の write 系を実装する将来 issue**では、共通売単価・原価・得意先別と同型のファクトリガード（`DeliveryLocationSellingPrice.create` にセット商品拒否）を適用する。
+2. **得意先別・納品先別の価格保守 UI・商品セレクタを実装する将来 issue**では、価格保守対象商品と同様にセット商品を選択肢から除外する（write ガードが最終担保だが、デッドエンド回避の UX 二重防御）。
+
+## ステップ
+
+### Step 1: 計画ファイルの保存
+- 対象ファイル: `docs/claude-plans/issue-515/set-product-price-cost-guard.md`（新規）
+- 作業内容:
+  - 本計画を保存
+- コミットメッセージ: `docs: #515 セット商品への単価・原価登録ガードの実装計画`
+
+### Step 2: 原価（CostPrice）ガード一式
+- 対象ファイル:
+  - `src/server/subdomains/pricing/domain/entities/CostPrice.ts`
+  - `src/server/subdomains/pricing/application/commands/RegisterCostPricePeriodCommand.ts`
+  - `src/server/subdomains/pricing/application/factories/registerCostPricePeriodCommandFactory.ts`
+  - `src/server/subdomains/pricing/domain/entities/__tests__/CostPrice.test.ts`
+  - `src/server/subdomains/pricing/application/commands/__tests__/RegisterCostPricePeriodCommand.test.ts`
+- 作業内容:
+  - `CostPrice.create(productId, category: ProductCategory)` に変更し、`category.isSet()` なら `ValidationError("セット商品には原価を登録できません")` を throw
+  - `RegisterCostPricePeriodCommand` の constructor に `ProductQueryService` を追加。`existing === null` 分岐で `findById` により区分を取得（不在は `ValidationError`）→ `ProductCategory.from(dto.category)` を `create` へ渡す
+  - factory で `new PrismaProductQueryService()` を注入
+  - ドメインテスト: セット商品区分で `create` が throw / 非セットで成功
+  - コマンドテスト: 既存テストの constructor に非セットを返す `ProductQueryService` スタブを追加。セット商品 `productId` の登録が throw するケースを追加
+- コミットメッセージ: `feat: #515 原価の期間登録でセット商品をファクトリガードで拒否`
+
+### Step 3: 共通売単価（CommonSellingPrice）ガード一式
+- 対象ファイル:
+  - `src/server/subdomains/pricing/domain/entities/CommonSellingPrice.ts`
+  - `src/server/subdomains/pricing/application/commands/RegisterCommonSellingPricePeriodCommand.ts`
+  - `src/server/subdomains/pricing/application/factories/registerCommonSellingPricePeriodCommandFactory.ts`
+  - 同名の domain / command テスト2ファイル
+- 作業内容:
+  - Step 2 と同型。`create(productId, category)`、`category.isSet()` で `ValidationError("セット商品には販売単価を登録できません")`
+  - Register への `ProductQueryService` 導入・factory 配線・テスト追加
+- コミットメッセージ: `feat: #515 共通売単価の期間登録でセット商品をファクトリガードで拒否`
+
+### Step 4: 得意先別販売単価（CustomerSellingPrice）ガード一式
+- 対象ファイル:
+  - `src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts`
+  - `src/server/subdomains/pricing/application/commands/RegisterCustomerSellingPricePeriodCommand.ts`
+  - `src/server/subdomains/pricing/application/factories/registerCustomerSellingPricePeriodCommandFactory.ts`
+  - 同名の domain / command テスト2ファイル
+- 作業内容:
+  - Step 2 と同型。`create(customerId, productId, category)`（customerId は先頭のまま維持）、`category.isSet()` で `ValidationError("セット商品には販売単価を登録できません")`
+  - Register への `ProductQueryService` 導入・factory 配線・テスト追加
+- コミットメッセージ: `feat: #515 得意先別販売単価の期間登録でセット商品をファクトリガードで拒否`
+
+### Step 5: 全体検証と逸脱記録
+- 作業内容:
+  - `pnpm test`（pricing の domain/application）と `pnpm lint` をグリーン確認
+  - 計画と異なる対応があれば `docs/claude-plans/issue-515/deviations.md` に記録
+- コミットメッセージ: （逸脱があれば）`docs: #515 実装計画からの逸脱記録`

--- a/src/server/subdomains/pricing/application/commands/RegisterCommonSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/RegisterCommonSellingPricePeriodCommand.ts
@@ -4,6 +4,8 @@ import { ValidationError } from "@server/shared/errors/DomainError";
 import { CommonSellingPrice } from "@subdomains/pricing/domain/entities";
 import { CommonSellingPriceRepository } from "@subdomains/pricing/domain/repositories/CommonSellingPriceRepository";
 import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { ProductQueryService } from "@subdomains/product/application/queries/ProductQueryService";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 
 export type RegisterCommonSellingPricePeriodInput = {
@@ -27,7 +29,10 @@ export type RegisterCommonSellingPricePeriodInput = {
  * 集約の `addPeriod` が参照日を使って強制する。戻り値は登録後の集約（ADR-0038）。
  */
 export class RegisterCommonSellingPricePeriodCommand {
-  constructor(private readonly repository: CommonSellingPriceRepository) {}
+  constructor(
+    private readonly repository: CommonSellingPriceRepository,
+    private readonly productQueryService: ProductQueryService
+  ) {}
 
   async execute(input: RegisterCommonSellingPricePeriodInput): Promise<CommonSellingPrice> {
     const productId = new ProductId(input.productId);
@@ -36,7 +41,17 @@ export class RegisterCommonSellingPricePeriodCommand {
 
     const existing = await this.repository.findByProductId(productId);
     if (existing === null) {
-      const aggregate = CommonSellingPrice.create(productId);
+      // 新規作成分岐でのみ商品区分をライブ取得する。区分不変ゆえ既存集約は必ず非セットで、
+      // 更新経路での取得は無駄なクエリになるため取得しない（ADR-0030）。セット商品拒否は
+      // 集約の構造的不変条件として `create` に置く（ファクトリガード・#515）。
+      const product = await this.productQueryService.findById(input.productId);
+      if (product === null) {
+        throw new ValidationError(`商品が存在しません: ${input.productId}`);
+      }
+      const aggregate = CommonSellingPrice.create(
+        productId,
+        ProductCategory.from(product.category)
+      );
       aggregate.addPeriod(period, price, input.referenceDate);
       await this.repository.insert(aggregate);
       return aggregate;

--- a/src/server/subdomains/pricing/application/commands/RegisterCostPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/RegisterCostPricePeriodCommand.ts
@@ -4,6 +4,8 @@ import { ValidationError } from "@server/shared/errors/DomainError";
 import { CostPrice } from "@subdomains/pricing/domain/entities";
 import { CostPriceRepository } from "@subdomains/pricing/domain/repositories/CostPriceRepository";
 import { CostUnitPrice } from "@subdomains/pricing/domain/values/CostUnitPrice";
+import { ProductQueryService } from "@subdomains/product/application/queries/ProductQueryService";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 
 export type RegisterCostPricePeriodInput = {
@@ -27,7 +29,10 @@ export type RegisterCostPricePeriodInput = {
  * 集約の `addPeriod` が参照日を使って強制する。戻り値は登録後の集約（ADR-0038）。
  */
 export class RegisterCostPricePeriodCommand {
-  constructor(private readonly repository: CostPriceRepository) {}
+  constructor(
+    private readonly repository: CostPriceRepository,
+    private readonly productQueryService: ProductQueryService
+  ) {}
 
   async execute(input: RegisterCostPricePeriodInput): Promise<CostPrice> {
     const productId = new ProductId(input.productId);
@@ -36,7 +41,14 @@ export class RegisterCostPricePeriodCommand {
 
     const existing = await this.repository.findByProductId(productId);
     if (existing === null) {
-      const aggregate = CostPrice.create(productId);
+      // 新規作成分岐でのみ商品区分をライブ取得する。区分不変ゆえ既存集約は必ず非セットで、
+      // 更新経路での取得は無駄なクエリになるため取得しない（ADR-0030）。セット商品拒否は
+      // 集約の構造的不変条件として `create` に置く（ファクトリガード・#515）。
+      const product = await this.productQueryService.findById(input.productId);
+      if (product === null) {
+        throw new ValidationError(`商品が存在しません: ${input.productId}`);
+      }
+      const aggregate = CostPrice.create(productId, ProductCategory.from(product.category));
       aggregate.addPeriod(period, price, input.referenceDate);
       await this.repository.insert(aggregate);
       return aggregate;

--- a/src/server/subdomains/pricing/application/commands/RegisterCustomerSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/RegisterCustomerSellingPricePeriodCommand.ts
@@ -5,6 +5,8 @@ import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { CustomerSellingPrice } from "@subdomains/pricing/domain/entities";
 import { CustomerSellingPriceRepository } from "@subdomains/pricing/domain/repositories/CustomerSellingPriceRepository";
 import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { ProductQueryService } from "@subdomains/product/application/queries/ProductQueryService";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 
 export type RegisterCustomerSellingPricePeriodInput = {
@@ -31,7 +33,10 @@ export type RegisterCustomerSellingPricePeriodInput = {
  * （ADR-20260624-8tg）。
  */
 export class RegisterCustomerSellingPricePeriodCommand {
-  constructor(private readonly repository: CustomerSellingPriceRepository) {}
+  constructor(
+    private readonly repository: CustomerSellingPriceRepository,
+    private readonly productQueryService: ProductQueryService
+  ) {}
 
   async execute(input: RegisterCustomerSellingPricePeriodInput): Promise<CustomerSellingPrice> {
     const customerId = new CustomerId(input.customerId);
@@ -41,7 +46,18 @@ export class RegisterCustomerSellingPricePeriodCommand {
 
     const existing = await this.repository.findByCustomerIdAndProductId(customerId, productId);
     if (existing === null) {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      // 新規作成分岐でのみ商品区分をライブ取得する。区分不変ゆえ既存集約は必ず非セットで、
+      // 更新経路での取得は無駄なクエリになるため取得しない（ADR-0030）。セット商品拒否は
+      // 集約の構造的不変条件として `create` に置く（ファクトリガード・#515）。
+      const product = await this.productQueryService.findById(input.productId);
+      if (product === null) {
+        throw new ValidationError(`商品が存在しません: ${input.productId}`);
+      }
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.from(product.category)
+      );
       aggregate.addPeriod(period, price, input.referenceDate);
       await this.repository.insert(aggregate);
       return aggregate;

--- a/src/server/subdomains/pricing/application/commands/__tests__/DeleteCommonSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/DeleteCommonSellingPricePeriodCommand.test.ts
@@ -49,7 +49,7 @@ describe("DeleteCommonSellingPricePeriodCommand", () => {
   afterEach(cleanup);
 
   it("将来行を削除できる", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2025-06-01");
     aggregate.addPeriod(period("2030-06-01", null), price(1200), "2025-06-01");
     await repository.insert(aggregate);
@@ -79,7 +79,7 @@ describe("DeleteCommonSellingPricePeriodCommand", () => {
   });
 
   it("現在有効行の削除は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByProductId(productId))!.periods[0].id;
@@ -95,7 +95,7 @@ describe("DeleteCommonSellingPricePeriodCommand", () => {
   });
 
   it("expectedVersion が古いと ConflictError", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByProductId(productId))!.periods[0].id;

--- a/src/server/subdomains/pricing/application/commands/__tests__/DeleteCostPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/DeleteCostPricePeriodCommand.test.ts
@@ -49,7 +49,7 @@ describe("DeleteCostPricePeriodCommand", () => {
   afterEach(cleanup);
 
   it("将来行を削除できる", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", "2030-06-01"), cost(1000), "2025-06-01");
     aggregate.addPeriod(period("2030-06-01", null), cost(1200), "2025-06-01");
     await repository.insert(aggregate);
@@ -79,7 +79,7 @@ describe("DeleteCostPricePeriodCommand", () => {
   });
 
   it("現在有効行の削除は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-04-01", null), cost(1000), "2025-03-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByProductId(productId))!.periods[0].id;
@@ -95,7 +95,7 @@ describe("DeleteCostPricePeriodCommand", () => {
   });
 
   it("expectedVersion が古いと ConflictError", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), cost(1000), "2025-06-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByProductId(productId))!.periods[0].id;

--- a/src/server/subdomains/pricing/application/commands/__tests__/DeleteCustomerSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/DeleteCustomerSellingPricePeriodCommand.test.ts
@@ -65,7 +65,11 @@ describe("DeleteCustomerSellingPricePeriodCommand", () => {
   afterEach(cleanup);
 
   it("将来行を削除できる", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2025-06-01");
     aggregate.addPeriod(period("2030-06-01", null), price(1200), "2025-06-01");
     await repository.insert(aggregate);
@@ -98,7 +102,11 @@ describe("DeleteCustomerSellingPricePeriodCommand", () => {
   });
 
   it("現在有効行の削除は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByCustomerIdAndProductId(customerId, productId))!
@@ -116,7 +124,11 @@ describe("DeleteCustomerSellingPricePeriodCommand", () => {
   });
 
   it("expectedVersion が古いと ConflictError", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByCustomerIdAndProductId(customerId, productId))!

--- a/src/server/subdomains/pricing/application/commands/__tests__/EditCommonSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/EditCommonSellingPricePeriodCommand.test.ts
@@ -50,7 +50,7 @@ describe("EditCommonSellingPricePeriodCommand", () => {
 
   /** 将来行を1本持つ集約を用意し、その periodId を返す。 */
   async function seedFuturePeriod(): Promise<CommonSellingPricePeriodId> {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
     return (await repository.findByProductId(productId))!.periods[0].id;
@@ -89,7 +89,7 @@ describe("EditCommonSellingPricePeriodCommand", () => {
   });
 
   it("現在有効行の編集は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-05-01", "2030-01-01"), price(1000), "2025-04-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByProductId(productId))!.periods[0].id;

--- a/src/server/subdomains/pricing/application/commands/__tests__/EditCostPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/EditCostPricePeriodCommand.test.ts
@@ -50,7 +50,7 @@ describe("EditCostPricePeriodCommand", () => {
 
   /** 将来行を1本持つ集約を用意し、その periodId を返す。 */
   async function seedFuturePeriod(): Promise<CostPricePeriodId> {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), cost(1000), "2025-06-01");
     await repository.insert(aggregate);
     return (await repository.findByProductId(productId))!.periods[0].id;
@@ -89,7 +89,7 @@ describe("EditCostPricePeriodCommand", () => {
   });
 
   it("現在有効行の編集は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-05-01", "2030-01-01"), cost(1000), "2025-04-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByProductId(productId))!.periods[0].id;

--- a/src/server/subdomains/pricing/application/commands/__tests__/EditCustomerSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/EditCustomerSellingPricePeriodCommand.test.ts
@@ -66,7 +66,11 @@ describe("EditCustomerSellingPricePeriodCommand", () => {
 
   /** 将来行を1本持つ集約を用意し、その periodId を返す。 */
   async function seedFuturePeriod(): Promise<CustomerSellingPricePeriodId> {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
     return (await repository.findByCustomerIdAndProductId(customerId, productId))!.periods[0].id;
@@ -107,7 +111,11 @@ describe("EditCustomerSellingPricePeriodCommand", () => {
   });
 
   it("現在有効行の編集は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-05-01", "2030-01-01"), price(1000), "2025-04-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByCustomerIdAndProductId(customerId, productId))!

--- a/src/server/subdomains/pricing/application/commands/__tests__/EndDateCommonSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/EndDateCommonSellingPricePeriodCommand.test.ts
@@ -50,7 +50,7 @@ describe("EndDateCommonSellingPricePeriodCommand", () => {
 
   /** 現在有効な無期限行を1本持つ集約を用意し、その periodId を返す。 */
   async function seedActivePeriod(): Promise<CommonSellingPricePeriodId> {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
     await repository.insert(aggregate);
     return (await repository.findByProductId(productId))!.periods[0].id;
@@ -84,7 +84,7 @@ describe("EndDateCommonSellingPricePeriodCommand", () => {
   });
 
   it("将来行への適用終了は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByProductId(productId))!.periods[0].id;

--- a/src/server/subdomains/pricing/application/commands/__tests__/EndDateCostPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/EndDateCostPricePeriodCommand.test.ts
@@ -50,7 +50,7 @@ describe("EndDateCostPricePeriodCommand", () => {
 
   /** 現在有効な無期限行を1本持つ集約を用意し、その periodId を返す。 */
   async function seedActivePeriod(): Promise<CostPricePeriodId> {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-04-01", null), cost(1000), "2025-03-01");
     await repository.insert(aggregate);
     return (await repository.findByProductId(productId))!.periods[0].id;
@@ -84,7 +84,7 @@ describe("EndDateCostPricePeriodCommand", () => {
   });
 
   it("将来行への適用終了は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), cost(1000), "2025-06-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByProductId(productId))!.periods[0].id;

--- a/src/server/subdomains/pricing/application/commands/__tests__/EndDateCustomerSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/EndDateCustomerSellingPricePeriodCommand.test.ts
@@ -66,7 +66,11 @@ describe("EndDateCustomerSellingPricePeriodCommand", () => {
 
   /** 現在有効な無期限行を1本持つ集約を用意し、その periodId を返す。 */
   async function seedActivePeriod(): Promise<CustomerSellingPricePeriodId> {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
     await repository.insert(aggregate);
     return (await repository.findByCustomerIdAndProductId(customerId, productId))!.periods[0].id;
@@ -102,7 +106,11 @@ describe("EndDateCustomerSellingPricePeriodCommand", () => {
   });
 
   it("将来行への適用終了は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
     const periodId = (await repository.findByCustomerIdAndProductId(customerId, productId))!

--- a/src/server/subdomains/pricing/application/commands/__tests__/RegisterCommonSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/RegisterCommonSellingPricePeriodCommand.test.ts
@@ -11,27 +11,36 @@ import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { ProductName } from "@subdomains/product/domain/values/ProductName";
 import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
 import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { PrismaProductQueryService } from "@subdomains/product/infrastructure/queries/PrismaProductQueryService";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RegisterCommonSellingPricePeriodCommand } from "../RegisterCommonSellingPricePeriodCommand";
 
 const TEST_PRODUCT_CODE = "CSPCMD10";
+const TEST_SET_PRODUCT_CODE = "CSPCMD11";
 const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
 
 async function cleanup(): Promise<void> {
-  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.product.deleteMany({
+    where: { code: { in: [TEST_PRODUCT_CODE, TEST_SET_PRODUCT_CODE] } },
+  });
 }
 
 describe("RegisterCommonSellingPricePeriodCommand", () => {
   let command: RegisterCommonSellingPricePeriodCommand;
   let repository: PrismaCommonSellingPriceRepository;
   let productId: ProductId;
+  let setProductId: ProductId;
 
   beforeEach(async () => {
     await cleanup();
     repository = new PrismaCommonSellingPriceRepository();
-    command = new RegisterCommonSellingPricePeriodCommand(repository);
+    command = new RegisterCommonSellingPricePeriodCommand(
+      repository,
+      new PrismaProductQueryService()
+    );
 
-    const product = await new PrismaProductRepository().insert(
+    const productRepository = new PrismaProductRepository();
+    const product = await productRepository.insert(
       Product.create(
         new ProductCode(TEST_PRODUCT_CODE),
         new ProductName(`登録コマンドテスト商品${TEST_PRODUCT_CODE}`),
@@ -40,6 +49,16 @@ describe("RegisterCommonSellingPricePeriodCommand", () => {
       )
     );
     productId = product.id;
+
+    const setProduct = await productRepository.insert(
+      Product.create(
+        new ProductCode(TEST_SET_PRODUCT_CODE),
+        new ProductName(`登録コマンドテストセット商品${TEST_SET_PRODUCT_CODE}`),
+        ProductCategory.SET,
+        ProductUnit.UNIT
+      )
+    );
+    setProductId = setProduct.id;
   });
 
   afterEach(cleanup);
@@ -110,6 +129,31 @@ describe("RegisterCommonSellingPricePeriodCommand", () => {
         start: "2030-06-01",
         end: null,
         price: "1200",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("セット商品には販売単価を登録できない（ValidationError・ファクトリガード / #515）", async () => {
+    // セット商品は自前の売単価を持たず構成商品から導出されるため、生成入口で拒否する。
+    await expect(
+      command.execute({
+        productId: setProductId.value,
+        start: "2030-01-01",
+        end: null,
+        price: "1000",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("存在しない商品IDでは登録できない（ValidationError・入力契約違反 / #515）", async () => {
+    await expect(
+      command.execute({
+        productId: ProductId.generate().value,
+        start: "2030-01-01",
+        end: null,
+        price: "1000",
         referenceDate: "2025-06-01",
       })
     ).rejects.toBeInstanceOf(ValidationError);

--- a/src/server/subdomains/pricing/application/commands/__tests__/RegisterCostPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/RegisterCostPricePeriodCommand.test.ts
@@ -11,27 +11,33 @@ import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { ProductName } from "@subdomains/product/domain/values/ProductName";
 import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
 import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { PrismaProductQueryService } from "@subdomains/product/infrastructure/queries/PrismaProductQueryService";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RegisterCostPricePeriodCommand } from "../RegisterCostPricePeriodCommand";
 
 const TEST_PRODUCT_CODE = "CPCMD10";
+const TEST_SET_PRODUCT_CODE = "CPCMD11";
 const cost = (yen: number) => CostUnitPrice.fromMoney(Money.fromMajorUnits(yen));
 
 async function cleanup(): Promise<void> {
-  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.product.deleteMany({
+    where: { code: { in: [TEST_PRODUCT_CODE, TEST_SET_PRODUCT_CODE] } },
+  });
 }
 
 describe("RegisterCostPricePeriodCommand", () => {
   let command: RegisterCostPricePeriodCommand;
   let repository: PrismaCostPriceRepository;
   let productId: ProductId;
+  let setProductId: ProductId;
 
   beforeEach(async () => {
     await cleanup();
     repository = new PrismaCostPriceRepository();
-    command = new RegisterCostPricePeriodCommand(repository);
+    command = new RegisterCostPricePeriodCommand(repository, new PrismaProductQueryService());
 
-    const product = await new PrismaProductRepository().insert(
+    const productRepository = new PrismaProductRepository();
+    const product = await productRepository.insert(
       Product.create(
         new ProductCode(TEST_PRODUCT_CODE),
         new ProductName(`登録コマンドテスト商品${TEST_PRODUCT_CODE}`),
@@ -40,6 +46,16 @@ describe("RegisterCostPricePeriodCommand", () => {
       )
     );
     productId = product.id;
+
+    const setProduct = await productRepository.insert(
+      Product.create(
+        new ProductCode(TEST_SET_PRODUCT_CODE),
+        new ProductName(`登録コマンドテストセット商品${TEST_SET_PRODUCT_CODE}`),
+        ProductCategory.SET,
+        ProductUnit.UNIT
+      )
+    );
+    setProductId = setProduct.id;
   });
 
   afterEach(cleanup);
@@ -110,6 +126,31 @@ describe("RegisterCostPricePeriodCommand", () => {
         start: "2030-06-01",
         end: null,
         price: "1200",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("セット商品には原価を登録できない（ValidationError・ファクトリガード / #515）", async () => {
+    // セット商品は自前の原価を持たず構成商品から導出されるため、生成入口で拒否する。
+    await expect(
+      command.execute({
+        productId: setProductId.value,
+        start: "2030-01-01",
+        end: null,
+        price: "1000",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("存在しない商品IDでは登録できない（ValidationError・入力契約違反 / #515）", async () => {
+    await expect(
+      command.execute({
+        productId: ProductId.generate().value,
+        start: "2030-01-01",
+        end: null,
+        price: "1000",
         referenceDate: "2025-06-01",
       })
     ).rejects.toBeInstanceOf(ValidationError);

--- a/src/server/subdomains/pricing/application/commands/__tests__/RegisterCustomerSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/RegisterCustomerSellingPricePeriodCommand.test.ts
@@ -16,15 +16,19 @@ import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { ProductName } from "@subdomains/product/domain/values/ProductName";
 import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
 import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { PrismaProductQueryService } from "@subdomains/product/infrastructure/queries/PrismaProductQueryService";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RegisterCustomerSellingPricePeriodCommand } from "../RegisterCustomerSellingPricePeriodCommand";
 
 const TEST_PRODUCT_CODE = "CUSPCMD10";
 const TEST_CUSTOMER_CODE = "CUSPCMD11";
+const TEST_SET_PRODUCT_CODE = "CUSPCMD12";
 const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
 
 async function cleanup(): Promise<void> {
-  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.product.deleteMany({
+    where: { code: { in: [TEST_PRODUCT_CODE, TEST_SET_PRODUCT_CODE] } },
+  });
   await prisma.customer.deleteMany({ where: { code: TEST_CUSTOMER_CODE } });
 }
 
@@ -33,11 +37,15 @@ describe("RegisterCustomerSellingPricePeriodCommand", () => {
   let repository: PrismaCustomerSellingPriceRepository;
   let customerId: CustomerId;
   let productId: ProductId;
+  let setProductId: ProductId;
 
   beforeEach(async () => {
     await cleanup();
     repository = new PrismaCustomerSellingPriceRepository();
-    command = new RegisterCustomerSellingPricePeriodCommand(repository);
+    command = new RegisterCustomerSellingPricePeriodCommand(
+      repository,
+      new PrismaProductQueryService()
+    );
 
     const customer = await new PrismaCustomerRepository().insert(
       Customer.create(
@@ -47,7 +55,8 @@ describe("RegisterCustomerSellingPricePeriodCommand", () => {
     );
     customerId = customer.id;
 
-    const product = await new PrismaProductRepository().insert(
+    const productRepository = new PrismaProductRepository();
+    const product = await productRepository.insert(
       Product.create(
         new ProductCode(TEST_PRODUCT_CODE),
         new ProductName(`登録コマンドテスト商品${TEST_PRODUCT_CODE}`),
@@ -56,6 +65,16 @@ describe("RegisterCustomerSellingPricePeriodCommand", () => {
       )
     );
     productId = product.id;
+
+    const setProduct = await productRepository.insert(
+      Product.create(
+        new ProductCode(TEST_SET_PRODUCT_CODE),
+        new ProductName(`登録コマンドテストセット商品${TEST_SET_PRODUCT_CODE}`),
+        ProductCategory.SET,
+        ProductUnit.UNIT
+      )
+    );
+    setProductId = setProduct.id;
   });
 
   afterEach(cleanup);
@@ -130,6 +149,33 @@ describe("RegisterCustomerSellingPricePeriodCommand", () => {
         start: "2030-06-01",
         end: null,
         price: "1200",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("セット商品には販売単価を登録できない（ValidationError・ファクトリガード / #515）", async () => {
+    // セット商品は自前の売単価を持たず構成商品から導出されるため、生成入口で拒否する。
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: setProductId.value,
+        start: "2030-01-01",
+        end: null,
+        price: "1000",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("存在しない商品IDでは登録できない（ValidationError・入力契約違反 / #515）", async () => {
+    await expect(
+      command.execute({
+        customerId: customerId.value,
+        productId: ProductId.generate().value,
+        start: "2030-01-01",
+        end: null,
+        price: "1000",
         referenceDate: "2025-06-01",
       })
     ).rejects.toBeInstanceOf(ValidationError);

--- a/src/server/subdomains/pricing/application/commands/__tests__/ReviseCommonSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/ReviseCommonSellingPricePeriodCommand.test.ts
@@ -50,7 +50,7 @@ describe("ReviseCommonSellingPricePeriodCommand", () => {
 
   /** 現在有効な無期限行（2025-04-01〜・1000円）を1本持つ集約を用意する。 */
   async function seedActivePeriod(): Promise<void> {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
     await repository.insert(aggregate);
   }
@@ -79,7 +79,7 @@ describe("ReviseCommonSellingPricePeriodCommand", () => {
 
   it("現在有効行が無い商品（将来行のみ）は BusinessRuleViolationError", async () => {
     // 集約は在るが現在有効行が無い（将来開始のみ）。loadOrThrow は通り改定対象が無いことで弾く。
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-12-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
 
@@ -162,7 +162,7 @@ describe("ReviseCommonSellingPricePeriodCommand", () => {
 
   it("改定日開始の新行が既存の将来行と重複すると BusinessRuleViolationError", async () => {
     // 現在有効行＋将来行（2025-10-01〜）。改定日2025-09-01開始の無期限新行が将来行と重なる。
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-04-01", "2025-10-01"), price(1000), "2025-03-01");
     aggregate.addPeriod(period("2025-10-01", null), price(1100), "2025-03-01");
     await repository.insert(aggregate);

--- a/src/server/subdomains/pricing/application/commands/__tests__/ReviseCostPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/ReviseCostPricePeriodCommand.test.ts
@@ -50,7 +50,7 @@ describe("ReviseCostPricePeriodCommand", () => {
 
   /** 現在有効な無期限行（2025-04-01〜・1000円）を1本持つ集約を用意する。 */
   async function seedActivePeriod(): Promise<void> {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-04-01", null), cost(1000), "2025-03-01");
     await repository.insert(aggregate);
   }
@@ -79,7 +79,7 @@ describe("ReviseCostPricePeriodCommand", () => {
 
   it("現在有効行が無い商品（将来行のみ）は BusinessRuleViolationError", async () => {
     // 集約は在るが現在有効行が無い（将来開始のみ）。loadOrThrow は通り改定対象が無いことで弾く。
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-12-01", null), cost(1000), "2025-06-01");
     await repository.insert(aggregate);
 
@@ -162,7 +162,7 @@ describe("ReviseCostPricePeriodCommand", () => {
 
   it("改定日開始の新行が既存の将来行と重複すると BusinessRuleViolationError", async () => {
     // 現在有効行＋将来行（2025-10-01〜）。改定日2025-09-01開始の無期限新行が将来行と重なる。
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-04-01", "2025-10-01"), cost(1000), "2025-03-01");
     aggregate.addPeriod(period("2025-10-01", null), cost(1100), "2025-03-01");
     await repository.insert(aggregate);

--- a/src/server/subdomains/pricing/application/commands/__tests__/ReviseCustomerSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/ReviseCustomerSellingPricePeriodCommand.test.ts
@@ -66,7 +66,11 @@ describe("ReviseCustomerSellingPricePeriodCommand", () => {
 
   /** 現在有効な無期限行（2025-04-01〜・1000円）を1本持つ集約を用意する。 */
   async function seedActivePeriod(): Promise<void> {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
     await repository.insert(aggregate);
   }
@@ -95,7 +99,11 @@ describe("ReviseCustomerSellingPricePeriodCommand", () => {
   });
 
   it("現在有効行が無い得意先×商品（将来行のみ）は BusinessRuleViolationError", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-12-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
 
@@ -182,7 +190,11 @@ describe("ReviseCustomerSellingPricePeriodCommand", () => {
   });
 
   it("改定日開始の新行が既存の将来行と重複すると BusinessRuleViolationError", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-04-01", "2025-10-01"), price(1000), "2025-03-01");
     aggregate.addPeriod(period("2025-10-01", null), price(1100), "2025-03-01");
     await repository.insert(aggregate);

--- a/src/server/subdomains/pricing/application/factories/registerCommonSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/registerCommonSellingPricePeriodCommandFactory.ts
@@ -1,7 +1,14 @@
+import { PrismaProductQueryService } from "@subdomains/product/infrastructure/queries/PrismaProductQueryService";
 import { RegisterCommonSellingPricePeriodCommand } from "../commands/RegisterCommonSellingPricePeriodCommand";
 import { PrismaCommonSellingPriceRepository } from "../../infrastructure/prisma/PrismaCommonSellingPriceRepository";
 
-/** 共通売単価の適用期間行を登録するコマンド（#429・#473）を Repository から構築する。 */
+/**
+ * 共通売単価の適用期間行を登録するコマンド（#429・#473）を Repository から構築する。
+ * セット商品拒否のガード（#515）のため商品区分を引く ProductQueryService も注入する。
+ */
 export function registerCommonSellingPricePeriodCommandFactory(): RegisterCommonSellingPricePeriodCommand {
-  return new RegisterCommonSellingPricePeriodCommand(new PrismaCommonSellingPriceRepository());
+  return new RegisterCommonSellingPricePeriodCommand(
+    new PrismaCommonSellingPriceRepository(),
+    new PrismaProductQueryService()
+  );
 }

--- a/src/server/subdomains/pricing/application/factories/registerCostPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/registerCostPricePeriodCommandFactory.ts
@@ -1,7 +1,14 @@
+import { PrismaProductQueryService } from "@subdomains/product/infrastructure/queries/PrismaProductQueryService";
 import { RegisterCostPricePeriodCommand } from "../commands/RegisterCostPricePeriodCommand";
 import { PrismaCostPriceRepository } from "../../infrastructure/prisma/PrismaCostPriceRepository";
 
-/** 原価の適用期間行を登録するコマンド（#502）を Repository から構築する。 */
+/**
+ * 原価の適用期間行を登録するコマンド（#502）を Repository から構築する。
+ * セット商品拒否のガード（#515）のため商品区分を引く ProductQueryService も注入する。
+ */
 export function registerCostPricePeriodCommandFactory(): RegisterCostPricePeriodCommand {
-  return new RegisterCostPricePeriodCommand(new PrismaCostPriceRepository());
+  return new RegisterCostPricePeriodCommand(
+    new PrismaCostPriceRepository(),
+    new PrismaProductQueryService()
+  );
 }

--- a/src/server/subdomains/pricing/application/factories/registerCustomerSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/registerCustomerSellingPricePeriodCommandFactory.ts
@@ -1,7 +1,14 @@
+import { PrismaProductQueryService } from "@subdomains/product/infrastructure/queries/PrismaProductQueryService";
 import { RegisterCustomerSellingPricePeriodCommand } from "../commands/RegisterCustomerSellingPricePeriodCommand";
 import { PrismaCustomerSellingPriceRepository } from "../../infrastructure/prisma/PrismaCustomerSellingPriceRepository";
 
-/** 得意先別売単価の適用期間行を登録するコマンド（#505）を Repository から構築する。 */
+/**
+ * 得意先別売単価の適用期間行を登録するコマンド（#505）を Repository から構築する。
+ * セット商品拒否のガード（#515）のため商品区分を引く ProductQueryService も注入する。
+ */
 export function registerCustomerSellingPricePeriodCommandFactory(): RegisterCustomerSellingPricePeriodCommand {
-  return new RegisterCustomerSellingPricePeriodCommand(new PrismaCustomerSellingPriceRepository());
+  return new RegisterCustomerSellingPricePeriodCommand(
+    new PrismaCustomerSellingPriceRepository(),
+    new PrismaProductQueryService()
+  );
 }

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveCommonSellingPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveCommonSellingPriceQuery.test.ts
@@ -52,7 +52,7 @@ describe("ResolveCommonSellingPriceQuery", () => {
   });
 
   it("基準暦日に有効な共通販売単価を解決する", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveCostPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveCostPriceQuery.test.ts
@@ -52,7 +52,7 @@ describe("ResolveCostPriceQuery", () => {
   });
 
   it("基準暦日に有効な原価を解決する", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), "2026-04-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveCustomerSellingPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveCustomerSellingPriceQuery.test.ts
@@ -69,7 +69,11 @@ describe("ResolveCustomerSellingPriceQuery", () => {
   });
 
   it("基準暦日に有効な得意先別販売単価を解決する", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveSellingPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveSellingPriceQuery.test.ts
@@ -108,7 +108,11 @@ describe("ResolveSellingPriceQuery", () => {
     common.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await commonRepository.insert(common);
 
-    const customerPrice = CustomerSellingPrice.create(customerId, productId);
+    const customerPrice = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     customerPrice.addPeriod(period("2025-07-01", null), price(800), "2025-07-01");
     await customerRepo.insert(customerPrice);
 

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveSellingPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveSellingPriceQuery.test.ts
@@ -104,7 +104,7 @@ describe("ResolveSellingPriceQuery", () => {
   });
 
   it("得意先宛: 得意先別の上書きがあれば共通より優先して採用する", async () => {
-    const common = CommonSellingPrice.create(productId);
+    const common = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     common.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await commonRepository.insert(common);
 
@@ -123,7 +123,7 @@ describe("ResolveSellingPriceQuery", () => {
   });
 
   it("得意先宛: 得意先別が無ければ共通へフォールバックする", async () => {
-    const common = CommonSellingPrice.create(productId);
+    const common = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     common.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await commonRepository.insert(common);
 
@@ -138,7 +138,7 @@ describe("ResolveSellingPriceQuery", () => {
   });
 
   it("納品先宛: 納品先別の上書きへルーティングして採用する", async () => {
-    const common = CommonSellingPrice.create(productId);
+    const common = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     common.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await commonRepository.insert(common);
 
@@ -172,7 +172,7 @@ describe("ResolveSellingPriceQuery", () => {
 
   it("JST境界: UTC 15:00 の見積年月日は JST 翌日として暦日変換され、その日始まりの期間に解決する", async () => {
     // 2026-06-25 始まりの期間。UTC 2026-06-24T15:00:00Z = JST 2026-06-25 00:00 が初日に当たる。
-    const common = CommonSellingPrice.create(productId);
+    const common = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     common.addPeriod(period("2026-06-25", null), price(1234), "2026-06-25");
     await commonRepository.insert(common);
 

--- a/src/server/subdomains/pricing/domain/entities/CommonSellingPrice.ts
+++ b/src/server/subdomains/pricing/domain/entities/CommonSellingPrice.ts
@@ -1,5 +1,6 @@
 import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
-import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { CommonSellingPricePeriodId } from "../values/CommonSellingPricePeriodId";
 import { SellingUnitPrice } from "../values/SellingUnitPrice";
@@ -28,8 +29,16 @@ export class CommonSellingPrice {
     private readonly _periods: CommonSellingPricePeriod[]
   ) {}
 
-  /** 空の集約を生成する。 */
-  static create(productId: ProductId): CommonSellingPrice {
+  /**
+   * 空の集約を生成する。セット商品は自前の売単価を持たず常に構成商品から導出されるため、
+   * 生成入口で拒否する（#515）。区分不変ゆえ生成入口を塞げば以後の追加・改定・削除も
+   * 既存集約が存在しないことで構造的に到達不能になる。区分は集約越えの事実のため
+   * アプリ層が取得して引数で渡す（ADR-0030）。
+   */
+  static create(productId: ProductId, category: ProductCategory): CommonSellingPrice {
+    if (category.isSet()) {
+      throw new ValidationError(`セット商品には${CommonSellingPrice.ENTITY_NAME}を登録できません`);
+    }
     return new CommonSellingPrice(productId, []);
   }
 

--- a/src/server/subdomains/pricing/domain/entities/CostPrice.ts
+++ b/src/server/subdomains/pricing/domain/entities/CostPrice.ts
@@ -1,5 +1,6 @@
 import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
-import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { CostPricePeriodId } from "../values/CostPricePeriodId";
 import { CostUnitPrice } from "../values/CostUnitPrice";
@@ -29,8 +30,16 @@ export class CostPrice {
     private readonly _periods: CostPricePeriod[]
   ) {}
 
-  /** 空の集約を生成する。 */
-  static create(productId: ProductId): CostPrice {
+  /**
+   * 空の集約を生成する。セット商品は自前の原価を持たず常に構成商品から導出されるため、
+   * 生成入口で拒否する（#515）。区分不変ゆえ生成入口を塞げば以後の追加・改定・削除も
+   * 既存集約が存在しないことで構造的に到達不能になる。区分は集約越えの事実のため
+   * アプリ層が取得して引数で渡す（ADR-0030）。
+   */
+  static create(productId: ProductId, category: ProductCategory): CostPrice {
+    if (category.isSet()) {
+      throw new ValidationError(`セット商品には${CostPrice.ENTITY_NAME}を登録できません`);
+    }
     return new CostPrice(productId, []);
   }
 

--- a/src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts
+++ b/src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts
@@ -1,6 +1,7 @@
 import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
-import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
 import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { CustomerSellingPricePeriodId } from "../values/CustomerSellingPricePeriodId";
 import { SellingUnitPrice } from "../values/SellingUnitPrice";
@@ -31,8 +32,22 @@ export class CustomerSellingPrice {
     private readonly _periods: CustomerSellingPricePeriod[]
   ) {}
 
-  /** 空の集約を生成する。 */
-  static create(customerId: CustomerId, productId: ProductId): CustomerSellingPrice {
+  /**
+   * 空の集約を生成する。セット商品は自前の売単価を持たず常に構成商品から導出されるため、
+   * 生成入口で拒否する（#515）。区分不変ゆえ生成入口を塞げば以後の追加・改定・削除も
+   * 既存集約が存在しないことで構造的に到達不能になる。区分は集約越えの事実のため
+   * アプリ層が取得して引数で渡す（ADR-0030）。customerId は複合自然キーの先頭のため維持する。
+   */
+  static create(
+    customerId: CustomerId,
+    productId: ProductId,
+    category: ProductCategory
+  ): CustomerSellingPrice {
+    if (category.isSet()) {
+      throw new ValidationError(
+        `セット商品には${CustomerSellingPrice.ENTITY_NAME}を登録できません`
+      );
+    }
     return new CustomerSellingPrice(customerId, productId, []);
   }
 

--- a/src/server/subdomains/pricing/domain/entities/__tests__/CommonSellingPrice.test.ts
+++ b/src/server/subdomains/pricing/domain/entities/__tests__/CommonSellingPrice.test.ts
@@ -1,6 +1,7 @@
 import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
 import { Money } from "@server/shared/domain/values/Money";
 import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { describe, expect, it } from "vitest";
 import { CommonSellingPricePeriodId } from "../../values/CommonSellingPricePeriodId";
@@ -14,9 +15,21 @@ const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(y
 describe("CommonSellingPrice 集約", () => {
   describe("生成", () => {
     it("商品IDで空の集約を生成できる", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       expect(aggregate.productId.equals(productId)).toBe(true);
       expect(aggregate.periods).toHaveLength(0);
+    });
+
+    it("消耗品でも空の集約を生成できる（価格保守対象商品・#515）", () => {
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.CONSUMABLE);
+      expect(aggregate.periods).toHaveLength(0);
+    });
+
+    it("セット商品区分では共通販売単価集約を生成できない（ValidationError・#515）", () => {
+      // セット商品は自前の売単価を持たず常に構成商品から導出されるため、生成入口で拒否する。
+      expect(() => CommonSellingPrice.create(productId, ProductCategory.SET)).toThrow(
+        ValidationError
+      );
     });
   });
 
@@ -24,7 +37,7 @@ describe("CommonSellingPrice 集約", () => {
     const today = "2025-06-01";
 
     it("期間行を追加でき、期間と単価が保持される", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
 
       expect(aggregate.periods).toHaveLength(1);
@@ -34,7 +47,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("採番された identity が各行に付与される", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
       aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
 
@@ -43,7 +56,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("重ならない期間は複数追加できる（隣接含む）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
       aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
 
@@ -51,7 +64,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("既存期間と重複する期間は BusinessRuleViolationError", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
 
       expect(() =>
@@ -62,7 +75,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("無期限行があるとき、その開始日以降に重なる期間は弾く", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
 
       expect(() =>
@@ -71,14 +84,14 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("開始日が今日と同じなら追加できる（境界・以上）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period(today, null), price(1000), today);
 
       expect(aggregate.periods).toHaveLength(1);
     });
 
     it("開始日が今日より前なら BusinessRuleViolationError（過去への後付け登録を禁止）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
 
       expect(() => aggregate.addPeriod(period("2025-05-31", null), price(1000), today)).toThrow(
         BusinessRuleViolationError
@@ -91,7 +104,7 @@ describe("CommonSellingPrice 集約", () => {
     const today = "2025-06-01";
 
     it("将来行の期間と単価を差し替えられる（identity は保持）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
       const id = aggregate.periods[0].id;
 
@@ -108,7 +121,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("現在有効行は編集できない（BusinessRuleViolationError・単価ロック）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       // 開始 ≤ 今日 < 終了 = 現在有効
       aggregate.addPeriod(period("2025-05-01", "2025-12-01"), price(1000), "2025-04-01");
       const id = aggregate.periods[0].id;
@@ -122,7 +135,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("失効行は編集できない（BusinessRuleViolationError）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       // 今日 ≥ 終了 = 失効
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
       const id = aggregate.periods[0].id;
@@ -133,7 +146,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("存在しない periodId は BusinessRuleViolationError", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
 
       expect(() =>
@@ -150,7 +163,7 @@ describe("CommonSellingPrice 集約", () => {
     const today = "2025-06-01";
 
     it("現在有効行に終了日を設定でき、開始日・単価は変わらない", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -163,7 +176,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("終了日が今日以前なら不可（過去の被覆を遡及削除させない）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -172,7 +185,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("将来行には適用終了できない（編集で対応する）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
       const id = aggregate.periods[0].id;
 
@@ -182,7 +195,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("失効行には適用終了できない", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
       const id = aggregate.periods[0].id;
 
@@ -192,7 +205,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("有界の現在有効行を既存終了日より後へは延長できない（短縮のみ許可）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -203,7 +216,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("有界の現在有効行で既存終了日と同一の終了日は不可（短縮になっていない）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -213,7 +226,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("有界の現在有効行を既存終了日より手前へは短縮できる", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -223,7 +236,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("実在しない日付の終了日は形式エラー（短縮判定より前に弾く）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -233,7 +246,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("空文字の終了日は形式エラー（今日比較より前に弾く）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -246,7 +259,7 @@ describe("CommonSellingPrice 集約", () => {
     const today = "2025-06-01";
 
     it("将来行を削除できる（誤入力訂正）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
       aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
       const id = aggregate.periods[0].id;
@@ -258,7 +271,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("現在有効行は削除できない（BusinessRuleViolationError）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -267,7 +280,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("失効行は削除できない（BusinessRuleViolationError）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
       const id = aggregate.periods[0].id;
 
@@ -276,7 +289,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("存在しない periodId は BusinessRuleViolationError", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
 
       expect(() => aggregate.deletePeriod(CommonSellingPricePeriodId.generate(), today)).toThrow(
@@ -289,7 +302,7 @@ describe("CommonSellingPrice 集約", () => {
     const today = "2025-06-01";
 
     it("現在有効行（開始 ≤ 今日 < 終了）を返す", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-12-01"), price(1000), "2025-03-01");
 
       const row = aggregate.currentValidPeriod(today);
@@ -300,7 +313,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("無期限の現在有効行（開始 ≤ 今日・終了なし）を返す", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
 
       const row = aggregate.currentValidPeriod(today);
@@ -309,7 +322,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("現在有効行が無ければ undefined（将来行・失効行のみ）", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01"); // 失効
       aggregate.addPeriod(period("2025-07-01", null), price(1200), today); // 将来
 
@@ -317,7 +330,7 @@ describe("CommonSellingPrice 集約", () => {
     });
 
     it("空集約では undefined", () => {
-      const aggregate = CommonSellingPrice.create(productId);
+      const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
       expect(aggregate.currentValidPeriod(today)).toBeUndefined();
     });
   });

--- a/src/server/subdomains/pricing/domain/entities/__tests__/CostPrice.test.ts
+++ b/src/server/subdomains/pricing/domain/entities/__tests__/CostPrice.test.ts
@@ -1,6 +1,7 @@
 import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
 import { Money } from "@server/shared/domain/values/Money";
 import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { describe, expect, it } from "vitest";
 import { CostPricePeriodId } from "../../values/CostPricePeriodId";
@@ -14,9 +15,20 @@ const cost = (yen: number) => CostUnitPrice.fromMoney(Money.fromMajorUnits(yen))
 describe("CostPrice 集約", () => {
   describe("生成", () => {
     it("商品IDで空の集約を生成できる", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       expect(aggregate.productId.equals(productId)).toBe(true);
       expect(aggregate.periods).toHaveLength(0);
+    });
+
+    it("消耗品でも空の集約を生成できる（価格保守対象商品・#515）", () => {
+      const aggregate = CostPrice.create(productId, ProductCategory.CONSUMABLE);
+      expect(aggregate.periods).toHaveLength(0);
+    });
+
+    it("セット商品区分では原価集約を生成できない（ValidationError・#515）", () => {
+      // セット商品は自前の原価を持たず常に構成商品から導出されるため、原価集約の生成入口で拒否する。
+      // 区分不変ゆえ生成入口を塞げば以後の全操作（追加・改定・削除）も構造的に到達不能になる。
+      expect(() => CostPrice.create(productId, ProductCategory.SET)).toThrow(ValidationError);
     });
   });
 
@@ -24,7 +36,7 @@ describe("CostPrice 集約", () => {
     const today = "2026-01-01";
 
     it("期間行を追加でき、期間と原価が保持される", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), today);
 
       expect(aggregate.periods).toHaveLength(1);
@@ -34,7 +46,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("採番された identity が各行に付与される", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), today);
       aggregate.addPeriod(period("2026-10-01", null), cost(700), today);
 
@@ -43,7 +55,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("重ならない期間は複数追加できる（隣接含む）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), today);
       aggregate.addPeriod(period("2026-10-01", null), cost(700), today);
 
@@ -51,14 +63,14 @@ describe("CostPrice 集約", () => {
     });
 
     it("0円の原価も保存できる（非複合品の本物の0）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2026-04-01", null), cost(0), today);
 
       expect(aggregate.periods[0].price.equals(cost(0))).toBe(true);
     });
 
     it("既存期間と重複する期間は BusinessRuleViolationError", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), today);
 
       expect(() =>
@@ -69,7 +81,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("無期限行があるとき、その開始日以降に重なる期間は弾く", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2026-04-01", null), cost(600), today);
 
       expect(() =>
@@ -78,14 +90,14 @@ describe("CostPrice 集約", () => {
     });
 
     it("開始日が今日と同じなら追加できる（境界・以上）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period(today, null), cost(600), today);
 
       expect(aggregate.periods).toHaveLength(1);
     });
 
     it("開始日が今日より前なら BusinessRuleViolationError（過去への後付け登録を禁止）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
 
       expect(() => aggregate.addPeriod(period("2025-12-31", null), cost(600), today)).toThrow(
         BusinessRuleViolationError
@@ -98,7 +110,7 @@ describe("CostPrice 集約", () => {
     const today = "2025-06-01";
 
     it("将来行の期間と単価を差し替えられる（identity は保持）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), cost(1000), today);
       const id = aggregate.periods[0].id;
 
@@ -115,7 +127,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("現在有効行は編集できない（BusinessRuleViolationError・単価ロック）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       // 開始 ≤ 今日 < 終了 = 現在有効
       aggregate.addPeriod(period("2025-05-01", "2025-12-01"), cost(1000), "2025-04-01");
       const id = aggregate.periods[0].id;
@@ -129,7 +141,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("失効行は編集できない（BusinessRuleViolationError）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       // 今日 ≥ 終了 = 失効
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), cost(1000), "2024-12-01");
       const id = aggregate.periods[0].id;
@@ -140,7 +152,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("存在しない periodId は BusinessRuleViolationError", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", null), cost(1000), today);
 
       expect(() =>
@@ -157,7 +169,7 @@ describe("CostPrice 集約", () => {
     const today = "2025-06-01";
 
     it("現在有効行に終了日を設定でき、開始日・単価は変わらない", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", null), cost(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -170,7 +182,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("終了日が今日以前なら不可（過去の被覆を遡及削除させない）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", null), cost(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -179,7 +191,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("将来行には適用終了できない（編集で対応する）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", null), cost(1000), today);
       const id = aggregate.periods[0].id;
 
@@ -189,7 +201,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("失効行には適用終了できない", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), cost(1000), "2024-12-01");
       const id = aggregate.periods[0].id;
 
@@ -199,7 +211,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("有界の現在有効行を既存終了日より後へは延長できない（短縮のみ許可）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), cost(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -210,7 +222,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("有界の現在有効行で既存終了日と同一の終了日は不可（短縮になっていない）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), cost(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -220,7 +232,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("有界の現在有効行を既存終了日より手前へは短縮できる", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), cost(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -230,7 +242,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("実在しない日付の終了日は形式エラー（短縮判定より前に弾く）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), cost(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -240,7 +252,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("空文字の終了日は形式エラー（今日比較より前に弾く）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), cost(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -253,7 +265,7 @@ describe("CostPrice 集約", () => {
     const today = "2025-06-01";
 
     it("将来行を削除できる（誤入力訂正）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), cost(1000), today);
       aggregate.addPeriod(period("2025-10-01", null), cost(1200), today);
       const id = aggregate.periods[0].id;
@@ -265,7 +277,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("現在有効行は削除できない（BusinessRuleViolationError）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", null), cost(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -274,7 +286,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("失効行は削除できない（BusinessRuleViolationError）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), cost(1000), "2024-12-01");
       const id = aggregate.periods[0].id;
 
@@ -283,7 +295,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("存在しない periodId は BusinessRuleViolationError", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-07-01", null), cost(1000), today);
 
       expect(() => aggregate.deletePeriod(CostPricePeriodId.generate(), today)).toThrow(
@@ -296,7 +308,7 @@ describe("CostPrice 集約", () => {
     const today = "2025-06-01";
 
     it("現在有効行（開始 ≤ 今日 < 終了）を返す", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", "2025-12-01"), cost(1000), "2025-03-01");
 
       const row = aggregate.currentValidPeriod(today);
@@ -307,7 +319,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("無期限の現在有効行（開始 ≤ 今日・終了なし）を返す", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-04-01", null), cost(1000), "2025-03-01");
 
       const row = aggregate.currentValidPeriod(today);
@@ -316,7 +328,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("現在有効行が無ければ undefined（将来行・失効行のみ）", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), cost(1000), "2024-12-01"); // 失効
       aggregate.addPeriod(period("2025-07-01", null), cost(1200), today); // 将来
 
@@ -324,7 +336,7 @@ describe("CostPrice 集約", () => {
     });
 
     it("空集約では undefined", () => {
-      const aggregate = CostPrice.create(productId);
+      const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
       expect(aggregate.currentValidPeriod(today)).toBeUndefined();
     });
   });

--- a/src/server/subdomains/pricing/domain/entities/__tests__/CustomerSellingPrice.test.ts
+++ b/src/server/subdomains/pricing/domain/entities/__tests__/CustomerSellingPrice.test.ts
@@ -2,6 +2,7 @@ import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod"
 import { Money } from "@server/shared/domain/values/Money";
 import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
 import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { describe, expect, it } from "vitest";
 import { CustomerSellingPricePeriodId } from "../../values/CustomerSellingPricePeriodId";
@@ -16,10 +17,30 @@ const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(y
 describe("CustomerSellingPrice 集約", () => {
   describe("生成", () => {
     it("得意先ID×商品IDで空の集約を生成できる", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       expect(aggregate.customerId.equals(customerId)).toBe(true);
       expect(aggregate.productId.equals(productId)).toBe(true);
       expect(aggregate.periods).toHaveLength(0);
+    });
+
+    it("消耗品でも空の集約を生成できる（価格保守対象商品・#515）", () => {
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.CONSUMABLE
+      );
+      expect(aggregate.periods).toHaveLength(0);
+    });
+
+    it("セット商品区分では得意先別販売単価集約を生成できない（ValidationError・#515）", () => {
+      // セット商品は自前の売単価を持たず常に構成商品から導出されるため、生成入口で拒否する。
+      expect(() => CustomerSellingPrice.create(customerId, productId, ProductCategory.SET)).toThrow(
+        ValidationError
+      );
     });
   });
 
@@ -27,7 +48,11 @@ describe("CustomerSellingPrice 集約", () => {
     const today = "2025-06-01";
 
     it("期間行を追加でき、期間と単価が保持される", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
 
       expect(aggregate.periods).toHaveLength(1);
@@ -37,7 +62,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("採番された identity が各行に付与される", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
       aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
 
@@ -46,7 +75,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("重ならない期間は複数追加できる（隣接含む）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
       aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
 
@@ -54,7 +87,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("既存期間と重複する期間は BusinessRuleViolationError", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
 
       expect(() =>
@@ -65,7 +102,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("無期限行があるとき、その開始日以降に重なる期間は弾く", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
 
       expect(() =>
@@ -74,14 +115,22 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("開始日が今日と同じなら追加できる（境界・以上）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period(today, null), price(1000), today);
 
       expect(aggregate.periods).toHaveLength(1);
     });
 
     it("開始日が今日より前なら BusinessRuleViolationError（過去への後付け登録を禁止）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
 
       expect(() => aggregate.addPeriod(period("2025-05-31", null), price(1000), today)).toThrow(
         BusinessRuleViolationError
@@ -94,7 +143,11 @@ describe("CustomerSellingPrice 集約", () => {
     const today = "2025-06-01";
 
     it("将来行の期間と単価を差し替えられる（identity は保持）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
       const id = aggregate.periods[0].id;
 
@@ -111,7 +164,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("現在有効行は編集できない（BusinessRuleViolationError・単価ロック）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       // 開始 ≤ 今日 < 終了 = 現在有効
       aggregate.addPeriod(period("2025-05-01", "2025-12-01"), price(1000), "2025-04-01");
       const id = aggregate.periods[0].id;
@@ -125,7 +182,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("失効行は編集できない（BusinessRuleViolationError）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       // 今日 ≥ 終了 = 失効
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
       const id = aggregate.periods[0].id;
@@ -136,7 +197,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("存在しない periodId は BusinessRuleViolationError", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
 
       expect(() =>
@@ -153,7 +218,11 @@ describe("CustomerSellingPrice 集約", () => {
     const today = "2025-06-01";
 
     it("現在有効行に終了日を設定でき、開始日・単価は変わらない", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -166,7 +235,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("終了日が今日以前なら不可（過去の被覆を遡及削除させない）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -174,7 +247,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("将来行には適用終了できない（編集で対応する）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
       const id = aggregate.periods[0].id;
 
@@ -184,7 +261,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("失効行には適用終了できない", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
       const id = aggregate.periods[0].id;
 
@@ -194,7 +275,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("有界の現在有効行を既存終了日より後へは延長できない（短縮のみ許可）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -204,7 +289,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("有界の現在有効行で既存終了日と同一の終了日は不可（短縮になっていない）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -214,7 +303,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("有界の現在有効行を既存終了日より手前へは短縮できる", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -224,7 +317,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("実在しない日付の終了日は形式エラー（短縮判定より前に弾く）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -232,7 +329,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("空文字の終了日は形式エラー（今日比較より前に弾く）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -244,7 +345,11 @@ describe("CustomerSellingPrice 集約", () => {
     const today = "2025-06-01";
 
     it("将来行を削除できる（誤入力訂正）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
       aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
       const id = aggregate.periods[0].id;
@@ -256,7 +361,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("現在有効行は削除できない（BusinessRuleViolationError）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
       const id = aggregate.periods[0].id;
 
@@ -265,7 +374,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("失効行は削除できない（BusinessRuleViolationError）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
       const id = aggregate.periods[0].id;
 
@@ -274,7 +387,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("存在しない periodId は BusinessRuleViolationError", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
 
       expect(() => aggregate.deletePeriod(CustomerSellingPricePeriodId.generate(), today)).toThrow(
@@ -287,7 +404,11 @@ describe("CustomerSellingPrice 集約", () => {
     const today = "2025-06-01";
 
     it("現在有効行（開始 ≤ 今日 < 終了）を返す", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-04-01", "2025-12-01"), price(1000), "2025-03-01");
 
       const row = aggregate.currentValidPeriod(today);
@@ -298,7 +419,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("無期限の現在有効行（開始 ≤ 今日・終了なし）を返す", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
 
       const row = aggregate.currentValidPeriod(today);
@@ -307,7 +432,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("現在有効行が無ければ undefined（将来行・失効行のみ）", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01"); // 失効
       aggregate.addPeriod(period("2025-07-01", null), price(1200), today); // 将来
 
@@ -315,7 +444,11 @@ describe("CustomerSellingPrice 集約", () => {
     });
 
     it("空集約では undefined", () => {
-      const aggregate = CustomerSellingPrice.create(customerId, productId);
+      const aggregate = CustomerSellingPrice.create(
+        customerId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       expect(aggregate.currentValidPeriod(today)).toBeUndefined();
     });
   });

--- a/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCommonSellingPriceRepository.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCommonSellingPriceRepository.test.ts
@@ -55,7 +55,7 @@ describe("PrismaCommonSellingPriceRepository", () => {
   });
 
   it("insert して findByProductId で往復できる（有界＋無期限・銭精度）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     aggregate.addPeriod(period("2025-10-01", null), price(1234.56), "2025-10-01");
     await repository.insert(aggregate);
@@ -75,7 +75,7 @@ describe("PrismaCommonSellingPriceRepository", () => {
   });
 
   it("update で期間行を追加同期できる（version 一致時・append-only）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -90,7 +90,7 @@ describe("PrismaCommonSellingPriceRepository", () => {
   });
 
   it("update は無変更の既存行の updated_at を変更しない（監査保持）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -122,7 +122,7 @@ describe("PrismaCommonSellingPriceRepository", () => {
   });
 
   it("update で将来行の単価改定が in-place 反映され、改定行の updated_at が進む（編集の永続化）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
 
@@ -159,7 +159,7 @@ describe("PrismaCommonSellingPriceRepository", () => {
   });
 
   it("update で集約から消えた将来行は DB からも削除される（削除の永続化）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2025-06-01");
     aggregate.addPeriod(period("2030-06-01", null), price(1200), "2025-06-01");
     await repository.insert(aggregate);
@@ -175,7 +175,7 @@ describe("PrismaCommonSellingPriceRepository", () => {
   });
 
   it("update で最後の将来行を削除すると期間行が0件になる（空集約 delete・空配列バインド）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
 
@@ -191,7 +191,7 @@ describe("PrismaCommonSellingPriceRepository", () => {
   });
 
   it("古い expectedVersion での update は ConflictError", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -199,18 +199,18 @@ describe("PrismaCommonSellingPriceRepository", () => {
   });
 
   it("同一商品への二重 insert は ConflictError（親 PK 衝突の翻訳）", async () => {
-    const first = CommonSellingPrice.create(productId);
+    const first = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     first.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await repository.insert(first);
 
     // アプリ層の存在チェックをすり抜けた二重作成レースを模す。
-    const second = CommonSellingPrice.create(productId);
+    const second = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     second.addPeriod(period("2025-07-01", null), price(2000), "2025-07-01");
     await expect(repository.insert(second)).rejects.toBeInstanceOf(ConflictError);
   });
 
   it("同一商品で適用期間が重複する行は EXCLUDE 制約で弾かれる", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCostPriceRepository.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCostPriceRepository.test.ts
@@ -55,7 +55,7 @@ describe("PrismaCostPriceRepository", () => {
   });
 
   it("insert して findByProductId で往復できる（有界＋無期限・銭精度）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), "2026-04-01");
     aggregate.addPeriod(period("2026-10-01", null), cost(1234.56), "2026-10-01");
     await repository.insert(aggregate);
@@ -75,7 +75,7 @@ describe("PrismaCostPriceRepository", () => {
   });
 
   it("0円の原価も往復できる（非複合品の本物の0）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", null), cost(0), "2026-04-01");
     await repository.insert(aggregate);
 
@@ -84,7 +84,7 @@ describe("PrismaCostPriceRepository", () => {
   });
 
   it("update で期間行を追加同期できる（version 一致時・append-only）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), "2026-04-01");
     await repository.insert(aggregate);
 
@@ -99,7 +99,7 @@ describe("PrismaCostPriceRepository", () => {
   });
 
   it("update は無変更の既存行の updated_at を変更しない（監査保持）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), "2026-04-01");
     await repository.insert(aggregate);
 
@@ -131,7 +131,7 @@ describe("PrismaCostPriceRepository", () => {
   });
 
   it("update で将来行の単価改定が in-place 反映され、改定行の updated_at が進む（編集の永続化）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), cost(600), "2025-06-01");
     await repository.insert(aggregate);
 
@@ -164,7 +164,7 @@ describe("PrismaCostPriceRepository", () => {
   });
 
   it("update で集約から消えた将来行は DB からも削除される（削除の永続化）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", "2030-06-01"), cost(600), "2025-06-01");
     aggregate.addPeriod(period("2030-06-01", null), cost(700), "2025-06-01");
     await repository.insert(aggregate);
@@ -180,7 +180,7 @@ describe("PrismaCostPriceRepository", () => {
   });
 
   it("update で最後の将来行を削除すると期間行が0件になる（空集約 delete・空配列バインド）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), cost(600), "2025-06-01");
     await repository.insert(aggregate);
 
@@ -196,7 +196,7 @@ describe("PrismaCostPriceRepository", () => {
   });
 
   it("古い expectedVersion での update は ConflictError", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", null), cost(600), "2026-04-01");
     await repository.insert(aggregate);
 
@@ -204,18 +204,18 @@ describe("PrismaCostPriceRepository", () => {
   });
 
   it("同一商品への二重 insert は ConflictError（親 PK 衝突の翻訳）", async () => {
-    const first = CostPrice.create(productId);
+    const first = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     first.addPeriod(period("2026-04-01", null), cost(600), "2026-04-01");
     await repository.insert(first);
 
     // アプリ層の存在チェックをすり抜けた二重作成レースを模す。
-    const second = CostPrice.create(productId);
+    const second = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     second.addPeriod(period("2026-04-01", null), cost(700), "2026-04-01");
     await expect(repository.insert(second)).rejects.toBeInstanceOf(ConflictError);
   });
 
   it("同一商品で適用期間が重複する行は EXCLUDE 制約で弾かれる", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), "2026-04-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCustomerSellingPriceRepository.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaCustomerSellingPriceRepository.test.ts
@@ -72,7 +72,11 @@ describe("PrismaCustomerSellingPriceRepository", () => {
   });
 
   it("insert して findByCustomerIdAndProductId で往復できる（有界＋無期限・銭精度）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     aggregate.addPeriod(period("2025-10-01", null), price(1234.56), "2025-10-01");
     await repository.insert(aggregate);
@@ -92,7 +96,11 @@ describe("PrismaCustomerSellingPriceRepository", () => {
   });
 
   it("update で期間行を追加同期できる（version 一致時・append-only）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -107,7 +115,11 @@ describe("PrismaCustomerSellingPriceRepository", () => {
   });
 
   it("update は無変更の既存行の updated_at を変更しない（監査保持）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -139,7 +151,11 @@ describe("PrismaCustomerSellingPriceRepository", () => {
   });
 
   it("update で将来行の単価改定が in-place 反映され、改定行の updated_at が進む（編集の永続化）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
 
@@ -176,7 +192,11 @@ describe("PrismaCustomerSellingPriceRepository", () => {
   });
 
   it("update で集約から消えた将来行は DB からも削除される（削除の永続化）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2025-06-01");
     aggregate.addPeriod(period("2030-06-01", null), price(1200), "2025-06-01");
     await repository.insert(aggregate);
@@ -192,7 +212,11 @@ describe("PrismaCustomerSellingPriceRepository", () => {
   });
 
   it("update で最後の将来行を削除すると期間行が0件になる（空集約 delete・空配列バインド）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
     await repository.insert(aggregate);
 
@@ -208,7 +232,11 @@ describe("PrismaCustomerSellingPriceRepository", () => {
   });
 
   it("古い expectedVersion での update は ConflictError", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -216,18 +244,22 @@ describe("PrismaCustomerSellingPriceRepository", () => {
   });
 
   it("同一の得意先×商品への二重 insert は ConflictError（親 複合PK 衝突の翻訳）", async () => {
-    const first = CustomerSellingPrice.create(customerId, productId);
+    const first = CustomerSellingPrice.create(customerId, productId, ProductCategory.INDIVIDUAL);
     first.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await repository.insert(first);
 
     // アプリ層の存在チェックをすり抜けた二重作成レースを模す。
-    const second = CustomerSellingPrice.create(customerId, productId);
+    const second = CustomerSellingPrice.create(customerId, productId, ProductCategory.INDIVIDUAL);
     second.addPeriod(period("2025-07-01", null), price(2000), "2025-07-01");
     await expect(repository.insert(second)).rejects.toBeInstanceOf(ConflictError);
   });
 
   it("同一の得意先×商品で適用期間が重複する行は EXCLUDE 制約で弾かれる", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCommonSellingPriceEditQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCommonSellingPriceEditQueryService.test.ts
@@ -47,7 +47,7 @@ describe("PrismaCommonSellingPriceEditQueryService", () => {
   afterEach(cleanup);
 
   it("identity・version・期間行配列を返し、各行に時点状態（将来/現在有効/失効）を算出する", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-01-01", "2025-03-01"), price(800), "2025-01-01"); // 失効
     aggregate.addPeriod(period("2025-03-01", "2025-09-01"), price(1000), "2025-03-01"); // 現在有効
     aggregate.addPeriod(period("2030-01-01", null), price(1200), "2025-01-01"); // 将来
@@ -101,7 +101,7 @@ describe("PrismaCommonSellingPriceEditQueryService", () => {
   });
 
   it("update 後の version を反映する（楽観ロックトークン）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2025-06-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCommonSellingPriceListQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCommonSellingPriceListQueryService.test.ts
@@ -56,7 +56,7 @@ describe("PrismaCommonSellingPriceListQueryService", () => {
 
   it("現在有効な単価がある商品は currentSellingPrice を値で返し priceStatus=active", async () => {
     const productId = await makeProduct(CODES.active, "現在有効商品");
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-01-01", null), price(1000), "2025-01-01");
     await repository.insert(aggregate);
 
@@ -70,7 +70,7 @@ describe("PrismaCommonSellingPriceListQueryService", () => {
 
   it("現在有効行が無期限なら currentPeriodStart は開始日・currentPeriodEnd は null", async () => {
     const productId = await makeProduct(CODES.active, "現在有効・無期限商品");
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-01-01", null), price(1000), "2025-01-01");
     await repository.insert(aggregate);
 
@@ -83,7 +83,7 @@ describe("PrismaCommonSellingPriceListQueryService", () => {
 
   it("現在有効行が有界なら currentPeriodStart/End に半開区間の生値（排他上端）を返す", async () => {
     const productId = await makeProduct(CODES.futureOnly, "現在有効・有界商品");
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-01-01", "2025-12-31"), price(1000), "2025-01-01");
     await repository.insert(aggregate);
 
@@ -109,7 +109,7 @@ describe("PrismaCommonSellingPriceListQueryService", () => {
 
   it("将来行のみの商品は currentSellingPrice=null・priceStatus=lapsed（失効中）", async () => {
     const productId = await makeProduct(CODES.futureOnly, "将来のみ商品");
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-01-01");
     await repository.insert(aggregate);
 
@@ -122,7 +122,7 @@ describe("PrismaCommonSellingPriceListQueryService", () => {
 
   it("失効行のみの商品は currentSellingPrice=null・priceStatus=lapsed（失効中）", async () => {
     const productId = await makeProduct(CODES.expiredOnly, "失効のみ商品");
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-01-01", "2025-03-01"), price(1000), "2025-01-01");
     await repository.insert(aggregate);
 
@@ -182,7 +182,7 @@ describe("PrismaCommonSellingPriceListQueryService", () => {
 
     it("priceStatus=unset は未設定のみへ絞り込む", async () => {
       const activeId = await makeProduct(CODES.active, "現在有効商品");
-      const aggregate = CommonSellingPrice.create(activeId);
+      const aggregate = CommonSellingPrice.create(activeId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-01-01", null), price(1000), "2025-01-01");
       await repository.insert(aggregate);
       await makeProduct(CODES.unset, "未設定商品");

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCommonSellingPriceQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCommonSellingPriceQueryService.test.ts
@@ -53,7 +53,7 @@ describe("PrismaCommonSellingPriceQueryService", () => {
   });
 
   it("区間内の暦日で有効な単価を引く", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -65,7 +65,7 @@ describe("PrismaCommonSellingPriceQueryService", () => {
   });
 
   it("適用期間の開始日ちょうどは含む（半開 [) の下端）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -75,7 +75,7 @@ describe("PrismaCommonSellingPriceQueryService", () => {
   });
 
   it("適用期間の終了日ちょうどは含まない（半開 [) の上端）", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -85,7 +85,7 @@ describe("PrismaCommonSellingPriceQueryService", () => {
   });
 
   it("どの適用期間にも覆われない暦日では null を返す", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -102,7 +102,7 @@ describe("PrismaCommonSellingPriceQueryService", () => {
   });
 
   it("無期限上端（end=null）の期間は遠い未来の暦日でもヒットする", async () => {
-    const aggregate = CommonSellingPrice.create(productId);
+    const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-10-01", null), price(1234.56), "2025-10-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCostPriceEditQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCostPriceEditQueryService.test.ts
@@ -47,7 +47,7 @@ describe("PrismaCostPriceEditQueryService", () => {
   afterEach(cleanup);
 
   it("identity・version・期間行配列を返し、各行に時点状態（将来/現在有効/失効）を算出する", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-01-01", "2025-03-01"), price(800), "2025-01-01"); // 失効
     aggregate.addPeriod(period("2025-03-01", "2025-09-01"), price(1000), "2025-03-01"); // 現在有効
     aggregate.addPeriod(period("2030-01-01", null), price(1200), "2030-01-01"); // 将来
@@ -101,7 +101,7 @@ describe("PrismaCostPriceEditQueryService", () => {
   });
 
   it("update 後の version を反映する（楽観ロックトークン）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2030-01-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCostPriceListQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCostPriceListQueryService.test.ts
@@ -56,7 +56,7 @@ describe("PrismaCostPriceListQueryService", () => {
 
   it("現在有効な原価がある商品は currentCostPrice を値で返し priceStatus=active", async () => {
     const productId = await makeProduct(CODES.active, "現在有効商品");
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-01-01", null), price(1000), "2025-01-01");
     await repository.insert(aggregate);
 
@@ -70,7 +70,7 @@ describe("PrismaCostPriceListQueryService", () => {
 
   it("現在有効行が無期限なら currentPeriodStart は開始日・currentPeriodEnd は null", async () => {
     const productId = await makeProduct(CODES.active, "現在有効・無期限商品");
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-01-01", null), price(1000), "2025-01-01");
     await repository.insert(aggregate);
 
@@ -83,7 +83,7 @@ describe("PrismaCostPriceListQueryService", () => {
 
   it("現在有効行が有界なら currentPeriodStart/End に半開区間の生値（排他上端）を返す", async () => {
     const productId = await makeProduct(CODES.futureOnly, "現在有効・有界商品");
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-01-01", "2025-12-31"), price(1000), "2025-01-01");
     await repository.insert(aggregate);
 
@@ -109,7 +109,7 @@ describe("PrismaCostPriceListQueryService", () => {
 
   it("将来行のみの商品は currentCostPrice=null・priceStatus=lapsed（失効中）", async () => {
     const productId = await makeProduct(CODES.futureOnly, "将来のみ商品");
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2030-01-01", null), price(1000), "2030-01-01");
     await repository.insert(aggregate);
 
@@ -122,7 +122,7 @@ describe("PrismaCostPriceListQueryService", () => {
 
   it("失効行のみの商品は currentCostPrice=null・priceStatus=lapsed（失効中）", async () => {
     const productId = await makeProduct(CODES.expiredOnly, "失効のみ商品");
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2025-01-01", "2025-03-01"), price(1000), "2025-01-01");
     await repository.insert(aggregate);
 
@@ -182,7 +182,7 @@ describe("PrismaCostPriceListQueryService", () => {
 
     it("priceStatus=unset は未設定のみへ絞り込む", async () => {
       const activeId = await makeProduct(CODES.active, "現在有効商品");
-      const aggregate = CostPrice.create(activeId);
+      const aggregate = CostPrice.create(activeId, ProductCategory.INDIVIDUAL);
       aggregate.addPeriod(period("2025-01-01", null), price(1000), "2025-01-01");
       await repository.insert(aggregate);
       await makeProduct(CODES.unset, "未設定商品");

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCostPriceQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCostPriceQueryService.test.ts
@@ -53,7 +53,7 @@ describe("PrismaCostPriceQueryService", () => {
   });
 
   it("区間内の暦日で有効な原価を引く", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), "2026-04-01");
     await repository.insert(aggregate);
 
@@ -65,7 +65,7 @@ describe("PrismaCostPriceQueryService", () => {
   });
 
   it("適用期間の開始日ちょうどは含む（半開 [) の下端）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), "2026-04-01");
     await repository.insert(aggregate);
 
@@ -75,7 +75,7 @@ describe("PrismaCostPriceQueryService", () => {
   });
 
   it("適用期間の終了日ちょうどは含まない（半開 [) の上端）", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), "2026-04-01");
     await repository.insert(aggregate);
 
@@ -85,7 +85,7 @@ describe("PrismaCostPriceQueryService", () => {
   });
 
   it("どの適用期間にも覆われない暦日では null を返す", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", "2026-10-01"), cost(600), "2026-04-01");
     await repository.insert(aggregate);
 
@@ -102,7 +102,7 @@ describe("PrismaCostPriceQueryService", () => {
   });
 
   it("無期限上端（end=null）の期間は遠い未来の暦日でもヒットする", async () => {
-    const aggregate = CostPrice.create(productId);
+    const aggregate = CostPrice.create(productId, ProductCategory.INDIVIDUAL);
     aggregate.addPeriod(period("2026-04-01", null), cost(1234.56), "2026-04-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCustomerSellingPriceQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCustomerSellingPriceQueryService.test.ts
@@ -139,7 +139,7 @@ describe("PrismaCustomerSellingPriceQueryService", () => {
   it("同じ商品に共通販売単価があっても得意先別としては引かない（層の隔離）", async () => {
     // 共通販売単価だけを登録し、得意先別は1件も登録しない。
     // 得意先別 QueryService は customer_selling_price_periods のみを見るため null になる。
-    const common = CommonSellingPrice.create(productId);
+    const common = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     common.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await new PrismaCommonSellingPriceRepository().insert(common);
 

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCustomerSellingPriceQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaCustomerSellingPriceQueryService.test.ts
@@ -95,7 +95,11 @@ describe("PrismaCustomerSellingPriceQueryService", () => {
   });
 
   it("区間内の暦日で有効な得意先別単価を引く", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -109,7 +113,11 @@ describe("PrismaCustomerSellingPriceQueryService", () => {
   });
 
   it("同じ商品でも別の得意先では引かない（得意先キーの隔離）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -123,7 +131,11 @@ describe("PrismaCustomerSellingPriceQueryService", () => {
   });
 
   it("同じ得意先でも別の商品では引かない（商品キーの隔離）", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
@@ -153,7 +165,11 @@ describe("PrismaCustomerSellingPriceQueryService", () => {
   });
 
   it("どの適用期間にも覆われない暦日では null を返す", async () => {
-    const aggregate = CustomerSellingPrice.create(customerId, productId);
+    const aggregate = CustomerSellingPrice.create(
+      customerId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceQueryService.test.ts
@@ -158,7 +158,7 @@ describe("PrismaDeliveryLocationSellingPriceQueryService", () => {
   it("同じ商品に共通販売単価があっても納品先別としては引かない（層の隔離）", async () => {
     // 共通販売単価だけを登録し、納品先別は1件も登録しない。
     // 納品先別 QueryService は delivery_location_selling_price_periods のみを見るため null になる。
-    const common = CommonSellingPrice.create(productId);
+    const common = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
     common.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await new PrismaCommonSellingPriceRepository().insert(common);
 

--- a/src/server/subdomains/product/domain/values/ProductCategory.ts
+++ b/src/server/subdomains/product/domain/values/ProductCategory.ts
@@ -66,4 +66,9 @@ export class ProductCategory extends ValueObject<string, "ProductCategory"> {
   canBeComponent(): boolean {
     return this._value !== "SET";
   }
+
+  /** セット商品か。価格集約（売単価・原価）の生成ガードで参照する（#515） */
+  isSet(): boolean {
+    return this._value === "SET";
+  }
 }

--- a/src/server/subdomains/product/domain/values/__tests__/ProductCategory.test.ts
+++ b/src/server/subdomains/product/domain/values/__tests__/ProductCategory.test.ts
@@ -92,4 +92,20 @@ describe("ProductCategory", () => {
   it("SETは構成商品になれない", () => {
     expect(ProductCategory.SET.canBeComponent()).toBe(false);
   });
+
+  // ========================================
+  // isSet: セット商品か（価格集約の生成ガードで使用・#515）
+  // ========================================
+
+  it("SETはセット商品である", () => {
+    expect(ProductCategory.SET.isSet()).toBe(true);
+  });
+
+  it("INDIVIDUALはセット商品ではない", () => {
+    expect(ProductCategory.INDIVIDUAL.isSet()).toBe(false);
+  });
+
+  it("CONSUMABLEはセット商品ではない", () => {
+    expect(ProductCategory.CONSUMABLE.isSet()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

セット商品（`ProductCategory.SET`）は売単価・原価とも自前の値を持たず常に構成商品から導出されるため、価格系4集約の write 系でセット商品への期間登録を一律拒否する。ガードは各集約のドメインファクトリ `create(..., category)` に構造的不変条件として配置し（案B×案①）、区分は ADR-0030 に従いアプリ層が `ProductQueryService` でライブ取得して渡す。write 系が実装済みの3集約（共通売単価・原価・得意先別販売単価）に適用し、納品先別は前方ポリシーとして申し送る。

Closes #515

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### set-product-price-cost-guard.md

# Issue #515: セット商品への単価・原価登録をファクトリガードで一律拒否する（4集約横断） — 実装計画

## Context

価格系の4集約（共通売単価 `CommonSellingPrice` / 原価 `CostPrice` / 得意先別販売単価 `CustomerSellingPrice` / 納品先別販売単価 `DeliveryLocationSellingPrice`）の write 系コマンドは `ProductCategory` を参照しておらず、セット商品（`ProductCategory.SET`）の `productId` を指定しても期間登録できてしまう（ガードなし）。#502（原価 BE write系）のグリル中に出た論点だが、原価単独ではなく4集約横断の方針決定になるため本 issue に先送りされていた。

### グリルで確定した業務ルール（ユーザー確認済み）

**セット商品は売単価・原価とも自前の値を持たず、常に構成商品から導出される。** 見積機構はセット商品を構成明細に自動展開し、各構成明細は構成商品自身のマスタ価格・原価を解決するため、セット商品 `productId` のマスタ価格・原価はどの機構からも参照されない（＝登録は常にデッドデータになる）。この理解は #514 が導入したグロッサリ（後述）と整合する。

### #514 グロッサリとの連携（別ブランチで先行編集）

#514 が CONTEXT.md に以下を導入済み。#515 はこの語彙に整合させる。

- **価格保守対象商品 (Priceable Product)**: 共通販売単価・原価を保守する対象。個別商品・消耗品が該当し、**セット商品は含まない**。原価一覧・共通販売単価一覧の母集合はこの区分に一致する（「全商品」ではない）。
- **未設定 (Unset)**: 期間行を1件も持たない派生状態。**母集合に含まないセット商品を「未設定」とは呼ばない**。
- **セット商品 (Set Product)**: それ自体は価格（単価・原価）を持たない（→価格保守対象商品ではない）。

### 調査で確定した事実

- **区分は不変**: `Product._category` は `private readonly`、`UpdateProductCommand` も「category は変更不可（B011）」。個別商品が後からセット商品になることはない。
- **ガードは生成入口のみで十分**: 区分不変ゆえセット商品は永久に価格集約を1つも持てない。`addPeriod`/`revise`/`editPeriod`/`endDate`/`delete` は既存集約のロードを前提とするため、セット商品では自然に「見つからない」で弾かれ到達不能。明示ガードが要るのは唯一の生成入口＝Register系コマンドの新規作成分岐（`existing === null → create`）だけ。ADR-0052 と同じ「ペイロード防御」の位置づけ。
- **read 側の母集合変更は #514 が担う**: 共通層2一覧の `FROM products p`（全商品）→ セット除外は #514 のスコープ。#515 は read 側コードを追加しない。
- **得意先別・納品先別は画面が未存在**: 価格保守UI・商品セレクタが無く、現時点でデッドエンドは発生しない。納品先別は write 系コマンド自体も未実装。
- **既存データは移行不要（監査済み）**: セット商品（`PRD005`/`PRD015–018`）と価格・原価対象（`PRD810/811/820–826`・`PRD840–847`）は重複ゼロ。得意先別・納品先別の価格 seed は存在しない。原価 backfill は既に `category === "SET"` を除外。

## 設計判断

### ガード対象範囲（Issue 未決事項）
- 案A: ガード不要（現状維持） / 案B: 4集約一律 / 案C: 集約ごと個別
- **採用: 案B（4集約一律）**（ユーザー確認済み）。業務ルールが集約横断で一様（売単価・原価とも構成品から導出）なため、案Cは根拠を欠く。上書き2層でセット商品を許すと「上書き対象の共通価格が存在しない上書き」という論理的に空虚なレコードを生む。
- 実装は write 系のある3集約（共通売単価・原価・得意先別）に施す。**納品先別は write 系未実装のため前方ポリシー**（後述）として記録。

### ガードの配置・実装方式（Issue 未決事項）
- 案①: ドメインのファクトリ `create(productId, category)` に不変条件として置く / 案②: アプリ層で `ValidationError` を投げる
- **採用: 案①（ファクトリガード）**（ユーザー確認済み）。「セット商品の価格集約は生成不能」を集約の構造的不変条件にでき、4集約で表現が統一され、将来コード・テストがうっかりセット商品の価格集約を作る事故も構造的に防げる。ADR-0052 の「ルール判定はドメインの純粋関数」に最も忠実。
- category は ADR-0030（集約越えの事実はアプリ層が集めメソッド引数で渡す）に従い、アプリ層が `ProductQueryService` でライブ取得して `create` に渡す。ドメインの純粋性を保つ。
- `ProductCategory` の pricing/domain への import は、既に全 pricing エンティティが `ProductId`（product/domain の VO）を import している越境と同性質（eslint 集約境界ルールが禁じるのは子エンティティの越境のみで VO は対象外）。

### category 取得のタイミング
- **`existing === null`（新規作成分岐）到達時のみ** `ProductQueryService.findById` を呼ぶ。区分不変性により既存集約は必ず非セットのため、更新経路では取得不要。無駄なクエリを増やさない。
- `findById` が `null`（商品不在）の場合は `ValidationError`（入力契約違反）で早期に弾く。

### インライン vs 共有ルール
- 3ファクトリの `if (category.isSet()) throw` は各1行の自明な重複。共有ヘルパ抽出は over-engineering のため**インライン**とする。

### read/UI 側の扱い（Issue 未決事項）
- **#515 では read 側コードを追加しない**（ユーザー確認済み）。共通層2一覧のセット除外は #514、得意先別・納品先別のセレクタは未存在。

### ADR 起票
- **不要**（ユーザー判断）。ファクトリガードは実装詳細であり、独立した ADR を要するアーキテクチャ判断ではない。既存の ADR-0030/0052（メソッド引数での文脈渡し・集約越え検証）の適用に閉じる。

## 前方ポリシー（将来 issue への申し送り）

1. **納品先別販売単価の write 系を実装する将来 issue**では、共通売単価・原価・得意先別と同型のファクトリガード（`DeliveryLocationSellingPrice.create` にセット商品拒否）を適用する。
2. **得意先別・納品先別の価格保守 UI・商品セレクタを実装する将来 issue**では、価格保守対象商品と同様にセット商品を選択肢から除外する（write ガードが最終担保だが、デッドエンド回避の UX 二重防御）。

</details>

## 計画からの逸脱

計画（案B×案①のファクトリガード）は方針どおり完遂。実装中に生じた機械的・補強的な逸脱が4点：

1. **`ProductCategory.isSet()` の新規追加**: 計画本文が `category.isSet()` を前提にしていたが、メソッド追加自体はステップ未記載だった。ガードの意図を明快に表す述語として `isSet()`（`this._value === "SET"`）を既存述語群に並べて追加し、専用テスト3件と共に独立コミット（`bf30e23`）。
2. **コマンドテストは「スタブ注入」ではなく「実サービス＋実SET商品」**: 既存 Register テストは実 Prisma リポジトリで実商品を insert する統合テストのため、スタブではなく実 `PrismaProductQueryService` を注入。セット商品ケースは実 SET 商品を insert して検証し、「存在しない商品ID → `ValidationError`」ケースも追加した。
3. **`create` シグネチャ変更に伴うテストフィクスチャの一括改修**: `category` を必須引数化した設計（案①）ゆえ、当該集約を組む全テストフィクスチャ（infra repository / query / list / edit、他コマンドの Revise/Edit/EndDate/Delete、`ResolveSellingPriceQuery` など横断テスト）の生成呼び出しに `ProductCategory.INDIVIDUAL` を機械的補完（各集約コミットに同梱）。
4. **各ドメインテストに「消耗品でも生成できる」ケースを追加**: 非セット成功ケースを INDIVIDUAL に加え CONSUMABLE でも明示し、ガードが SET のみを弾き CONSUMABLE を通すことを固定（#514 グロッサリ「価格保守対象商品＝個別商品・消耗品」の明文化）。

詳細は `docs/claude-plans/issue-515/deviations.md` 参照。

## Test Plan

- [ ] ドメインテスト（`CostPrice` / `CommonSellingPrice` / `CustomerSellingPrice`）: セット商品区分で `create` が `ValidationError` を throw、INDIVIDUAL / CONSUMABLE で成功する
- [ ] コマンドテスト（Register 系3集約）: セット商品 `productId` の期間登録が拒否され、存在しない商品IDは `ValidationError` になる
- [ ] `ProductCategory.isSet()` の述語テスト（SET=true / その他=false）
- [ ] `create` シグネチャ変更に追随した既存フィクスチャ（infra / query / 横断テスト）がグリーン
- [ ] `pnpm test`（pricing の domain/application）と `pnpm lint` がグリーン

---

Generated with [Claude Code](https://claude.ai/code)
