### PR TITLE
feat: 納品先別販売単価の読みモデル（一覧 / 編集 QueryService + DTO）

### DIFF
--- a/docs/claude-plans/issue-546/delivery-location-selling-price-read-model.md
+++ b/docs/claude-plans/issue-546/delivery-location-selling-price-read-model.md
@@ -1,0 +1,117 @@
+# Issue #546: 納品先別販売単価の読みモデル（一覧 / 編集 QueryService + DTO）— 実装計画
+
+## 概要
+
+親 #544 の分割のうち **BE 読み取り側**。納品先別販売単価の保守画面（FE は #547/#548）が消費する「読みモデル」を、得意先別 #506 とほぼ完全な同型で追加する。価格決定エンジン用の**時点解決 QueryService（既存）とは別物**で、本イシューは「一覧・保守画面に表示するための読み取りビュー」を担う。
+
+現状、納品先別は書き込み側 #550・リポジトリ・時点解決 QueryService・factory 群までコミット済みだが、**保守画面向けの List/Edit QueryService と DTO が未実装**。これを埋めるのが本イシューのゴール。Issue が明示した4つの未決事項はユーザー確認済み（下記「設計判断」に反映）。
+
+## 設計判断
+
+### 一覧の対比列（未決#3）→ 決定: 共通のみ併記
+- A. **共通単価のみ併記**（`currentCommonSellingPrice`）← 採用
+- B. 得意先別 + 共通の両方併記
+- C. 対比なし
+- 理由: 納品先宛の価格解決連鎖は `PriceResolutionPolicy` で **`納品先別 ?? 共通`**。得意先別は連鎖に入らない（`SellingPriceResolutionTarget` の宛先分岐で排他）。得意先別 #506 と同型で、DTO が実連鎖と一致し意味論のズレが無い。
+
+### 納品先セレクタの絞り込み（未決#2）→ 決定: 得意先→納品先の2段
+- A. **得意先→納品先の2段**（既存 `searchDeliveryLocationsForSelection(customerId, ...)` 流用）← 採用
+- B. 納品先の横断検索
+- 理由: 見積フローと同じメンタルモデル。既存の選択アクション（2段）をそのまま流用でき、新規BEコード不要。
+
+### 候補クエリの配置（未決#1）→ 決定: 既存クエリを流用（新規なし）
+- A. **既存 `SearchDeliveryLocationsQuery` を流用**（`customerId` オプショナルで両モード対応済み）← 採用
+- B. pricing 側に候補クエリを新設
+- 理由: 納品先の検索は納品先サブドメインの責務（DDD）。`searchDeliveryLocationsForSelection` / `searchCustomersForSelection` が両段を既にカバー。**スコープ第4項「候補クエリ」は新規BEコード不要**（作らないことを明示決定 → deviations.md に記録）。
+
+### priceStatus の導出位置（未決#4）→ 決定: SQL 内 CASE 式で導出
+- 得意先別 #506（`PrismaCustomerSellingPriceListQueryService` の `CASE ... EXISTS`）と同型で SQL 内導出。判断不要（既存パターン踏襲）。
+
+### 封筒/Edit DTO への親得意先 identity 同梱（新規の設計判断）
+- 一覧封筒・Edit DTO に、納品先自身の identity に加え**親得意先の identity（customerCode / customerName）を同梱する**。
+- 理由: 保守画面ヘッダは納品先だけでなく親得意先の文脈提示が自然。FE 側の code→id 二重取得を避ける（#473 の素描画方針）。`DeliveryLocationDTO` が既に customer リレーションをモデル化済み。得意先別 #506 からの唯一の実質的な形状差 → コミットボディに理由を記載。
+- Edit DTO は3エンティティ（納品先・商品・親得意先）を載せるため、有効フラグは接頭辞命名（`deliveryLocationIsActive` / `productIsActive`）で自己記述性を確保する。
+
+## ステップ
+
+> 各ステップ = 1コミット。ミラー元は得意先別 #506 の対応ファイル（`Customer*` → `DeliveryLocation*`、identity キーを `customerCode` → `deliveryLocationCode`、期間テーブルを `customer_selling_price_periods` → `delivery_location_selling_price_periods`、JOIN 固定キーを `customer_id` → `delivery_location_id` に読み替え）。
+
+### Step 1: 一覧 DTO
+- 対象ファイル（新規）: `src/server/subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceListDTO.ts`
+- ミラー元: `dto/CustomerSellingPriceListDTO.ts`
+- 作業内容:
+  - `DeliveryLocationSellingPricePriceStatus = "active" | "lapsed" | "none"`（型は集約ごとに独立複製・ADR-20260627-a5c）
+  - `DeliveryLocationSellingPriceListItemDTO`: productId/Code/Name, isActive, currentSellingPrice, currentPeriodStart/End, `currentCommonSellingPrice`, priceStatus（得意先別と同一構造）
+  - `DeliveryLocationSellingPriceListDTO`（封筒）: deliveryLocationId/Code/Name, deliveryLocationIsActive, **customerId/Code/Name（親得意先）**, items
+- コミットメッセージ: `feat: 納品先別販売単価 一覧読みモデルDTO（封筒に親得意先identity同梱）`
+
+### Step 2: 編集 DTO
+- 対象ファイル（新規）: `src/server/subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceEditDTO.ts`
+- ミラー元: `dto/CustomerSellingPriceEditDTO.ts`
+- 作業内容:
+  - `DeliveryLocationSellingPricePeriodStatus = "future" | "active" | "expired"`
+  - `DeliveryLocationSellingPriceEditPeriodDTO`: periodId, start, end, sellingPrice, status
+  - `DeliveryLocationSellingPriceEditDTO`: deliveryLocationId/Code/Name/IsActive, productId/Code/Name/IsActive, **customerId/Code/Name（親得意先）**, version（`number | null`）, periods
+- コミットメッセージ: `feat: 納品先別販売単価 編集読みモデルDTO`
+
+### Step 3: 一覧 QueryService IF
+- 対象ファイル（新規）: `src/server/subdomains/pricing/application/queries/DeliveryLocationSellingPriceListQueryService.ts`
+- ミラー元: `CustomerSellingPriceListQueryService.ts`
+- 作業内容: `find({ deliveryLocationCode, referenceDate, code?, name?, priceStatus? }): Promise<DeliveryLocationSellingPriceListDTO | null>` を定義（納品先不在なら null）
+- コミットメッセージ: `feat: 納品先別販売単価 一覧QueryServiceインターフェース`
+
+### Step 4: 編集 QueryService IF
+- 対象ファイル（新規）: `src/server/subdomains/pricing/application/queries/DeliveryLocationSellingPriceEditQueryService.ts`
+- ミラー元: `CustomerSellingPriceEditQueryService.ts`
+- 作業内容: `find({ deliveryLocationCode, productCode, referenceDate }): Promise<DeliveryLocationSellingPriceEditDTO | null>` を定義
+- コミットメッセージ: `feat: 納品先別販売単価 編集QueryServiceインターフェース`
+
+### Step 5: 一覧 QueryService Prisma 実装 + テスト
+- 対象ファイル（新規）:
+  - `src/server/subdomains/pricing/infrastructure/queries/PrismaDeliveryLocationSellingPriceListQueryService.ts`
+  - `.../infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceListQueryService.test.ts`
+- ミラー元: `PrismaCustomerSellingPriceListQueryService.ts` / 同 `.test.ts`
+- 作業内容:
+  - 納品先を `code`（グローバル一意）で引き（不在なら null）、親得意先を JOIN/select して封筒に同梱
+  - 母集合 = 価格保守対象商品（`ProductCategory.priceableValues()`・セット除外）
+  - `LEFT JOIN delivery_location_selling_price_periods dl ON dl.product_id = p.id AND dl.delivery_location_id = $固定 AND dl.applicable_period @> $参照日::date`
+  - `LEFT JOIN common_selling_price_periods com`（共通並記・COALESCE しない）
+  - priceStatus = SQL 内 CASE（`dl.id IS NOT NULL`→active／`EXISTS(delivery_location_id 相関)`→lapsed／else none）
+  - 検索条件（code/name 部分一致・`containsPattern`・`ESCAPE`／priceStatus）は派生テーブル外側 WHERE
+  - テスト: 得意先別リストのテスト（active/none/lapsed×2/共通並記×2/セット除外/他納品先の隔離/昇順/検索3種）を納品先文脈へ移植。シードは親得意先→納品先→単価の順（`PrismaDeliveryLocationSellingPriceQueryService.test.ts` のパターン踏襲）
+- コミットメッセージ: `feat: 納品先別販売単価 一覧QueryServiceのPrisma実装 + 結合テスト`
+
+### Step 6: 編集 QueryService Prisma 実装 + テスト
+- 対象ファイル（新規）:
+  - `src/server/subdomains/pricing/infrastructure/queries/PrismaDeliveryLocationSellingPriceEditQueryService.ts`
+  - `.../infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceEditQueryService.test.ts`
+- ミラー元: `PrismaCustomerSellingPriceEditQueryService.ts` / 同 `.test.ts`
+- 作業内容:
+  - 納品先（code・親得意先同梱）と商品（code）を引き、どちらか不在なら null
+  - 親 `delivery_location_selling_prices` を複合キー（delivery_location_id, product_id）で `findFirst` して version 取得（上書きなしなら version=null＝新規登録モード・periods 空配列）
+  - 期間行は `$queryRaw` で `applicablePeriodBounds` + `selling_price::text` + 時点状態 CASE（active/future/expired）、`lower(applicable_period)` 昇順
+  - テスト: 不在→null／identity 同梱／version・periods／各時点状態を移植
+- コミットメッセージ: `feat: 納品先別販売単価 編集QueryServiceのPrisma実装 + 結合テスト`
+
+### Step 7: factory 登録
+- 対象ファイル（編集）: `src/server/subdomains/pricing/application/factories/pricingQueryFactory.ts`
+- ミラー元: `customerSellingPriceList/EditQueryFactory`
+- 作業内容: `deliveryLocationSellingPriceListQueryFactory()` / `deliveryLocationSellingPriceEditQueryFactory()` を追加（Prisma 実装を直接返す既存規約）
+- コミットメッセージ: `feat: 納品先別販売単価 読みモデルのfactory登録`
+
+### Step 8: 逸脱記録
+- 対象ファイル（新規）: `docs/claude-plans/issue-546/deviations.md`
+- 作業内容: スコープ第4項「納品先セレクタ用の候補クエリ」を**新規実装せず既存 `SearchDeliveryLocationsQuery` 流用で満たした**旨（元計画=候補クエリ新設の余地／実際=既存流用／理由=納品先検索は納品先サブドメイン責務・既存で両段カバー）を記録。封筒/Edit DTO への親得意先 identity 同梱の判断も併記
+- コミットメッセージ: `docs: issue-546 逸脱記録（候補クエリは既存流用・親得意先identity同梱）`
+
+## 対象外（スコープ含まない）
+
+- 書き込み系 → #545/#550（コミット済み）
+- FE 一切（一覧画面 #548 / 管理画面 #547 が本読みモデルを消費）
+- 候補クエリの新規実装（既存 `SearchDeliveryLocationsQuery` で充足）
+
+## 検証
+
+- `pnpm test src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceListQueryService.test.ts` および `...EditQueryService.test.ts`（結合テストは実 DB・ADR-0012。既存の納品先別/得意先別テストと同じ実行系）
+- `pnpm lint`（型・境界チェック。QueryService 境界を VO が越えないこと）
+- 全体 E2E はローカルで回さず CI に委ねる（feedback_no_full_e2e_locally）。本イシューは BE 読みモデルのみで FE 動線が無いため、実機確認は消費側 #547/#548 で行う

