### PR TITLE
feat: 納品先別販売単価の書き込みユースケース（ドメイン編集操作 + commands/factories）

### DIFF
--- a/docs/claude-plans/issue-545/delivery-location-selling-price-write-usecase.md
+++ b/docs/claude-plans/issue-545/delivery-location-selling-price-write-usecase.md
@@ -1,0 +1,134 @@
+# Issue #545: 納品先別販売単価の書き込みユースケース（ドメイン編集操作 + commands/factories） — 実装計画
+
+## Context
+
+納品先別販売単価 `DeliveryLocationSellingPrice` は、集約・スキーマ・時点解決 QueryService まで実装済みだが、
+編集系の「書き込み」関心が未実装。現状の集約は `addPeriod`（追加）しか持たず、application 層に
+コマンドも factory も無いため、画面から登録・編集・改定・適用終了・削除ができない。
+
+本 Issue は親 #544 の分割のうち **BE 書き込み側**。既に完成している **得意先別 #505**（`CustomerSellingPrice`）が
+ほぼ完全なテンプレートで、identity が複合自然キー `DeliveryLocationId × ProductId` である点だけが異なる。
+得意先別と同型に補完し、納品先別の書き込みユースケースを機能させることが目的。
+
+**調査で判明した重要事実**: Issue 本文の「含む」スコープはドメイン編集操作 + commands + factories を挙げるが、
+現状の `PrismaDeliveryLocationSellingPriceRepository` は **追記専用（append-only, `ON CONFLICT DO NOTHING`）**で
+実装されている（過去に mutation が `addPeriod` のみだった前提）。`editPeriod`（将来行の内容差し替え）・
+`endDatePeriod`（終了日書き換え）・`deletePeriod`（行削除）は既存行の in-place 更新・削除を伴うため、
+追記専用のままではこれらの書き込みが**黙って失われる**。したがってインフラ層の改修が必須で、
+ユーザー確認済みで本 Issue に含める。
+
+## 設計判断
+
+### 全体方針: 得意先別 #505 の完全踏襲
+- 得意先別（`CustomerSellingPrice` 集約 / `*CustomerSellingPricePeriodCommand` / `*CommandFactory`）を
+  identity（`CustomerId` → `DeliveryLocationId`）だけ差し替えて模倣する。参照日注入（input に `referenceDate`）・
+  楽観ロック（input に `expectedVersion`、既存集約追加時は必須で未指定は `ValidationError`）・結果型（登録後の集約を返す）は
+  すべて得意先別と同一契約。判断不要（既存パターン踏襲）。
+
+### インフラ層の期間行永続化ヘルパの共有範囲（Issue の未決事項）
+- 共通ヘルパ `sellingPricePeriodPersistence.ts` に差分同期版 `syncPeriodRows`（upsert＋消えた id の削除）が
+  **既に存在**し、得意先別リポジトリが使用中。納品先別も `update()` を `appendPeriodRows` → `syncPeriodRows` へ
+  切替え、`delete()` を追加するだけでよい。**ヘルパ自体の改修は不要**。判断不要。
+
+### factory の「pricingQueryFactory への配線」の解釈
+- Issue は「`pricingQueryFactory` への配線含む」と記すが、得意先別の書き込み factory は
+  `registerCustomerSellingPricePeriodCommandFactory.ts` 等の**独立ファイル**として実装されており、
+  `pricingQueryFactory.ts`（読みモデル/時点解決 query の factory 群）には**書き込みコマンドは配線されていない**。
+- 推奨: 得意先別踏襲で独立 factory ファイル 5 本を新設し、`pricingQueryFactory.ts` は**変更しない**。
+  （書き込み factory を pricingQueryFactory に集約する構成変更は本 Issue の関心外）
+
+### 状態別（future / active / expired）の編集・削除権限
+- 集約の不変条件として得意先別と同一に展開する（判断不要）:
+  editPeriod=将来行のみ / endDatePeriod=現在有効行のみ・短縮限定 / deletePeriod=未来開始行のみ /
+  addPeriod=開始日 ≥ 参照日・重複禁止。すべて `BusinessRuleViolationError`。
+
+### スコープ逸脱の記録
+- Issue「含む」に無いインフラ層改修を追加するため、完了時に `docs/claude-plans/issue-545/deviations.md` へ
+  {元の計画=含むにインフラ層記載なし}／{実際=書き込み機能に必須のため追加}／{理由} を記録する（CLAUDE.md 準拠）。
+
+## ステップ
+
+### Step 1: ドメイン層 — 編集操作の補完
+- 対象ファイル:
+  - `src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPricePeriod.ts`
+  - `src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPrice.ts`
+  - `src/server/subdomains/pricing/domain/entities/__tests__/DeliveryLocationSellingPrice.test.ts`
+- 作業内容（得意先別を鏡像コピー）:
+  - 子エンティティ: `_period`/`_price` を mutable 化し、`changeTo(period, price)` と `endDateOn(endDate)` を追加
+    （`CustomerSellingPricePeriod.ts` L33-48 と同一）
+  - 集約ルート: `addPeriod` に `referenceDate` 引数を追加（`assertStartNotPast`）。
+    `editPeriod` / `endDatePeriod` / `deletePeriod` / `currentValidPeriod` / `isEmpty` getter と、
+    private helper `requireRow` / `isFuture` / `assertStartNotPast` / `assertNoOverlap` を追加
+    （`CustomerSellingPrice.ts` L79-233 と同一。ENTITY_NAME だけ「納品先別販売単価」）
+  - 集約テスト: 得意先別 `CustomerSellingPrice.test.ts`（34 ケース）を鏡像に拡充。
+    編集・適用終了・削除・現在有効行取得・過去不変ガード・状態別権限を網羅
+- コミットメッセージ: `feat: 納品先別販売単価集約に編集系ミューテータを補完（edit/endDate/delete/currentValid）`
+
+### Step 2: インフラ層 — 差分同期化と delete 追加
+- 対象ファイル:
+  - `src/server/subdomains/pricing/domain/repositories/DeliveryLocationSellingPriceRepository.ts`
+  - `src/server/subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository.ts`
+  - `src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts`
+- 作業内容（得意先別リポジトリ L80-143 と同型）:
+  - interface に `delete(aggregate, expectedVersion): Promise<void>` を追加（`CustomerSellingPriceRepository` L36-46 相当）
+  - Prisma 実装: `PERIOD_TABLE` を static 定数化。`update()` の `writePeriods`（append）を
+    `syncPeriodRows(tx, PERIOD_TABLE, [deliveryLocationId, productId], toWriteRows)` へ切替。
+    `writePeriods`（`appendPeriodRows`）は insert 専用として残す。`delete()` を `deleteMany`＋`assertVersionBumped` で追加。
+    クラス doc の「append-only で削除分岐は到達不能」の記述を差分 sync 前提へ更新
+  - リポジトリテスト: 得意先別テストの追加ケースを移植 — 将来行の in-place 編集反映／消えた行の削除／
+    最終行削除で 0 件（空配列バインド）／`delete` の cascade／`delete` の古い version で ConflictError／
+    delete 後の再 insert 成功。既存の「append-only」文言のテストを sync 前提へ修正
+- コミットメッセージ: `feat: 納品先別販売単価リポジトリを差分sync化しdeleteを追加（編集・適用終了・削除の永続化）`
+  - ボディに「append-only→syncPeriodRows 切替の理由（edit/endDate/delete が既存行の in-place 更新・削除を伴うため）」を記載
+
+### Step 3: application/commands — 共有ヘルパ + Register
+- 対象ファイル（新規）:
+  - `src/server/subdomains/pricing/application/commands/loadDeliveryLocationSellingPriceOrThrow.ts`
+  - `src/server/subdomains/pricing/application/commands/RegisterDeliveryLocationSellingPricePeriodCommand.ts`
+  - `src/server/subdomains/pricing/application/commands/__tests__/RegisterDeliveryLocationSellingPricePeriodCommand.test.ts`
+- 作業内容:
+  - `loadDeliveryLocationSellingPriceOrThrow`: `findByDeliveryLocationIdAndProductId` で取得し無ければ `NotFoundEntityError`
+    （得意先別 `loadCustomerSellingPriceOrThrow.ts` と同型）
+  - Register: 未設定なら `ProductQueryService.findById` で区分取得 → `DeliveryLocationSellingPrice.create`（セット商品ガード・
+    **create() の初回呼び出し元**・#531 申し送り確認）→ `addPeriod` → `insert`。既存なら `expectedVersion` 必須で `addPeriod` → `update`
+    （得意先別 `RegisterCustomerSellingPricePeriodCommand.ts` L41-78 と同一）
+  - テストは得意先別 Register テストを鏡像に移植
+- コミットメッセージ: `feat: 納品先別販売単価の登録コマンドと取得ヘルパを追加`
+
+### Step 4: application/commands — 編集系 4 種（Edit / EndDate / Delete / Revise）
+- 対象ファイル（新規、各コマンド + テスト）:
+  - `Edit` / `EndDate` / `Delete` / `Revise` `DeliveryLocationSellingPricePeriodCommand.ts` と `__tests__/*`
+- 作業内容:
+  - いずれも `loadDeliveryLocationSellingPriceOrThrow` で集約取得後、対応ミューテータを呼んで `update`
+    （Delete のみ `aggregate.isEmpty` で `delete`/`update` を分岐、Revise は endDate→addPeriod の順で合成）。
+    得意先別の同名コマンドを identity 差し替えで鏡像コピー
+  - 各コマンドテストも得意先別から移植
+- コミットメッセージ: `feat: 納品先別販売単価の編集・適用終了・削除・改定コマンドを追加`
+
+### Step 5: application/factories — 書き込みコマンドの DI
+- 対象ファイル（新規 5 本）:
+  - `register` / `edit` / `revise` / `endDate` / `delete` `DeliveryLocationSellingPricePeriodCommandFactory.ts`
+- 作業内容:
+  - 各 factory は `new PrismaDeliveryLocationSellingPriceRepository()` を注入して対応コマンドを構築。
+    Register のみ `new PrismaProductQueryService()` も注入（得意先別 factory 群と同型）。
+  - `pricingQueryFactory.ts` は変更しない（設計判断参照）。factory はテスト対象外（薄い DI・得意先別も無し）
+- コミットメッセージ: `feat: 納品先別販売単価 書き込みコマンドの factory を追加`
+
+### Step 6: 逸脱記録
+- 対象ファイル: `docs/claude-plans/issue-545/deviations.md`（新規）
+- 作業内容: インフラ層改修をスコープに追加した経緯を記録（設計判断「スコープ逸脱の記録」参照）
+- コミットメッセージ: `docs: issue-545 のスコープ逸脱（インフラ層追加）を記録`
+
+## 検証
+
+- **ユニット/統合**: 変更に関係するスペックのみ実行（ローカルで全 E2E は回さない）
+  ```bash
+  pnpm test src/server/subdomains/pricing/domain/entities/__tests__/DeliveryLocationSellingPrice.test.ts
+  pnpm test src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts
+  pnpm test src/server/subdomains/pricing/application/commands/__tests__/  # 5 コマンド
+  ```
+  - リポジトリテストは実 DB を使う統合テスト。差分 sync（in-place 編集反映・消えた行削除・空集約 delete）と
+    delete の cascade / ConflictError が緑になることを確認
+- **型/lint**: `pnpm lint`（子エンティティを集約外から import していないか eslint `no-restricted-imports` で担保されることも確認）
+- **レイヤ規約**: ドメイン層が Prisma/Next を import していないこと、application が repository **interface** に依存していることを確認（CLAUDE.md DDD ルール）
+- **読みモデル/FE は本 Issue 対象外**（#546 以降）。書き込みコマンドが集約経由で永続化まで通ることをテストで担保する

--- a/docs/claude-plans/issue-545/deviations.md
+++ b/docs/claude-plans/issue-545/deviations.md
@@ -1,0 +1,47 @@
+# Issue #545 実装の逸脱記録
+
+## 1. スコープ外のインフラ層改修（リポジトリの差分sync化 + delete追加 + interfaceへのdelete追加）
+
+### 元の計画 / Issue 文言
+
+Issue #545 の「含む」スコープは以下の3点のみを挙げていた:
+
+> - ドメイン編集操作（`editPeriod` / `endDatePeriod` / `deletePeriod` / `currentValidPeriod`）
+> - application/commands（Register / Edit / Revise / EndDate / Delete + 共有ヘルパ）
+> - application/factories（DI・pricingQueryFactory への配線含む）
+
+インフラ層（`PrismaDeliveryLocationSellingPriceRepository` / `DeliveryLocationSellingPriceRepository`
+インターフェース）の改修は Issue 本文に一切記載がなかった。
+
+### 実際の実装
+
+以下のインフラ層改修を本 Issue に追加した（計画時にユーザー承認済み）:
+
+- **リポジトリ interface**: `delete(aggregate, expectedVersion): Promise<void>` を追加。
+  `update` の doc を append-only → 差分 sync 前提へ更新。
+- **Prisma 実装**: `update` の期間行同期を `appendPeriodRows`（追記専用）から `syncPeriodRows`
+  （差分 upsert + 集約から消えた id の削除）へ切替。`delete` を親 version 条件付き `deleteMany` +
+  `assertVersionBumped` で実装。`PERIOD_TABLE` を static 定数化し、insert 専用の append `writePeriods`
+  と行変換 `toWriteRows` を分離。クラス doc を差分 sync 前提へ改稿。
+- **リポジトリテスト**: 差分 sync（将来行の in-place 編集反映・消えた行の削除・最終行削除で0件の空配列
+  バインド）、`delete` の cascade / 古い version での ConflictError / delete 後の再 insert 成功、を追加。
+
+### 逸脱の理由
+
+調査の結果、既存の `PrismaDeliveryLocationSellingPriceRepository` は **追記専用実装**
+（`appendPeriodRows` / `ON CONFLICT (id) DO NOTHING`）だった。これは過去に納品先別集約の変更操作が
+`addPeriod`（追加）のみで、子が id 単位で内容不変だった前提に基づく。
+
+本 Issue で追加する `editPeriod`（将来行の内容差し替え）・`endDatePeriod`（終了日書き換え）・
+`deletePeriod`（行削除）は、いずれも**既存行の in-place 更新・削除**を伴う。追記専用のままでは:
+
+- `editPeriod` / `endDatePeriod`: 既存 id の値変更が `DO NOTHING` で握り潰され、**黙って永続化されない**
+- `deletePeriod`: 集約から消えた行が DB に残り続け、**削除が反映されない**
+- 最終行削除（空集約）: 親行を掃除する `delete` メソッド自体が存在しない（空シェルが残る）
+
+したがってインフラ層の改修は、本 Issue が「含む」とした書き込みコマンドを**実際に機能させるための必須作業**
+であり、これ無しでは commands / factories が完成しても書き込みが成立しない。共通ヘルパ
+`sellingPricePeriodPersistence` には差分同期版 `syncPeriodRows` が既に存在し得意先別 #505 が使用中の
+ため、ヘルパ自体の改修は不要で、納品先別リポジトリの呼び先を切り替えるだけで足りた。
+
+計画作成時にこの隠れた必須作業をユーザーへ提示し、本 Issue に含める承認を得た。

