### PR TITLE
refactor: ProductCategoryのisSetをcanHavePriceに置き換える

### DIFF
--- a/docs/claude-plans/issue-531/replace-isset-with-canhaveprice.md
+++ b/docs/claude-plans/issue-531/replace-isset-with-canhaveprice.md
@@ -1,0 +1,71 @@
+# Issue #531: refactor: ProductCategoryのisSetをcanHavePriceに置き換える — 実装計画
+
+## 背景・目的（Context）
+
+#515 で価格集約（共通売単価・原価・得意先別）の `create` 生成ガードに `category.isSet()` を使い、セット商品への価格登録を拒否している。しかしこのガードの**本当の責務は「その商品が価格（単価・原価）を持てるか」の判別**であり、「セット商品かどうか」という種別判定は責務の代理にすぎない。#514 で既に `canHavePrice()`（`PRICEABLE_VALUES` = INDIVIDUAL/CONSUMABLE を単一の真実源として参照）が実装済みなので、こちらに置き換えるのが的を射ている。
+
+現行3区分では `isSet()` と `!canHavePrice()` は動作同値だが、将来「価格を持てない新区分」が増えたとき、生成ガードとして正しく拒否できるのは `canHavePrice()` 側。真実源の一元化と責務表現の是正を目的とする、振る舞いを変えないリファクタリング。
+
+あわせて、#515 で「4集約横断」と謳いつつ生成ガードが未実装だった **納品先別販売単価（DeliveryLocationSellingPrice）にもガードを追加**し、4集約を対称化する（ユーザー確認済み方針）。
+
+## 設計判断
+
+### `isSet()` メソッドの扱い
+- 置き換え後 `isSet()` の実使用は消える。**メソッド本体・テスト（3ケース）とも削除**する（ユーザー確認済み）。真実源を `canHavePrice()` / `PRICEABLE_VALUES` に一元化する。
+
+### 生成ガードのエラーメッセージ
+- 現状「セット商品には{ENTITY}を登録できません」を**維持**する（ユーザー確認済み）。現行区分では拒否対象がSETのみのため文言は正確。よって既存ガードテスト（3集約分）はアサーション変更なしで通過する。
+
+### 納品先別のガード追加の実効範囲
+- `DeliveryLocationSellingPrice.create()` に `category: ProductCategory` を必須引数として追加し、他3集約と対称化する。ただし**納品先別には Register コマンド（アプリ層の登録経路）が未実装**のため、本番コードに `create()` の呼び出し元は存在しない。したがって本Issueでの追加は「create署名＋ガード＋ドメイン/インフラテストの更新」に留まり、実効的な保護経路は将来 DL Register 実装時に有効化される（予防的な対称化）。
+
+### DDDレイヤリング
+- 変更は Domain 層（ProductCategory VO と4集約エンティティ）に閉じる。区分は集約越えの事実のためアプリ層がライブ取得してドメインへ引数で渡す既存方式（ADR-0030）を踏襲。新規のレイヤ違反なし。
+
+## ステップ
+
+### Step 1: 既存3集約の生成ガードを canHavePrice ベースに置き換え
+- 対象ファイル:
+  - `src/server/subdomains/pricing/domain/entities/CommonSellingPrice.ts`（L39）
+  - `src/server/subdomains/pricing/domain/entities/CostPrice.ts`（L40）
+  - `src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts`（L46）
+- 作業内容:
+  - 各 `create()` 内の `if (category.isSet())` を `if (!category.canHavePrice())` に置換
+  - エラーメッセージは現状維持
+  - JSDoc コメントの「#515」参照・文言を責務ベース（価格を持てない商品を生成入口で拒否）に微修正（意味は維持）
+  - 3集約のテストがガード挙動（SET拒否・非SET許可）を担保していることを確認（アサーション変更不要の想定）
+- コミットメッセージ: `refactor: 価格3集約の生成ガードを isSet から canHavePrice に置換 (#531)`
+
+### Step 2: 納品先別販売単価にも canHavePrice ガードを追加
+- 対象ファイル:
+  - `src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPrice.ts`
+  - テスト呼び出し側（`create` にcategory引数追加のため更新）:
+    - `.../domain/entities/__tests__/DeliveryLocationSellingPrice.test.ts`
+    - `.../infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts`
+    - `.../infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceQueryService.test.ts`
+    - `.../application/queries/__tests__/ResolveSellingPriceQuery.test.ts`
+    - `.../application/queries/__tests__/ResolveDeliveryLocationSellingPriceQuery.test.ts`
+- 作業内容:
+  - `create(deliveryLocationId, productId)` → `create(deliveryLocationId, productId, category: ProductCategory)` に変更し、`if (!category.canHavePrice())` ガードを追加（他3集約と同型のJSDoc・エラーメッセージ「セット商品には納品先別販売単価を登録できません」）
+  - 既存の全 `create` 呼び出しに `ProductCategory.INDIVIDUAL` 等の非セット区分を渡すよう更新
+  - DL集約テストに「SET拒否・非SET許可」ケースを追加
+- コミットメッセージ: `feat: 納品先別販売単価の生成ガードを追加し価格4集約を対称化 (#531)`
+
+### Step 3: ProductCategory の isSet メソッドとテストを削除
+- 対象ファイル:
+  - `src/server/subdomains/product/domain/values/ProductCategory.ts`（L93-96）
+  - `src/server/subdomains/product/domain/values/__tests__/ProductCategory.test.ts`（L120-134 の isSet 3ケース）
+- 作業内容:
+  - 未使用になった `isSet()` メソッド定義を削除
+  - 対応する isSet テスト3ケースを削除
+  - `canHavePrice()` / `priceableValues()` のテストが引き続き責務を担保していることを確認
+- コミットメッセージ: `refactor: 未使用になった ProductCategory.isSet を削除 (#531)`
+
+## 検証（Verification）
+
+- `pnpm test` — 変更した4集約・ProductCategory・関連アプリ/インフラテストが全て通過すること
+  - 特に3集約の既存ガードテスト（SET拒否）がアサーション変更なしで緑であること（＝振る舞い不変の確認）
+  - DL集約に追加したガードテスト（SET拒否・非SET許可）が通過すること
+- `pnpm lint` — 型エラー・未使用importなし
+- `grep -rn "isSet" src` — 参照が完全に消えていること（メソッド・テスト・コメント）
+- （任意）`grep -rn "canHavePrice" src` — 4集約すべてがガードに `canHavePrice` を使う状態に揃っていること

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveDeliveryLocationSellingPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveDeliveryLocationSellingPriceQuery.test.ts
@@ -84,7 +84,11 @@ describe("ResolveDeliveryLocationSellingPriceQuery", () => {
   });
 
   it("基準暦日に有効な納品先別販売単価を解決する", async () => {
-    const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveSellingPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveSellingPriceQuery.test.ts
@@ -148,7 +148,8 @@ describe("ResolveSellingPriceQuery", () => {
 
     const deliveryLocationPrice = DeliveryLocationSellingPrice.create(
       deliveryLocationId,
-      productId
+      productId,
+      ProductCategory.INDIVIDUAL
     );
     deliveryLocationPrice.addPeriod(period("2025-07-01", null), price(700));
     await deliveryLocationRepo.insert(deliveryLocationPrice);

--- a/src/server/subdomains/pricing/domain/entities/CommonSellingPrice.ts
+++ b/src/server/subdomains/pricing/domain/entities/CommonSellingPrice.ts
@@ -30,13 +30,14 @@ export class CommonSellingPrice {
   ) {}
 
   /**
-   * 空の集約を生成する。セット商品は自前の売単価を持たず常に構成商品から導出されるため、
-   * 生成入口で拒否する（#515）。区分不変ゆえ生成入口を塞げば以後の追加・改定・削除も
-   * 既存集約が存在しないことで構造的に到達不能になる。区分は集約越えの事実のため
-   * アプリ層が取得して引数で渡す（ADR-0030）。
+   * 空の集約を生成する。価格を持てない商品（現状はセット商品。自前の売単価を持たず常に
+   * 構成商品から導出される）を生成入口で拒否する（#515/#531）。判定は「価格を持てるか」
+   * という責務そのものを表す canHavePrice に委ねる。区分不変ゆえ生成入口を塞げば以後の
+   * 追加・改定・削除も既存集約が存在しないことで構造的に到達不能になる。区分は集約越えの
+   * 事実のためアプリ層が取得して引数で渡す（ADR-0030）。
    */
   static create(productId: ProductId, category: ProductCategory): CommonSellingPrice {
-    if (category.isSet()) {
+    if (!category.canHavePrice()) {
       throw new ValidationError(`セット商品には${CommonSellingPrice.ENTITY_NAME}を登録できません`);
     }
     return new CommonSellingPrice(productId, []);

--- a/src/server/subdomains/pricing/domain/entities/CostPrice.ts
+++ b/src/server/subdomains/pricing/domain/entities/CostPrice.ts
@@ -31,13 +31,14 @@ export class CostPrice {
   ) {}
 
   /**
-   * 空の集約を生成する。セット商品は自前の原価を持たず常に構成商品から導出されるため、
-   * 生成入口で拒否する（#515）。区分不変ゆえ生成入口を塞げば以後の追加・改定・削除も
-   * 既存集約が存在しないことで構造的に到達不能になる。区分は集約越えの事実のため
-   * アプリ層が取得して引数で渡す（ADR-0030）。
+   * 空の集約を生成する。価格を持てない商品（現状はセット商品。自前の原価を持たず常に
+   * 構成商品から導出される）を生成入口で拒否する（#515/#531）。判定は「価格を持てるか」
+   * という責務そのものを表す canHavePrice に委ねる。区分不変ゆえ生成入口を塞げば以後の
+   * 追加・改定・削除も既存集約が存在しないことで構造的に到達不能になる。区分は集約越えの
+   * 事実のためアプリ層が取得して引数で渡す（ADR-0030）。
    */
   static create(productId: ProductId, category: ProductCategory): CostPrice {
-    if (category.isSet()) {
+    if (!category.canHavePrice()) {
       throw new ValidationError(`セット商品には${CostPrice.ENTITY_NAME}を登録できません`);
     }
     return new CostPrice(productId, []);

--- a/src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts
+++ b/src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts
@@ -33,17 +33,18 @@ export class CustomerSellingPrice {
   ) {}
 
   /**
-   * 空の集約を生成する。セット商品は自前の売単価を持たず常に構成商品から導出されるため、
-   * 生成入口で拒否する（#515）。区分不変ゆえ生成入口を塞げば以後の追加・改定・削除も
-   * 既存集約が存在しないことで構造的に到達不能になる。区分は集約越えの事実のため
-   * アプリ層が取得して引数で渡す（ADR-0030）。customerId は複合自然キーの先頭のため維持する。
+   * 空の集約を生成する。価格を持てない商品（現状はセット商品。自前の売単価を持たず常に
+   * 構成商品から導出される）を生成入口で拒否する（#515/#531）。判定は「価格を持てるか」
+   * という責務そのものを表す canHavePrice に委ねる。区分不変ゆえ生成入口を塞げば以後の
+   * 追加・改定・削除も既存集約が存在しないことで構造的に到達不能になる。区分は集約越えの
+   * 事実のためアプリ層が取得して引数で渡す（ADR-0030）。customerId は複合自然キーの先頭のため維持する。
    */
   static create(
     customerId: CustomerId,
     productId: ProductId,
     category: ProductCategory
   ): CustomerSellingPrice {
-    if (category.isSet()) {
+    if (!category.canHavePrice()) {
       throw new ValidationError(
         `セット商品には${CustomerSellingPrice.ENTITY_NAME}を登録できません`
       );

--- a/src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPrice.ts
+++ b/src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPrice.ts
@@ -1,6 +1,7 @@
 import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
-import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
 import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { DeliveryLocationSellingPricePeriodId } from "../values/DeliveryLocationSellingPricePeriodId";
 import { SellingUnitPrice } from "../values/SellingUnitPrice";
@@ -31,11 +32,23 @@ export class DeliveryLocationSellingPrice {
     private readonly _periods: DeliveryLocationSellingPricePeriod[]
   ) {}
 
-  /** 空の集約を生成する。 */
+  /**
+   * 空の集約を生成する。価格を持てない商品（現状はセット商品。自前の売単価を持たず常に
+   * 構成商品から導出される）を生成入口で拒否する（#515/#531）。判定は「価格を持てるか」
+   * という責務そのものを表す canHavePrice に委ねる。区分不変ゆえ生成入口を塞げば以後の
+   * 追加・改定・削除も既存集約が存在しないことで構造的に到達不能になる。区分は集約越えの
+   * 事実のためアプリ層が取得して引数で渡す（ADR-0030）。
+   */
   static create(
     deliveryLocationId: DeliveryLocationId,
-    productId: ProductId
+    productId: ProductId,
+    category: ProductCategory
   ): DeliveryLocationSellingPrice {
+    if (!category.canHavePrice()) {
+      throw new ValidationError(
+        `セット商品には${DeliveryLocationSellingPrice.ENTITY_NAME}を登録できません`
+      );
+    }
     return new DeliveryLocationSellingPrice(deliveryLocationId, productId, []);
   }
 

--- a/src/server/subdomains/pricing/domain/entities/__tests__/DeliveryLocationSellingPrice.test.ts
+++ b/src/server/subdomains/pricing/domain/entities/__tests__/DeliveryLocationSellingPrice.test.ts
@@ -1,7 +1,8 @@
 import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
 import { Money } from "@server/shared/domain/values/Money";
-import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
 import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
 import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { describe, expect, it } from "vitest";
 import { DeliveryLocationSellingPricePeriodId } from "../../values/DeliveryLocationSellingPricePeriodId";
@@ -16,16 +17,40 @@ const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(y
 describe("DeliveryLocationSellingPrice 集約", () => {
   describe("生成", () => {
     it("納品先ID×商品IDで空の集約を生成できる", () => {
-      const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       expect(aggregate.deliveryLocationId.equals(deliveryLocationId)).toBe(true);
       expect(aggregate.productId.equals(productId)).toBe(true);
       expect(aggregate.periods).toHaveLength(0);
+    });
+
+    it("消耗品でも空の集約を生成できる（価格保守対象商品・#531）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.CONSUMABLE
+      );
+      expect(aggregate.periods).toHaveLength(0);
+    });
+
+    it("セット商品区分では納品先別販売単価集約を生成できない（ValidationError・#531）", () => {
+      // 価格を持てない商品（現状はセット商品）は生成入口で拒否する（canHavePrice ガード）。
+      expect(() =>
+        DeliveryLocationSellingPrice.create(deliveryLocationId, productId, ProductCategory.SET)
+      ).toThrow(ValidationError);
     });
   });
 
   describe("addPeriod — 適用期間行の追加", () => {
     it("期間行を追加でき、期間と単価が保持される", () => {
-      const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
 
       expect(aggregate.periods).toHaveLength(1);
@@ -35,7 +60,11 @@ describe("DeliveryLocationSellingPrice 集約", () => {
     });
 
     it("採番された identity が各行に付与される", () => {
-      const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
       aggregate.addPeriod(period("2025-10-01", null), price(1200));
 
@@ -44,7 +73,11 @@ describe("DeliveryLocationSellingPrice 集約", () => {
     });
 
     it("重ならない期間は複数追加できる（隣接含む）", () => {
-      const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
       aggregate.addPeriod(period("2025-10-01", null), price(1200));
 
@@ -52,7 +85,11 @@ describe("DeliveryLocationSellingPrice 集約", () => {
     });
 
     it("既存期間と重複する期間は BusinessRuleViolationError", () => {
-      const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
 
       expect(() => aggregate.addPeriod(period("2025-09-01", "2025-12-01"), price(1100))).toThrow(
@@ -63,7 +100,11 @@ describe("DeliveryLocationSellingPrice 集約", () => {
     });
 
     it("無期限行があるとき、その開始日以降に重なる期間は弾く", () => {
-      const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
       aggregate.addPeriod(period("2025-07-01", null), price(1000));
 
       expect(() => aggregate.addPeriod(period("2030-01-01", "2030-02-01"), price(1100))).toThrow(

--- a/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts
@@ -88,7 +88,11 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
   });
 
   it("insert して findByDeliveryLocationIdAndProductId で往復できる（有界＋無期限・銭精度）", async () => {
-    const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
     aggregate.addPeriod(period("2025-10-01", null), price(1234.56));
     await repository.insert(aggregate);
@@ -111,7 +115,11 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
   });
 
   it("update で期間行を追加同期できる（version 一致時・append-only）", async () => {
-    const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
     await repository.insert(aggregate);
 
@@ -132,7 +140,11 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
   });
 
   it("update は既存期間行の updated_at を変更しない（append-only・監査保持）", async () => {
-    const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
     await repository.insert(aggregate);
 
@@ -167,7 +179,11 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
   });
 
   it("古い expectedVersion での update は ConflictError", async () => {
-    const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", null), price(1000));
     await repository.insert(aggregate);
 
@@ -175,18 +191,30 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
   });
 
   it("同一の納品先×商品への二重 insert は ConflictError（親 複合PK 衝突の翻訳）", async () => {
-    const first = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const first = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     first.addPeriod(period("2025-07-01", null), price(1000));
     await repository.insert(first);
 
     // アプリ層の存在チェックをすり抜けた二重作成レースを模す。
-    const second = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const second = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     second.addPeriod(period("2025-07-01", null), price(2000));
     await expect(repository.insert(second)).rejects.toBeInstanceOf(ConflictError);
   });
 
   it("同一の納品先×商品で適用期間が重複する行は EXCLUDE 制約で弾かれる", async () => {
-    const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceQueryService.test.ts
@@ -114,7 +114,11 @@ describe("PrismaDeliveryLocationSellingPriceQueryService", () => {
   });
 
   it("区間内の暦日で有効な納品先別単価を引く", async () => {
-    const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
     await repository.insert(aggregate);
 
@@ -128,7 +132,11 @@ describe("PrismaDeliveryLocationSellingPriceQueryService", () => {
   });
 
   it("同じ商品でも別の納品先では引かない（納品先キーの隔離）", async () => {
-    const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
     await repository.insert(aggregate);
 
@@ -142,7 +150,11 @@ describe("PrismaDeliveryLocationSellingPriceQueryService", () => {
   });
 
   it("同じ納品先でも別の商品では引かない（商品キーの隔離）", async () => {
-    const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
     await repository.insert(aggregate);
 
@@ -172,7 +184,11 @@ describe("PrismaDeliveryLocationSellingPriceQueryService", () => {
   });
 
   it("どの適用期間にも覆われない暦日では null を返す", async () => {
-    const aggregate = DeliveryLocationSellingPrice.create(deliveryLocationId, productId);
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
     await repository.insert(aggregate);
 

--- a/src/server/subdomains/product/domain/values/ProductCategory.ts
+++ b/src/server/subdomains/product/domain/values/ProductCategory.ts
@@ -89,9 +89,4 @@ export class ProductCategory extends ValueObject<string, "ProductCategory"> {
   static priceableValues(): readonly string[] {
     return PRICEABLE_VALUES;
   }
-
-  /** セット商品か。価格集約（売単価・原価）の生成ガードで参照する（#515） */
-  isSet(): boolean {
-    return this._value === "SET";
-  }
 }

--- a/src/server/subdomains/product/domain/values/__tests__/ProductCategory.test.ts
+++ b/src/server/subdomains/product/domain/values/__tests__/ProductCategory.test.ts
@@ -116,20 +116,4 @@ describe("ProductCategory", () => {
   it("価格保守対象商品の区分値は個別商品・消耗品", () => {
     expect(ProductCategory.priceableValues()).toEqual(["INDIVIDUAL", "CONSUMABLE"]);
   });
-
-  // ========================================
-  // isSet: セット商品か（価格集約の生成ガードで使用・#515）
-  // ========================================
-
-  it("SETはセット商品である", () => {
-    expect(ProductCategory.SET.isSet()).toBe(true);
-  });
-
-  it("INDIVIDUALはセット商品ではない", () => {
-    expect(ProductCategory.INDIVIDUAL.isSet()).toBe(false);
-  });
-
-  it("CONSUMABLEはセット商品ではない", () => {
-    expect(ProductCategory.CONSUMABLE.isSet()).toBe(false);
-  });
 });


### PR DESCRIPTION
## Summary

価格を持てるかどうかの判別を `ProductCategory.isSet` から本来の責務を表す `canHavePrice()` に置き換え、価格4集約（共通販売単価・原価・得意先別販売単価・納品先別販売単価）の生成ガードを対称化しました。未使用となった `isSet` は削除しています。

Closes #531

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### replace-isset-with-canhaveprice.md

# Issue #531: refactor: ProductCategoryのisSetをcanHavePriceに置き換える — 実装計画

## 背景・目的（Context）

#515 で価格集約（共通売単価・原価・得意先別）の `create` 生成ガードに `category.isSet()` を使い、セット商品への価格登録を拒否している。しかしこのガードの**本当の責務は「その商品が価格（単価・原価）を持てるか」の判別**であり、「セット商品かどうか」という種別判定は責務の代理にすぎない。#514 で既に `canHavePrice()`（`PRICEABLE_VALUES` = INDIVIDUAL/CONSUMABLE を単一の真実源として参照）が実装済みなので、こちらに置き換えるのが的を射ている。

現行3区分では `isSet()` と `!canHavePrice()` は動作同値だが、将来「価格を持てない新区分」が増えたとき、生成ガードとして正しく拒否できるのは `canHavePrice()` 側。真実源の一元化と責務表現の是正を目的とする、振る舞いを変えないリファクタリング。

あわせて、#515 で「4集約横断」と謳いつつ生成ガードが未実装だった **納品先別販売単価（DeliveryLocationSellingPrice）にもガードを追加**し、4集約を対称化する（ユーザー確認済み方針）。

## 設計判断

### `isSet()` メソッドの扱い
- 置き換え後 `isSet()` の実使用は消える。**メソッド本体・テスト（3ケース）とも削除**する（ユーザー確認済み）。真実源を `canHavePrice()` / `PRICEABLE_VALUES` に一元化する。

### 生成ガードのエラーメッセージ
- 現状「セット商品には{ENTITY}を登録できません」を**維持**する（ユーザー確認済み）。現行区分では拒否対象がSETのみのため文言は正確。よって既存ガードテスト（3集約分）はアサーション変更なしで通過する。

### 納品先別のガード追加の実効範囲
- `DeliveryLocationSellingPrice.create()` に `category: ProductCategory` を必須引数として追加し、他3集約と対称化する。ただし**納品先別には Register コマンド（アプリ層の登録経路）が未実装**のため、本番コードに `create()` の呼び出し元は存在しない。したがって本Issueでの追加は「create署名＋ガード＋ドメイン/インフラテストの更新」に留まり、実効的な保護経路は将来 DL Register 実装時に有効化される（予防的な対称化）。

### DDDレイヤリング
- 変更は Domain 層（ProductCategory VO と4集約エンティティ）に閉じる。区分は集約越えの事実のためアプリ層がライブ取得してドメインへ引数で渡す既存方式（ADR-0030）を踏襲。新規のレイヤ違反なし。

## ステップ

### Step 1: 既存3集約の生成ガードを canHavePrice ベースに置き換え
- 対象ファイル:
  - `src/server/subdomains/pricing/domain/entities/CommonSellingPrice.ts`（L39）
  - `src/server/subdomains/pricing/domain/entities/CostPrice.ts`（L40）
  - `src/server/subdomains/pricing/domain/entities/CustomerSellingPrice.ts`（L46）
- 作業内容:
  - 各 `create()` 内の `if (category.isSet())` を `if (!category.canHavePrice())` に置換
  - エラーメッセージは現状維持
  - JSDoc コメントの「#515」参照・文言を責務ベース（価格を持てない商品を生成入口で拒否）に微修正（意味は維持）
  - 3集約のテストがガード挙動（SET拒否・非SET許可）を担保していることを確認（アサーション変更不要の想定）
- コミットメッセージ: `refactor: 価格3集約の生成ガードを isSet から canHavePrice に置換 (#531)`

### Step 2: 納品先別販売単価にも canHavePrice ガードを追加
- 対象ファイル:
  - `src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPrice.ts`
  - テスト呼び出し側（`create` にcategory引数追加のため更新）:
    - `.../domain/entities/__tests__/DeliveryLocationSellingPrice.test.ts`
    - `.../infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts`
    - `.../infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceQueryService.test.ts`
    - `.../application/queries/__tests__/ResolveSellingPriceQuery.test.ts`
    - `.../application/queries/__tests__/ResolveDeliveryLocationSellingPriceQuery.test.ts`
- 作業内容:
  - `create(deliveryLocationId, productId)` → `create(deliveryLocationId, productId, category: ProductCategory)` に変更し、`if (!category.canHavePrice())` ガードを追加（他3集約と同型のJSDoc・エラーメッセージ「セット商品には納品先別販売単価を登録できません」）
  - 既存の全 `create` 呼び出しに `ProductCategory.INDIVIDUAL` 等の非セット区分を渡すよう更新
  - DL集約テストに「SET拒否・非SET許可」ケースを追加
- コミットメッセージ: `feat: 納品先別販売単価の生成ガードを追加し価格4集約を対称化 (#531)`

### Step 3: ProductCategory の isSet メソッドとテストを削除
- 対象ファイル:
  - `src/server/subdomains/product/domain/values/ProductCategory.ts`（L93-96）
  - `src/server/subdomains/product/domain/values/__tests__/ProductCategory.test.ts`（L120-134 の isSet 3ケース）
- 作業内容:
  - 未使用になった `isSet()` メソッド定義を削除
  - 対応する isSet テスト3ケースを削除
  - `canHavePrice()` / `priceableValues()` のテストが引き続き責務を担保していることを確認
- コミットメッセージ: `refactor: 未使用になった ProductCategory.isSet を削除 (#531)`

## 検証（Verification）

- `pnpm test` — 変更した4集約・ProductCategory・関連アプリ/インフラテストが全て通過すること
  - 特に3集約の既存ガードテスト（SET拒否）がアサーション変更なしで緑であること（＝振る舞い不変の確認）
  - DL集約に追加したガードテスト（SET拒否・非SET許可）が通過すること
- `pnpm lint` — 型エラー・未使用importなし
- `grep -rn "isSet" src` — 参照が完全に消えていること（メソッド・テスト・コメント）
- （任意）`grep -rn "canHavePrice" src` — 4集約すべてがガードに `canHavePrice` を使う状態に揃っていること

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

---

Generated with [Claude Code](https://claude.ai/code)