--- a/docs/claude-plans/issue-546/deviations.md
+++ b/docs/claude-plans/issue-546/deviations.md
@@ -1,0 +1,20 @@
+# Issue #546 実装 逸脱記録
+
+計画（`delivery-location-selling-price-read-model.md`）からの逸脱および、計画時に確定した非自明な設計判断を記録する（CLAUDE.md「Record deviations from plan」）。
+
+## 1. 納品先セレクタ用の候補クエリを新規実装しなかった
+
+- **元の計画内容**: 親 Issue #544 のスコープ第4項に「納品先セレクタ用の候補クエリ」が挙がっており、pricing 側に候補クエリを新設する余地があった。
+- **実際の実装内容**: 候補クエリを一切新規実装していない。既存の `SearchDeliveryLocationsQuery`（`searchDeliveryLocationsForSelection(customerId, criteria)` / `searchCustomersForSelection(criteria)`）を流用して満たすこととし、本イシューでは BE コードを追加しなかった。
+- **逸脱の理由**: 納品先の検索は納品先サブドメインの責務（DDD レイヤリング）であり、pricing 側に候補クエリを置くのは責務の越境になる。既存の選択アクションが「得意先→納品先」の2段選択を両段ともカバー済みで、`DeliveryLocationSearchCriteria.customerId` はオプショナルのため横断・得意先スコープの両モードに対応する。したがって新規 BE コードは不要と明示的に判断した。実機動線は消費側 #547/#548 の FE で既存アクションを呼び出す。
+
+## 2. 一覧封筒・編集 DTO に親得意先 identity を同梱した（計画時の設計判断）
+
+- **元の計画内容（ミラー元の形状）**: 得意先別 #506 の `CustomerSellingPriceListDTO` / `CustomerSellingPriceEditDTO` は、指定エンティティ（得意先）＋商品の identity のみを載せる。
+- **実際の実装内容**: 納品先版では、納品先自身の identity に加え**親得意先の identity（`customerId` / `customerCode` / `customerName`）** を封筒・編集 DTO の双方に同梱した。Prisma 実装は `deliveryLocation.customer` リレーションを `select` して解決する。得意先別 #506 からの唯一の実質的な形状差。
+- **理由**: 納品先は親得意先の文脈が無いと保守画面ヘッダで意味を成さず（`DeliveryLocation` が既に customer リレーションをモデル化済み）、FE 側の code→id 二重取得を避ける（#473 素描画方針）。編集 DTO は3エンティティ（納品先・商品・親得意先）が載るため、有効フラグは接頭辞命名（`deliveryLocationIsActive` / `productIsActive`）で自己記述性を確保した。親得意先の有効フラグは保守判断の材料にならないため同梱しない。
+
+## 3. 一覧の対比列は共通単価のみ併記（確定した設計判断）
+
+- 得意先別 + 共通の両方併記や対比なしではなく、**共通単価のみ併記**（`currentCommonSellingPrice`）を採用。
+- **理由**: 納品先宛の価格解決連鎖は `PriceResolutionPolicy` で **`納品先別 ?? 共通`**。得意先別は連鎖に入らない（`SellingPriceResolutionTarget` の宛先分岐で排他）。DTO を実連鎖と一致させ意味論のズレを排除する。得意先別 #506 と同型。

--- a/src/server/subdomains/pricing/application/factories/pricingQueryFactory.ts
+++ b/src/server/subdomains/pricing/application/factories/pricingQueryFactory.ts
@@ -5,6 +5,8 @@ import { CostPriceEditQueryService } from "../queries/CostPriceEditQueryService"
 import { CostPriceListQueryService } from "../queries/CostPriceListQueryService";
 import { CustomerSellingPriceEditQueryService } from "../queries/CustomerSellingPriceEditQueryService";
 import { CustomerSellingPriceListQueryService } from "../queries/CustomerSellingPriceListQueryService";
+import { DeliveryLocationSellingPriceEditQueryService } from "../queries/DeliveryLocationSellingPriceEditQueryService";
+import { DeliveryLocationSellingPriceListQueryService } from "../queries/DeliveryLocationSellingPriceListQueryService";
 import { ResolveCommonSellingPriceQuery } from "../queries/ResolveCommonSellingPriceQuery";
 import { ResolveCostPriceQuery } from "../queries/ResolveCostPriceQuery";
 import { ResolveCustomerSellingPriceQuery } from "../queries/ResolveCustomerSellingPriceQuery";
@@ -20,6 +22,8 @@ import { PrismaCostPriceQueryService } from "../../infrastructure/queries/Prisma
 import { PrismaCustomerSellingPriceEditQueryService } from "../../infrastructure/queries/PrismaCustomerSellingPriceEditQueryService";
 import { PrismaCustomerSellingPriceListQueryService } from "../../infrastructure/queries/PrismaCustomerSellingPriceListQueryService";
 import { PrismaCustomerSellingPriceQueryService } from "../../infrastructure/queries/PrismaCustomerSellingPriceQueryService";
+import { PrismaDeliveryLocationSellingPriceEditQueryService } from "../../infrastructure/queries/PrismaDeliveryLocationSellingPriceEditQueryService";
+import { PrismaDeliveryLocationSellingPriceListQueryService } from "../../infrastructure/queries/PrismaDeliveryLocationSellingPriceListQueryService";
 import { PrismaDeliveryLocationSellingPriceQueryService } from "../../infrastructure/queries/PrismaDeliveryLocationSellingPriceQueryService";
 
 /**
@@ -54,6 +58,19 @@ export function customerSellingPriceListQueryFactory(): CustomerSellingPriceList
 /** 得意先別販売単価 編集の読みモデル（#506）を Prisma 実装から構築する。 */
 export function customerSellingPriceEditQueryFactory(): CustomerSellingPriceEditQueryService {
   return new PrismaCustomerSellingPriceEditQueryService();
+}
+
+/**
+ * 納品先別販売単価 保守一覧の読みモデル（#546）を Prisma 実装から構築する。
+ * 読みモデルは Query ラッパを介さず QueryService インターフェースを直接返す（既存規約）。
+ */
+export function deliveryLocationSellingPriceListQueryFactory(): DeliveryLocationSellingPriceListQueryService {
+  return new PrismaDeliveryLocationSellingPriceListQueryService();
+}
+
+/** 納品先別販売単価 編集の読みモデル（#546）を Prisma 実装から構築する。 */
+export function deliveryLocationSellingPriceEditQueryFactory(): DeliveryLocationSellingPriceEditQueryService {
+  return new PrismaDeliveryLocationSellingPriceEditQueryService();
 }
 
 /**

--- a/src/server/subdomains/pricing/application/queries/DeliveryLocationSellingPriceEditQueryService.ts
+++ b/src/server/subdomains/pricing/application/queries/DeliveryLocationSellingPriceEditQueryService.ts
@@ -1,0 +1,28 @@
+import { DeliveryLocationSellingPriceEditDTO } from "./dto/DeliveryLocationSellingPriceEditDTO";
+
+/**
+ * 納品先別販売単価 編集画面の読みモデル（#546 保守画面・read 関心）。
+ *
+ * 納品先 × 商品1組の集約スナップショット（version＋期間行＋各行の時点状態）を編集フォーム向けに返す。
+ * 集約・Repository を介さず Prisma 直当てで DTO を返す（既存 QueryService 規約）。得意先別
+ * `CustomerSellingPriceEditQueryService` と同型で、identity が複合自然キー（納品先コード × 商品コード）で
+ * あり、封筒に親得意先 identity を同梱する点だけが異なる。
+ */
+export interface DeliveryLocationSellingPriceEditQueryService {
+  /**
+   * 指定**納品先コード × 商品コード**の編集用スナップショットを返す。納品先または商品が存在しなければ
+   * `null`（FE は `notFound()`。どちらが不在かは区別しない）。両方在るが納品先別販売単価が上書きなし
+   * （集約なし）なら identity＋`version: null`＋空 `periods`（新規登録モード）を返す。
+   *
+   * @param input.deliveryLocationCode 納品先コード（route の `[deliveryLocationCd]`）。これをキーに
+   *   identity を解決する。
+   * @param input.productCode 商品コード（route の `[productCd]`）。これをキーに identity を解決する。
+   * @param input.referenceDate `"YYYY-MM-DD"` 暦日（今日）。各行の時点状態算出に用いる。アプリ層が
+   *   `toJstCalendarDay` で生成して注入する（`CURRENT_DATE` 不使用・ADR-20260627-86b）。
+   */
+  find(input: {
+    deliveryLocationCode: string;
+    productCode: string;
+    referenceDate: string;
+  }): Promise<DeliveryLocationSellingPriceEditDTO | null>;
+}