--- a/src/server/subdomains/pricing/application/commands/DeleteDeliveryLocationSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/DeleteDeliveryLocationSellingPricePeriodCommand.ts
@@ -1,0 +1,51 @@
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { DeliveryLocationSellingPriceRepository } from "@subdomains/pricing/domain/repositories/DeliveryLocationSellingPriceRepository";
+import { DeliveryLocationSellingPricePeriodId } from "@subdomains/pricing/domain/values/DeliveryLocationSellingPricePeriodId";
+import { loadDeliveryLocationSellingPriceOrThrow } from "./loadDeliveryLocationSellingPriceOrThrow";
+
+export type DeleteDeliveryLocationSellingPricePeriodInput = {
+  deliveryLocationId: string;
+  productId: string;
+  periodId: string;
+  /** 参照日（今日・JST 暦日）。Server Action がサーバー生成して詰める。 */
+  referenceDate: string;
+  /** 編集画面表示時の version（楽観ロック・ADR-0039）。 */
+  expectedVersion: number;
+};
+
+/**
+ * 納品先別売単価の未来開始行を削除するコマンド（誤入力の訂正）。
+ *
+ * 現在有効・失効の行は過去そのもの／既発行見積が時点解決した履歴のため削除できない。状態違反は
+ * 集約の不変条件が `BusinessRuleViolationError` で弾く（参照日に依存・ADR-20260627-86b）。得意先別売単価
+ * の削除コマンドと同型で、identity が複合自然キー（納品先 × 商品）である点が異なる（ADR-20260624-8tg）。
+ */
+export class DeleteDeliveryLocationSellingPricePeriodCommand {
+  constructor(private readonly repository: DeliveryLocationSellingPriceRepository) {}
+
+  async execute(
+    input: DeleteDeliveryLocationSellingPricePeriodInput
+  ): Promise<DeliveryLocationSellingPrice> {
+    const aggregate = await loadDeliveryLocationSellingPriceOrThrow(
+      this.repository,
+      input.deliveryLocationId,
+      input.productId
+    );
+
+    aggregate.deletePeriod(
+      new DeliveryLocationSellingPricePeriodId(input.periodId),
+      input.referenceDate
+    );
+
+    // 最終期間の削除で集約が空になったらルートごと削除し「空集約シェル」を残さない（#512・B案）。
+    // insert/update をアプリ層で選ぶ RegisterCommand の鏡像で、集約消滅のライフサイクル遷移をここに
+    // 可視化する。空シェルを残すと edit query が version:非null を返す一方 UI は0件を新規登録と見なし
+    // version を送らず ValidationError で詰まるため、DB状態を用語定義「未設定＝0件」に一致させる。
+    if (aggregate.isEmpty) {
+      await this.repository.delete(aggregate, input.expectedVersion);
+    } else {
+      await this.repository.update(aggregate, input.expectedVersion);
+    }
+    return aggregate;
+  }
+}

--- a/src/server/subdomains/pricing/application/commands/EditDeliveryLocationSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/EditDeliveryLocationSellingPricePeriodCommand.ts
@@ -1,0 +1,54 @@
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { Money } from "@server/shared/domain/values/Money";
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { DeliveryLocationSellingPriceRepository } from "@subdomains/pricing/domain/repositories/DeliveryLocationSellingPriceRepository";
+import { DeliveryLocationSellingPricePeriodId } from "@subdomains/pricing/domain/values/DeliveryLocationSellingPricePeriodId";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { loadDeliveryLocationSellingPriceOrThrow } from "./loadDeliveryLocationSellingPriceOrThrow";
+
+export type EditDeliveryLocationSellingPricePeriodInput = {
+  deliveryLocationId: string;
+  productId: string;
+  periodId: string;
+  start: string;
+  end: string | null;
+  /** 通貨スケール固定の10進文字列。 */
+  price: string;
+  /** 参照日（今日・JST 暦日）。Server Action がサーバー生成して詰める。 */
+  referenceDate: string;
+  /** 編集画面表示時の version（楽観ロック・ADR-0039）。 */
+  expectedVersion: number;
+};
+
+/**
+ * 納品先別売単価の将来行を編集するコマンド（全項目）。
+ *
+ * 集約を取得し（無ければ NotFoundEntityError）、`editPeriod` で将来行のみ差し替える。現在有効・
+ * 失効の行への編集や開始日が今日より前の指定は集約の不変条件が `BusinessRuleViolationError` で弾く
+ * （参照日に依存・ADR-20260627-86b）。戻り値は編集後の集約。得意先別売単価の編集コマンドと同型で、
+ * identity が複合自然キー（納品先 × 商品）である点が異なる（ADR-20260624-8tg）。
+ */
+export class EditDeliveryLocationSellingPricePeriodCommand {
+  constructor(private readonly repository: DeliveryLocationSellingPriceRepository) {}
+
+  async execute(
+    input: EditDeliveryLocationSellingPricePeriodInput
+  ): Promise<DeliveryLocationSellingPrice> {
+    const aggregate = await loadDeliveryLocationSellingPriceOrThrow(
+      this.repository,
+      input.deliveryLocationId,
+      input.productId
+    );
+
+    const period = ApplicablePeriod.create({ start: input.start, end: input.end });
+    const price = SellingUnitPrice.fromMoney(Money.fromDecimalString(input.price));
+    aggregate.editPeriod(
+      new DeliveryLocationSellingPricePeriodId(input.periodId),
+      { period, price },
+      input.referenceDate
+    );
+
+    await this.repository.update(aggregate, input.expectedVersion);
+    return aggregate;
+  }
+}

--- a/src/server/subdomains/pricing/application/commands/EndDateDeliveryLocationSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/EndDateDeliveryLocationSellingPricePeriodCommand.ts
@@ -1,0 +1,47 @@
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { DeliveryLocationSellingPriceRepository } from "@subdomains/pricing/domain/repositories/DeliveryLocationSellingPriceRepository";
+import { DeliveryLocationSellingPricePeriodId } from "@subdomains/pricing/domain/values/DeliveryLocationSellingPricePeriodId";
+import { loadDeliveryLocationSellingPriceOrThrow } from "./loadDeliveryLocationSellingPriceOrThrow";
+
+export type EndDateDeliveryLocationSellingPricePeriodInput = {
+  deliveryLocationId: string;
+  productId: string;
+  periodId: string;
+  /** 適用終了日（今日より後・JST 暦日）。 */
+  endDate: string;
+  /** 参照日（今日・JST 暦日）。Server Action がサーバー生成して詰める。 */
+  referenceDate: string;
+  /** 編集画面表示時の version（楽観ロック・ADR-0039）。 */
+  expectedVersion: number;
+};
+
+/**
+ * 納品先別売単価の現在有効行を適用終了するコマンド（end-dating・独立コマンド）。
+ *
+ * 単価・開始日は変えず終了日のみ未来方向に確定する。入力が `{ periodId, endDate }` のみで将来行の
+ * 全項目編集とは形が異なるため独立コマンドにする（ADR-0018 流・ADR-20260627-86b 軸4）。現在有効行
+ * 以外への適用終了や今日以前の終了日は集約の不変条件が `BusinessRuleViolationError` で弾く。得意先別売単価
+ * の適用終了コマンドと同型で、identity が複合自然キー（納品先 × 商品）である点が異なる（ADR-20260624-8tg）。
+ */
+export class EndDateDeliveryLocationSellingPricePeriodCommand {
+  constructor(private readonly repository: DeliveryLocationSellingPriceRepository) {}
+
+  async execute(
+    input: EndDateDeliveryLocationSellingPricePeriodInput
+  ): Promise<DeliveryLocationSellingPrice> {
+    const aggregate = await loadDeliveryLocationSellingPriceOrThrow(
+      this.repository,
+      input.deliveryLocationId,
+      input.productId
+    );
+
+    aggregate.endDatePeriod(
+      new DeliveryLocationSellingPricePeriodId(input.periodId),
+      input.endDate,
+      input.referenceDate
+    );
+
+    await this.repository.update(aggregate, input.expectedVersion);
+    return aggregate;
+  }
+}

--- a/src/server/subdomains/pricing/application/commands/RegisterDeliveryLocationSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/RegisterDeliveryLocationSellingPricePeriodCommand.ts
@@ -1,0 +1,84 @@
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { Money } from "@server/shared/domain/values/Money";
+import { ValidationError } from "@server/shared/errors/DomainError";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { DeliveryLocationSellingPriceRepository } from "@subdomains/pricing/domain/repositories/DeliveryLocationSellingPriceRepository";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { ProductQueryService } from "@subdomains/product/application/queries/ProductQueryService";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+
+export type RegisterDeliveryLocationSellingPricePeriodInput = {
+  deliveryLocationId: string;
+  productId: string;
+  start: string;
+  end: string | null;
+  /** 通貨スケール固定の10進文字列（float を経由しない・ADR-0022）。 */
+  price: string;
+  /** 参照日（今日・JST 暦日）。Server Action がサーバー生成して詰める（ADR-20260627-86b）。 */
+  referenceDate: string;
+  /** 既存集約へ追加する場合の編集画面表示時 version（楽観ロック・ADR-0039）。未設定への初回登録では不要。 */
+  expectedVersion?: number;
+};
+
+/**
+ * 納品先別売単価の適用期間行を登録するコマンド。
+ *
+ * 母集合は納品先 × 商品で「未設定（集約が無い）」組み合わせが初期は多数を占める。集約が無ければ
+ * 新規作成して insert（version 1 始まり）、既に在れば期間を追加して update（expectedVersion で
+ * 楽観ロック）する。insert/update の選択はインフラ関心としてここで吸収する。開始日 ≥ 今日・重複禁止の
+ * 不変条件は集約の `addPeriod` が参照日を使って強制する。戻り値は登録後の集約（ADR-0038）。
+ * 得意先別売単価の登録コマンドと同型で、identity が複合自然キー（納品先 × 商品）である点が異なる
+ * （ADR-20260624-8tg）。
+ */
+export class RegisterDeliveryLocationSellingPricePeriodCommand {
+  constructor(
+    private readonly repository: DeliveryLocationSellingPriceRepository,
+    private readonly productQueryService: ProductQueryService
+  ) {}
+
+  async execute(
+    input: RegisterDeliveryLocationSellingPricePeriodInput
+  ): Promise<DeliveryLocationSellingPrice> {
+    const deliveryLocationId = new DeliveryLocationId(input.deliveryLocationId);
+    const productId = new ProductId(input.productId);
+    const period = ApplicablePeriod.create({ start: input.start, end: input.end });
+    const price = SellingUnitPrice.fromMoney(Money.fromDecimalString(input.price));
+
+    const existing = await this.repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    if (existing === null) {
+      // 新規作成分岐でのみ商品区分をライブ取得する。区分不変ゆえ既存集約は必ず非セットで、
+      // 更新経路での取得は無駄なクエリになるため取得しない（ADR-0030）。セット商品拒否は
+      // 集約の構造的不変条件として `create` に置く（ファクトリガード・#531）。
+      const product = await this.productQueryService.findById(input.productId);
+      if (product === null) {
+        throw new ValidationError(`商品が存在しません: ${input.productId}`);
+      }
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.from(product.category)
+      );
+      aggregate.addPeriod(period, price, input.referenceDate);
+      await this.repository.insert(aggregate);
+      return aggregate;
+    }
+
+    // 既存集約への追加は version を渡した楽観ロックが必須。未指定を `?? 0` で吸収すると 1 始まりの
+    // 実 version と永久に一致せず必ず ConflictError（「他のユーザーが更新」の誤表示）になるため、
+    // 入力契約違反として ValidationError で早期に弾く（silent conflict を loud failure へ）。
+    if (input.expectedVersion === undefined) {
+      throw new ValidationError(
+        "既存の納品先別販売単価へ期間を追加するには expectedVersion（編集画面表示時の version）が必要です"
+      );
+    }
+
+    existing.addPeriod(period, price, input.referenceDate);
+    await this.repository.update(existing, input.expectedVersion);
+    return existing;
+  }
+}

--- a/src/server/subdomains/pricing/application/commands/ReviseDeliveryLocationSellingPricePeriodCommand.ts
+++ b/src/server/subdomains/pricing/application/commands/ReviseDeliveryLocationSellingPricePeriodCommand.ts
@@ -1,0 +1,66 @@
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { Money } from "@server/shared/domain/values/Money";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { DeliveryLocationSellingPriceRepository } from "@subdomains/pricing/domain/repositories/DeliveryLocationSellingPriceRepository";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { loadDeliveryLocationSellingPriceOrThrow } from "./loadDeliveryLocationSellingPriceOrThrow";
+
+export type ReviseDeliveryLocationSellingPricePeriodInput = {
+  deliveryLocationId: string;
+  productId: string;
+  /** 改定日（＝現在有効行の適用終了日＝新行の適用開始日。今日より後・JST 暦日）。 */
+  revisionDate: string;
+  /** 改定後の単価。通貨スケール固定の10進文字列（float を経由しない・ADR-0022）。 */
+  price: string;
+  /** 参照日（今日・JST 暦日）。Server Action がサーバー生成して詰める（ADR-20260627-86b）。 */
+  referenceDate: string;
+  /** 編集画面表示時の version（楽観ロック・ADR-0039）。 */
+  expectedVersion: number;
+};
+
+/**
+ * 納品先別売単価を改定日から新単価へ切り替えるコマンド（単価改定）。
+ *
+ * 改定は新しい原子操作ではなく「現在有効行の適用終了（終了日＝改定日）」＋「改定日開始の新規期間追加」
+ * の合成糖衣（CONTEXT.md `単価改定`）。1ロードした集約に両ミューテータを順適用し1セーブすることで、
+ * 単一集約 version の楽観ロックでアトミック性（部分適用なし）を担保する。各原子操作は ADR-20260627-86b
+ * の温度ガード（適用終了＝終了日>今日／追加＝開始≥今日）を持つため、過去日改定の遡及改竄は構造的に閉じる。
+ *
+ * 適用終了→追加の順で呼ぶ（逆順だと旧行が現在有効行のまま新行と接触判定され重複しうる）。
+ * 現在有効行が無い（未設定・失効のみ）は改定対象が無く {@link BusinessRuleViolationError} で拒否する。
+ * 得意先別売単価の改定コマンドと同型で、identity が複合自然キー（納品先 × 商品）である点が異なる
+ * （ADR-20260624-8tg）。
+ */
+export class ReviseDeliveryLocationSellingPricePeriodCommand {
+  constructor(private readonly repository: DeliveryLocationSellingPriceRepository) {}
+
+  async execute(
+    input: ReviseDeliveryLocationSellingPricePeriodInput
+  ): Promise<DeliveryLocationSellingPrice> {
+    const aggregate = await loadDeliveryLocationSellingPriceOrThrow(
+      this.repository,
+      input.deliveryLocationId,
+      input.productId
+    );
+
+    const current = aggregate.currentValidPeriod(input.referenceDate);
+    if (current === undefined) {
+      throw new BusinessRuleViolationError(
+        `${DeliveryLocationSellingPrice.ENTITY_NAME}の改定には現在有効な単価が必要です（未設定・失効の納品先×商品は新規登録から行ってください）`
+      );
+    }
+
+    const newPrice = SellingUnitPrice.fromMoney(Money.fromDecimalString(input.price));
+
+    aggregate.endDatePeriod(current.id, input.revisionDate, input.referenceDate);
+    aggregate.addPeriod(
+      ApplicablePeriod.create({ start: input.revisionDate, end: null }),
+      newPrice,
+      input.referenceDate
+    );
+
+    await this.repository.update(aggregate, input.expectedVersion);
+    return aggregate;
+  }
+}