--- a/src/server/subdomains/pricing/application/queries/DeliveryLocationSellingPriceListQueryService.ts
+++ b/src/server/subdomains/pricing/application/queries/DeliveryLocationSellingPriceListQueryService.ts
@@ -1,0 +1,38 @@
+import {
+  DeliveryLocationSellingPriceListDTO,
+  DeliveryLocationSellingPricePriceStatus,
+} from "./dto/DeliveryLocationSellingPriceListDTO";
+
+/**
+ * 納品先別販売単価 保守一覧の読みモデル（#546 保守画面・read 関心）。
+ *
+ * 指定納品先について、価格保守対象商品（個別商品・消耗品。セット商品を除く）ごとに参照日（今日）で有効な
+ * 納品先別単価を1件添え、同参照日の共通単価を並記して一覧化する。並記は共通のみ（納品先宛の価格解決連鎖は
+ * `納品先別 ?? 共通` で得意先別は連鎖に入らない）。上書きが無い商品も母集合に含めるため、一覧から新規登録の
+ * 動線が立つ。検索条件（商品コード／商品名／単価状態）での絞り込みは BE 側で1クエリに寄せる（FE での全件
+ * 取得→絞り込みを避ける・#473）。集約・Repository を介さず Prisma 直当てで DTO を返す（既存 QueryService
+ * 規約）。得意先別 #506 と同型で、identity キーが納品先コードである点と封筒に親得意先 identity を同梱する点
+ * だけが異なる。
+ */
+export interface DeliveryLocationSellingPriceListQueryService {
+  /**
+   * 指定**納品先コード**の一覧封筒（納品先 identity + 親得意先 identity + 商品行配列）を、検索条件で
+   * 絞り込んで返す。納品先が存在しなければ `null`（FE は `notFound()`）。裸配列ではなく封筒型 `| null` を
+   * 返すのは、存在しない納品先で全商品が「上書きなし」に化ける契約事故を構造的に排除するため。
+   *
+   * @param input.deliveryLocationCode 納品先コード（route の `[deliveryLocationCd]`）。グローバル一意で
+   *   これをキーに identity を解決する。
+   * @param input.referenceDate `"YYYY-MM-DD"` 暦日（今日）。アプリ層が `toJstCalendarDay` で生成して
+   *   注入する（`CURRENT_DATE` 不使用・DB サーバー TZ 非依存・ADR-20260627-86b）。
+   * @param input.code 商品コードの部分一致（大小無視）。未指定は無条件。
+   * @param input.name 商品名の部分一致（大小無視）。未指定は無条件。
+   * @param input.priceStatus 納品先別単価状態での絞り込み（active／lapsed／none）。未指定は無条件。
+   */
+  find(input: {
+    deliveryLocationCode: string;
+    referenceDate: string;
+    code?: string;
+    name?: string;
+    priceStatus?: DeliveryLocationSellingPricePriceStatus;
+  }): Promise<DeliveryLocationSellingPriceListDTO | null>;
+}

--- a/src/server/subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceEditDTO.ts
+++ b/src/server/subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceEditDTO.ts
@@ -1,0 +1,64 @@
+/**
+ * 期間行の時点状態（参照日＝今日 を基準にした行の位置づけ・ADR-20260627-86b 軸1）。
+ *
+ * - `future`: 今日 < 開始（まだどの見積も時点解決していない・全項目編集／削除が可能）
+ * - `active`: 開始 ≤ 今日 < 終了（現在有効・適用終了のみ可）
+ * - `expired`: 今日 ≥ 終了（過去・編集／削除不可）
+ *
+ * 読み側で算出し、UI の操作可否（編集／適用終了／削除ボタンの出し分け）の判断材料にする。判定は
+ * 集約の `ApplicablePeriod.contains`・一覧の `daterange @>` と同一の半開区間意味論で揃える。
+ *
+ * 得意先別・共通販売単価の同名型と字面は同一だが、型は集約ごとに独立複製し共有しない
+ * （ADR-20260627-a5c）。
+ */
+export type DeliveryLocationSellingPricePeriodStatus = "future" | "active" | "expired";
+
+/** 編集画面の期間行1件 DTO。 */
+export interface DeliveryLocationSellingPriceEditPeriodDTO {
+  periodId: string;
+  start: string;
+  end: string | null;
+  /** 10進文字列の売単価（消費側で `Money.fromDecimalString`）。 */
+  sellingPrice: string;
+  status: DeliveryLocationSellingPricePeriodStatus;
+}
+
+/**
+ * 納品先別販売単価 編集画面の読みモデル DTO（#546・read 関心）。
+ *
+ * 納品先 identity（id/code/name/deliveryLocationIsActive）・商品 identity（id/code/name/productIsActive）に
+ * 加え、**親得意先 identity（id/code/name）** を同梱し、FE 側の code→id 解決クエリ・名称の二重取得を不要に
+ * する（#473・FE 素描画方針）。親得意先を載せるのは、納品先は親得意先の文脈が無いと保守画面ヘッダで意味を
+ * 成さないため。3エンティティ（納品先・商品・親得意先）が載る DTO の自己記述性のため、有効フラグは裸の
+ * `isActive` ではなく `deliveryLocationIsActive`/`productIsActive` の接頭辞命名で載せる（親得意先の有効フラグは
+ * 保守の判断材料にならないため同梱しない）。`deliveryLocationId`/`productId` はコマンド宛先キーとして
+ * フォームが往復させる。
+ *
+ * version は楽観ロックトークンで、編集フォームが往復させ保存時に `expectedVersion` として戻す
+ * （ADR-0039）。納品先別販売単価が**上書きなし**（集約なし＝行が無いのは正常な既定状態）でも、納品先・商品が
+ * ともに在れば identity を返し `version: null`＝新規登録モードとする（`periods` は空配列・Register コマンドと
+ * 1:1対応）。この安全性は #512 の解決（最終期間削除で集約ルートごと削除→「集約が存在する ⇔ 期間行が1件
+ * 以上」の不変条件）に依拠する。納品先または商品が存在しない場合のみ QueryService は `null` を返す
+ * （FE は `notFound()`。どちらが不在かは区別しない）。
+ *
+ * 期間行は `lower(applicable_period)` 昇順の配列で、各行に時点状態を添える。Decimal は文字列で運ぶ。
+ */
+export interface DeliveryLocationSellingPriceEditDTO {
+  deliveryLocationId: string;
+  deliveryLocationCode: string;
+  deliveryLocationName: string;
+  /** 納品先マスタの有効フラグ（無効納品先の編集時バッジ表示用）。 */
+  deliveryLocationIsActive: boolean;
+  productId: string;
+  productCode: string;
+  productName: string;
+  /** 商品マスタの有効フラグ（無効商品の編集時バッジ表示用）。 */
+  productIsActive: boolean;
+  /** 親得意先の識別子（保守画面ヘッダの文脈提示用。納品先は親得意先の文脈が無いと意味を成さない）。 */
+  customerId: string;
+  customerCode: string;
+  customerName: string;
+  /** 楽観ロックトークン。上書きなし（集約なし＝新規登録モード）なら null。 */
+  version: number | null;
+  periods: DeliveryLocationSellingPriceEditPeriodDTO[];
+}

--- a/src/server/subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceListDTO.ts
+++ b/src/server/subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceListDTO.ts
@@ -1,0 +1,78 @@
+/**
+ * 一覧の単価状態（参照日＝今日 を基準にした、納品先別上書きの設定状況・#546／得意先別 #506 と同型）。
+ *
+ * - `active`: 参照日を覆う納品先別期間行がある（現在有効な上書き単価あり）
+ * - `lapsed`: 納品先別期間行は存在するが参照日を覆う行が無い（将来のみ／失効のみ＝失効中）
+ * - `none`: 納品先別期間行が1件も無い（**上書きなし**＝この納品先には既定の共通単価が適用される正常状態）
+ *
+ * 第三状態は共通販売単価の `"unset"`（未設定＝異常状態・保守アクション要求の含意）を流用せず `"none"`
+ * とする。上書きレイヤーで行が無いのは正常な既定状態であり、CONTEXT.md の正準語「上書きなし
+ * (None / No Override)」に対応する。`currentSellingPrice` の null だけでは `lapsed`/`none` を判別できない
+ * ため、業務要件として三状態を BE が直接返す。型は集約ごとに独立複製し共有しない（ADR-20260627-a5c）。
+ */
+export type DeliveryLocationSellingPricePriceStatus = "active" | "lapsed" | "none";
+
+/**
+ * 納品先別販売単価 保守一覧の1行 DTO（read 関心・#546）。行＝価格保守対象商品1件。
+ *
+ * `currentSellingPrice` は参照日（今日）に有効な**納品先別**単価を「値 or null」の2値で持つ（上書きなし・
+ * 将来のみ・失効のみは一様に null）。`priceStatus` で null の内訳（失効中／上書きなし）を区別する。
+ * `currentCommonSellingPrice` は同参照日に有効な**共通**単価を独立カラムで並記する（COALESCE しない）。
+ * 納品先宛の価格解決連鎖は `納品先別 ?? 共通`（得意先別は連鎖に入らない）なので、比較の基準は共通単価のみ
+ * を並置する。フォールバック解決（実効単価）ではなく納品先別・共通の事実を並置し、優遇額の比較に供する。
+ *
+ * 価格は精度保持のため `::text` の10進文字列で運ぶ（消費側で `Money.fromDecimalString`）。ドメイン VO は
+ * QueryService の境界を越えさせない（既存 QueryService 規約）。
+ */
+export interface DeliveryLocationSellingPriceListItemDTO {
+  productId: string;
+  productCode: string;
+  productName: string;
+  /** 商品マスタの有効フラグ（行＝商品なので裸で曖昧さなし。UI 側のバッジ判定に渡す）。 */
+  isActive: boolean;
+  /** 参照日に有効な納品先別単価の10進文字列。今日有効な上書き行が無ければ null（`priceStatus` で内訳判別）。 */
+  currentSellingPrice: string | null;
+  /**
+   * 現在有効な納品先別行の適用開始日（`"YYYY-MM-DD"`）。有効行が無い（lapsed／none）なら null。
+   * `null` ＝有効行なし／`start` あり・`end` null ＝無期限、の2フィールドで多義を捌く（#513・共通一覧と同型）。
+   */
+  currentPeriodStart: string | null;
+  /**
+   * 現在有効な納品先別行の適用終了日（半開区間の排他上端の生値・`"YYYY-MM-DD"`）。無期限または有効行なしなら
+   * null（編集 DTO の `end: null`＝無期限と同一意味論。包含端への変換は一覧では行わない）。
+   */
+  currentPeriodEnd: string | null;
+  /**
+   * 参照日に有効な**共通**単価の10進文字列（並記・COALESCE しない）。共通単価も無ければ null
+   * （＝この納品先にも共通にも単価が無い）。納品先別優遇額の比較の基準として並置する。
+   */
+  currentCommonSellingPrice: string | null;
+  /** 納品先別単価の設定状況（active／lapsed／none）。null の `currentSellingPrice` の内訳を区別する。 */
+  priceStatus: DeliveryLocationSellingPricePriceStatus;
+}
+
+/**
+ * 納品先別販売単価 保守一覧の封筒型 DTO（read 関心・#546・#473 素描画方針）。
+ *
+ * 指定納品先の identity（id/code/name/deliveryLocationIsActive）に加え、**親得意先の identity
+ * （customerId/Code/Name）** を封筒に同梱し、行配列（価格保守対象商品×現在有効単価）を包む。親得意先を
+ * 同梱するのは、納品先は親得意先の文脈が無いと保守画面ヘッダで意味を成さず、`DeliveryLocation` が既に
+ * customer リレーションをモデル化しているため（得意先別 #506 からの唯一の実質的な形状差）。これで FE 側の
+ * code→id 二重取得を避ける（#473 素描画方針）。
+ *
+ * 裸配列（共通販売単価の字面ミラー）ではなく封筒型 `| null` を採るのは、存在しない納品先で LEFT JOIN が
+ * 静かに空振りし「全商品が上書きなし」に見える契約事故を、納品先不在→`null` で構造的に排除するため。
+ */
+export interface DeliveryLocationSellingPriceListDTO {
+  deliveryLocationId: string;
+  deliveryLocationCode: string;
+  deliveryLocationName: string;
+  /** 納品先マスタの有効フラグ（無効納品先の一覧ヘッダのバッジ表示用）。 */
+  deliveryLocationIsActive: boolean;
+  /** 親得意先の識別子（保守画面ヘッダの文脈提示用。納品先は親得意先の文脈が無いと意味を成さない）。 */
+  customerId: string;
+  customerCode: string;
+  customerName: string;
+  /** 価格保守対象商品×現在有効な納品先別単価の行配列（productCode 昇順）。 */
+  items: DeliveryLocationSellingPriceListItemDTO[];
+}