--- a/src/server/subdomains/pricing/application/commands/__tests__/DeleteDeliveryLocationSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/DeleteDeliveryLocationSellingPricePeriodCommand.test.ts
@@ -1,0 +1,228 @@
+import prisma from "@server/prisma";
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { DeliveryLocationSellingPricePeriodId } from "@subdomains/pricing/domain/values/DeliveryLocationSellingPricePeriodId";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaDeliveryLocationSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DeleteDeliveryLocationSellingPricePeriodCommand } from "../DeleteDeliveryLocationSellingPricePeriodCommand";
+
+const TEST_PRODUCT_CODE = "DLSPCMD40";
+const TEST_DELIVERY_LOCATION_CODE = "DLSPCMD41";
+const PARENT_CUSTOMER_CODE = "DLSPCMD42";
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+const period = (start: string, end: string | null) => ApplicablePeriod.create({ start, end });
+
+async function cleanup(): Promise<void> {
+  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.deliveryLocation.deleteMany({ where: { code: TEST_DELIVERY_LOCATION_CODE } });
+  await prisma.customer.deleteMany({ where: { code: PARENT_CUSTOMER_CODE } });
+}
+
+describe("DeleteDeliveryLocationSellingPricePeriodCommand", () => {
+  let command: DeleteDeliveryLocationSellingPricePeriodCommand;
+  let repository: PrismaDeliveryLocationSellingPriceRepository;
+  let deliveryLocationId: DeliveryLocationId;
+  let productId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    repository = new PrismaDeliveryLocationSellingPriceRepository();
+    command = new DeleteDeliveryLocationSellingPricePeriodCommand(repository);
+
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(
+        new CompanyCode(PARENT_CUSTOMER_CODE),
+        new CompanyName("削除コマンドテスト親得意先")
+      )
+    );
+    const deliveryLocation = await new PrismaDeliveryLocationRepository().insert(
+      DeliveryLocation.create(
+        new CompanyCode(TEST_DELIVERY_LOCATION_CODE),
+        new CompanyName("削除コマンドテスト納品先"),
+        customer.id
+      )
+    );
+    deliveryLocationId = deliveryLocation.id;
+
+    const product = await new PrismaProductRepository().insert(
+      Product.create(
+        new ProductCode(TEST_PRODUCT_CODE),
+        new ProductName(`削除コマンドテスト商品${TEST_PRODUCT_CODE}`),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+  });
+
+  afterEach(cleanup);
+
+  it("将来行を削除できる", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2025-06-01");
+    aggregate.addPeriod(period("2030-06-01", null), price(1200), "2025-06-01");
+    await repository.insert(aggregate);
+    const firstId = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!.periods[0].id;
+
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      periodId: firstId.value,
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    expect(found!.periods).toHaveLength(1);
+    expect(found!.periods[0].period.equals(period("2030-06-01", null))).toBe(true);
+  });
+
+  it("最後の1行を削除すると集約ごと消え、空シェルを残さない（#512・B案）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+    const onlyId = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!.periods[0].id;
+
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      periodId: onlyId.value,
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    expect(
+      await repository.findByDeliveryLocationIdAndProductId(deliveryLocationId, productId)
+    ).toBeNull();
+  });
+
+  it("最後の1行を削除した後、同一の納品先×商品へ version 1 で再登録できる（再登録経路の回帰・#512）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+    const onlyId = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!.periods[0].id;
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      periodId: onlyId.value,
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const reregister = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    reregister.addPeriod(period("2030-02-01", null), price(2000), "2025-06-01");
+    await repository.insert(reregister);
+    const found = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!;
+    expect(found.periods).toHaveLength(1);
+    expect(found.periods[0].price.equals(price(2000))).toBe(true);
+  });
+
+  it("集約が無い納品先×商品では NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: DeliveryLocationSellingPricePeriodId.generate().value,
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(NotFoundEntityError);
+  });
+
+  it("現在有効行の削除は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+    await repository.insert(aggregate);
+    const periodId = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!.periods[0].id;
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+  });
+
+  it("expectedVersion が古いと ConflictError", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+    const periodId = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!.periods[0].id;
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        referenceDate: "2025-06-01",
+        expectedVersion: 999,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/src/server/subdomains/pricing/application/commands/__tests__/EditDeliveryLocationSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/EditDeliveryLocationSellingPricePeriodCommand.test.ts
@@ -1,0 +1,171 @@
+import prisma from "@server/prisma";
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { DeliveryLocationSellingPricePeriodId } from "@subdomains/pricing/domain/values/DeliveryLocationSellingPricePeriodId";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaDeliveryLocationSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EditDeliveryLocationSellingPricePeriodCommand } from "../EditDeliveryLocationSellingPricePeriodCommand";
+
+const TEST_PRODUCT_CODE = "DLSPCMD20";
+const TEST_DELIVERY_LOCATION_CODE = "DLSPCMD21";
+const PARENT_CUSTOMER_CODE = "DLSPCMD22";
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+const period = (start: string, end: string | null) => ApplicablePeriod.create({ start, end });
+
+async function cleanup(): Promise<void> {
+  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.deliveryLocation.deleteMany({ where: { code: TEST_DELIVERY_LOCATION_CODE } });
+  await prisma.customer.deleteMany({ where: { code: PARENT_CUSTOMER_CODE } });
+}
+
+describe("EditDeliveryLocationSellingPricePeriodCommand", () => {
+  let command: EditDeliveryLocationSellingPricePeriodCommand;
+  let repository: PrismaDeliveryLocationSellingPriceRepository;
+  let deliveryLocationId: DeliveryLocationId;
+  let productId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    repository = new PrismaDeliveryLocationSellingPriceRepository();
+    command = new EditDeliveryLocationSellingPricePeriodCommand(repository);
+
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(
+        new CompanyCode(PARENT_CUSTOMER_CODE),
+        new CompanyName("編集コマンドテスト親得意先")
+      )
+    );
+    const deliveryLocation = await new PrismaDeliveryLocationRepository().insert(
+      DeliveryLocation.create(
+        new CompanyCode(TEST_DELIVERY_LOCATION_CODE),
+        new CompanyName("編集コマンドテスト納品先"),
+        customer.id
+      )
+    );
+    deliveryLocationId = deliveryLocation.id;
+
+    const product = await new PrismaProductRepository().insert(
+      Product.create(
+        new ProductCode(TEST_PRODUCT_CODE),
+        new ProductName(`編集コマンドテスト商品${TEST_PRODUCT_CODE}`),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+  });
+
+  afterEach(cleanup);
+
+  /** 将来行を1本持つ集約を用意し、その periodId を返す。 */
+  async function seedFuturePeriod(): Promise<DeliveryLocationSellingPricePeriodId> {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+    return (await repository.findByDeliveryLocationIdAndProductId(deliveryLocationId, productId))!
+      .periods[0].id;
+  }
+
+  it("将来行の単価・期間を編集できる", async () => {
+    const periodId = await seedFuturePeriod();
+
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      periodId: periodId.value,
+      start: "2030-02-01",
+      end: null,
+      price: "1500",
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    expect(found!.periods[0].price.equals(price(1500))).toBe(true);
+    expect(found!.periods[0].period.equals(period("2030-02-01", null))).toBe(true);
+  });
+
+  it("集約が無い納品先×商品では NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: DeliveryLocationSellingPricePeriodId.generate().value,
+        start: "2030-02-01",
+        end: null,
+        price: "1500",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(NotFoundEntityError);
+  });
+
+  it("現在有効行の編集は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2025-05-01", "2030-01-01"), price(1000), "2025-04-01");
+    await repository.insert(aggregate);
+    const periodId = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!.periods[0].id;
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        start: "2030-02-01",
+        end: null,
+        price: "1500",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+  });
+
+  it("expectedVersion が古いと ConflictError", async () => {
+    const periodId = await seedFuturePeriod();
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        start: "2030-02-01",
+        end: null,
+        price: "1500",
+        referenceDate: "2025-06-01",
+        expectedVersion: 999,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/src/server/subdomains/pricing/application/commands/__tests__/EndDateDeliveryLocationSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/EndDateDeliveryLocationSellingPricePeriodCommand.test.ts
@@ -1,0 +1,162 @@
+import prisma from "@server/prisma";
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { DeliveryLocationSellingPricePeriodId } from "@subdomains/pricing/domain/values/DeliveryLocationSellingPricePeriodId";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaDeliveryLocationSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EndDateDeliveryLocationSellingPricePeriodCommand } from "../EndDateDeliveryLocationSellingPricePeriodCommand";
+
+const TEST_PRODUCT_CODE = "DLSPCMD30";
+const TEST_DELIVERY_LOCATION_CODE = "DLSPCMD31";
+const PARENT_CUSTOMER_CODE = "DLSPCMD32";
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+const period = (start: string, end: string | null) => ApplicablePeriod.create({ start, end });
+
+async function cleanup(): Promise<void> {
+  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.deliveryLocation.deleteMany({ where: { code: TEST_DELIVERY_LOCATION_CODE } });
+  await prisma.customer.deleteMany({ where: { code: PARENT_CUSTOMER_CODE } });
+}
+
+describe("EndDateDeliveryLocationSellingPricePeriodCommand", () => {
+  let command: EndDateDeliveryLocationSellingPricePeriodCommand;
+  let repository: PrismaDeliveryLocationSellingPriceRepository;
+  let deliveryLocationId: DeliveryLocationId;
+  let productId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    repository = new PrismaDeliveryLocationSellingPriceRepository();
+    command = new EndDateDeliveryLocationSellingPricePeriodCommand(repository);
+
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(
+        new CompanyCode(PARENT_CUSTOMER_CODE),
+        new CompanyName("適用終了コマンドテスト親得意先")
+      )
+    );
+    const deliveryLocation = await new PrismaDeliveryLocationRepository().insert(
+      DeliveryLocation.create(
+        new CompanyCode(TEST_DELIVERY_LOCATION_CODE),
+        new CompanyName("適用終了コマンドテスト納品先"),
+        customer.id
+      )
+    );
+    deliveryLocationId = deliveryLocation.id;
+
+    const product = await new PrismaProductRepository().insert(
+      Product.create(
+        new ProductCode(TEST_PRODUCT_CODE),
+        new ProductName(`適用終了コマンドテスト商品${TEST_PRODUCT_CODE}`),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+  });
+
+  afterEach(cleanup);
+
+  /** 現在有効な無期限行を1本持つ集約を用意し、その periodId を返す。 */
+  async function seedActivePeriod(): Promise<DeliveryLocationSellingPricePeriodId> {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+    await repository.insert(aggregate);
+    return (await repository.findByDeliveryLocationIdAndProductId(deliveryLocationId, productId))!
+      .periods[0].id;
+  }
+
+  it("現在有効行に終了日を設定できる（適用終了）", async () => {
+    const periodId = await seedActivePeriod();
+
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      periodId: periodId.value,
+      endDate: "2030-01-01",
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    expect(found!.periods[0].period.equals(period("2025-04-01", "2030-01-01"))).toBe(true);
+  });
+
+  it("集約が無い納品先×商品では NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: DeliveryLocationSellingPricePeriodId.generate().value,
+        endDate: "2030-01-01",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(NotFoundEntityError);
+  });
+
+  it("将来行への適用終了は BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+    const periodId = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!.periods[0].id;
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        endDate: "2031-01-01",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+  });
+
+  it("expectedVersion が古いと ConflictError", async () => {
+    const periodId = await seedActivePeriod();
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: periodId.value,
+        endDate: "2030-01-01",
+        referenceDate: "2025-06-01",
+        expectedVersion: 999,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/src/server/subdomains/pricing/application/commands/__tests__/RegisterDeliveryLocationSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/RegisterDeliveryLocationSellingPricePeriodCommand.test.ts
@@ -1,0 +1,225 @@
+import prisma from "@server/prisma";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError, ValidationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaDeliveryLocationSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { PrismaProductQueryService } from "@subdomains/product/infrastructure/queries/PrismaProductQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RegisterDeliveryLocationSellingPricePeriodCommand } from "../RegisterDeliveryLocationSellingPricePeriodCommand";
+
+const TEST_PRODUCT_CODE = "DLSPCMD10";
+const TEST_DELIVERY_LOCATION_CODE = "DLSPCMD11";
+const PARENT_CUSTOMER_CODE = "DLSPCMD12";
+const TEST_SET_PRODUCT_CODE = "DLSPCMD13";
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+
+async function cleanup(): Promise<void> {
+  await prisma.product.deleteMany({
+    where: { code: { in: [TEST_PRODUCT_CODE, TEST_SET_PRODUCT_CODE] } },
+  });
+  await prisma.deliveryLocation.deleteMany({ where: { code: TEST_DELIVERY_LOCATION_CODE } });
+  await prisma.customer.deleteMany({ where: { code: PARENT_CUSTOMER_CODE } });
+}
+
+describe("RegisterDeliveryLocationSellingPricePeriodCommand", () => {
+  let command: RegisterDeliveryLocationSellingPricePeriodCommand;
+  let repository: PrismaDeliveryLocationSellingPriceRepository;
+  let deliveryLocationId: DeliveryLocationId;
+  let productId: ProductId;
+  let setProductId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    repository = new PrismaDeliveryLocationSellingPriceRepository();
+    command = new RegisterDeliveryLocationSellingPricePeriodCommand(
+      repository,
+      new PrismaProductQueryService()
+    );
+
+    // 納品先別販売単価は納品先 × 商品を親に持つ（FK 制約）。納品先はさらに得意先を親に持つ。
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(
+        new CompanyCode(PARENT_CUSTOMER_CODE),
+        new CompanyName("登録コマンドテスト親得意先")
+      )
+    );
+
+    const deliveryLocation = await new PrismaDeliveryLocationRepository().insert(
+      DeliveryLocation.create(
+        new CompanyCode(TEST_DELIVERY_LOCATION_CODE),
+        new CompanyName("登録コマンドテスト納品先"),
+        customer.id
+      )
+    );
+    deliveryLocationId = deliveryLocation.id;
+
+    const productRepository = new PrismaProductRepository();
+    const product = await productRepository.insert(
+      Product.create(
+        new ProductCode(TEST_PRODUCT_CODE),
+        new ProductName(`登録コマンドテスト商品${TEST_PRODUCT_CODE}`),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+
+    const setProduct = await productRepository.insert(
+      Product.create(
+        new ProductCode(TEST_SET_PRODUCT_CODE),
+        new ProductName(`登録コマンドテストセット商品${TEST_SET_PRODUCT_CODE}`),
+        ProductCategory.SET,
+        ProductUnit.UNIT
+      )
+    );
+    setProductId = setProduct.id;
+  });
+
+  afterEach(cleanup);
+
+  it("未設定の納品先×商品に最初の期間を登録できる（新規 insert）", async () => {
+    const result = await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      start: "2030-01-01",
+      end: null,
+      price: "1000",
+      referenceDate: "2025-06-01",
+    });
+
+    expect(result.periods).toHaveLength(1);
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    expect(found!.periods).toHaveLength(1);
+    expect(found!.periods[0].price.equals(price(1000))).toBe(true);
+  });
+
+  it("既存集約へ2本目の期間を追加できる（expectedVersion での update）", async () => {
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      start: "2030-01-01",
+      end: "2030-06-01",
+      price: "1000",
+      referenceDate: "2025-06-01",
+    });
+
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      start: "2030-06-01",
+      end: null,
+      price: "1200",
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    expect(found!.periods).toHaveLength(2);
+  });
+
+  it("開始日が今日より前なら BusinessRuleViolationError（参照日が domain まで素通しされる）", async () => {
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        start: "2025-05-31",
+        end: null,
+        price: "1000",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+  });
+
+  it("既存集約への追加で expectedVersion 未指定なら ValidationError（楽観ロック失敗ではなく入力契約違反）", async () => {
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      start: "2030-01-01",
+      end: "2030-06-01",
+      price: "1000",
+      referenceDate: "2025-06-01",
+    });
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        start: "2030-06-01",
+        end: null,
+        price: "1200",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("セット商品には販売単価を登録できない（ValidationError・ファクトリガード / #531）", async () => {
+    // セット商品は自前の売単価を持たず構成商品から導出されるため、生成入口で拒否する。
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: setProductId.value,
+        start: "2030-01-01",
+        end: null,
+        price: "1000",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("存在しない商品IDでは登録できない（ValidationError・入力契約違反 / #531）", async () => {
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: ProductId.generate().value,
+        start: "2030-01-01",
+        end: null,
+        price: "1000",
+        referenceDate: "2025-06-01",
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("既存集約への追加で expectedVersion が古いと ConflictError（expectedVersion が repo まで素通しされる）", async () => {
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      start: "2030-01-01",
+      end: "2030-06-01",
+      price: "1000",
+      referenceDate: "2025-06-01",
+    });
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        start: "2030-06-01",
+        end: null,
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 999,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/src/server/subdomains/pricing/application/commands/__tests__/ReviseDeliveryLocationSellingPricePeriodCommand.test.ts
+++ b/src/server/subdomains/pricing/application/commands/__tests__/ReviseDeliveryLocationSellingPricePeriodCommand.test.ts
@@ -1,0 +1,283 @@
+import prisma from "@server/prisma";
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { ConflictError, NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaDeliveryLocationSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EndDateDeliveryLocationSellingPricePeriodCommand } from "../EndDateDeliveryLocationSellingPricePeriodCommand";
+import { ReviseDeliveryLocationSellingPricePeriodCommand } from "../ReviseDeliveryLocationSellingPricePeriodCommand";
+
+const TEST_PRODUCT_CODE = "DLSPCMD50";
+const TEST_DELIVERY_LOCATION_CODE = "DLSPCMD51";
+const PARENT_CUSTOMER_CODE = "DLSPCMD52";
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+const period = (start: string, end: string | null) => ApplicablePeriod.create({ start, end });
+
+async function cleanup(): Promise<void> {
+  await prisma.product.deleteMany({ where: { code: TEST_PRODUCT_CODE } });
+  await prisma.deliveryLocation.deleteMany({ where: { code: TEST_DELIVERY_LOCATION_CODE } });
+  await prisma.customer.deleteMany({ where: { code: PARENT_CUSTOMER_CODE } });
+}
+
+describe("ReviseDeliveryLocationSellingPricePeriodCommand", () => {
+  let command: ReviseDeliveryLocationSellingPricePeriodCommand;
+  let repository: PrismaDeliveryLocationSellingPriceRepository;
+  let deliveryLocationId: DeliveryLocationId;
+  let productId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    repository = new PrismaDeliveryLocationSellingPriceRepository();
+    command = new ReviseDeliveryLocationSellingPricePeriodCommand(repository);
+
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(
+        new CompanyCode(PARENT_CUSTOMER_CODE),
+        new CompanyName("単価改定コマンドテスト親得意先")
+      )
+    );
+    const deliveryLocation = await new PrismaDeliveryLocationRepository().insert(
+      DeliveryLocation.create(
+        new CompanyCode(TEST_DELIVERY_LOCATION_CODE),
+        new CompanyName("単価改定コマンドテスト納品先"),
+        customer.id
+      )
+    );
+    deliveryLocationId = deliveryLocation.id;
+
+    const product = await new PrismaProductRepository().insert(
+      Product.create(
+        new ProductCode(TEST_PRODUCT_CODE),
+        new ProductName(`単価改定コマンドテスト商品${TEST_PRODUCT_CODE}`),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+  });
+
+  afterEach(cleanup);
+
+  /** 現在有効な無期限行（2025-04-01〜・1000円）を1本持つ集約を用意する。 */
+  async function seedActivePeriod(): Promise<void> {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+    await repository.insert(aggregate);
+  }
+
+  it("現在有効行を改定日で終了し、改定日開始の新行を連続して追加する", async () => {
+    await seedActivePeriod();
+
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      revisionDate: "2025-09-01",
+      price: "1200",
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    const rows = [...found!.periods].sort((a, b) => a.period.start.localeCompare(b.period.start));
+    expect(rows).toHaveLength(2);
+    // 旧行: 改定日で終了、単価据え置き
+    expect(rows[0].period.equals(period("2025-04-01", "2025-09-01"))).toBe(true);
+    expect(rows[0].price.equals(price(1000))).toBe(true);
+    // 新行: 改定日開始の無期限、新単価
+    expect(rows[1].period.equals(period("2025-09-01", null))).toBe(true);
+    expect(rows[1].price.equals(price(1200))).toBe(true);
+  });
+
+  it("現在有効行が無い納品先×商品（将来行のみ）は BusinessRuleViolationError", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2025-12-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        revisionDate: "2026-01-01",
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+  });
+
+  it("集約が無い納品先×商品（未設定）は NotFoundEntityError", async () => {
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        revisionDate: "2025-09-01",
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(NotFoundEntityError);
+  });
+
+  it("改定日が今日以前なら BusinessRuleViolationError（適用終了ガード由来・遡及改竄を閉じる）", async () => {
+    await seedActivePeriod();
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        revisionDate: "2025-06-01", // = referenceDate（今日）
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+
+    // 失敗時は集約が変わらない（部分適用なし）
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    expect(found!.periods).toHaveLength(1);
+    expect(found!.periods[0].period.equals(period("2025-04-01", null))).toBe(true);
+  });
+
+  it("据え置き（新単価＝現単価）も改定として成立する（拒否しない）", async () => {
+    await seedActivePeriod();
+
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      revisionDate: "2025-09-01",
+      price: "1000", // 現単価と同一
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    const rows = [...found!.periods].sort((a, b) => a.period.start.localeCompare(b.period.start));
+    expect(rows).toHaveLength(2);
+    expect(rows[1].period.equals(period("2025-09-01", null))).toBe(true);
+    expect(rows[1].price.equals(price(1000))).toBe(true);
+  });
+
+  it("expectedVersion が古いと ConflictError（部分適用なし）", async () => {
+    await seedActivePeriod();
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        revisionDate: "2025-09-01",
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 999,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    expect(found!.periods).toHaveLength(1);
+  });
+
+  it("改定日開始の新行が既存の将来行と重複すると BusinessRuleViolationError", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2025-04-01", "2025-10-01"), price(1000), "2025-03-01");
+    aggregate.addPeriod(period("2025-10-01", null), price(1100), "2025-03-01");
+    await repository.insert(aggregate);
+
+    await expect(
+      command.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        revisionDate: "2025-09-01",
+        price: "1200",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(BusinessRuleViolationError);
+
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    expect(found!.periods).toHaveLength(2);
+  });
+
+  it("version は改定1回につき1度だけ上がる（後続操作が expectedVersion=2 で通り 1 で弾かれる）", async () => {
+    await seedActivePeriod();
+
+    await command.execute({
+      deliveryLocationId: deliveryLocationId.value,
+      productId: productId.value,
+      revisionDate: "2025-09-01",
+      price: "1200",
+      referenceDate: "2025-06-01",
+      expectedVersion: 1,
+    });
+
+    const endDate = new EndDateDeliveryLocationSellingPricePeriodCommand(repository);
+    const currentId = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!.periods.find((r) => r.period.contains("2025-06-01"))!.id.value;
+
+    await expect(
+      endDate.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: currentId,
+        endDate: "2025-08-01",
+        referenceDate: "2025-06-01",
+        expectedVersion: 1,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    await expect(
+      endDate.execute({
+        deliveryLocationId: deliveryLocationId.value,
+        productId: productId.value,
+        periodId: currentId,
+        endDate: "2025-08-01",
+        referenceDate: "2025-06-01",
+        expectedVersion: 2,
+      })
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/server/subdomains/pricing/application/commands/loadDeliveryLocationSellingPriceOrThrow.ts
+++ b/src/server/subdomains/pricing/application/commands/loadDeliveryLocationSellingPriceOrThrow.ts
@@ -1,0 +1,27 @@
+import { NotFoundEntityError } from "@server/shared/errors/ApplicationError";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { DeliveryLocationSellingPriceRepository } from "@subdomains/pricing/domain/repositories/DeliveryLocationSellingPriceRepository";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+
+/**
+ * 納品先ID×商品IDから納品先別売単価集約を取得し、無ければ {@link NotFoundEntityError} を投げる。
+ *
+ * 既存集約の存在を前提とする編集系コマンド（編集・適用終了・削除）が共有する定型。「無ければ NotFound」
+ * はアプリ層のユースケース上の関心であり、Repository は null を返す問い合わせに徹する（既存規約）。
+ * 登録コマンドは null を正常系（新規 insert）に分岐するため、このヘルパは使わない。
+ */
+export async function loadDeliveryLocationSellingPriceOrThrow(
+  repository: DeliveryLocationSellingPriceRepository,
+  deliveryLocationId: string,
+  productId: string
+): Promise<DeliveryLocationSellingPrice> {
+  const aggregate = await repository.findByDeliveryLocationIdAndProductId(
+    new DeliveryLocationId(deliveryLocationId),
+    new ProductId(productId)
+  );
+  if (aggregate === null) {
+    throw new NotFoundEntityError(DeliveryLocationSellingPrice, { deliveryLocationId, productId });
+  }
+  return aggregate;
+}

--- a/src/server/subdomains/pricing/application/factories/deleteDeliveryLocationSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/deleteDeliveryLocationSellingPricePeriodCommandFactory.ts
@@ -1,0 +1,9 @@
+import { DeleteDeliveryLocationSellingPricePeriodCommand } from "../commands/DeleteDeliveryLocationSellingPricePeriodCommand";
+import { PrismaDeliveryLocationSellingPriceRepository } from "../../infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+
+/** 納品先別売単価の未来開始行を削除するコマンド（#545）を Repository から構築する。 */
+export function deleteDeliveryLocationSellingPricePeriodCommandFactory(): DeleteDeliveryLocationSellingPricePeriodCommand {
+  return new DeleteDeliveryLocationSellingPricePeriodCommand(
+    new PrismaDeliveryLocationSellingPriceRepository()
+  );
+}

--- a/src/server/subdomains/pricing/application/factories/editDeliveryLocationSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/editDeliveryLocationSellingPricePeriodCommandFactory.ts
@@ -1,0 +1,9 @@
+import { EditDeliveryLocationSellingPricePeriodCommand } from "../commands/EditDeliveryLocationSellingPricePeriodCommand";
+import { PrismaDeliveryLocationSellingPriceRepository } from "../../infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+
+/** 納品先別売単価の将来行を編集するコマンド（#545）を Repository から構築する。 */
+export function editDeliveryLocationSellingPricePeriodCommandFactory(): EditDeliveryLocationSellingPricePeriodCommand {
+  return new EditDeliveryLocationSellingPricePeriodCommand(
+    new PrismaDeliveryLocationSellingPriceRepository()
+  );
+}

--- a/src/server/subdomains/pricing/application/factories/endDateDeliveryLocationSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/endDateDeliveryLocationSellingPricePeriodCommandFactory.ts
@@ -1,0 +1,9 @@
+import { EndDateDeliveryLocationSellingPricePeriodCommand } from "../commands/EndDateDeliveryLocationSellingPricePeriodCommand";
+import { PrismaDeliveryLocationSellingPriceRepository } from "../../infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+
+/** 納品先別売単価の現在有効行を適用終了するコマンド（#545）を Repository から構築する。 */
+export function endDateDeliveryLocationSellingPricePeriodCommandFactory(): EndDateDeliveryLocationSellingPricePeriodCommand {
+  return new EndDateDeliveryLocationSellingPricePeriodCommand(
+    new PrismaDeliveryLocationSellingPriceRepository()
+  );
+}

--- a/src/server/subdomains/pricing/application/factories/registerDeliveryLocationSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/registerDeliveryLocationSellingPricePeriodCommandFactory.ts
@@ -1,0 +1,14 @@
+import { PrismaProductQueryService } from "@subdomains/product/infrastructure/queries/PrismaProductQueryService";
+import { RegisterDeliveryLocationSellingPricePeriodCommand } from "../commands/RegisterDeliveryLocationSellingPricePeriodCommand";
+import { PrismaDeliveryLocationSellingPriceRepository } from "../../infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+
+/**
+ * 納品先別売単価の適用期間行を登録するコマンド（#545）を Repository から構築する。
+ * セット商品拒否のガード（#531）のため商品区分を引く ProductQueryService も注入する。
+ */
+export function registerDeliveryLocationSellingPricePeriodCommandFactory(): RegisterDeliveryLocationSellingPricePeriodCommand {
+  return new RegisterDeliveryLocationSellingPricePeriodCommand(
+    new PrismaDeliveryLocationSellingPriceRepository(),
+    new PrismaProductQueryService()
+  );
+}

--- a/src/server/subdomains/pricing/application/factories/reviseDeliveryLocationSellingPricePeriodCommandFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/reviseDeliveryLocationSellingPricePeriodCommandFactory.ts
@@ -1,0 +1,9 @@
+import { ReviseDeliveryLocationSellingPricePeriodCommand } from "../commands/ReviseDeliveryLocationSellingPricePeriodCommand";
+import { PrismaDeliveryLocationSellingPriceRepository } from "../../infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+
+/** 納品先別売単価を改定日から新単価へ切り替えるコマンド（#545）を Repository から構築する。 */
+export function reviseDeliveryLocationSellingPricePeriodCommandFactory(): ReviseDeliveryLocationSellingPricePeriodCommand {
+  return new ReviseDeliveryLocationSellingPricePeriodCommand(
+    new PrismaDeliveryLocationSellingPriceRepository()
+  );
+}

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveDeliveryLocationSellingPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveDeliveryLocationSellingPriceQuery.test.ts
@@ -89,7 +89,7 @@ describe("ResolveDeliveryLocationSellingPriceQuery", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     const result = await query.execute({

--- a/src/server/subdomains/pricing/application/queries/__tests__/ResolveSellingPriceQuery.test.ts
+++ b/src/server/subdomains/pricing/application/queries/__tests__/ResolveSellingPriceQuery.test.ts
@@ -151,7 +151,7 @@ describe("ResolveSellingPriceQuery", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    deliveryLocationPrice.addPeriod(period("2025-07-01", null), price(700));
+    deliveryLocationPrice.addPeriod(period("2025-07-01", null), price(700), "2025-07-01");
     await deliveryLocationRepo.insert(deliveryLocationPrice);
 
     const resolved = await query.execute({

--- a/src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPrice.ts
+++ b/src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPrice.ts
@@ -68,17 +68,156 @@ export class DeliveryLocationSellingPrice {
   }
 
   /**
-   * 適用期間行を追加する。既存のどの期間とも重ならない場合のみ許す。
-   * 重なる場合は不変条件違反として {@link BusinessRuleViolationError} を投げ、集約は変更しない。
+   * 適用期間行を追加する。既存のどの期間とも重ならず、かつ開始日が参照日（今日）以降の場合のみ許す。
+   *
+   * 過去にさかのぼった行の後付け登録は「過去不変」を破るため禁止する（ADR-20260627-86b）。
+   * 過去日データの投入は移行用の {@link reconstruct} 経路に限定し、業務操作からは閉じる。
+   * 重複・過去開始は不変条件違反として {@link BusinessRuleViolationError} を投げ、集約は変更しない。
+   *
+   * @param referenceDate 参照日（今日・JST 暦日 `"YYYY-MM-DD"`）。保存実行時にサーバー生成して注入する。
    */
-  addPeriod(period: ApplicablePeriod, price: SellingUnitPrice): void {
-    const overlapping = this._periods.find((row) => row.period.overlaps(period));
+  addPeriod(period: ApplicablePeriod, price: SellingUnitPrice, referenceDate: string): void {
+    this.assertStartNotPast(period.start, referenceDate);
+    this.assertNoOverlap(period);
+    this._periods.push(DeliveryLocationSellingPricePeriod.create(period, price));
+  }
+
+  /**
+   * 将来行（今日 < 開始）の期間・単価を差し替える。将来行はまだどの見積も時点解決していないため
+   * 全項目訂正できる（ADR-20260627-86b 軸1）。現在有効・失効の行は編集できない。
+   * 新しい開始日も今日以降であり、他の行と重ならない必要がある。
+   *
+   * @param referenceDate 参照日（今日・JST 暦日 `"YYYY-MM-DD"`）。
+   */
+  editPeriod(
+    periodId: DeliveryLocationSellingPricePeriodId,
+    changes: { period: ApplicablePeriod; price: SellingUnitPrice },
+    referenceDate: string
+  ): void {
+    const row = this.requireRow(periodId);
+    if (!this.isFuture(row.period, referenceDate)) {
+      throw new BusinessRuleViolationError(
+        `${DeliveryLocationSellingPrice.ENTITY_NAME}は将来行のみ編集できます（現在有効・失効の行は変更不可）`
+      );
+    }
+    this.assertStartNotPast(changes.period.start, referenceDate);
+    this.assertNoOverlap(changes.period, row);
+    row.changeTo(changes.period, changes.price);
+  }
+
+  /**
+   * 現在有効行（開始 ≤ 今日 < 終了）に終了日を設定して打ち切る（適用終了・end-dating）。
+   * 単価・開始日は変えず、終了日のみを未来方向に確定する（現在有効行に許される唯一の編集）。
+   * 単価改定は「適用終了＋新規期間追加」で表現し、各行を不変の履歴として残す（ADR-20260627-86b）。
+   *
+   * 終了日は今日より後でなければならない（半開区間 `[開始, 終了)` ゆえ終了日=今日は今日を被覆外にし
+   * 遡及削除になるため）。また「適用終了」は打ち切り＝短縮であり延長ではないため、既存終了日が有界なら
+   * 新しい終了日はそれより手前でなければならない（延長は本来失効すべき単価を生かし未来見積の単価判定を
+   * 誤らせる）。既存が無期限（end=null）なら任意の未来日が正当な短縮として許される。
+   *
+   * @param referenceDate 参照日（今日・JST 暦日 `"YYYY-MM-DD"`）。
+   */
+  endDatePeriod(
+    periodId: DeliveryLocationSellingPricePeriodId,
+    endDate: string,
+    referenceDate: string
+  ): void {
+    const row = this.requireRow(periodId);
+    if (!row.period.contains(referenceDate)) {
+      throw new BusinessRuleViolationError(
+        `${DeliveryLocationSellingPrice.ENTITY_NAME}は現在有効行のみ適用終了できます`
+      );
+    }
+    // 業務ルール（今日比較・短縮限定）の前に endDate の形式・実在性を検証する。後回しにすると
+    // 不正値が文字列比較で「短縮のみ」「今日より後」などの無関係なメッセージへ誤って落ちるため、
+    // ここで ApplicablePeriod を生成して形式エラー（ValidationError）を前倒しする。
+    const ended = ApplicablePeriod.create({ start: row.period.start, end: endDate });
+    if (endDate <= referenceDate) {
+      throw new BusinessRuleViolationError(
+        `${DeliveryLocationSellingPrice.ENTITY_NAME}の適用終了日は今日より後である必要があります: ${endDate} <= ${referenceDate}`
+      );
+    }
+    if (row.period.end !== null && endDate >= row.period.end) {
+      throw new BusinessRuleViolationError(
+        `${DeliveryLocationSellingPrice.ENTITY_NAME}の適用終了は短縮のみ可能です（既存終了日より後へは延長できません）: ${endDate} >= ${row.period.end}`
+      );
+    }
+    this.assertNoOverlap(ended, row);
+    row.endDateOn(endDate);
+  }
+
+  /**
+   * 未来開始行（今日 < 開始）を削除する（誤入力の訂正）。現在有効・失効の行は過去そのもの／
+   * 既発行見積が時点解決した履歴のため削除できない（ADR-20260627-86b 軸1）。
+   *
+   * @param referenceDate 参照日（今日・JST 暦日 `"YYYY-MM-DD"`）。
+   */
+  deletePeriod(periodId: DeliveryLocationSellingPricePeriodId, referenceDate: string): void {
+    const row = this.requireRow(periodId);
+    if (!this.isFuture(row.period, referenceDate)) {
+      throw new BusinessRuleViolationError(
+        `${DeliveryLocationSellingPrice.ENTITY_NAME}は未来開始行のみ削除できます（現在有効・失効の行は削除不可）`
+      );
+    }
+    this._periods.splice(this._periods.indexOf(row), 1);
+  }
+
+  /**
+   * 参照日（今日）時点で現在有効な期間行（開始 ≤ 今日 < 終了）を返す。無ければ undefined。
+   *
+   * 「現在有効」という述語を集約に集約するクエリ（read-only）。単価改定はこの行を `endDatePeriod`
+   * の対象として特定するために使う。半開区間の被覆判定はそのまま `ApplicablePeriod.contains` に委ねる。
+   * 集約内の重複ゼロ不変条件（`addPeriod`）により、被覆する行は高々1つに定まる。
+   *
+   * @param referenceDate 参照日（今日・JST 暦日 `"YYYY-MM-DD"`）。
+   */
+  currentValidPeriod(referenceDate: string): DeliveryLocationSellingPricePeriod | undefined {
+    return this._periods.find((row) => row.period.contains(referenceDate));
+  }
+
+  /** identity で期間行を引く。存在しなければ不変条件違反として投げる。 */
+  private requireRow(
+    periodId: DeliveryLocationSellingPricePeriodId
+  ): DeliveryLocationSellingPricePeriod {
+    const row = this._periods.find((r) => r.id.equals(periodId));
+    if (row === undefined) {
+      throw new BusinessRuleViolationError(
+        `${DeliveryLocationSellingPrice.ENTITY_NAME}に指定された適用期間行が存在しません`
+      );
+    }
+    return row;
+  }
+
+  /** 将来行か（今日 < 開始）。 */
+  private isFuture(period: ApplicablePeriod, referenceDate: string): boolean {
+    return referenceDate < period.start;
+  }
+
+  /** 適用開始日が参照日（今日）より前なら過去不変違反として投げる（ADR-20260627-86b）。 */
+  private assertStartNotPast(start: string, referenceDate: string): void {
+    if (start < referenceDate) {
+      throw new BusinessRuleViolationError(
+        `${DeliveryLocationSellingPrice.ENTITY_NAME}の適用開始日は今日以降である必要があります: ${start} < ${referenceDate}`
+      );
+    }
+  }
+
+  /**
+   * 指定期間が既存のどの行とも重ならないことを保証する。重なれば不変条件違反として投げる。
+   * `excludeRow` を渡すと自分自身（編集・適用終了の対象行）を比較から除外する。
+   */
+  private assertNoOverlap(
+    period: ApplicablePeriod,
+    excludeRow?: DeliveryLocationSellingPricePeriod
+  ): void {
+    const overlapping = this._periods.find(
+      (row) => row !== excludeRow && row.period.overlaps(period)
+    );
     if (overlapping !== undefined) {
       throw new BusinessRuleViolationError(
         `${DeliveryLocationSellingPrice.ENTITY_NAME}の適用期間が既存の期間と重複しています`
       );
     }
-    this._periods.push(DeliveryLocationSellingPricePeriod.create(period, price));
   }
 
   get deliveryLocationId(): DeliveryLocationId {
@@ -87,6 +226,15 @@ export class DeliveryLocationSellingPrice {
 
   get productId(): ProductId {
     return this._productId;
+  }
+
+  /**
+   * 期間行を1件も持たない空集約（＝未設定）か。CONTEXT.md の「未設定＝期間行0件」の派生状態を
+   * 集約自身の語彙で表す。最終期間の削除で 0 件になった器を「集約ごと片付ける」判断に使い、
+   * 不変条件「親行の存在 ⟺ 期間行≥1件」を回復する（#512・B案）。
+   */
+  get isEmpty(): boolean {
+    return this._periods.length === 0;
   }
 
   /** 適用期間行（読み取り専用ビュー）。 */

--- a/src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPricePeriod.ts
+++ b/src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPricePeriod.ts
@@ -12,8 +12,8 @@ import { SellingUnitPrice } from "../values/SellingUnitPrice";
 export class DeliveryLocationSellingPricePeriod {
   private constructor(
     private readonly _id: DeliveryLocationSellingPricePeriodId,
-    private readonly _period: ApplicablePeriod,
-    private readonly _price: SellingUnitPrice
+    private _period: ApplicablePeriod,
+    private _price: SellingUnitPrice
   ) {}
 
   /** 新規の期間行を生成する（identity を採番）。 */
@@ -35,6 +35,23 @@ export class DeliveryLocationSellingPricePeriod {
     price: SellingUnitPrice
   ): DeliveryLocationSellingPricePeriod {
     return new DeliveryLocationSellingPricePeriod(id, period, price);
+  }
+
+  /**
+   * 期間と単価を差し替える（将来行の編集用・集約ルートからのみ呼ぶ）。
+   * 行状態ガード（将来行限定）は集約ルート側の不変条件で守るため、ここでは状態を見ない。
+   */
+  changeTo(period: ApplicablePeriod, price: SellingUnitPrice): void {
+    this._period = period;
+    this._price = price;
+  }
+
+  /**
+   * 終了日のみを差し替える（適用終了用・集約ルートからのみ呼ぶ）。
+   * 開始日・単価は変えない。状態ガード（現在有効行限定）は集約ルート側で守る。
+   */
+  endDateOn(endDate: string): void {
+    this._period = ApplicablePeriod.create({ start: this._period.start, end: endDate });
   }
 
   get id(): DeliveryLocationSellingPricePeriodId {

--- a/src/server/subdomains/pricing/domain/entities/__tests__/DeliveryLocationSellingPrice.test.ts
+++ b/src/server/subdomains/pricing/domain/entities/__tests__/DeliveryLocationSellingPrice.test.ts
@@ -45,13 +45,15 @@ describe("DeliveryLocationSellingPrice 集約", () => {
   });
 
   describe("addPeriod — 適用期間行の追加", () => {
+    const today = "2025-06-01";
+
     it("期間行を追加でき、期間と単価が保持される", () => {
       const aggregate = DeliveryLocationSellingPrice.create(
         deliveryLocationId,
         productId,
         ProductCategory.INDIVIDUAL
       );
-      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
 
       expect(aggregate.periods).toHaveLength(1);
       const row = aggregate.periods[0];
@@ -65,8 +67,8 @@ describe("DeliveryLocationSellingPrice 集約", () => {
         productId,
         ProductCategory.INDIVIDUAL
       );
-      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
-      aggregate.addPeriod(period("2025-10-01", null), price(1200));
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
+      aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
 
       const [a, b] = aggregate.periods;
       expect(a.id.equals(b.id)).toBe(false);
@@ -78,8 +80,8 @@ describe("DeliveryLocationSellingPrice 集約", () => {
         productId,
         ProductCategory.INDIVIDUAL
       );
-      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
-      aggregate.addPeriod(period("2025-10-01", null), price(1200));
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
+      aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
 
       expect(aggregate.periods).toHaveLength(2);
     });
@@ -90,11 +92,11 @@ describe("DeliveryLocationSellingPrice 集約", () => {
         productId,
         ProductCategory.INDIVIDUAL
       );
-      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
 
-      expect(() => aggregate.addPeriod(period("2025-09-01", "2025-12-01"), price(1100))).toThrow(
-        BusinessRuleViolationError
-      );
+      expect(() =>
+        aggregate.addPeriod(period("2025-09-01", "2025-12-01"), price(1100), today)
+      ).toThrow(BusinessRuleViolationError);
       // 失敗時は追加されない
       expect(aggregate.periods).toHaveLength(1);
     });
@@ -105,11 +107,367 @@ describe("DeliveryLocationSellingPrice 集約", () => {
         productId,
         ProductCategory.INDIVIDUAL
       );
-      aggregate.addPeriod(period("2025-07-01", null), price(1000));
+      aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
 
-      expect(() => aggregate.addPeriod(period("2030-01-01", "2030-02-01"), price(1100))).toThrow(
+      expect(() =>
+        aggregate.addPeriod(period("2030-01-01", "2030-02-01"), price(1100), today)
+      ).toThrow(BusinessRuleViolationError);
+    });
+
+    it("開始日が今日と同じなら追加できる（境界・以上）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period(today, null), price(1000), today);
+
+      expect(aggregate.periods).toHaveLength(1);
+    });
+
+    it("開始日が今日より前なら BusinessRuleViolationError（過去への後付け登録を禁止）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+
+      expect(() => aggregate.addPeriod(period("2025-05-31", null), price(1000), today)).toThrow(
         BusinessRuleViolationError
       );
+      expect(aggregate.periods).toHaveLength(0);
+    });
+  });
+
+  describe("editPeriod — 将来行の全項目編集", () => {
+    const today = "2025-06-01";
+
+    it("将来行の期間と単価を差し替えられる（identity は保持）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
+      const id = aggregate.periods[0].id;
+
+      aggregate.editPeriod(
+        id,
+        { period: period("2025-08-01", "2025-11-01"), price: price(1500) },
+        today
+      );
+
+      const row = aggregate.periods[0];
+      expect(row.id.equals(id)).toBe(true);
+      expect(row.period.equals(period("2025-08-01", "2025-11-01"))).toBe(true);
+      expect(row.price.equals(price(1500))).toBe(true);
+    });
+
+    it("現在有効行は編集できない（BusinessRuleViolationError・単価ロック）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      // 開始 ≤ 今日 < 終了 = 現在有効
+      aggregate.addPeriod(period("2025-05-01", "2025-12-01"), price(1000), "2025-04-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() =>
+        aggregate.editPeriod(id, { period: period("2025-07-01", null), price: price(1500) }, today)
+      ).toThrow(BusinessRuleViolationError);
+      // 失敗時は元のまま
+      expect(aggregate.periods[0].period.equals(period("2025-05-01", "2025-12-01"))).toBe(true);
+      expect(aggregate.periods[0].price.equals(price(1000))).toBe(true);
+    });
+
+    it("失効行は編集できない（BusinessRuleViolationError）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      // 今日 ≥ 終了 = 失効
+      aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() =>
+        aggregate.editPeriod(id, { period: period("2025-07-01", null), price: price(1500) }, today)
+      ).toThrow(BusinessRuleViolationError);
+    });
+
+    it("存在しない periodId は BusinessRuleViolationError", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
+
+      expect(() =>
+        aggregate.editPeriod(
+          DeliveryLocationSellingPricePeriodId.generate(),
+          { period: period("2025-08-01", null), price: price(1500) },
+          today
+        )
+      ).toThrow(BusinessRuleViolationError);
+    });
+  });
+
+  describe("endDatePeriod — 現在有効行の適用終了", () => {
+    const today = "2025-06-01";
+
+    it("現在有効行に終了日を設定でき、開始日・単価は変わらない", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      aggregate.endDatePeriod(id, "2025-09-01", today);
+
+      const row = aggregate.periods[0];
+      expect(row.period.equals(period("2025-04-01", "2025-09-01"))).toBe(true);
+      expect(row.price.equals(price(1000))).toBe(true);
+      expect(row.id.equals(id)).toBe(true);
+    });
+
+    it("終了日が今日以前なら不可（過去の被覆を遡及削除させない）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, today, today)).toThrow(BusinessRuleViolationError);
+    });
+
+    it("将来行には適用終了できない（編集で対応する）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "2025-12-01", today)).toThrow(
+        BusinessRuleViolationError
+      );
+    });
+
+    it("失効行には適用終了できない", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "2025-12-01", today)).toThrow(
+        BusinessRuleViolationError
+      );
+    });
+
+    it("有界の現在有効行を既存終了日より後へは延長できない（短縮のみ許可）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "2025-12-01", today)).toThrow(
+        BusinessRuleViolationError
+      );
+    });
+
+    it("有界の現在有効行で既存終了日と同一の終了日は不可（短縮になっていない）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "2025-07-01", today)).toThrow(
+        BusinessRuleViolationError
+      );
+    });
+
+    it("有界の現在有効行を既存終了日より手前へは短縮できる", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      aggregate.endDatePeriod(id, "2025-06-15", today);
+
+      expect(aggregate.periods[0].period.equals(period("2025-04-01", "2025-06-15"))).toBe(true);
+    });
+
+    it("実在しない日付の終了日は形式エラー（短縮判定より前に弾く）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "9999-99-99", today)).toThrow(ValidationError);
+    });
+
+    it("空文字の終了日は形式エラー（今日比較より前に弾く）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-04-01", "2025-07-01"), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.endDatePeriod(id, "", today)).toThrow(ValidationError);
+    });
+  });
+
+  describe("deletePeriod — 未来開始行の削除", () => {
+    const today = "2025-06-01";
+
+    it("将来行を削除できる（誤入力訂正）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), today);
+      aggregate.addPeriod(period("2025-10-01", null), price(1200), today);
+      const id = aggregate.periods[0].id;
+
+      aggregate.deletePeriod(id, today);
+
+      expect(aggregate.periods).toHaveLength(1);
+      expect(aggregate.periods[0].period.equals(period("2025-10-01", null))).toBe(true);
+    });
+
+    it("現在有効行は削除できない（BusinessRuleViolationError）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.deletePeriod(id, today)).toThrow(BusinessRuleViolationError);
+      expect(aggregate.periods).toHaveLength(1);
+    });
+
+    it("失効行は削除できない（BusinessRuleViolationError）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01");
+      const id = aggregate.periods[0].id;
+
+      expect(() => aggregate.deletePeriod(id, today)).toThrow(BusinessRuleViolationError);
+      expect(aggregate.periods).toHaveLength(1);
+    });
+
+    it("存在しない periodId は BusinessRuleViolationError", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-07-01", null), price(1000), today);
+
+      expect(() =>
+        aggregate.deletePeriod(DeliveryLocationSellingPricePeriodId.generate(), today)
+      ).toThrow(BusinessRuleViolationError);
+    });
+  });
+
+  describe("currentValidPeriod — 現在有効行の照会", () => {
+    const today = "2025-06-01";
+
+    it("現在有効行（開始 ≤ 今日 < 終了）を返す", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-04-01", "2025-12-01"), price(1000), "2025-03-01");
+
+      const row = aggregate.currentValidPeriod(today);
+
+      expect(row).toBeDefined();
+      expect(row?.period.equals(period("2025-04-01", "2025-12-01"))).toBe(true);
+      expect(row?.price.equals(price(1000))).toBe(true);
+    });
+
+    it("無期限の現在有効行（開始 ≤ 今日・終了なし）を返す", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-04-01", null), price(1000), "2025-03-01");
+
+      const row = aggregate.currentValidPeriod(today);
+
+      expect(row?.period.equals(period("2025-04-01", null))).toBe(true);
+    });
+
+    it("現在有効行が無ければ undefined（将来行・失効行のみ）", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      aggregate.addPeriod(period("2025-01-01", "2025-04-01"), price(1000), "2024-12-01"); // 失効
+      aggregate.addPeriod(period("2025-07-01", null), price(1200), today); // 将来
+
+      expect(aggregate.currentValidPeriod(today)).toBeUndefined();
+    });
+
+    it("空集約では undefined", () => {
+      const aggregate = DeliveryLocationSellingPrice.create(
+        deliveryLocationId,
+        productId,
+        ProductCategory.INDIVIDUAL
+      );
+      expect(aggregate.currentValidPeriod(today)).toBeUndefined();
+    });
+  });
+
+  describe("isEmpty — 空集約の判定", () => {
+    it("期間行が0件なら true（未設定＝空集約シェル）", () => {
+      const aggregate = DeliveryLocationSellingPrice.reconstruct(deliveryLocationId, productId, []);
+      expect(aggregate.isEmpty).toBe(true);
+    });
+
+    it("期間行が1件以上あれば false", () => {
+      const aggregate = DeliveryLocationSellingPrice.reconstruct(deliveryLocationId, productId, [
+        {
+          id: DeliveryLocationSellingPricePeriodId.generate(),
+          period: period("2025-07-01", null),
+          price: price(1000),
+        },
+      ]);
+      expect(aggregate.isEmpty).toBe(false);
     });
   });
 

--- a/src/server/subdomains/pricing/domain/repositories/DeliveryLocationSellingPriceRepository.ts
+++ b/src/server/subdomains/pricing/domain/repositories/DeliveryLocationSellingPriceRepository.ts
@@ -8,8 +8,8 @@ import { DeliveryLocationSellingPrice } from "../entities";
  * 時点解決（見積年月日で有効な売単価を引く）は read 関心として価格決定フェーズの
  * QueryService に置くため、本リポジトリは集約単位の取得・永続化に限定する（ADR-0066 /
  * 20260624-8tg）。集約の identity は複合自然キー（納品先 × 商品）のため取得 API も両キーを
- * 受ける。永続化は親 version＋期間行の append-only 同期で行い、楽観ロックは insert/update
- * 分割で扱う（ADR-0039）。
+ * 受ける。insert は append-only、update は差分 sync（編集・適用終了・削除を反映）で永続化し、
+ * 楽観ロックは親 version の条件付き更新を insert/update 分割で扱う（ADR-0032 / 0039）。
  */
 export interface DeliveryLocationSellingPriceRepository {
   /** 納品先ID×商品IDで集約を取得する。未登録なら null。 */
@@ -24,10 +24,24 @@ export interface DeliveryLocationSellingPriceRepository {
   /**
    * 既存の納品先別販売単価集約を更新する（楽観ロック / ADR-0039）。
    *
-   * 期間行は append-only で同期し、親 version を条件に更新する。
+   * 期間行は差分 sync（編集の in-place 更新・適用終了・削除を反映）で集約の現在状態へ収束させ、
+   * 親 version を条件に更新する（ADR-0032）。
    *
    * @param expectedVersion 編集画面表示時に取得した version（フォーム往復で持ち回るトークン）。
    *   保存時点の version と一致しない場合は ConflictError を throw し、後勝ちの変更喪失を防ぐ。
    */
   update(aggregate: DeliveryLocationSellingPrice, expectedVersion: number): Promise<void>;
+
+  /**
+   * 空になった集約をルート行ごと削除する（insert の対・#512 B案）。
+   *
+   * 最終期間の削除で期間行が0件になったとき、アプリ層がこれを呼び「空集約シェル」を残さず
+   * 不変条件「親行の存在 ⟺ 期間行≥1件」を回復する。親（delivery_location_selling_prices）を1本
+   * 消せば FK `onDelete: Cascade` で残りの期間行も掃かれるため、子の明示削除は不要。
+   *
+   * @param expectedVersion 編集画面表示時に取得した version（楽観ロック・ADR-0039）。保存時点の
+   *   version と一致しない場合は ConflictError を throw し、「A が最終行削除中に B が期間追加」の
+   *   競合を握り潰さない。
+   */
+  delete(aggregate: DeliveryLocationSellingPrice, expectedVersion: number): Promise<void>;
 }

--- a/src/server/subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository.ts
+++ b/src/server/subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository.ts
@@ -10,6 +10,7 @@ import {
 import {
   appendPeriodRows,
   assertVersionBumped,
+  syncPeriodRows,
   translateInsertConflict,
   type Tx,
 } from "@subdomains/pricing/infrastructure/prisma/sellingPricePeriodPersistence";
@@ -20,12 +21,14 @@ import { ProductId } from "@subdomains/product/domain/values/ProductId";
  *
  * 共通・得意先別販売単価リポジトリと同型で、宛先が納品先（複合自然キー identity）である点だけが
  * 異なる（ADR-20260624-8tg）。適用期間（daterange）は Prisma typed では扱えないため、期間行の
- * 読み出しは `$queryRaw`・境界展開は `applicablePeriodBounds` に委ねる（ADR-0067）。期間行の書き込み
- * （append-only INSERT）・P2002 の ConflictError 翻訳・楽観ロックの version 判定は、3層で共通の
- * 永続化ヘルパ `sellingPricePeriodPersistence` に委譲する（#458）。期間行の同期は append-only で、
- * 新規 id のみを挿入し既存行には触れない（`ON CONFLICT (id) DO NOTHING`）。ドメインの変更操作が
- * addPeriod（追加）のみ・子が id 単位で内容不変ゆえ削除分岐は到達不能で、既存行を触らないため
- * 改定時に updated_at を保持できる（監査保持）。楽観ロックは親 version の条件付き更新で行う（ADR-0039）。
+ * 読み出しは `$queryRaw`・境界展開は `applicablePeriodBounds` に委ねる（ADR-0067）。期間行の書き込み・
+ * P2002 の ConflictError 翻訳・楽観ロックの version 判定は、3層で共通の永続化ヘルパ
+ * `sellingPricePeriodPersistence` に委譲する（#458）。
+ *
+ * insert は新規作成ゆえ衝突が無く append-only（`ON CONFLICT (id) DO NOTHING`）で足りる。update は
+ * 編集・適用終了・削除を伴うため差分 sync（`syncPeriodRows`）で DB を集約の現在状態へ収束させる:
+ * 既存 id は値が変わった行だけ in-place 更新し（無変更行は `updated_at` 据え置き＝監査保持）、
+ * 集約から消えた id の行は削除する（ADR-0032）。楽観ロックは親 version の条件付き更新（ADR-0039）。
  */
 export class PrismaDeliveryLocationSellingPriceRepository implements DeliveryLocationSellingPriceRepository {
   async findByDeliveryLocationIdAndProductId(
@@ -95,30 +98,54 @@ export class PrismaDeliveryLocationSellingPriceRepository implements DeliveryLoc
       });
       assertVersionBumped(result.count);
 
-      // 期間行は append-only で同期する。ドメインの変更操作は addPeriod（追加）のみで子は
-      // id 単位で内容不変ゆえ、集約は常に DB の id を包含し「DB にあって集約に無い id（=削除）」
-      // は発生しない。よって既存行に触れず新規 id のみ挿入すればよく、既存行の updated_at は
-      // まったく動かない（監査保持）。
-      await this.writePeriods(tx, aggregate);
+      // 期間行は差分 sync で集約の現在状態へ収束させる（編集の in-place 更新・適用終了・削除を反映）。
+      // 値が変わった行だけ updated_at が前進し、無変更行は据え置かれる（監査保持）。
+      await syncPeriodRows(
+        tx,
+        PrismaDeliveryLocationSellingPriceRepository.PERIOD_TABLE,
+        [aggregate.deliveryLocationId.value, aggregate.productId.value],
+        this.toWriteRows(aggregate)
+      );
     });
   }
 