--- a/src/server/subdomains/pricing/infrastructure/queries/PrismaDeliveryLocationSellingPriceEditQueryService.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/PrismaDeliveryLocationSellingPriceEditQueryService.ts
@@ -1,0 +1,96 @@
+import prisma from "@server/prisma";
+import { applicablePeriodBounds } from "@server/shared/infrastructure/dateRange";
+import { DeliveryLocationSellingPriceEditQueryService } from "@subdomains/pricing/application/queries/DeliveryLocationSellingPriceEditQueryService";
+import {
+  DeliveryLocationSellingPriceEditDTO,
+  DeliveryLocationSellingPriceEditPeriodDTO,
+} from "@subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceEditDTO";
+
+/**
+ * 納品先別販売単価 編集読みモデルの Prisma 実装（ADR-0066・0067・0039・20260627-86b・#473・#546）。
+ *
+ * route の `[deliveryLocationCd]`/`[productCd]` をキーに納品先・商品を引き（どちらか無ければ `null`＝不在→FE は
+ * `notFound()`。どちらが不在かは区別しない）、納品先・商品・**親得意先**の identity を同梱して返す。これで
+ * FE 側の code→id 解決・名称の二重取得を不要にする。納品先の親得意先は `customer` リレーションを select して
+ * 載せる（得意先別 #506 からの唯一の形状差）。有効フラグは接頭辞命名（deliveryLocationIsActive/productIsActive）
+ * で載せ、3エンティティが載る DTO の自己記述性を確保する（親得意先の有効フラグは保守判断に不要のため同梱しない）。
+ *
+ * 親（`delivery_location_selling_prices`）を複合キー（delivery_location_id, product_id）で引いて version を取る。
+ * 複合 PK は一意だが Prisma の複合 `findUnique` キーは命名規約に抵触するため `findFirst` のスカラー条件で引く
+ * （Repository と同方針）。上書きなし（集約なし）なら version=null＝新規登録モードで periods は空配列になる。
+ * この安全性は #512 の不変条件「集約が存在する ⇔ 期間行が1件以上」に依拠する。
+ *
+ * 期間行は `$queryRaw` で `lower(applicable_period)` 昇順に取る（`daterange` は typed 不可）。各行の時点状態は
+ * daterange 演算で算出する: `@> 参照日`＝現在有効、`lower > 参照日`＝将来、それ以外＝失効。集約の
+ * `ApplicablePeriod.contains`・一覧の `@>` と同一の半開区間意味論で判定を揃える。単価は精度保持のため
+ * `::text`。参照日はアプリ注入で `CURRENT_DATE` を使わない。得意先別実装との差分は宛先キーと親得意先 identity
+ * 同梱起因のみ。
+ */
+export class PrismaDeliveryLocationSellingPriceEditQueryService implements DeliveryLocationSellingPriceEditQueryService {
+  async find(input: {
+    deliveryLocationCode: string;
+    productCode: string;
+    referenceDate: string;
+  }): Promise<DeliveryLocationSellingPriceEditDTO | null> {
+    const deliveryLocation = await prisma.deliveryLocation.findUnique({
+      where: { code: input.deliveryLocationCode },
+      select: {
+        id: true,
+        code: true,
+        name: true,
+        isActive: true,
+        customer: { select: { id: true, code: true, name: true } },
+      },
+    });
+    if (deliveryLocation === null) {
+      return null;
+    }
+
+    const product = await prisma.product.findUnique({
+      where: { code: input.productCode },
+      select: { id: true, code: true, name: true, isActive: true },
+    });
+    if (product === null) {
+      return null;
+    }
+
+    // 複合 PK (delivery_location_id, product_id) は一意なので findFirst で 0/1 行に定まる（Repository と同方針）。
+    const parent = await prisma.deliveryLocationSellingPrice.findFirst({
+      where: { deliveryLocationId: deliveryLocation.id, productId: product.id },
+      select: { version: true },
+    });
+
+    const periods =
+      parent === null
+        ? []
+        : await prisma.$queryRaw<DeliveryLocationSellingPriceEditPeriodDTO[]>`
+            SELECT id::text AS "periodId",
+                   ${applicablePeriodBounds},
+                   selling_price::text AS "sellingPrice",
+                   CASE
+                     WHEN applicable_period @> ${input.referenceDate}::date THEN 'active'
+                     WHEN lower(applicable_period) > ${input.referenceDate}::date THEN 'future'
+                     ELSE 'expired'
+                   END AS "status"
+            FROM delivery_location_selling_price_periods
+            WHERE delivery_location_id = ${deliveryLocation.id}::uuid AND product_id = ${product.id}::uuid
+            ORDER BY lower(applicable_period)
+          `;
+
+    return {
+      deliveryLocationId: deliveryLocation.id,
+      deliveryLocationCode: deliveryLocation.code,
+      deliveryLocationName: deliveryLocation.name,
+      deliveryLocationIsActive: deliveryLocation.isActive,
+      productId: product.id,
+      productCode: product.code,
+      productName: product.name,
+      productIsActive: product.isActive,
+      customerId: deliveryLocation.customer.id,
+      customerCode: deliveryLocation.customer.code,
+      customerName: deliveryLocation.customer.name,
+      version: parent?.version ?? null,
+      periods,
+    };
+  }
+}