-  /** 集約の全期間行を append-only で同期する（共通ヘルパへ委譲）。 */
+  async delete(aggregate: DeliveryLocationSellingPrice, expectedVersion: number): Promise<void> {
+    // WHERE 複合キー AND version の条件付き削除で「比較→削除」を原子化する。count = 0 は
+    // version 不一致（並行更新・例: 最終行削除中の期間追加）と行消失の両方を覆い ConflictError
+    // へ翻訳する（ADR-0039）。親 1 行の削除で FK onDelete: Cascade が期間行も掃くため子は書かない。
+    const result = await prisma.deliveryLocationSellingPrice.deleteMany({
+      where: {
+        deliveryLocationId: aggregate.deliveryLocationId.value,
+        productId: aggregate.productId.value,
+        version: expectedVersion,
+      },
+    });
+    assertVersionBumped(result.count);
+  }
+
+  private static readonly PERIOD_TABLE = {
+    table: "delivery_location_selling_price_periods",
+    keyColumns: ["delivery_location_id", "product_id"],
+    valueColumn: "selling_price",
+  } as const;
+
+  /** 集約の全期間行を append-only で挿入する（新規作成専用・共通ヘルパへ委譲）。 */
   private async writePeriods(tx: Tx, aggregate: DeliveryLocationSellingPrice): Promise<void> {
     await appendPeriodRows(
       tx,
-      {
-        table: "delivery_location_selling_price_periods",
-        keyColumns: ["delivery_location_id", "product_id"],
-        valueColumn: "selling_price",
-      },
-      DeliveryLocationSellingPriceMapper.toPeriodWriteRows(aggregate).map((row) => ({
-        id: row.id,
-        keyValues: [row.deliveryLocationId, row.productId],
-        value: row.sellingPrice,
-        start: row.start,
-        end: row.end,
-      }))
+      PrismaDeliveryLocationSellingPriceRepository.PERIOD_TABLE,
+      this.toWriteRows(aggregate)
     );
+  }
+
+  /** 集約の期間行を永続化ヘルパの行形式へ変換する。 */
+  private toWriteRows(aggregate: DeliveryLocationSellingPrice) {
+    return DeliveryLocationSellingPriceMapper.toPeriodWriteRows(aggregate).map((row) => ({
+      id: row.id,
+      keyValues: [row.deliveryLocationId, row.productId],
+      value: row.sellingPrice,
+      start: row.start,
+      end: row.end,
+    }));
   }
 }