--- a/src/server/subdomains/pricing/infrastructure/queries/PrismaDeliveryLocationSellingPriceListQueryService.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/PrismaDeliveryLocationSellingPriceListQueryService.ts
@@ -1,0 +1,120 @@
+import { Prisma } from "@generated/prisma/client";
+import prisma from "@server/prisma";
+import { containsPattern } from "@server/shared/infrastructure/escapeLikePattern";
+import { DeliveryLocationSellingPriceListQueryService } from "@subdomains/pricing/application/queries/DeliveryLocationSellingPriceListQueryService";
+import {
+  DeliveryLocationSellingPriceListDTO,
+  DeliveryLocationSellingPriceListItemDTO,
+  DeliveryLocationSellingPricePriceStatus,
+} from "@subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceListDTO";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+
+/**
+ * 納品先別販売単価 保守一覧の読みモデルの Prisma 実装（ADR-0066・0067・20260627-86b・#473・#546）。
+ *
+ * まず `[deliveryLocationCd]` で納品先を引き（無ければ `null`＝納品先不在→FE は `notFound()`）、納品先自身の
+ * identity と**親得意先の identity（`customer` リレーションを select）** を封筒に同梱する。親得意先を載せるのは
+ * 納品先が親得意先の文脈無しに保守画面ヘッダで意味を成さないため（得意先別 #506 からの唯一の形状差・#473
+ * 素描画方針）。裸配列ではなく封筒型 `| null` を返すのは、存在しない納品先で LEFT JOIN が静かに空振りし「全商品
+ * が上書きなし」に化ける契約事故を構造的に排除するため。
+ *
+ * 母集合=価格保守対象商品（個別商品・消耗品。セット商品を除く。区分は `ProductCategory.priceableValues()` を
+ * 単一源に注入・#514）を左表に、指定納品先の現在有効な納品先別期間行を
+ * `LEFT JOIN ... delivery_location_id = $固定 AND applicable_period @> $参照日::date` で添える。納品先を JOIN
+ * 条件に固定するため他納品先の行は混入しない。`applicable_period` の EXCLUDE 制約が区間重複ゼロを物理保証する
+ * ため、参照日を覆う行は（納品先×商品）ごと最大1件で JOIN は最大1行に収束する。同参照日の共通単価も別
+ * LEFT JOIN で並記し（COALESCE しない）、納品先別優遇額の比較の基準として並置する。並記は共通のみ（納品先宛の
+ * 価格解決連鎖は `納品先別 ?? 共通` で得意先別は連鎖に入らない）。
+ *
+ * 単価状態 `priceStatus` は null（現在有効な上書きなし）の内訳を区別する三状態（#546・業務要件）:
+ *   - 参照日を覆う納品先別行が JOIN された → `active`
+ *   - 覆う行は無いが納品先別期間行が1件でも在る（`EXISTS` の相関条件に `delivery_location_id` を含める） → `lapsed`
+ *   - 納品先別期間行が皆無 → `none`（上書きなし＝正常な既定状態）
+ *
+ * 検索条件（code/name の部分一致・priceStatus の絞り込み）は派生テーブルの外側 `WHERE` で適用し、FE での
+ * 全件取得→絞り込みを避けて1クエリに寄せる。`daterange` は Prisma typed では扱えないため `$queryRaw`。単価は
+ * 精度保持のため `::text`。参照日はアプリ注入で `CURRENT_DATE` を使わない。得意先別実装との差分は宛先キー
+ * （納品先固定 JOIN）と親得意先 identity 同梱起因のみ。
+ */
+export class PrismaDeliveryLocationSellingPriceListQueryService implements DeliveryLocationSellingPriceListQueryService {
+  async find(input: {
+    deliveryLocationCode: string;
+    referenceDate: string;
+    code?: string;
+    name?: string;
+    priceStatus?: DeliveryLocationSellingPricePriceStatus;
+  }): Promise<DeliveryLocationSellingPriceListDTO | null> {
+    const deliveryLocation = await prisma.deliveryLocation.findUnique({
+      where: { code: input.deliveryLocationCode },
+      select: {
+        id: true,
+        code: true,
+        name: true,
+        isActive: true,
+        customer: { select: { id: true, code: true, name: true } },
+      },
+    });
+    if (deliveryLocation === null) {
+      return null;
+    }
+
+    const conditions: Prisma.Sql[] = [];
+    if (input.code) {
+      conditions.push(Prisma.sql`t."productCode" ILIKE ${containsPattern(input.code)} ESCAPE '\\'`);
+    }
+    if (input.name) {
+      conditions.push(Prisma.sql`t."productName" ILIKE ${containsPattern(input.name)} ESCAPE '\\'`);
+    }
+    if (input.priceStatus) {
+      conditions.push(Prisma.sql`t."priceStatus" = ${input.priceStatus}`);
+    }
+    const where =
+      conditions.length > 0 ? Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}` : Prisma.empty;
+
+    // 母集合を価格保守対象商品（個別商品・消耗品）に限定する（セット商品を除外・#514）。
+    const priceableCategories = [...ProductCategory.priceableValues()];
+
+    const items = await prisma.$queryRaw<DeliveryLocationSellingPriceListItemDTO[]>`
+      SELECT * FROM (
+        SELECT p.id                    AS "productId",
+               p.code                  AS "productCode",
+               p.name                  AS "productName",
+               p.is_active             AS "isActive",
+               dl.selling_price::text  AS "currentSellingPrice",
+               lower(dl.applicable_period)::text AS "currentPeriodStart",
+               upper(dl.applicable_period)::text AS "currentPeriodEnd",
+               com.selling_price::text AS "currentCommonSellingPrice",
+               CASE
+                 WHEN dl.id IS NOT NULL THEN 'active'
+                 WHEN EXISTS (
+                   SELECT 1 FROM delivery_location_selling_price_periods x
+                   WHERE x.product_id = p.id AND x.delivery_location_id = ${deliveryLocation.id}::uuid
+                 ) THEN 'lapsed'
+                 ELSE 'none'
+               END AS "priceStatus"
+        FROM products p
+        LEFT JOIN delivery_location_selling_price_periods dl
+          ON dl.product_id = p.id
+          AND dl.delivery_location_id = ${deliveryLocation.id}::uuid
+          AND dl.applicable_period @> ${input.referenceDate}::date
+        LEFT JOIN common_selling_price_periods com
+          ON com.product_id = p.id
+          AND com.applicable_period @> ${input.referenceDate}::date
+        WHERE p.category IN (${Prisma.join(priceableCategories)})
+      ) t
+      ${where}
+      ORDER BY t."productCode"
+    `;
+
+    return {
+      deliveryLocationId: deliveryLocation.id,
+      deliveryLocationCode: deliveryLocation.code,
+      deliveryLocationName: deliveryLocation.name,
+      deliveryLocationIsActive: deliveryLocation.isActive,
+      customerId: deliveryLocation.customer.id,
+      customerCode: deliveryLocation.customer.code,
+      customerName: deliveryLocation.customer.name,
+      items,
+    };
+  }
+}

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceEditQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceEditQueryService.test.ts
@@ -1,0 +1,202 @@
+import prisma from "@server/prisma";
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
+import { DeliveryLocationSellingPrice } from "@subdomains/pricing/domain/entities";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaDeliveryLocationSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PrismaDeliveryLocationSellingPriceEditQueryService } from "../PrismaDeliveryLocationSellingPriceEditQueryService";
+
+// DLSPE{...} = delivery-location-selling-price 編集読みモデルのテスト用予約コード（他ファイルとの並列衝突回避）。
+const CUSTOMER_CODE = "DLSPE01C";
+const CUSTOMER_NAME = "納品先別編集読みモデルテスト親得意先";
+const DL_CODE = "DLSPE01D";
+const DL_NAME = "納品先別編集読みモデルテスト納品先";
+const PRODUCT_CODE = "DLSPE01P";
+const PRODUCT_NAME = `納品先別編集読みモデルテスト商品${PRODUCT_CODE}`;
+
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+const period = (start: string, end: string | null) => ApplicablePeriod.create({ start, end });
+
+async function cleanup(): Promise<void> {
+  // products を消すと FK Cascade で単価・期間行も消える。
+  await prisma.product.deleteMany({ where: { code: PRODUCT_CODE } });
+  // delivery_locations を消すと集約も消える。親得意先は最後（FK 順序）。
+  await prisma.deliveryLocation.deleteMany({ where: { code: DL_CODE } });
+  await prisma.customer.deleteMany({ where: { code: CUSTOMER_CODE } });
+}
+
+describe("PrismaDeliveryLocationSellingPriceEditQueryService", () => {
+  let queryService: PrismaDeliveryLocationSellingPriceEditQueryService;
+  let repository: PrismaDeliveryLocationSellingPriceRepository;
+  let customerId: CustomerId;
+  let deliveryLocationId: DeliveryLocationId;
+  let productId: ProductId;
+
+  beforeEach(async () => {
+    await cleanup();
+    queryService = new PrismaDeliveryLocationSellingPriceEditQueryService();
+    repository = new PrismaDeliveryLocationSellingPriceRepository();
+
+    const customer = await new PrismaCustomerRepository().insert(
+      Customer.create(new CompanyCode(CUSTOMER_CODE), new CompanyName(CUSTOMER_NAME))
+    );
+    customerId = customer.id;
+
+    const deliveryLocation = await new PrismaDeliveryLocationRepository().insert(
+      DeliveryLocation.create(new CompanyCode(DL_CODE), new CompanyName(DL_NAME), customerId)
+    );
+    deliveryLocationId = deliveryLocation.id;
+
+    const product = await new PrismaProductRepository().insert(
+      Product.create(
+        new ProductCode(PRODUCT_CODE),
+        new ProductName(PRODUCT_NAME),
+        ProductCategory.INDIVIDUAL,
+        ProductUnit.UNIT
+      )
+    );
+    productId = product.id;
+  });
+
+  afterEach(cleanup);
+
+  it("identity（親得意先含む）・version・期間行配列を返し、各行に時点状態（将来/現在有効/失効）を算出する", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2025-01-01", "2025-03-01"), price(800), "2025-01-01"); // 失効
+    aggregate.addPeriod(period("2025-03-01", "2025-09-01"), price(1000), "2025-03-01"); // 現在有効
+    aggregate.addPeriod(period("2030-01-01", null), price(1200), "2025-01-01"); // 将来
+    await repository.insert(aggregate);
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      productCode: PRODUCT_CODE,
+      referenceDate: "2025-06-15",
+    });
+
+    expect(dto).not.toBeNull();
+    expect(dto!.deliveryLocationId).toBe(deliveryLocationId.value);
+    expect(dto!.deliveryLocationCode).toBe(DL_CODE);
+    expect(dto!.deliveryLocationName).toBe(DL_NAME);
+    expect(dto!.deliveryLocationIsActive).toBe(true);
+    expect(dto!.productId).toBe(productId.value);
+    expect(dto!.productCode).toBe(PRODUCT_CODE);
+    expect(dto!.productName).toBe(PRODUCT_NAME);
+    expect(dto!.productIsActive).toBe(true);
+    // 親得意先 identity（得意先別 #506 からの形状差）
+    expect(dto!.customerId).toBe(customerId.value);
+    expect(dto!.customerCode).toBe(CUSTOMER_CODE);
+    expect(dto!.customerName).toBe(CUSTOMER_NAME);
+    expect(dto!.version).toBe(1);
+
+    // lower(applicable_period) 昇順
+    expect(dto!.periods).toHaveLength(3);
+    expect(dto!.periods.map((p) => p.status)).toEqual(["expired", "active", "future"]);
+
+    const [expired, active, future] = dto!.periods;
+    expect(expired.start).toBe("2025-01-01");
+    expect(expired.end).toBe("2025-03-01");
+    expect(expired.sellingPrice).toBe("800.00");
+    expect(active.sellingPrice).toBe("1000.00");
+    expect(future.end).toBeNull();
+    expect(future.sellingPrice).toBe("1200.00");
+  });
+
+  it("納品先・商品は在るが集約が無い場合は identity＋version=null＋空 periods（新規登録モード）", async () => {
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      productCode: PRODUCT_CODE,
+      referenceDate: "2025-06-15",
+    });
+
+    expect(dto).not.toBeNull();
+    expect(dto!.deliveryLocationId).toBe(deliveryLocationId.value);
+    expect(dto!.productId).toBe(productId.value);
+    expect(dto!.customerId).toBe(customerId.value);
+    expect(dto!.version).toBeNull();
+    expect(dto!.periods).toEqual([]);
+  });
+
+  it("納品先が存在しない場合は null（FE は notFound）", async () => {
+    const dto = await queryService.find({
+      deliveryLocationCode: "DLSPE99D",
+      productCode: PRODUCT_CODE,
+      referenceDate: "2025-06-15",
+    });
+    expect(dto).toBeNull();
+  });
+
+  it("商品が存在しない場合は null（FE は notFound）", async () => {
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      productCode: "DLSPE99P",
+      referenceDate: "2025-06-15",
+    });
+    expect(dto).toBeNull();
+  });
+
+  it("無効な納品先・無効な商品でも identity を返し、有効フラグに反映する", async () => {
+    const dlRepo = new PrismaDeliveryLocationRepository();
+    const deactivatedDl = (await dlRepo.findById(deliveryLocationId))!;
+    deactivatedDl.deactivate();
+    await dlRepo.update(deactivatedDl, 1);
+
+    const productRepo = new PrismaProductRepository();
+    const reloadedProduct = (await productRepo.findById(productId))!;
+    reloadedProduct.deactivate();
+    await productRepo.update(reloadedProduct, 1);
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      productCode: PRODUCT_CODE,
+      referenceDate: "2025-06-15",
+    });
+
+    expect(dto).not.toBeNull();
+    expect(dto!.deliveryLocationIsActive).toBe(false);
+    expect(dto!.productIsActive).toBe(false);
+  });
+
+  it("update 後の version を反映する（楽観ロックトークン）", async () => {
+    const aggregate = DeliveryLocationSellingPrice.create(
+      deliveryLocationId,
+      productId,
+      ProductCategory.INDIVIDUAL
+    );
+    aggregate.addPeriod(period("2030-01-01", "2030-06-01"), price(1000), "2025-06-01");
+    await repository.insert(aggregate);
+
+    const reloaded = (await repository.findByDeliveryLocationIdAndProductId(
+      deliveryLocationId,
+      productId
+    ))!;
+    reloaded.addPeriod(period("2030-06-01", null), price(1200), "2025-06-01");
+    await repository.update(reloaded, 1);
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      productCode: PRODUCT_CODE,
+      referenceDate: "2025-06-15",
+    });
+    expect(dto!.version).toBe(2);
+  });
+});

--- a/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceListQueryService.test.ts
+++ b/src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceListQueryService.test.ts
@@ -1,0 +1,400 @@
+import prisma from "@server/prisma";
+import { ApplicablePeriod } from "@server/shared/domain/values/ApplicablePeriod";
+import { CompanyCode } from "@server/shared/domain/values/CompanyCode";
+import { CompanyName } from "@server/shared/domain/values/CompanyName";
+import { Money } from "@server/shared/domain/values/Money";
+import { Customer } from "@subdomains/customer/domain/entities/Customer";
+import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
+import { PrismaCustomerRepository } from "@subdomains/customer/infrastructure/prisma/PrismaCustomerRepository";
+import { DeliveryLocation } from "@subdomains/delivery-location/domain/entities/DeliveryLocation";
+import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
+import { PrismaDeliveryLocationRepository } from "@subdomains/delivery-location/infrastructure/prisma/PrismaDeliveryLocationRepository";
+import {
+  CommonSellingPrice,
+  DeliveryLocationSellingPrice,
+} from "@subdomains/pricing/domain/entities";
+import { SellingUnitPrice } from "@subdomains/pricing/domain/values/SellingUnitPrice";
+import { PrismaCommonSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaCommonSellingPriceRepository";
+import { PrismaDeliveryLocationSellingPriceRepository } from "@subdomains/pricing/infrastructure/prisma/PrismaDeliveryLocationSellingPriceRepository";
+import { Product } from "@subdomains/product/domain/entities/Product";
+import { ProductCategory } from "@subdomains/product/domain/values/ProductCategory";
+import { ProductCode } from "@subdomains/product/domain/values/ProductCode";
+import { ProductId } from "@subdomains/product/domain/values/ProductId";
+import { ProductName } from "@subdomains/product/domain/values/ProductName";
+import { ProductUnit } from "@subdomains/product/domain/values/ProductUnit";
+import { PrismaProductRepository } from "@subdomains/product/infrastructure/prisma/PrismaProductRepository";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PrismaDeliveryLocationSellingPriceListQueryService } from "../PrismaDeliveryLocationSellingPriceListQueryService";
+
+// DLSPL{...} = delivery-location-selling-price 一覧読みモデルのテスト用予約コード（他ファイルとの並列衝突回避）。
+const CUSTOMER_CODE = "DLSPL01C";
+const CUSTOMER_NAME = "納品先別一覧読みモデルテスト親得意先";
+const DL_CODE = "DLSPL01D";
+const DL_NAME = "納品先別一覧読みモデルテスト納品先";
+const OTHER_DL_CODE = "DLSPL02D"; // 他納品先（行が混入しないことの確認用・親得意先は同じでよい）
+const OTHER_DL_NAME = "納品先別一覧読みモデルテスト他納品先";
+const CODES = {
+  active: "DLSPL01P",
+  none: "DLSPL02P",
+  futureOnly: "DLSPL03P",
+  expiredOnly: "DLSPL04P",
+  set: "DLSPL05P",
+  common: "DLSPL06P",
+} as const;
+
+const price = (yen: number) => SellingUnitPrice.fromMoney(Money.fromMajorUnits(yen));
+const period = (start: string, end: string | null) => ApplicablePeriod.create({ start, end });
+
+async function cleanup(): Promise<void> {
+  // products を消すと FK Cascade で単価・期間行も消える。
+  await prisma.product.deleteMany({ where: { code: { in: Object.values(CODES) } } });
+  // delivery_locations を消すと同様に集約も消える。親得意先は最後に消す（FK 順序）。
+  await prisma.deliveryLocation.deleteMany({ where: { code: { in: [DL_CODE, OTHER_DL_CODE] } } });
+  await prisma.customer.deleteMany({ where: { code: CUSTOMER_CODE } });
+}
+
+async function makeCustomer(code: string, name: string): Promise<CustomerId> {
+  const customer = await new PrismaCustomerRepository().insert(
+    Customer.create(new CompanyCode(code), new CompanyName(name))
+  );
+  return customer.id;
+}
+
+async function makeDeliveryLocation(
+  code: string,
+  name: string,
+  customerId: CustomerId
+): Promise<DeliveryLocationId> {
+  const deliveryLocation = await new PrismaDeliveryLocationRepository().insert(
+    DeliveryLocation.create(new CompanyCode(code), new CompanyName(name), customerId)
+  );
+  return deliveryLocation.id;
+}
+
+async function makeProduct(
+  code: string,
+  name: string,
+  category: ProductCategory = ProductCategory.INDIVIDUAL
+): Promise<ProductId> {
+  const product = await new PrismaProductRepository().insert(
+    Product.create(
+      new ProductCode(code),
+      // products.name は @unique。他テストファイルとの並列実行衝突を code 接尾で防ぐ（#517）
+      new ProductName(`${name}${code}`),
+      category,
+      ProductUnit.UNIT
+    )
+  );
+  return product.id;
+}
+
+async function addDeliveryLocationPrice(
+  deliveryLocationId: DeliveryLocationId,
+  productId: ProductId,
+  start: string,
+  end: string | null,
+  yen: number,
+  referenceDate: string
+): Promise<void> {
+  const aggregate = DeliveryLocationSellingPrice.create(
+    deliveryLocationId,
+    productId,
+    ProductCategory.INDIVIDUAL
+  );
+  aggregate.addPeriod(period(start, end), price(yen), referenceDate);
+  await new PrismaDeliveryLocationSellingPriceRepository().insert(aggregate);
+}
+
+async function addCommonPrice(
+  productId: ProductId,
+  start: string,
+  end: string | null,
+  yen: number,
+  referenceDate: string
+): Promise<void> {
+  const aggregate = CommonSellingPrice.create(productId, ProductCategory.INDIVIDUAL);
+  aggregate.addPeriod(period(start, end), price(yen), referenceDate);
+  await new PrismaCommonSellingPriceRepository().insert(aggregate);
+}
+
+describe("PrismaDeliveryLocationSellingPriceListQueryService", () => {
+  let queryService: PrismaDeliveryLocationSellingPriceListQueryService;
+  let customerId: CustomerId;
+  let deliveryLocationId: DeliveryLocationId;
+
+  beforeEach(async () => {
+    await cleanup();
+    queryService = new PrismaDeliveryLocationSellingPriceListQueryService();
+    customerId = await makeCustomer(CUSTOMER_CODE, CUSTOMER_NAME);
+    deliveryLocationId = await makeDeliveryLocation(DL_CODE, DL_NAME, customerId);
+  });
+
+  afterEach(cleanup);
+
+  it("納品先が存在しなければ null（FE は notFound）", async () => {
+    const dto = await queryService.find({
+      deliveryLocationCode: "DLSPL99D",
+      referenceDate: "2025-06-15",
+    });
+    expect(dto).toBeNull();
+  });
+
+  it("封筒に納品先 identity と親得意先 identity を同梱して返す", async () => {
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      referenceDate: "2025-06-15",
+    });
+
+    expect(dto).not.toBeNull();
+    expect(dto!.deliveryLocationId).toBe(deliveryLocationId.value);
+    expect(dto!.deliveryLocationCode).toBe(DL_CODE);
+    expect(dto!.deliveryLocationName).toBe(DL_NAME);
+    expect(dto!.deliveryLocationIsActive).toBe(true);
+    // 親得意先 identity（得意先別 #506 からの形状差）
+    expect(dto!.customerId).toBe(customerId.value);
+    expect(dto!.customerCode).toBe(CUSTOMER_CODE);
+    expect(dto!.customerName).toBe(CUSTOMER_NAME);
+  });
+
+  it("現在有効な納品先別単価がある商品は currentSellingPrice を値で返し priceStatus=active", async () => {
+    const productId = await makeProduct(CODES.active, "現在有効商品");
+    await addDeliveryLocationPrice(
+      deliveryLocationId,
+      productId,
+      "2025-01-01",
+      null,
+      900,
+      "2025-01-01"
+    );
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      referenceDate: "2025-06-15",
+    });
+    const item = dto!.items.find((i) => i.productCode === CODES.active);
+
+    expect(item).toBeDefined();
+    expect(item!.currentSellingPrice).toBe("900.00");
+    expect(item!.priceStatus).toBe("active");
+    expect(item!.currentPeriodStart).toBe("2025-01-01");
+    expect(item!.currentPeriodEnd).toBeNull();
+  });
+
+  it("納品先別期間行が無い商品は currentSellingPrice=null・priceStatus=none（上書きなし）", async () => {
+    await makeProduct(CODES.none, "上書きなし商品");
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      referenceDate: "2025-06-15",
+    });
+    const item = dto!.items.find((i) => i.productCode === CODES.none);
+
+    expect(item).toBeDefined();
+    expect(item!.currentSellingPrice).toBeNull();
+    expect(item!.priceStatus).toBe("none");
+    expect(item!.currentPeriodStart).toBeNull();
+    expect(item!.currentPeriodEnd).toBeNull();
+  });
+
+  it("将来行のみの商品は currentSellingPrice=null・priceStatus=lapsed（失効中）", async () => {
+    const productId = await makeProduct(CODES.futureOnly, "将来のみ商品");
+    await addDeliveryLocationPrice(
+      deliveryLocationId,
+      productId,
+      "2030-01-01",
+      null,
+      900,
+      "2025-01-01"
+    );
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      referenceDate: "2025-06-15",
+    });
+    const item = dto!.items.find((i) => i.productCode === CODES.futureOnly);
+
+    expect(item!.currentSellingPrice).toBeNull();
+    expect(item!.priceStatus).toBe("lapsed");
+  });
+
+  it("失効行のみの商品は currentSellingPrice=null・priceStatus=lapsed（失効中）", async () => {
+    const productId = await makeProduct(CODES.expiredOnly, "失効のみ商品");
+    await addDeliveryLocationPrice(
+      deliveryLocationId,
+      productId,
+      "2025-01-01",
+      "2025-03-01",
+      900,
+      "2025-01-01"
+    );
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      referenceDate: "2025-06-15",
+    });
+    const item = dto!.items.find((i) => i.productCode === CODES.expiredOnly);
+
+    expect(item!.currentSellingPrice).toBeNull();
+    expect(item!.priceStatus).toBe("lapsed");
+  });
+
+  it("共通単価を currentCommonSellingPrice に並記する（COALESCE しない）", async () => {
+    // 納品先別あり・共通ありの商品: 両方が独立カラムに並ぶ
+    const productId = await makeProduct(CODES.common, "納品先別と共通の両方がある商品");
+    await addDeliveryLocationPrice(
+      deliveryLocationId,
+      productId,
+      "2025-01-01",
+      null,
+      900,
+      "2025-01-01"
+    );
+    await addCommonPrice(productId, "2025-01-01", null, 1000, "2025-01-01");
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      referenceDate: "2025-06-15",
+    });
+    const item = dto!.items.find((i) => i.productCode === CODES.common);
+
+    expect(item!.currentSellingPrice).toBe("900.00");
+    expect(item!.currentCommonSellingPrice).toBe("1000.00");
+  });
+
+  it("共通単価が無ければ currentCommonSellingPrice=null（並記対象なし）", async () => {
+    const productId = await makeProduct(CODES.active, "共通なし商品");
+    await addDeliveryLocationPrice(
+      deliveryLocationId,
+      productId,
+      "2025-01-01",
+      null,
+      900,
+      "2025-01-01"
+    );
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      referenceDate: "2025-06-15",
+    });
+    const item = dto!.items.find((i) => i.productCode === CODES.active);
+
+    expect(item!.currentSellingPrice).toBe("900.00");
+    expect(item!.currentCommonSellingPrice).toBeNull();
+  });
+
+  it("セット商品は価格保守対象外なので一覧に現れない（#514）", async () => {
+    await makeProduct(CODES.set, "セット商品", ProductCategory.SET);
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      referenceDate: "2025-06-15",
+    });
+    const codes = dto!.items.map((i) => i.productCode);
+
+    expect(codes).not.toContain(CODES.set);
+  });
+
+  it("他納品先の納品先別行は混入しない（priceStatus は指定納品先の行のみで判定）", async () => {
+    // 商品は共通の母集合。指定納品先には上書きなし、他納品先にだけ上書きがある。
+    const productId = await makeProduct(CODES.none, "他納品先のみ上書き商品");
+    const otherDlId = await makeDeliveryLocation(OTHER_DL_CODE, OTHER_DL_NAME, customerId);
+    await addDeliveryLocationPrice(otherDlId, productId, "2025-01-01", null, 900, "2025-01-01");
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      referenceDate: "2025-06-15",
+    });
+    const item = dto!.items.find((i) => i.productCode === CODES.none);
+
+    // 指定納品先から見れば上書きは無い＝none。他納品先の active 行に引きずられてはならない。
+    expect(item!.currentSellingPrice).toBeNull();
+    expect(item!.priceStatus).toBe("none");
+  });
+
+  it("items は productCode 昇順で返す", async () => {
+    await makeProduct(CODES.expiredOnly, "商品D");
+    await makeProduct(CODES.active, "商品A");
+    await makeProduct(CODES.none, "商品B");
+
+    const dto = await queryService.find({
+      deliveryLocationCode: DL_CODE,
+      referenceDate: "2025-06-15",
+    });
+    const reserved = dto!.items
+      .map((i) => i.productCode)
+      .filter((c) => (Object.values(CODES) as string[]).includes(c));
+
+    expect(reserved).toEqual([...reserved].sort());
+  });
+
+  describe("検索条件で絞り込む", () => {
+    it("code は部分一致（大小無視）で絞り込む", async () => {
+      await makeProduct(CODES.active, "現在有効商品");
+      await makeProduct(CODES.none, "上書きなし商品");
+
+      const dto = await queryService.find({
+        deliveryLocationCode: DL_CODE,
+        referenceDate: "2025-06-15",
+        code: "dlspl02p",
+      });
+      const codes = dto!.items.map((i) => i.productCode);
+
+      expect(codes).toContain(CODES.none);
+      expect(codes).not.toContain(CODES.active);
+    });
+
+    it("name は部分一致（大小無視）で絞り込む", async () => {
+      await makeProduct(CODES.active, "現在有効商品");
+      await makeProduct(CODES.none, "上書きなし商品");
+
+      const dto = await queryService.find({
+        deliveryLocationCode: DL_CODE,
+        referenceDate: "2025-06-15",
+        name: "上書きなし",
+      });
+      const codes = dto!.items.map((i) => i.productCode);
+
+      expect(codes).toContain(CODES.none);
+      expect(codes).not.toContain(CODES.active);
+    });
+
+    it("name の LIKE メタ文字 _ はリテラルとして扱い、ワイルドカード解釈しない（#518）", async () => {
+      await makeProduct(CODES.active, "SPECIAL_ITEM"); // リテラル _ を含む→一致すべき
+      await makeProduct(CODES.none, "SPECIALXITEM"); // _ をワイルドカード化した時のみ一致するデコイ
+
+      const dto = await queryService.find({
+        deliveryLocationCode: DL_CODE,
+        referenceDate: "2025-06-15",
+        name: "SPECIAL_ITEM",
+      });
+      const codes = dto!.items.map((i) => i.productCode);
+
+      expect(codes).toContain(CODES.active);
+      expect(codes).not.toContain(CODES.none);
+    });
+
+    it("priceStatus=none は上書きなしのみへ絞り込む", async () => {
+      const activeId = await makeProduct(CODES.active, "現在有効商品");
+      await addDeliveryLocationPrice(
+        deliveryLocationId,
+        activeId,
+        "2025-01-01",
+        null,
+        900,
+        "2025-01-01"
+      );
+      await makeProduct(CODES.none, "上書きなし商品");
+
+      const dto = await queryService.find({
+        deliveryLocationCode: DL_CODE,
+        referenceDate: "2025-06-15",
+        priceStatus: "none",
+      });
+      const reserved = dto!.items.filter((i) =>
+        (Object.values(CODES) as string[]).includes(i.productCode)
+      );
+
+      expect(reserved.map((i) => i.productCode)).toEqual([CODES.none]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

納品先別販売単価の FE 保守画面向け読みモデルを実装。一覧 QueryService・編集 QueryService（それぞれ IF + Prisma 実装 + 結合テスト）と対応 DTO を得意先別 #506 と同型で追加し、pricingQueryFactory に登録した。納品先セレクタの候補取得は既存 delivery-location サブドメインの検索を流用し、一覧 DTO の封筒に親得意先 identity を同梱する方針とした。

Closes #546

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### delivery-location-selling-price-read-model.md

# Issue #546: 納品先別販売単価の読みモデル（一覧 / 編集 QueryService + DTO）— 実装計画

## 概要

親 #544 の分割のうち **BE 読み取り側**。納品先別販売単価の保守画面（FE は #547/#548）が消費する「読みモデル」を、得意先別 #506 とほぼ完全な同型で追加する。価格決定エンジン用の**時点解決 QueryService（既存）とは別物**で、本イシューは「一覧・保守画面に表示するための読み取りビュー」を担う。

現状、納品先別は書き込み側 #550・リポジトリ・時点解決 QueryService・factory 群までコミット済みだが、**保守画面向けの List/Edit QueryService と DTO が未実装**。これを埋めるのが本イシューのゴール。Issue が明示した4つの未決事項はユーザー確認済み（下記「設計判断」に反映）。

## 設計判断

### 一覧の対比列（未決#3）→ 決定: 共通のみ併記
- A. **共通単価のみ併記**（`currentCommonSellingPrice`）← 採用
- B. 得意先別 + 共通の両方併記
- C. 対比なし
- 理由: 納品先宛の価格解決連鎖は `PriceResolutionPolicy` で **`納品先別 ?? 共通`**。得意先別は連鎖に入らない（`SellingPriceResolutionTarget` の宛先分岐で排他）。得意先別 #506 と同型で、DTO が実連鎖と一致し意味論のズレが無い。

### 納品先セレクタの絞り込み（未決#2）→ 決定: 得意先→納品先の2段
- A. **得意先→納品先の2段**（既存 `searchDeliveryLocationsForSelection(customerId, ...)` 流用）← 採用
- B. 納品先の横断検索
- 理由: 見積フローと同じメンタルモデル。既存の選択アクション（2段）をそのまま流用でき、新規BEコード不要。

### 候補クエリの配置（未決#1）→ 決定: 既存クエリを流用（新規なし）
- A. **既存 `SearchDeliveryLocationsQuery` を流用**（`customerId` オプショナルで両モード対応済み）← 採用
- B. pricing 側に候補クエリを新設
- 理由: 納品先の検索は納品先サブドメインの責務（DDD）。`searchDeliveryLocationsForSelection` / `searchCustomersForSelection` が両段を既にカバー。**スコープ第4項「候補クエリ」は新規BEコード不要**（作らないことを明示決定 → deviations.md に記録）。

### priceStatus の導出位置（未決#4）→ 決定: SQL 内 CASE 式で導出
- 得意先別 #506（`PrismaCustomerSellingPriceListQueryService` の `CASE ... EXISTS`）と同型で SQL 内導出。判断不要（既存パターン踏襲）。

### 封筒/Edit DTO への親得意先 identity 同梱（新規の設計判断）
- 一覧封筒・Edit DTO に、納品先自身の identity に加え**親得意先の identity（customerCode / customerName）を同梱する**。
- 理由: 保守画面ヘッダは納品先だけでなく親得意先の文脈提示が自然。FE 側の code→id 二重取得を避ける（#473 の素描画方針）。`DeliveryLocationDTO` が既に customer リレーションをモデル化済み。得意先別 #506 からの唯一の実質的な形状差 → コミットボディに理由を記載。
- Edit DTO は3エンティティ（納品先・商品・親得意先）を載せるため、有効フラグは接頭辞命名（`deliveryLocationIsActive` / `productIsActive`）で自己記述性を確保する。

## ステップ

> 各ステップ = 1コミット。ミラー元は得意先別 #506 の対応ファイル（`Customer*` → `DeliveryLocation*`、identity キーを `customerCode` → `deliveryLocationCode`、期間テーブルを `customer_selling_price_periods` → `delivery_location_selling_price_periods`、JOIN 固定キーを `customer_id` → `delivery_location_id` に読み替え）。

### Step 1: 一覧 DTO
- 対象ファイル（新規）: `src/server/subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceListDTO.ts`
- ミラー元: `dto/CustomerSellingPriceListDTO.ts`
- 作業内容:
  - `DeliveryLocationSellingPricePriceStatus = "active" | "lapsed" | "none"`（型は集約ごとに独立複製・ADR-20260627-a5c）
  - `DeliveryLocationSellingPriceListItemDTO`: productId/Code/Name, isActive, currentSellingPrice, currentPeriodStart/End, `currentCommonSellingPrice`, priceStatus（得意先別と同一構造）
  - `DeliveryLocationSellingPriceListDTO`（封筒）: deliveryLocationId/Code/Name, deliveryLocationIsActive, **customerId/Code/Name（親得意先）**, items
- コミットメッセージ: `feat: 納品先別販売単価 一覧読みモデルDTO（封筒に親得意先identity同梱）`

### Step 2: 編集 DTO
- 対象ファイル（新規）: `src/server/subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceEditDTO.ts`
- ミラー元: `dto/CustomerSellingPriceEditDTO.ts`
- 作業内容:
  - `DeliveryLocationSellingPricePeriodStatus = "future" | "active" | "expired"`
  - `DeliveryLocationSellingPriceEditPeriodDTO`: periodId, start, end, sellingPrice, status
  - `DeliveryLocationSellingPriceEditDTO`: deliveryLocationId/Code/Name/IsActive, productId/Code/Name/IsActive, **customerId/Code/Name（親得意先）**, version（`number | null`）, periods
- コミットメッセージ: `feat: 納品先別販売単価 編集読みモデルDTO`

### Step 3: 一覧 QueryService IF
- 対象ファイル（新規）: `src/server/subdomains/pricing/application/queries/DeliveryLocationSellingPriceListQueryService.ts`
- ミラー元: `CustomerSellingPriceListQueryService.ts`
- 作業内容: `find({ deliveryLocationCode, referenceDate, code?, name?, priceStatus? }): Promise<DeliveryLocationSellingPriceListDTO | null>` を定義（納品先不在なら null）
- コミットメッセージ: `feat: 納品先別販売単価 一覧QueryServiceインターフェース`

### Step 4: 編集 QueryService IF
- 対象ファイル（新規）: `src/server/subdomains/pricing/application/queries/DeliveryLocationSellingPriceEditQueryService.ts`
- ミラー元: `CustomerSellingPriceEditQueryService.ts`
- 作業内容: `find({ deliveryLocationCode, productCode, referenceDate }): Promise<DeliveryLocationSellingPriceEditDTO | null>` を定義
- コミットメッセージ: `feat: 納品先別販売単価 編集QueryServiceインターフェース`

### Step 5: 一覧 QueryService Prisma 実装 + テスト
- 対象ファイル（新規）:
  - `src/server/subdomains/pricing/infrastructure/queries/PrismaDeliveryLocationSellingPriceListQueryService.ts`
  - `.../infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceListQueryService.test.ts`
- ミラー元: `PrismaCustomerSellingPriceListQueryService.ts` / 同 `.test.ts`
- 作業内容:
  - 納品先を `code`（グローバル一意）で引き（不在なら null）、親得意先を JOIN/select して封筒に同梱
  - 母集合 = 価格保守対象商品（`ProductCategory.priceableValues()`・セット除外）
  - `LEFT JOIN delivery_location_selling_price_periods dl ON dl.product_id = p.id AND dl.delivery_location_id = $固定 AND dl.applicable_period @> $参照日::date`
  - `LEFT JOIN common_selling_price_periods com`（共通並記・COALESCE しない）
  - priceStatus = SQL 内 CASE（`dl.id IS NOT NULL`→active／`EXISTS(delivery_location_id 相関)`→lapsed／else none）
  - 検索条件（code/name 部分一致・`containsPattern`・`ESCAPE`／priceStatus）は派生テーブル外側 WHERE
  - テスト: 得意先別リストのテスト（active/none/lapsed×2/共通並記×2/セット除外/他納品先の隔離/昇順/検索3種）を納品先文脈へ移植。シードは親得意先→納品先→単価の順（`PrismaDeliveryLocationSellingPriceQueryService.test.ts` のパターン踏襲）
- コミットメッセージ: `feat: 納品先別販売単価 一覧QueryServiceのPrisma実装 + 結合テスト`

### Step 6: 編集 QueryService Prisma 実装 + テスト
- 対象ファイル（新規）:
  - `src/server/subdomains/pricing/infrastructure/queries/PrismaDeliveryLocationSellingPriceEditQueryService.ts`
  - `.../infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceEditQueryService.test.ts`
- ミラー元: `PrismaCustomerSellingPriceEditQueryService.ts` / 同 `.test.ts`
- 作業内容:
  - 納品先（code・親得意先同梱）と商品（code）を引き、どちらか不在なら null
  - 親 `delivery_location_selling_prices` を複合キー（delivery_location_id, product_id）で `findFirst` して version 取得（上書きなしなら version=null＝新規登録モード・periods 空配列）
  - 期間行は `$queryRaw` で `applicablePeriodBounds` + `selling_price::text` + 時点状態 CASE（active/future/expired）、`lower(applicable_period)` 昇順
  - テスト: 不在→null／identity 同梱／version・periods／各時点状態を移植
- コミットメッセージ: `feat: 納品先別販売単価 編集QueryServiceのPrisma実装 + 結合テスト`

### Step 7: factory 登録
- 対象ファイル（編集）: `src/server/subdomains/pricing/application/factories/pricingQueryFactory.ts`
- ミラー元: `customerSellingPriceList/EditQueryFactory`
- 作業内容: `deliveryLocationSellingPriceListQueryFactory()` / `deliveryLocationSellingPriceEditQueryFactory()` を追加（Prisma 実装を直接返す既存規約）
- コミットメッセージ: `feat: 納品先別販売単価 読みモデルのfactory登録`

### Step 8: 逸脱記録
- 対象ファイル（新規）: `docs/claude-plans/issue-546/deviations.md`
- 作業内容: スコープ第4項「納品先セレクタ用の候補クエリ」を**新規実装せず既存 `SearchDeliveryLocationsQuery` 流用で満たした**旨（元計画=候補クエリ新設の余地／実際=既存流用／理由=納品先検索は納品先サブドメイン責務・既存で両段カバー）を記録。封筒/Edit DTO への親得意先 identity 同梱の判断も併記
- コミットメッセージ: `docs: issue-546 逸脱記録（候補クエリは既存流用・親得意先identity同梱）`

## 対象外（スコープ含まない）

- 書き込み系 → #545/#550（コミット済み）
- FE 一切（一覧画面 #548 / 管理画面 #547 が本読みモデルを消費）
- 候補クエリの新規実装（既存 `SearchDeliveryLocationsQuery` で充足）

## 検証

- `pnpm test src/server/subdomains/pricing/infrastructure/queries/__tests__/PrismaDeliveryLocationSellingPriceListQueryService.test.ts` および `...EditQueryService.test.ts`（結合テストは実 DB・ADR-0012。既存の納品先別/得意先別テストと同じ実行系）
- `pnpm lint`（型・境界チェック。QueryService 境界を VO が越えないこと）
- 全体 E2E はローカルで回さず CI に委ねる（feedback_no_full_e2e_locally）。本イシューは BE 読みモデルのみで FE 動線が無いため、実機確認は消費側 #547/#548 で行う

</details>

## 計画からの逸脱

# Issue #546 実装 逸脱記録

計画（`delivery-location-selling-price-read-model.md`）からの逸脱および、計画時に確定した非自明な設計判断を記録する（CLAUDE.md「Record deviations from plan」）。

## 1. 納品先セレクタ用の候補クエリを新規実装しなかった

- **元の計画内容**: 親 Issue #544 のスコープ第4項に「納品先セレクタ用の候補クエリ」が挙がっており、pricing 側に候補クエリを新設する余地があった。
- **実際の実装内容**: 候補クエリを一切新規実装していない。既存の `SearchDeliveryLocationsQuery`（`searchDeliveryLocationsForSelection(customerId, criteria)` / `searchCustomersForSelection(criteria)`）を流用して満たすこととし、本イシューでは BE コードを追加しなかった。
- **逸脱の理由**: 納品先の検索は納品先サブドメインの責務（DDD レイヤリング）であり、pricing 側に候補クエリを置くのは責務の越境になる。既存の選択アクションが「得意先→納品先」の2段選択を両段ともカバー済みで、`DeliveryLocationSearchCriteria.customerId` はオプショナルのため横断・得意先スコープの両モードに対応する。したがって新規 BE コードは不要と明示的に判断した。実機動線は消費側 #547/#548 の FE で既存アクションを呼び出す。

## 2. 一覧封筒・編集 DTO に親得意先 identity を同梱した（計画時の設計判断）

- **元の計画内容（ミラー元の形状）**: 得意先別 #506 の `CustomerSellingPriceListDTO` / `CustomerSellingPriceEditDTO` は、指定エンティティ（得意先）＋商品の identity のみを載せる。
- **実際の実装内容**: 納品先版では、納品先自身の identity に加え**親得意先の identity（`customerId` / `customerCode` / `customerName`）** を封筒・編集 DTO の双方に同梱した。Prisma 実装は `deliveryLocation.customer` リレーションを `select` して解決する。得意先別 #506 からの唯一の実質的な形状差。
- **理由**: 納品先は親得意先の文脈が無いと保守画面ヘッダで意味を成さず（`DeliveryLocation` が既に customer リレーションをモデル化済み）、FE 側の code→id 二重取得を避ける（#473 素描画方針）。編集 DTO は3エンティティ（納品先・商品・親得意先）が載るため、有効フラグは接頭辞命名（`deliveryLocationIsActive` / `productIsActive`）で自己記述性を確保した。親得意先の有効フラグは保守判断の材料にならないため同梱しない。

## 3. 一覧の対比列は共通単価のみ併記（確定した設計判断）

- 得意先別 + 共通の両方併記や対比なしではなく、**共通単価のみ併記**（`currentCommonSellingPrice`）を採用。
- **理由**: 納品先宛の価格解決連鎖は `PriceResolutionPolicy` で **`納品先別 ?? 共通`**。得意先別は連鎖に入らない（`SellingPriceResolutionTarget` の宛先分岐で排他）。DTO を実連鎖と一致させ意味論のズレを排除する。得意先別 #506 と同型。


---

Generated with [Claude Code](https://claude.ai/code)