--- a/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts
@@ -94,7 +94,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       ProductCategory.INDIVIDUAL
     );
     aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
-    aggregate.addPeriod(period("2025-10-01", null), price(1234.56), "2025-07-01");
+    aggregate.addPeriod(period("2025-10-01", null), price(1234.56), "2025-10-01");
     await repository.insert(aggregate);
 
     const found = await repository.findByDeliveryLocationIdAndProductId(
@@ -128,7 +128,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       deliveryLocationId,
       productId
     ))!;
-    reloaded.addPeriod(period("2025-10-01", null), price(1200), "2025-07-01");
+    reloaded.addPeriod(period("2025-10-01", null), price(1200), "2025-10-01");
     await repository.update(reloaded, 1);
 
     const found = (await repository.findByDeliveryLocationIdAndProductId(
@@ -139,7 +139,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
     expect(found.periods[1].price.equals(price(1200))).toBe(true);
   });
 
-  it("update は既存期間行の updated_at を変更しない（append-only・監査保持）", async () => {
+  it("update は無変更の既存行の updated_at を変更しない（監査保持）", async () => {
     const aggregate = DeliveryLocationSellingPrice.create(
       deliveryLocationId,
       productId,
@@ -161,7 +161,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       deliveryLocationId,
       productId
     ))!;
-    reloaded.addPeriod(period("2025-10-01", null), price(1200), "2025-07-01");
+    reloaded.addPeriod(period("2025-10-01", null), price(1200), "2025-10-01");
     await repository.update(reloaded, 1);
 
     const rows = await prisma.$queryRaw<{ updatedAt: Date; start: string }[]>`
@@ -176,6 +176,178 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
     expect(rows[0].updatedAt.toISOString()).toBe(frozen.toISOString());
     // 追加行（2025-10-01 始まり）は今回の挿入なので過去値ではない。
     expect(rows[1].updatedAt.getTime()).toBeGreaterThan(frozen.getTime());
+  });
+
+  it("update で将来行の単価改定が in-place 反映され、改定行の updated_at が進む（編集の永続化）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+
+    // 改定前の updated_at を既知の過去値へ固定し、in-place 更新で前進したことを検出可能にする。
+    const frozen = new Date("2020-01-01T00:00:00.000Z");
+    await prisma.$executeRaw`
+      UPDATE delivery_location_selling_price_periods
+      SET updated_at = ${frozen}
+      WHERE delivery_location_id = ${deliveryLocationId.value}::uuid AND product_id = ${productId.value}::uuid
+    `;
+
+    const reloaded = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!;
+    const id = reloaded.periods[0].id;
+    reloaded.editPeriod(
+      id,
+      { period: period("2030-01-01", null), price: price(1500) },
+      "2025-06-01"
+    );
+    await repository.update(reloaded, 1);
+
+    const found = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!;
+    expect(found.periods).toHaveLength(1);
+    // id を保ったまま（差分 upsert・新規行を作らない）単価が改定される。
+    expect(found.periods[0].id.equals(id)).toBe(true);
+    expect(found.periods[0].price.equals(price(1500))).toBe(true);
+
+    const rows = await prisma.$queryRaw<{ updatedAt: Date }[]>`
+      SELECT updated_at AS "updatedAt"
+      FROM delivery_location_selling_price_periods
+      WHERE delivery_location_id = ${deliveryLocationId.value}::uuid AND product_id = ${productId.value}::uuid
+    `;
+    // 改定した行は updated_at が前進する（監査）。
+    expect(rows[0].updatedAt.getTime()).toBeGreaterThan(frozen.getTime());
+  });
+
+  it("update で集約から消えた将来行は DB からも削除される（削除の永続化）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2025-06-01");
+    aggregate.addPeriod(period("2030-06-01", null), price(1200), "2025-06-01");
+    await repository.insert(aggregate);
+
+    const reloaded = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!;
+    const firstId = reloaded.periods[0].id;
+    reloaded.deletePeriod(firstId, "2025-06-01");
+    await repository.update(reloaded, 1);
+
+    const found = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!;
+    expect(found.periods).toHaveLength(1);
+    expect(found.periods[0].period.equals(period("2030-06-01", null))).toBe(true);
+  });
+
+  it("update で最後の将来行を削除すると期間行が0件になる（空集約 delete・空配列バインド）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+
+    // 唯一の将来行を削除 → syncPeriodRows が rows=[] で DELETE ... ANY('{}'::uuid[]) を走らせる経路。
+    const reloaded = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!;
+    reloaded.deletePeriod(reloaded.periods[0].id, "2025-06-01");
+    await repository.update(reloaded, 1);
+
+    // 親（delivery_location_selling_prices）は残り、期間行だけ0件＝空集約として往復する（例外なく完了）。
+    const found = await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    );
+    expect(found).not.toBeNull();
+    expect(found!.periods).toHaveLength(0);
+  });
+
+  it("delete で親行を削除すると期間行も cascade で消える（空集約の後始末・#512）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+
+    const reloaded = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!;
+    reloaded.deletePeriod(reloaded.periods[0].id, "2025-06-01");
+    await repository.delete(reloaded, 1);
+
+    expect(
+      await repository.findByDeliveryLocationIdAndProductId(deliveryLocationId, productId)
+    ).toBeNull();
+    const remaining = await prisma.$queryRaw<{ count: bigint }[]>`
+      SELECT count(*)::bigint AS count
+      FROM delivery_location_selling_price_periods
+      WHERE delivery_location_id = ${deliveryLocationId.value}::uuid AND product_id = ${productId.value}::uuid
+    `;
+    expect(Number(remaining[0].count)).toBe(0);
+  });
+
+  it("delete で expectedVersion が古いと ConflictError（最終行削除中の並行追加を握り潰さない）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+
+    await expect(repository.delete(aggregate, 999)).rejects.toBeInstanceOf(ConflictError);
+    expect(
+      await repository.findByDeliveryLocationIdAndProductId(deliveryLocationId, productId)
+    ).not.toBeNull();
+  });
+
+  it("delete 後に同一の納品先×商品で insert が成功する（version 1・再登録経路の回帰・#512）", async () => {
+    const first = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    first.addPeriod(period("2030-01-01", null), price(1000), "2025-06-01");
+    await repository.insert(first);
+    const reloaded = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!;
+    reloaded.deletePeriod(reloaded.periods[0].id, "2025-06-01");
+    await repository.delete(reloaded, 1);
+
+    const reregister = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    reregister.addPeriod(period("2030-02-01", null), price(2000), "2025-06-01");
+    await repository.insert(reregister);
+
+    const found = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!;
+    expect(found.periods).toHaveLength(1);
+    expect(found.periods[0].price.equals(price(2000))).toBe(true);
   });
 
   it("古い expectedVersion での update は ConflictError", async () => {

--- a/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts
@@ -93,8 +93,8 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
-    aggregate.addPeriod(period("2025-10-01", null), price(1234.56));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
+    aggregate.addPeriod(period("2025-10-01", null), price(1234.56), "2025-07-01");
     await repository.insert(aggregate);
 
     const found = await repository.findByDeliveryLocationIdAndProductId(
@@ -120,7 +120,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     // 画面表示時の version=1 を持ち回って改定（期間を1本追加）
@@ -128,7 +128,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       deliveryLocationId,
       productId
     ))!;
-    reloaded.addPeriod(period("2025-10-01", null), price(1200));
+    reloaded.addPeriod(period("2025-10-01", null), price(1200), "2025-07-01");
     await repository.update(reloaded, 1);
 
     const found = (await repository.findByDeliveryLocationIdAndProductId(
@@ -145,7 +145,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     // 既存行の updated_at を既知の過去値に固定し、偶発的な現在時刻一致を排除する。
@@ -161,7 +161,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       deliveryLocationId,
       productId
     ))!;
-    reloaded.addPeriod(period("2025-10-01", null), price(1200));
+    reloaded.addPeriod(period("2025-10-01", null), price(1200), "2025-07-01");
     await repository.update(reloaded, 1);
 
     const rows = await prisma.$queryRaw<{ updatedAt: Date; start: string }[]>`
@@ -184,7 +184,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    aggregate.addPeriod(period("2025-07-01", null), price(1000));
+    aggregate.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     await expect(repository.update(aggregate, 999)).rejects.toBeInstanceOf(ConflictError);
@@ -196,7 +196,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    first.addPeriod(period("2025-07-01", null), price(1000));
+    first.addPeriod(period("2025-07-01", null), price(1000), "2025-07-01");
     await repository.insert(first);
 
     // アプリ層の存在チェックをすり抜けた二重作成レースを模す。
@@ -205,7 +205,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    second.addPeriod(period("2025-07-01", null), price(2000));
+    second.addPeriod(period("2025-07-01", null), price(2000), "2025-07-01");
     await expect(repository.insert(second)).rejects.toBeInstanceOf(ConflictError);
   });
 
@@ -215,7 +215,7 @@ describe("PrismaDeliveryLocationSellingPriceRepository", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     // 並行 stale 書き込みを模して、ドメインのガードを迂回し重なる期間を直接 INSERT する。

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceQueryService.test.ts
@@ -119,7 +119,7 @@ describe("PrismaDeliveryLocationSellingPriceQueryService", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     const result = await queryService.resolve({
@@ -137,7 +137,7 @@ describe("PrismaDeliveryLocationSellingPriceQueryService", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     const result = await queryService.resolve({
@@ -155,7 +155,7 @@ describe("PrismaDeliveryLocationSellingPriceQueryService", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     const result = await queryService.resolve({
@@ -189,7 +189,7 @@ describe("PrismaDeliveryLocationSellingPriceQueryService", () => {
       productId,
       ProductCategory.INDIVIDUAL
     );
-    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000));
+    aggregate.addPeriod(period("2025-07-01", "2025-10-01"), price(1000), "2025-07-01");
     await repository.insert(aggregate);
 
     const result = await queryService.resolve({


### PR DESCRIPTION
## Summary

納品先別販売単価の「書き込み」関心を実装。ドメイン集約 `DeliveryLocationSellingPrice` に編集系ミューテータ（edit/endDate/delete/currentValid）を補完し、application/commands（Register/Edit/Revise/EndDate/Delete）と factories、取得ヘルパを追加。編集・適用終了・削除の永続化のためリポジトリを差分sync化し delete を追加した。

Closes #545

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### delivery-location-selling-price-write-usecase.md

# Issue #545: 納品先別販売単価の書き込みユースケース（ドメイン編集操作 + commands/factories） — 実装計画

## Context

納品先別販売単価 `DeliveryLocationSellingPrice` は、集約・スキーマ・時点解決 QueryService まで実装済みだが、
編集系の「書き込み」関心が未実装。現状の集約は `addPeriod`（追加）しか持たず、application 層に
コマンドも factory も無いため、画面から登録・編集・改定・適用終了・削除ができない。

本 Issue は親 #544 の分割のうち **BE 書き込み側**。既に完成している **得意先別 #505**（`CustomerSellingPrice`）が
ほぼ完全なテンプレートで、identity が複合自然キー `DeliveryLocationId × ProductId` である点だけが異なる。
得意先別と同型に補完し、納品先別の書き込みユースケースを機能させることが目的。

**調査で判明した重要事実**: Issue 本文の「含む」スコープはドメイン編集操作 + commands + factories を挙げるが、
現状の `PrismaDeliveryLocationSellingPriceRepository` は **追記専用（append-only, `ON CONFLICT DO NOTHING`）**で
実装されている（過去に mutation が `addPeriod` のみだった前提）。`editPeriod`（将来行の内容差し替え）・
`endDatePeriod`（終了日書き換え）・`deletePeriod`（行削除）は既存行の in-place 更新・削除を伴うため、
追記専用のままではこれらの書き込みが**黙って失われる**。したがってインフラ層の改修が必須で、
ユーザー確認済みで本 Issue に含める。

## 設計判断

### 全体方針: 得意先別 #505 の完全踏襲
- 得意先別（`CustomerSellingPrice` 集約 / `*CustomerSellingPricePeriodCommand` / `*CommandFactory`）を
  identity（`CustomerId` → `DeliveryLocationId`）だけ差し替えて模倣する。参照日注入（input に `referenceDate`）・
  楽観ロック（input に `expectedVersion`、既存集約追加時は必須で未指定は `ValidationError`）・結果型（登録後の集約を返す）は
  すべて得意先別と同一契約。判断不要（既存パターン踏襲）。

### インフラ層の期間行永続化ヘルパの共有範囲（Issue の未決事項）
- 共通ヘルパ `sellingPricePeriodPersistence.ts` に差分同期版 `syncPeriodRows`（upsert＋消えた id の削除）が
  **既に存在**し、得意先別リポジトリが使用中。納品先別も `update()` を `appendPeriodRows` → `syncPeriodRows` へ
  切替え、`delete()` を追加するだけでよい。**ヘルパ自体の改修は不要**。判断不要。

### factory の「pricingQueryFactory への配線」の解釈
- Issue は「`pricingQueryFactory` への配線含む」と記すが、得意先別の書き込み factory は
  `registerCustomerSellingPricePeriodCommandFactory.ts` 等の**独立ファイル**として実装されており、
  `pricingQueryFactory.ts`（読みモデル/時点解決 query の factory 群）には**書き込みコマンドは配線されていない**。
- 推奨: 得意先別踏襲で独立 factory ファイル 5 本を新設し、`pricingQueryFactory.ts` は**変更しない**。
  （書き込み factory を pricingQueryFactory に集約する構成変更は本 Issue の関心外）

### 状態別（future / active / expired）の編集・削除権限
- 集約の不変条件として得意先別と同一に展開する（判断不要）:
  editPeriod=将来行のみ / endDatePeriod=現在有効行のみ・短縮限定 / deletePeriod=未来開始行のみ /
  addPeriod=開始日 ≥ 参照日・重複禁止。すべて `BusinessRuleViolationError`。

### スコープ逸脱の記録
- Issue「含む」に無いインフラ層改修を追加するため、完了時に `docs/claude-plans/issue-545/deviations.md` へ
  {元の計画=含むにインフラ層記載なし}／{実際=書き込み機能に必須のため追加}／{理由} を記録する（CLAUDE.md 準拠）。

## ステップ

### Step 1: ドメイン層 — 編集操作の補完
- 対象ファイル:
  - `src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPricePeriod.ts`
  - `src/server/subdomains/pricing/domain/entities/DeliveryLocationSellingPrice.ts`
  - `src/server/subdomains/pricing/domain/entities/__tests__/DeliveryLocationSellingPrice.test.ts`
- 作業内容（得意先別を鏡像コピー）:
  - 子エンティティ: `_period`/`_price` を mutable 化し、`changeTo(period, price)` と `endDateOn(endDate)` を追加
    （`CustomerSellingPricePeriod.ts` L33-48 と同一）
  - 集約ルート: `addPeriod` に `referenceDate` 引数を追加（`assertStartNotPast`）。
    `editPeriod` / `endDatePeriod` / `deletePeriod` / `currentValidPeriod` / `isEmpty` getter と、
    private helper `requireRow` / `isFuture` / `assertStartNotPast` / `assertNoOverlap` を追加
    （`CustomerSellingPrice.ts` L79-233 と同一。ENTITY_NAME だけ「納品先別販売単価」）
  - 集約テスト: 得意先別 `CustomerSellingPrice.test.ts`（34 ケース）を鏡像に拡充。
    編集・適用終了・削除・現在有効行取得・過去不変ガード・状態別権限を網羅
- コミットメッセージ: `feat: 納品先別販売単価集約に編集系ミューテータを補完（edit/endDate/delete/currentValid）`

### Step 2: インフラ層 — 差分同期化と delete 追加
- 対象ファイル:
  - `src/server/subdomains/pricing/domain/repositories/DeliveryLocationSellingPriceRepository.ts`
  - `src/server/subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository.ts`
  - `src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts`
- 作業内容（得意先別リポジトリ L80-143 と同型）:
  - interface に `delete(aggregate, expectedVersion): Promise<void>` を追加（`CustomerSellingPriceRepository` L36-46 相当）
  - Prisma 実装: `PERIOD_TABLE` を static 定数化。`update()` の `writePeriods`（append）を
    `syncPeriodRows(tx, PERIOD_TABLE, [deliveryLocationId, productId], toWriteRows)` へ切替。
    `writePeriods`（`appendPeriodRows`）は insert 専用として残す。`delete()` を `deleteMany`＋`assertVersionBumped` で追加。
    クラス doc の「append-only で削除分岐は到達不能」の記述を差分 sync 前提へ更新
  - リポジトリテスト: 得意先別テストの追加ケースを移植 — 将来行の in-place 編集反映／消えた行の削除／
    最終行削除で 0 件（空配列バインド）／`delete` の cascade／`delete` の古い version で ConflictError／
    delete 後の再 insert 成功。既存の「append-only」文言のテストを sync 前提へ修正
- コミットメッセージ: `feat: 納品先別販売単価リポジトリを差分sync化しdeleteを追加（編集・適用終了・削除の永続化）`
  - ボディに「append-only→syncPeriodRows 切替の理由（edit/endDate/delete が既存行の in-place 更新・削除を伴うため）」を記載

### Step 3: application/commands — 共有ヘルパ + Register
- 対象ファイル（新規）:
  - `src/server/subdomains/pricing/application/commands/loadDeliveryLocationSellingPriceOrThrow.ts`
  - `src/server/subdomains/pricing/application/commands/RegisterDeliveryLocationSellingPricePeriodCommand.ts`
  - `src/server/subdomains/pricing/application/commands/__tests__/RegisterDeliveryLocationSellingPricePeriodCommand.test.ts`
- 作業内容:
  - `loadDeliveryLocationSellingPriceOrThrow`: `findByDeliveryLocationIdAndProductId` で取得し無ければ `NotFoundEntityError`
    （得意先別 `loadCustomerSellingPriceOrThrow.ts` と同型）
  - Register: 未設定なら `ProductQueryService.findById` で区分取得 → `DeliveryLocationSellingPrice.create`（セット商品ガード・
    **create() の初回呼び出し元**・#531 申し送り確認）→ `addPeriod` → `insert`。既存なら `expectedVersion` 必須で `addPeriod` → `update`
    （得意先別 `RegisterCustomerSellingPricePeriodCommand.ts` L41-78 と同一）
  - テストは得意先別 Register テストを鏡像に移植
- コミットメッセージ: `feat: 納品先別販売単価の登録コマンドと取得ヘルパを追加`

### Step 4: application/commands — 編集系 4 種（Edit / EndDate / Delete / Revise）
- 対象ファイル（新規、各コマンド + テスト）:
  - `Edit` / `EndDate` / `Delete` / `Revise` `DeliveryLocationSellingPricePeriodCommand.ts` と `__tests__/*`
- 作業内容:
  - いずれも `loadDeliveryLocationSellingPriceOrThrow` で集約取得後、対応ミューテータを呼んで `update`
    （Delete のみ `aggregate.isEmpty` で `delete`/`update` を分岐、Revise は endDate→addPeriod の順で合成）。
    得意先別の同名コマンドを identity 差し替えで鏡像コピー
  - 各コマンドテストも得意先別から移植
- コミットメッセージ: `feat: 納品先別販売単価の編集・適用終了・削除・改定コマンドを追加`

### Step 5: application/factories — 書き込みコマンドの DI
- 対象ファイル（新規 5 本）:
  - `register` / `edit` / `revise` / `endDate` / `delete` `DeliveryLocationSellingPricePeriodCommandFactory.ts`
- 作業内容:
  - 各 factory は `new PrismaDeliveryLocationSellingPriceRepository()` を注入して対応コマンドを構築。
    Register のみ `new PrismaProductQueryService()` も注入（得意先別 factory 群と同型）。
  - `pricingQueryFactory.ts` は変更しない（設計判断参照）。factory はテスト対象外（薄い DI・得意先別も無し）
- コミットメッセージ: `feat: 納品先別販売単価 書き込みコマンドの factory を追加`

### Step 6: 逸脱記録
- 対象ファイル: `docs/claude-plans/issue-545/deviations.md`（新規）
- 作業内容: インフラ層改修をスコープに追加した経緯を記録（設計判断「スコープ逸脱の記録」参照）
- コミットメッセージ: `docs: issue-545 のスコープ逸脱（インフラ層追加）を記録`

## 検証

- **ユニット/統合**: 変更に関係するスペックのみ実行（ローカルで全 E2E は回さない）
  ```bash
  pnpm test src/server/subdomains/pricing/domain/entities/__tests__/DeliveryLocationSellingPrice.test.ts
  pnpm test src/server/subdomains/pricing/infrastructure/prisma/__tests__/PrismaDeliveryLocationSellingPriceRepository.test.ts
  pnpm test src/server/subdomains/pricing/application/commands/__tests__/  # 5 コマンド
  ```
  - リポジトリテストは実 DB を使う統合テスト。差分 sync（in-place 編集反映・消えた行削除・空集約 delete）と
    delete の cascade / ConflictError が緑になることを確認
- **型/lint**: `pnpm lint`（子エンティティを集約外から import していないか eslint `no-restricted-imports` で担保されることも確認）
- **レイヤ規約**: ドメイン層が Prisma/Next を import していないこと、application が repository **interface** に依存していることを確認（CLAUDE.md DDD ルール）
- **読みモデル/FE は本 Issue 対象外**（#546 以降）。書き込みコマンドが集約経由で永続化まで通ることをテストで担保する

</details>

## 計画からの逸脱

# Issue #545 実装の逸脱記録

## 1. スコープ外のインフラ層改修（リポジトリの差分sync化 + delete追加 + interfaceへのdelete追加）

### 元の計画 / Issue 文言

Issue #545 の「含む」スコープは以下の3点のみを挙げていた:

> - ドメイン編集操作（`editPeriod` / `endDatePeriod` / `deletePeriod` / `currentValidPeriod`）
> - application/commands（Register / Edit / Revise / EndDate / Delete + 共有ヘルパ）
> - application/factories（DI・pricingQueryFactory への配線含む）

インフラ層（`PrismaDeliveryLocationSellingPriceRepository` / `DeliveryLocationSellingPriceRepository`
インターフェース）の改修は Issue 本文に一切記載がなかった。

### 実際の実装

以下のインフラ層改修を本 Issue に追加した（計画時にユーザー承認済み）:

- **リポジトリ interface**: `delete(aggregate, expectedVersion): Promise<void>` を追加。
  `update` の doc を append-only → 差分 sync 前提へ更新。
- **Prisma 実装**: `update` の期間行同期を `appendPeriodRows`（追記専用）から `syncPeriodRows`
  （差分 upsert + 集約から消えた id の削除）へ切替。`delete` を親 version 条件付き `deleteMany` +
  `assertVersionBumped` で実装。`PERIOD_TABLE` を static 定数化し、insert 専用の append `writePeriods`
  と行変換 `toWriteRows` を分離。クラス doc を差分 sync 前提へ改稿。
- **リポジトリテスト**: 差分 sync（将来行の in-place 編集反映・消えた行の削除・最終行削除で0件の空配列
  バインド）、`delete` の cascade / 古い version での ConflictError / delete 後の再 insert 成功、を追加。

### 逸脱の理由

調査の結果、既存の `PrismaDeliveryLocationSellingPriceRepository` は **追記専用実装**
（`appendPeriodRows` / `ON CONFLICT (id) DO NOTHING`）だった。これは過去に納品先別集約の変更操作が
`addPeriod`（追加）のみで、子が id 単位で内容不変だった前提に基づく。

本 Issue で追加する `editPeriod`（将来行の内容差し替え）・`endDatePeriod`（終了日書き換え）・
`deletePeriod`（行削除）は、いずれも**既存行の in-place 更新・削除**を伴う。追記専用のままでは:

- `editPeriod` / `endDatePeriod`: 既存 id の値変更が `DO NOTHING` で握り潰され、**黙って永続化されない**
- `deletePeriod`: 集約から消えた行が DB に残り続け、**削除が反映されない**
- 最終行削除（空集約）: 親行を掃除する `delete` メソッド自体が存在しない（空シェルが残る）

したがってインフラ層の改修は、本 Issue が「含む」とした書き込みコマンドを**実際に機能させるための必須作業**
であり、これ無しでは commands / factories が完成しても書き込みが成立しない。共通ヘルパ
`sellingPricePeriodPersistence` には差分同期版 `syncPeriodRows` が既に存在し得意先別 #505 が使用中の
ため、ヘルパ自体の改修は不要で、納品先別リポジトリの呼び先を切り替えるだけで足りた。

計画作成時にこの隠れた必須作業をユーザーへ提示し、本 Issue に含める承認を得た。


---

Generated with [Claude Code](https://claude.ai/code)
