### PR TITLE
feat: 納品先別販売単価 管理画面（登録・編集・適用終了・削除 + 改訂ウィザード + タイムライン）

### DIFF
--- a/docs/claude-plans/issue-547/delivery-location-selling-price-maintenance-screen.md
+++ b/docs/claude-plans/issue-547/delivery-location-selling-price-maintenance-screen.md
@@ -1,0 +1,83 @@
+# Issue #547: 納品先別販売単価 管理画面（登録・編集・適用終了・削除 + 改訂ウィザード + タイムライン） — 実装計画
+
+## Context
+
+納品先別販売単価の価格決定は「**納品先別 → 得意先別 → 共通**」の3段フォールバック。親 #544 の分割のうち本イシューは **FE 管理画面**で、ある納品先 × 商品の適用期間行に対する登録・編集・適用終了・削除と、改訂ウィザード・タイムライン帯を1画面に含める。
+
+BE は完成済み（書き込み #545/#550・読みモデル #546/#552）で、本イシューは **FE のみ**（BE に接続するだけ）。一覧画面 #548 は出荷済みで、そこから行クリックで本管理画面へ遷移する。得意先別 #507 とほぼ同型のため、`customer-selling-prices/[customerCd]/[productCd]/` を**ディレクトリごとコピー写像**し、宛先軸を「得意先→納品先」に差し替えるのが基本方針。唯一 #507 の単純写像で済まないのがタイムラインで、フォールバック層が1段深い（得意先別レーンが増える）ため従レーンが2本になる。
+
+## 設計判断
+
+### 得意先別 #507 の流用方針 — 判断不要（前例踏襲）
+`customer-selling-prices/[customerCd]/[productCd]/` をディレクトリごとコピー写像し、`_shared` の原子（`authorityFor` / `computeTimelineLayout` / `formatYenFromDecimal` / `formatPeriod` / `handleCommandError`）は共有を続ける。ADR-20260627-a5c（型は集約ごとに独立複製し共有しない）と対称。BE factory も既に `DeliveryLocation` へ置換した同名構造で実装済み。
+
+### ルート階層（2階層 vs 3階層） — 確定（#548 に追従）
+**2階層 `/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]`**。出荷済みの #548 が `columns.tsx` で `href=/delivery-location-selling-prices/${deliveryLocationCode}/${productCode}`（customerCd を挟まない）と遷移リンクを組んでおり、本管理画面はその受け側。追従一択。
+
+### タイムラインのフォールバック層 — 確定（ユーザー選択: 得意先別＋共通の2従レーン）
+主レーン=納品先別（操作対象）、従レーン=得意先別＋共通（淡色・表示専用）の**3レーン**。3段フォールバックの「上書きが無い期間に実際いくらが適用されるか（得意先別があればそれ、無ければ共通）」を一目で対比できる。データは編集DTOの親 `customerCode` から得意先別を、`productCode` から共通を追加取得でき、BE 追加実装ゼロ。
+
+### `computeTimelineLayout` の複数従レーン一般化方式 — 推奨 A
+現状は主 + 従レーン**1本**（`secondaryPeriods: TimelinePeriod[]` → `secondaryBars: TimelineBar[]`）まで。従レーン2本には拡張が必要。
+- **A（推奨）**: `secondaryPeriods` を従レーンの配列 `secondaryLanes: TimelinePeriod[][]` に一般化し、`secondaryBars: TimelineBar[][]` を返す。軸範囲は主＋全従レーンの和集合から算出。得意先別 #507 側は `[commonPeriods]` と配列でラップして渡す1行修正＋`PriceTimeline` の `secondaryBars` 消費を `secondaryBars[0]` に読み替える軽微修正。
+- **B**: 第4引数 `tertiaryPeriods` を足し `tertiaryBars` を返す（2従レーン固定）。得意先別は第4引数省略で無修正。ただし「従レーン2本まで」を型に刻み、将来の拡張余地を狭める。
+- 採用理由: #507 計画が予告した「**抽象化は納品先別（3例目）が出てから**」の実行タイミング。従レーン数を型で固定しない一般化が正しい方向。跨ぎ作業（#507 の2ファイル修正）は発生するが軽微で、純関数ゆえ TDD で既存の単レーン（共通単価・原価）・2レーン（得意先別）テスト GREEN を担保できる。
+
+### 得意先別レーンの取得順 — detail 依存の2段取得
+得意先別レーンを引くには親得意先コードが要り、これは納品先別の編集DTO（`detail`）取得後に判明する。よって `page.tsx` は「①納品先別 detail と共通（`productCode` のみで引ける）を `Promise.all`、②detail から得た `customerCode` で得意先別を引く」の2段。共通は最初から並行、得意先別のみ detail 依存。得意先別が null（商品不在等）でも従レーンを空扱いで描画継続（#507 の共通レーンと同じ堅牢性）。
+
+### 「上書きなし」状態の画面表現 — 3段フォールバックに合わせた情報提供トーン
+`version: null` + `periods` 空は異常ではなく正常な派生状態。文言は「**この納品先×商品の上書きはありません。価格決定は得意先別販売単価を、無ければ共通販売単価を適用します。**」（警告 UI なし）。タイムラインは上書きなしでも描画し、従レーン（得意先別・共通）のみが表示される。
+
+### 戻りリンク — 納品先選択済み一覧へ戻す
+#548 出荷済みかつ納品先選択状態をパスに持つため、`/delivery-location-selling-prices/${deliveryLocationCode}`（選択済み一覧）へ戻す。#507 が一覧トップに戻したのは #508 未出荷時の死リンク回避事情によるもので、本イシューは選択状態を保った戻りが可能。
+
+### フォーム統一（#351）・権限 — 判断不要（前例踏襲）
+`PeriodForm` の3モード（new/edit/endDate 単一フォーム切替・`pickRuntime` で action(bind)＋zod スキーマ選択・`version==null` で新規/既存分岐）写像で自動充足。権限は `authorityFor(status)`（`_shared/period-rules.ts`・集約非依存）× `isAdmin(session)` の踏襲。
+
+## TDD 適用方針
+- **新規純ロジックは `computeTimelineLayout` の複数従レーン一般化のみ** → red-green-refactor（Step 3-1）。`_shared/timeline-layout.test.ts` に前例あり。
+- コピー写像部分（画面部品・actions・schema）はコンポーネントテスト前例がなく、挙動担保は別イシューの E2E に委ねる。写像部分にテストを新設する逸脱はしない。
+
+## ステップ
+
+コミットは Issue 方針（基本操作 → 改訂ウィザード → タイムライン）の順で刻む。
+
+### Step 1: 基本操作（登録・編集・適用終了・削除）
+- 対象ファイル（すべて `src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/` 配下・新規写像）:
+  - `page.tsx` — `deliveryLocationSellingPriceEditQueryFactory().find({ deliveryLocationCode, productCode, referenceDate })`。null → `notFound()`。ヘッダに納品先・親得意先・商品の identity（コード/名称/無効バッジ）を dl 表示。`isAdmin(session)` 算出。戻りリンクは `/delivery-location-selling-prices/${deliveryLocationCode}`。この Step では共通のみ従レーン取得（後述 PriceTimeline 先行作成）。
+  - `PeriodDetailPanel.tsx` — 期間行を束ねる中核 client。`PanelMode`(closed/new/edit/endDate/revise/delete) を client state 保持、表示/タイムライントグル、`authorityFor` で行操作出し分け、`isAdmin` false でミューテーションUI非描画。
+  - `PeriodForm.tsx` — new/edit/endDate 単一フォーム写像。宛先キーを `(deliveryLocationId, productId)`、route キーを `(deliveryLocationCode, productCode)` に差し替え。
+  - `PeriodDeleteConfirm.tsx` — 行内2段階削除確認。
+  - `PriceTimeline.tsx` — **この Step では #507 の2レーン版を写像**（主=納品先別 / 従=共通1本）で先行作成しビルド可能に保つ（PeriodDetailPanel がトグルで参照するため。Step 3-2 で3レーン化。#507 と同じ先行作成パターンを計画に織り込み逸脱化を回避）。
+  - `actions.ts` — add / updateFuture / endDate / delete の4 action。`register`/`edit`/`endDate`/`delete` `DeliveryLocationSellingPricePeriodCommandFactory` に接続、宛先キーを `.bind()`。parse→command→`handleCommandError`→revalidate（詳細＋一覧、redirect せず留まる）。
+  - `schema.ts` — `addPeriodSchema`/`updateFuturePeriodSchema`/`endDatePeriodSchema`/`deletePeriodSchema`。conform 空文字→undefined 規約に従い必須でない string は `.optional()`。
+- 空状態文言: 「この納品先×商品の上書きはありません。価格決定は得意先別販売単価を、無ければ共通販売単価を適用します。」
+- コミット: `feat: 納品先別販売単価 管理画面の基本操作（登録・編集・適用終了・削除） (#547)`
+
+### Step 2: 改訂ウィザード
+- 対象ファイル:
+  - `ReviseForm.tsx`（新規写像・改定日＋新単価のみ、periodId 送らない。方向ラベル表示）
+  - `actions.ts` / `schema.ts`（revise action + `revisePeriodSchema` 追記）
+- `reviseDeliveryLocationSellingPricePeriodCommandFactory` に接続（合成＝適用終了+新期間は BE 単一コマンドがアトミック実行、FE では合成しない）。`PeriodDetailPanel` の `PanelMode` に `revise` 配線。
+- コミット: `feat: 納品先別販売単価 改訂ウィザード (#547)`
+
+### Step 3-1: `computeTimelineLayout` の複数従レーン一般化（TDD）
+- 対象ファイル: `src/app/(features)/_shared/timeline-layout.ts` / `timeline-layout.test.ts`、および写像元 `customer-selling-prices/.../PriceTimeline.tsx`（`secondaryBars[0]` 読み替え）
+- Red: 「主＋従レーン**複数**の和集合から軸範囲を決め、各従レーンを同一軸に載せる」テストを先に書く。
+- Green: `secondaryLanes: TimelinePeriod[][]` へ一般化、`secondaryBars: TimelineBar[][]` を返す（採用A）。
+- Refactor: 既存の単レーン（共通・原価）・得意先別（従1本→`[commonPeriods]`）呼び出しのテストが全て GREEN であることを確認。
+- コミット: `feat: タイムライン帯レイアウトを複数従レーンに一般化 (#547)`
+
+### Step 3-2: タイムライン（納品先別＋得意先別＋共通の3レーン）
+- 対象ファイル: 当該 `PriceTimeline.tsx`（3レーン化）／`page.tsx`・`PeriodDetailPanel.tsx`（得意先別・共通 DTO の取得・受け渡し）
+- `page.tsx`: 共通を初回 `Promise.all` で並行取得、detail の `customerCode` で `customerSellingPriceEditQueryFactory().find()` を追加取得。両従レーンを `PeriodDetailPanel` 経由で `PriceTimeline` に渡す。
+- `PriceTimeline.tsx`: 主=納品先別、従1=得意先別、従2=共通の3レーン描画（従は淡色・破線・表示専用）。上書きなしでも描画。凡例に得意先別・共通のフォールバック表示を追記。
+- コミット: `feat: 納品先別販売単価 タイムライン（得意先別・共通レーン並記） (#547)`
+
+## 検証
+
+- `pnpm test` — `timeline-layout.test.ts`（複数従レーン一般化の red-green＋既存レーン回帰 GREEN）。
+- `pnpm lint` / `pnpm build` — 型チェック（写像元 #507 の `secondaryBars[0]` 修正含む全体ビルド）。
+- 実機確認（verify-frontend / playwright MCP・要ログイン）: 一覧 #548 から行クリック遷移 → 管理画面表示 → 登録/編集/適用終了/削除/改訂の一連、上書きなし状態の文言、タイムライン3レーン（納品先別・得意先別・共通）の対比表示、戻りリンクが選択済み一覧に戻ること。
+- E2E テストは別イシュー（納品先別 E2E があれば別途）。本イシューにコンポーネントテスト/E2E は新設しない。

--- a/docs/claude-plans/issue-547/deviations.md
+++ b/docs/claude-plans/issue-547/deviations.md
@@ -1,0 +1,23 @@
+# Issue #547 実装 — 計画からの逸脱記録
+
+## 1. 改訂（revise）系を Step 1 の PanelMode から Step 2 へ全面分離
+
+### 元の計画内容
+Step 1 の `PeriodDetailPanel.tsx` の記述で `PanelMode` を
+`closed/new/edit/endDate/revise/delete` と列挙しており、`revise` 分岐が Step 1 に含まれるよう
+読める。一方 Step 2 は「`PeriodDetailPanel` の `PanelMode` に `revise` 配線」とも書いており、
+計画内で revise の配置 Step が自己矛盾していた。
+
+### 実際の実装内容
+revise を Step 1 から完全に除外し、Step 2 でまとめて配線した。
+- Step 1: `PanelMode` は `closed/new/edit/endDate/delete`（revise なし）。`ReviseForm` 未作成、
+  actions/schema に revise なし、「改定」ボタンなし。
+- Step 2: `PanelMode` に `revise` を追加、`ReviseForm.tsx` 写像、revise action / `revisePeriodSchema`
+  追加、「改定」ボタン＋ReviseForm JSX を配線。
+
+### 逸脱の理由
+CLAUDE.md「意味のあるまとまりでコミットし、各コミットを独立ビルド可能に保つ」に従うため。
+Step 1 の PanelMode に `revise` を含めると `ReviseForm` の import が必要になり、Step 2 で作る
+`ReviseForm.tsx` が未作成の時点でビルドが割れる。Issue 方針のコミット順（基本操作 → 改訂
+ウィザード）とも整合し、Step 2 の「revise 配線」記述に寄せる形で解消した。挙動・最終成果物は
+計画と同一で、Step 境界のみを明確化した。

--- a/src/app/(features)/_shared/timeline-layout.test.ts
+++ b/src/app/(features)/_shared/timeline-layout.test.ts
@@ -121,27 +121,27 @@ describe("computeTimelineLayout", () => {
 });
 
 /**
- * 複数レーン共有軸対応（#507・得意先別販売単価）。
+ * 複数レーン共有軸対応（#507・得意先別販売単価 → #547 で複数従レーンへ一般化）。
  *
- * 得意先別レーン（主・操作対象）と共通販売単価レーン（従・フォールバック・表示専用）を同一の時間軸に
- * 重ねて対比するための拡張。第3引数 `secondaryPeriods` はオプションで、既存の単レーン呼び出し（共通売単価・
- * 原価）は後方互換のまま影響を受けない。両系列の和集合から軸範囲（axisStart/axisEnd/todayPct）を決め、
- * 各系列の bars を同一の pct 写像に載せる（同じ日付は両レーンで同じ left% に揃う）。
+ * 主レーン（操作対象）と従レーン（フォールバック・表示専用）を同一の時間軸に重ねて対比するための拡張。
+ * 第3引数 `secondaryLanes`（従レーンの配列）はオプションで、既存の単レーン呼び出し（共通売単価・原価）は
+ * 後方互換のまま影響を受けない。全系列の和集合から軸範囲（axisStart/axisEnd/todayPct）を決め、各系列の
+ * bars を同一の pct 写像に載せる（同じ日付は全レーンで同じ left% に揃う）。`secondaryBars` はレーンごとの配列。
  */
 describe("computeTimelineLayout（複数レーン共有軸）", () => {
-  it("従レーンを渡すと secondaryBars を返し、軸は両系列の和集合から決まる", () => {
+  it("従レーンを1本渡すと secondaryBars[0] を返し、軸は両系列の和集合から決まる", () => {
     // 主（得意先別）は 2026 に1本、従（共通）は 2020 に1本。従の開始が主より過去にあるため、
     // 和集合を取れば従の開始位置は主の開始位置より左（小さい left%）になる。
     const layout = computeTimelineLayout(
       [period({ periodId: "cust-1", start: "2026-01-01", end: null, status: "active" })],
       "2026-06-27",
-      [period({ periodId: "common-1", start: "2020-01-01", end: null, status: "active" })]
+      [[period({ periodId: "common-1", start: "2020-01-01", end: null, status: "active" })]]
     );
 
-    expect(layout.secondaryBars).toBeDefined();
-    expect(layout.secondaryBars.map((b) => b.periodId)).toEqual(["common-1"]);
+    expect(layout.secondaryBars).toHaveLength(1);
+    expect(layout.secondaryBars[0].map((b) => b.periodId)).toEqual(["common-1"]);
     const primary = layout.bars[0];
-    const secondary = layout.secondaryBars[0];
+    const secondary = layout.secondaryBars[0][0];
     // 共通（従）の開始 2020 は得意先別（主）の開始 2026 より過去 → より左に置かれる。
     expect(secondary.leftPct).toBeLessThan(primary.leftPct);
   });
@@ -150,19 +150,19 @@ describe("computeTimelineLayout（複数レーン共有軸）", () => {
     const layout = computeTimelineLayout(
       [period({ periodId: "cust-1", start: "2026-03-01", end: "2026-09-01", status: "active" })],
       "2026-06-27",
-      [period({ periodId: "common-1", start: "2026-03-01", end: null, status: "active" })]
+      [[period({ periodId: "common-1", start: "2026-03-01", end: null, status: "active" })]]
     );
     const primary = layout.bars[0];
-    const secondary = layout.secondaryBars[0];
+    const secondary = layout.secondaryBars[0][0];
     expect(secondary.leftPct).toBeCloseTo(primary.leftPct, 5);
   });
 
   it("主レーンが空でも従レーンがあれば軸を描く（上書きなしのフォールバック表示）", () => {
     const layout = computeTimelineLayout([], "2026-06-27", [
-      period({ periodId: "common-1", start: "2025-04-01", end: null, status: "active" }),
+      [period({ periodId: "common-1", start: "2025-04-01", end: null, status: "active" })],
     ]);
     expect(layout.bars).toEqual([]);
-    expect(layout.secondaryBars.map((b) => b.periodId)).toEqual(["common-1"]);
+    expect(layout.secondaryBars[0].map((b) => b.periodId)).toEqual(["common-1"]);
     expect(layout.axisStart).not.toBe("");
     expect(layout.axisEnd).not.toBe("");
   });
@@ -173,5 +173,30 @@ describe("computeTimelineLayout（複数レーン共有軸）", () => {
     expect(layout.secondaryBars).toEqual([]);
     expect(layout.axisStart).toBe("");
     expect(layout.axisEnd).toBe("");
+  });
+});
+
+/**
+ * 複数従レーンの一般化（#547・納品先別販売単価）。
+ *
+ * 納品先別の価格決定は「納品先別 → 得意先別 → 共通」の3段フォールバック。タイムラインは主＝納品先別に
+ * 従レーンを2本（得意先別・共通）重ねて対比する。第3引数を単一従レーンから**従レーンの配列**
+ * `secondaryLanes: TimelinePeriod[][]` へ一般化し、`secondaryBars: TimelineBar[][]` をレーンごとに返す。
+ * 軸範囲は主＋全従レーンの和集合から決め、全系列を同一の pct 写像に載せる（同じ日付は全レーンで同じ left%）。
+ */
+describe("computeTimelineLayout（複数従レーンの一般化）", () => {
+  it("複数の従レーンを渡すと secondaryBars をレーンごとの配列で返す", () => {
+    // 主=納品先別、従1=得意先別、従2=共通の3段フォールバックを同一軸へ重ねる。
+    const layout = computeTimelineLayout(
+      [period({ periodId: "loc-1", start: "2026-01-01", end: null, status: "active" })],
+      "2026-06-27",
+      [
+        [period({ periodId: "cust-1", start: "2025-01-01", end: null, status: "active" })],
+        [period({ periodId: "common-1", start: "2020-01-01", end: null, status: "active" })],
+      ]
+    );
+    expect(layout.secondaryBars).toHaveLength(2);
+    expect(layout.secondaryBars[0].map((b) => b.periodId)).toEqual(["cust-1"]);
+    expect(layout.secondaryBars[1].map((b) => b.periodId)).toEqual(["common-1"]);
   });
 });

--- a/src/app/(features)/_shared/timeline-layout.ts
+++ b/src/app/(features)/_shared/timeline-layout.ts
@@ -46,10 +46,11 @@ export interface TimelineBar {
 export interface TimelineLayout {
   bars: TimelineBar[];
   /**
-   * 従レーンの帯（複数レーン共有軸・#507）。得意先別販売単価画面が共通販売単価を
-   * フォールバック層として重ねる従属レーン。単レーン呼び出し（従を渡さない）では空配列。
+   * 従レーンごとの帯（複数レーン共有軸・#507→#547 で複数レーンへ一般化）。得意先別販売単価画面は
+   * 共通販売単価を1レーン、納品先別販売単価画面は得意先別＋共通の2レーンを主レーンへ重ねる。
+   * 外側の配列がレーン、内側が各レーンの帯。従レーンを渡さない単レーン呼び出しでは空配列。
    */
-  secondaryBars: TimelineBar[];
+  secondaryBars: TimelineBar[][];
   /** 今日マーカーの軸位置（%）。 */
   todayPct: number;
   /** 軸左端の日付ラベル `YYYY/MM/DD`（periods 空なら空文字）。 */
@@ -91,19 +92,20 @@ function round2(value: number): number {
  * 無期限（end === null）の帯は軸右端まで伸ばす。今日が全期間の外にあっても軸内に収まるよう、
  * lo/hi の双方を今日まで拡張する（プロトは hi のみ拡張だったが、参照日マーカーを常に可視にするため両端に拡張）。
  *
- * 複数レーン共有軸（#507）: 第3引数 `secondaryPeriods` を渡すと従レーンの帯を `secondaryBars` に返す。
- * 軸範囲は主・従の**和集合**から決め、両系列を同一の pct 写像に載せる（同じ日付は両レーンで同じ left% に
- * 揃う＝対比が成立する）。既存の単レーン呼び出し（共通売単価・原価）は第3引数省略で後方互換のまま動き、
- * `secondaryBars` は空配列を返す。主レーンが空でも従レーンがあれば軸を描く（得意先別の「上書きなし」で
- * 共通レーンだけをフォールバック表示する要件・決定）。主・従の双方が空のときのみ空レイアウトを返す。
+ * 複数レーン共有軸（#507→#547 で複数従レーンへ一般化）: 第3引数 `secondaryLanes`（従レーンの配列）を
+ * 渡すと、各レーンの帯を `secondaryBars`（レーンごとの配列）に返す。軸範囲は主・全従レーンの**和集合**から
+ * 決め、全系列を同一の pct 写像に載せる（同じ日付は全レーンで同じ left% に揃う＝対比が成立する）。既存の
+ * 単レーン呼び出し（共通売単価・原価）は第3引数省略で後方互換のまま動き、`secondaryBars` は空配列を返す。
+ * 主レーンが空でも従レーンがあれば軸を描く（納品先別／得意先別の「上書きなし」で従レーンだけをフォールバック
+ * 表示する要件・決定）。主・全従レーンが空のときのみ空レイアウトを返す。
  */
 export function computeTimelineLayout(
   periods: TimelinePeriod[],
   referenceDate: string,
-  secondaryPeriods: TimelinePeriod[] = []
+  secondaryLanes: TimelinePeriod[][] = []
 ): TimelineLayout {
-  // 軸範囲は主・従の和集合から決める（従レーンだけでも軸を描けるようにする）。
-  const axisPeriods = [...periods, ...secondaryPeriods];
+  // 軸範囲は主・全従レーンの和集合から決める（従レーンだけでも軸を描けるようにする）。
+  const axisPeriods = [...periods, ...secondaryLanes.flat()];
   if (axisPeriods.length === 0) {
     return { bars: [], secondaryBars: [], todayPct: 50, axisStart: "", axisEnd: "" };
   }
@@ -137,7 +139,7 @@ export function computeTimelineLayout(
 
   return {
     bars: periods.map(toBar),
-    secondaryBars: secondaryPeriods.map(toBar),
+    secondaryBars: secondaryLanes.map((lane) => lane.map(toBar)),
     todayPct: round2(pct(today)),
     axisStart: formatDay(lo),
     axisEnd: formatDay(hi),

--- a/src/app/(features)/customer-selling-prices/[customerCd]/[productCd]/PeriodDetailPanel.tsx
+++ b/src/app/(features)/customer-selling-prices/[customerCd]/[productCd]/PeriodDetailPanel.tsx
@@ -149,8 +149,9 @@ export function PeriodDetailPanel({ detail, commonPeriods, isAdmin, referenceDat
           layout={computeTimelineLayout(
             detail.periods.map(toTimelinePeriod),
             referenceDate,
-            // 従レーン（共通販売単価・フォールバック）。同一の中立構造へマップして重ねる（表示専用）。
-            commonPeriods.map(toTimelinePeriod)
+            // 従レーン（共通販売単価・フォールバック）を1本重ねる。複数従レーン一般化（#547）に伴い
+            // 従レーンの配列で渡す（本画面は共通1本のみ）。同一の中立構造へマップする（表示専用）。
+            [commonPeriods.map(toTimelinePeriod)]
           )}
         />
       )}

--- a/src/app/(features)/customer-selling-prices/[customerCd]/[productCd]/PriceTimeline.tsx
+++ b/src/app/(features)/customer-selling-prices/[customerCd]/[productCd]/PriceTimeline.tsx
@@ -82,7 +82,9 @@ function SecondaryBar({ bar }: { bar: TimelineBar }) {
 }
 
 export function PriceTimeline({ layout }: Props) {
-  const { bars, secondaryBars, todayPct, axisStart, axisEnd } = layout;
+  const { bars, todayPct, axisStart, axisEnd } = layout;
+  // 従レーンは1本（共通販売単価）。複数従レーン一般化（#547）後も本画面は第0レーンのみ消費する。
+  const secondaryBars = layout.secondaryBars[0] ?? [];
 
   if (bars.length === 0 && secondaryBars.length === 0) {
     return (

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodDeleteConfirm.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodDeleteConfirm.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { getFormProps } from "@conform-to/react";
+import { useEffect } from "react";
+import { useServerForm } from "@/app/_hooks/useServerForm";
+import { deletePeriodAction } from "./actions";
+import { deletePeriodSchema } from "./schema";
+
+type Props = {
+  /** コマンド宛先キー（編集読みモデルが返す deliveryLocationId を bind）。 */
+  deliveryLocationId: string;
+  /** コマンド宛先キー（編集読みモデルが返す productId を bind）。 */
+  productId: string;
+  /** route／revalidate 用キー（編集読みモデルが返す deliveryLocationCode を bind）。 */
+  deliveryLocationCode: string;
+  /** route／revalidate 用キー（編集読みモデルが返す productCode を bind）。 */
+  productCode: string;
+  periodId: string;
+  /** 集約ルートの楽観ロックversion（削除対象＝将来行は集約が在るため非null）。 */
+  version: number;
+  onSuccess: () => void;
+  onCancel: () => void;
+};
+
+/**
+ * UC-5 削除の行内2段階確認（決定5）。
+ *
+ * 将来開始行の [削除] 押下でこの確認に切り替わり、[削除する]/[取消] を提示する。
+ * shadcn AlertDialog を使わず、パネル用 client state を流用して追加依存なしで
+ * undo 無しの物理削除に最小ガードを掛ける。成功/エラーの解釈は PeriodForm と
+ * 同じ conform 機構（form.status / form.errors）に揃える。
+ */
+export function PeriodDeleteConfirm({
+  deliveryLocationId,
+  productId,
+  deliveryLocationCode,
+  productCode,
+  periodId,
+  version,
+  onSuccess,
+  onCancel,
+}: Props) {
+  const { form, fields, isPending } = useServerForm({
+    action: deletePeriodAction.bind(
+      null,
+      deliveryLocationId,
+      productId,
+      deliveryLocationCode,
+      productCode
+    ),
+    schema: deletePeriodSchema,
+    defaultValue: { version: String(version), periodId },
+  });
+
+  // 成功時（redirectせず留まる設計・決定8）にパネルを閉じる。
+  useEffect(() => {
+    if (form.status === "success") onSuccess();
+  }, [form.status, onSuccess]);
+
+  return (
+    <div className="flex flex-col gap-1 items-end">
+      <form {...getFormProps(form)} noValidate className="flex gap-2 items-center">
+        <input type="hidden" name={fields.version.name} value={String(version)} />
+        <input type="hidden" name={fields.periodId.name} value={periodId} />
+        <span className="text-sm text-gray-700">削除しますか？</span>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="bg-red-500 hover:bg-red-700 text-white text-sm font-bold py-1 px-3 rounded disabled:bg-gray-400 disabled:cursor-not-allowed"
+        >
+          {isPending ? "削除中..." : "削除する"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPending}
+          className="bg-gray-200 hover:bg-gray-300 text-gray-700 text-sm font-bold py-1 px-3 rounded disabled:opacity-50"
+        >
+          取消
+        </button>
+      </form>
+      {form.errors && (
+        <p className="text-red-500 text-xs" role="alert">
+          {form.errors[0]}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodDetailPanel.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodDetailPanel.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Badge } from "@/app/_components/shadcnui/badge";
+import type {
+  DeliveryLocationSellingPriceEditDTO,
+  DeliveryLocationSellingPricePeriodStatus,
+} from "@subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceEditDTO";
+import type { CommonSellingPriceEditPeriodDTO } from "@subdomains/pricing/application/queries/dto/CommonSellingPriceEditDTO";
+import { authorityFor, type PeriodStatus } from "../../../_shared/period-rules";
+import { computeTimelineLayout, type TimelinePeriod } from "../../../_shared/timeline-layout";
+import { formatYenFromDecimal } from "../../../_shared/formatYen";
+import { PeriodDeleteConfirm } from "./PeriodDeleteConfirm";
+import { PeriodForm } from "./PeriodForm";
+import { PriceTimeline } from "./PriceTimeline";
+
+/** BE 時点状態のラベルと Badge variant（現在有効=active/将来=future/失効=expired）。 */
+const STATUS_BADGE: Record<
+  DeliveryLocationSellingPricePeriodStatus,
+  { label: string; variant: "default" | "outline" | "secondary" }
+> = {
+  active: { label: "現在有効", variant: "default" },
+  future: { label: "将来", variant: "outline" },
+  expired: { label: "失効", variant: "secondary" },
+};
+
+/**
+ * 納品先別・共通いずれの期間 DTO も持つ最小フィールド。`toTimelinePeriod` の入力に使う
+ * （主レーン＝納品先別 / 従レーン＝共通 を同一の中立構造へ写像するため）。
+ */
+type TimelinePeriodSource = {
+  periodId: string;
+  start: string;
+  end: string | null;
+  status: PeriodStatus;
+  sellingPrice: string;
+};
+
+/** 期間 DTO を `computeTimelineLayout` の中立構造 `TimelinePeriod` へ写像（主・従レーン共通・`sellingPrice`→`price`）。 */
+const toTimelinePeriod = (p: TimelinePeriodSource): TimelinePeriod => ({
+  periodId: p.periodId,
+  start: p.start,
+  end: p.end,
+  status: p.status,
+  price: p.sellingPrice,
+});
+
+/**
+ * パネルの開閉モード（決定2: URLに載せずクライアント状態で保持）。
+ * 対象は periodId で保持し、revalidate後の最新 detail から都度引き直す（stale回避）。
+ */
+type PanelMode =
+  | { kind: "closed" }
+  | { kind: "new" }
+  | { kind: "edit"; periodId: string }
+  | { kind: "endDate"; periodId: string }
+  | { kind: "delete"; periodId: string };
+
+type Props = {
+  detail: DeliveryLocationSellingPriceEditDTO;
+  /**
+   * 共通販売単価の期間行（フォールバック層・#547）。タイムラインの従レーンとして重ねて対比する
+   * （表示専用）。共通が未設定なら空配列。納品先別レーンと同一の中立構造へマップして
+   * `computeTimelineLayout` の第2系列に渡す（Step 3-2 で得意先別レーンを加えた3レーンへ拡張）。
+   */
+  commonPeriods: CommonSellingPriceEditPeriodDTO[];
+  /** 管理者のみミューテーション系UI（新規追加・編集・適用終了・削除）を描画する。認可の正本はサーバー側 verifyAdmin。 */
+  isAdmin: boolean;
+  /** 今日マーカーの基準日（`YYYY-MM-DD`）。status 算出と同一基準日をサーバーから受け取る（#475）。 */
+  referenceDate: string;
+};
+
+/**
+ * UC-2 期間明細の表示＋UC-3/4/5 の操作配線（client wrapper）。
+ *
+ * 時点状態（現在有効/将来/失効）に応じて各行の編集/適用終了/削除ボタンを出し分け
+ * （use-cases.md §7・authorityFor）、登録/編集/適用終了は単一 PeriodForm をモードで
+ * 切り替えて下部パネルに表示する。削除は行内2段階確認（決定5）。
+ *
+ * 得意先別販売単価（`customer-selling-prices/[customerCd]/[productCd]/PeriodDetailPanel.tsx`）の同型写像で、
+ * 宛先軸が得意先から納品先へ替わる点が異なる（上書きなし＝集約なしが正常な既定状態である点は共通）。
+ */
+export function PeriodDetailPanel({ detail, commonPeriods, isAdmin, referenceDate }: Props) {
+  const [mode, setMode] = useState<PanelMode>({ kind: "closed" });
+  const close = useCallback(() => setMode({ kind: "closed" }), []);
+
+  // タイムライン帯の表示トグル（決定: 既定は table＝帯なし。決定2 と同じくクライアント状態で保持）。
+  const [showTimeline, setShowTimeline] = useState(false);
+
+  // 編集系パネルの対象行を最新 detail から引く（削除済みなら閉じる）。
+  const formMode =
+    mode.kind === "new" || mode.kind === "edit" || mode.kind === "endDate" ? mode : null;
+  const formPeriod =
+    formMode != null && formMode.kind !== "new"
+      ? detail.periods.find((p) => p.periodId === formMode.periodId)
+      : undefined;
+
+  return (
+    <div className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-semibold text-gray-500">適用期間</h2>
+        <div className="flex items-center gap-3">
+          {/* 表示切替（テーブル／タイムライン）。タイムラインは付加式で、テーブルは常時表示のまま。 */}
+          <div className="inline-flex rounded-md border border-gray-300 p-0.5 text-sm">
+            <button
+              type="button"
+              aria-pressed={!showTimeline}
+              onClick={() => setShowTimeline(false)}
+              className={`rounded px-3 py-1 font-semibold ${
+                showTimeline ? "text-gray-600 hover:bg-gray-100" : "bg-blue-500 text-white"
+              }`}
+            >
+              テーブル
+            </button>
+            <button
+              type="button"
+              aria-pressed={showTimeline}
+              onClick={() => setShowTimeline(true)}
+              className={`rounded px-3 py-1 font-semibold ${
+                showTimeline ? "bg-blue-500 text-white" : "text-gray-600 hover:bg-gray-100"
+              }`}
+            >
+              タイムライン
+            </button>
+          </div>
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={() => setMode({ kind: "new" })}
+              className="bg-blue-500 hover:bg-blue-700 text-white text-sm font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            >
+              新規追加
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* タイムライン帯（付加式・トグル ON 時のみ）。テーブルの上に重ねて期間の連続・隙間・無期限を可視化。 */}
+      {showTimeline && (
+        <PriceTimeline
+          layout={computeTimelineLayout(
+            detail.periods.map(toTimelinePeriod),
+            referenceDate,
+            // 従レーン（共通販売単価・フォールバック）。同一の中立構造へマップして重ねる（表示専用）。
+            commonPeriods.map(toTimelinePeriod)
+          )}
+        />
+      )}
+
+      {detail.periods.length > 0 ? (
+        <table className="w-full text-left">
+          <thead>
+            <tr className="border-b">
+              <th className="py-2 text-sm font-bold text-gray-700">適用開始日</th>
+              <th className="py-2 text-sm font-bold text-gray-700">適用終了日</th>
+              <th className="py-2 text-sm font-bold text-gray-700 text-right">納品先別販売単価</th>
+              <th className="py-2 text-sm font-bold text-gray-700">状態</th>
+              {isAdmin && <th className="py-2 text-sm font-bold text-gray-700 text-right">操作</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {detail.periods.map((period) => {
+              const badge = STATUS_BADGE[period.status];
+              const auth = authorityFor(period.status);
+              const isDeleting = mode.kind === "delete" && mode.periodId === period.periodId;
+              return (
+                <tr key={period.periodId} className="border-b">
+                  <td className="py-2 tabular-nums">{period.start}</td>
+                  <td className="py-2 tabular-nums">
+                    {period.end ?? <span className="text-gray-500">無期限</span>}
+                  </td>
+                  <td className="py-2 text-right font-medium tabular-nums">
+                    {formatYenFromDecimal(period.sellingPrice)}
+                  </td>
+                  <td className="py-2">
+                    <Badge variant={badge.variant}>{badge.label}</Badge>
+                  </td>
+                  {isAdmin && (
+                    <td className="py-2">
+                      {isDeleting ? (
+                        <PeriodDeleteConfirm
+                          deliveryLocationId={detail.deliveryLocationId}
+                          productId={detail.productId}
+                          deliveryLocationCode={detail.deliveryLocationCode}
+                          productCode={detail.productCode}
+                          periodId={period.periodId}
+                          version={detail.version ?? 0}
+                          onSuccess={close}
+                          onCancel={close}
+                        />
+                      ) : (
+                        <div className="flex gap-2 justify-end">
+                          {auth.editable && (
+                            <button
+                              type="button"
+                              onClick={() => setMode({ kind: "edit", periodId: period.periodId })}
+                              className="text-blue-600 hover:text-blue-800 hover:underline text-sm"
+                            >
+                              編集
+                            </button>
+                          )}
+                          {auth.endDatable && (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setMode({ kind: "endDate", periodId: period.periodId })
+                              }
+                              className="text-blue-600 hover:text-blue-800 hover:underline text-sm"
+                            >
+                              適用終了
+                            </button>
+                          )}
+                          {auth.deletable && (
+                            <button
+                              type="button"
+                              onClick={() => setMode({ kind: "delete", periodId: period.periodId })}
+                              className="text-red-600 hover:text-red-800 hover:underline text-sm"
+                            >
+                              削除
+                            </button>
+                          )}
+                          {!auth.editable && !auth.endDatable && !auth.deletable && (
+                            <span className="text-gray-400 text-sm">—</span>
+                          )}
+                        </div>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      ) : (
+        <p className="text-gray-500">
+          この納品先×商品の上書きはありません。価格決定は得意先別販売単価を、無ければ共通販売単価を適用します。
+        </p>
+      )}
+
+      {/* 登録／編集／適用終了の単一フォーム（決定3）。編集系で対象行が消えていたら表示しない。 */}
+      {formMode != null && (formMode.kind === "new" || formPeriod != null) && (
+        <PeriodForm
+          deliveryLocationId={detail.deliveryLocationId}
+          productId={detail.productId}
+          deliveryLocationCode={detail.deliveryLocationCode}
+          productCode={detail.productCode}
+          version={detail.version}
+          mode={formMode.kind}
+          period={formPeriod}
+          onSuccess={close}
+          onCancel={close}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodDetailPanel.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodDetailPanel.tsx
@@ -7,6 +7,7 @@ import type {
   DeliveryLocationSellingPricePeriodStatus,
 } from "@subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceEditDTO";
 import type { CommonSellingPriceEditPeriodDTO } from "@subdomains/pricing/application/queries/dto/CommonSellingPriceEditDTO";
+import type { CustomerSellingPriceEditPeriodDTO } from "@subdomains/pricing/application/queries/dto/CustomerSellingPriceEditDTO";
 import { authorityFor, type PeriodStatus } from "../../../_shared/period-rules";
 import { computeTimelineLayout, type TimelinePeriod } from "../../../_shared/timeline-layout";
 import { formatYenFromDecimal } from "../../../_shared/formatYen";
@@ -61,9 +62,15 @@ type PanelMode =
 type Props = {
   detail: DeliveryLocationSellingPriceEditDTO;
   /**
-   * 共通販売単価の期間行（フォールバック層・#547）。タイムラインの従レーンとして重ねて対比する
-   * （表示専用）。共通が未設定なら空配列。納品先別レーンと同一の中立構造へマップして
-   * `computeTimelineLayout` の第2系列に渡す（Step 3-2 で得意先別レーンを加えた3レーンへ拡張）。
+   * 得意先別販売単価の期間行（フォールバック層・従1・#547）。納品先別の価格決定は
+   * 「納品先別 → 得意先別 → 共通」の3段フォールバックで、その中間層を表示専用の従レーンとして重ねる。
+   * 当該親得意先×商品に得意先別の上書きが無ければ空配列。
+   */
+  customerPeriods: CustomerSellingPriceEditPeriodDTO[];
+  /**
+   * 共通販売単価の期間行（フォールバック層・従2・#547）。3段フォールバックの最下層。
+   * 共通が未設定なら空配列。得意先別・共通とも納品先別レーンと同一の中立構造へマップして
+   * `computeTimelineLayout` の従レーン配列（[得意先別, 共通]）に渡す。
    */
   commonPeriods: CommonSellingPriceEditPeriodDTO[];
   /** 管理者のみミューテーション系UI（新規追加・編集・適用終了・削除）を描画する。認可の正本はサーバー側 verifyAdmin。 */
@@ -82,7 +89,13 @@ type Props = {
  * 得意先別販売単価（`customer-selling-prices/[customerCd]/[productCd]/PeriodDetailPanel.tsx`）の同型写像で、
  * 宛先軸が得意先から納品先へ替わる点が異なる（上書きなし＝集約なしが正常な既定状態である点は共通）。
  */
-export function PeriodDetailPanel({ detail, commonPeriods, isAdmin, referenceDate }: Props) {
+export function PeriodDetailPanel({
+  detail,
+  customerPeriods,
+  commonPeriods,
+  isAdmin,
+  referenceDate,
+}: Props) {
   const [mode, setMode] = useState<PanelMode>({ kind: "closed" });
   const close = useCallback(() => setMode({ kind: "closed" }), []);
 
@@ -149,9 +162,9 @@ export function PeriodDetailPanel({ detail, commonPeriods, isAdmin, referenceDat
           layout={computeTimelineLayout(
             detail.periods.map(toTimelinePeriod),
             referenceDate,
-            // 従レーン（共通販売単価・フォールバック）を1本重ねる（表示専用）。複数従レーンの配列で渡す。
-            // Step 3-2 で得意先別レーンを加えた2従レーンへ拡張する。
-            [commonPeriods.map(toTimelinePeriod)]
+            // 従レーンは2本：[得意先別, 共通]（3段フォールバックの中間・最下層・いずれも表示専用）。
+            // 同一の中立構造へマップし同一軸へ重ねる。順序が PriceTimeline のレーン描画順と対応する。
+            [customerPeriods.map(toTimelinePeriod), commonPeriods.map(toTimelinePeriod)]
           )}
         />
       )}

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodDetailPanel.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodDetailPanel.tsx
@@ -149,8 +149,9 @@ export function PeriodDetailPanel({ detail, commonPeriods, isAdmin, referenceDat
           layout={computeTimelineLayout(
             detail.periods.map(toTimelinePeriod),
             referenceDate,
-            // 従レーン（共通販売単価・フォールバック）。同一の中立構造へマップして重ねる（表示専用）。
-            commonPeriods.map(toTimelinePeriod)
+            // 従レーン（共通販売単価・フォールバック）を1本重ねる（表示専用）。複数従レーンの配列で渡す。
+            // Step 3-2 で得意先別レーンを加えた2従レーンへ拡張する。
+            [commonPeriods.map(toTimelinePeriod)]
           )}
         />
       )}

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodDetailPanel.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodDetailPanel.tsx
@@ -13,6 +13,7 @@ import { formatYenFromDecimal } from "../../../_shared/formatYen";
 import { PeriodDeleteConfirm } from "./PeriodDeleteConfirm";
 import { PeriodForm } from "./PeriodForm";
 import { PriceTimeline } from "./PriceTimeline";
+import { ReviseForm } from "./ReviseForm";
 
 /** BE 時点状態のラベルと Badge variant（現在有効=active/将来=future/失効=expired）。 */
 const STATUS_BADGE: Record<
@@ -54,6 +55,7 @@ type PanelMode =
   | { kind: "new" }
   | { kind: "edit"; periodId: string }
   | { kind: "endDate"; periodId: string }
+  | { kind: "revise"; periodId: string }
   | { kind: "delete"; periodId: string };
 
 type Props = {
@@ -93,6 +95,12 @@ export function PeriodDetailPanel({ detail, commonPeriods, isAdmin, referenceDat
   const formPeriod =
     formMode != null && formMode.kind !== "new"
       ? detail.periods.find((p) => p.periodId === formMode.periodId)
+      : undefined;
+
+  // 改定パネルの対象（現在有効行）を最新 detail から引く（状態が変わっていたら閉じる）。
+  const revisePeriod =
+    mode.kind === "revise"
+      ? detail.periods.find((p) => p.periodId === mode.periodId && p.status === "active")
       : undefined;
 
   return (
@@ -199,6 +207,15 @@ export function PeriodDetailPanel({ detail, commonPeriods, isAdmin, referenceDat
                               編集
                             </button>
                           )}
+                          {auth.revisable && (
+                            <button
+                              type="button"
+                              onClick={() => setMode({ kind: "revise", periodId: period.periodId })}
+                              className="text-blue-600 hover:text-blue-800 hover:underline text-sm"
+                            >
+                              改定
+                            </button>
+                          )}
                           {auth.endDatable && (
                             <button
                               type="button"
@@ -247,6 +264,20 @@ export function PeriodDetailPanel({ detail, commonPeriods, isAdmin, referenceDat
           version={detail.version}
           mode={formMode.kind}
           period={formPeriod}
+          onSuccess={close}
+          onCancel={close}
+        />
+      )}
+
+      {/* 単価改定の専用フォーム（#474）。現在有効行が在るときのみ。version は集約が在るため非null。 */}
+      {revisePeriod != null && detail.version != null && (
+        <ReviseForm
+          deliveryLocationId={detail.deliveryLocationId}
+          productId={detail.productId}
+          deliveryLocationCode={detail.deliveryLocationCode}
+          productCode={detail.productCode}
+          version={detail.version}
+          currentPrice={revisePeriod.sellingPrice}
           onSuccess={close}
           onCancel={close}
         />

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodForm.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PeriodForm.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { getFormProps, getInputProps } from "@conform-to/react";
+import { useEffect } from "react";
+import { z } from "zod";
+import { useServerForm } from "@/app/_hooks/useServerForm";
+import type { DeliveryLocationSellingPriceEditPeriodDTO } from "@subdomains/pricing/application/queries/dto/DeliveryLocationSellingPriceEditDTO";
+import { formatYenFromDecimal } from "../../../_shared/formatYen";
+import { addPeriodAction, endDatePeriodAction, updateFuturePeriodAction } from "./actions";
+import { addPeriodSchema, endDatePeriodSchema, updateFuturePeriodSchema } from "./schema";
+
+/** 登録（新規追加）・将来行の全項目編集・適用終了 を1つのフォームで切り替える（決定3）。 */
+export type PeriodFormMode = "new" | "edit" | "endDate";
+
+/**
+ * fields の型付け専用スキーマ（全モードのフィールドを網羅）。
+ * 実行時の検証には使わない（検証はモード別スキーマ）。conform の `fields` 型を
+ * モードに依らず安定させ、`fields.startDate` 等へ型安全にアクセスするためだけに用いる。
+ * 値としては参照しない（型のみ）ため `_` プレフィックスで no-unused-vars を回避する。
+ */
+const _periodFormFieldsSchema = z.object({
+  version: z.coerce.number(),
+  periodId: z.string(),
+  startDate: z.string(),
+  endDate: z.string().optional(),
+  price: z.coerce.number(),
+});
+
+type Props = {
+  /** コマンド宛先キー（編集読みモデルが返す deliveryLocationId を bind）。 */
+  deliveryLocationId: string;
+  /** コマンド宛先キー（編集読みモデルが返す productId を bind）。 */
+  productId: string;
+  /** route／revalidate 用キー（編集読みモデルが返す deliveryLocationCode を bind）。 */
+  deliveryLocationCode: string;
+  /** route／revalidate 用キー（編集読みモデルが返す productCode を bind）。 */
+  productCode: string;
+  /** 集約ルートの楽観ロックversion（hidden で往復）。上書きなし（新規登録モード）では null。 */
+  version: number | null;
+  mode: PeriodFormMode;
+  /** edit / endDate で対象行。new では未指定。 */
+  period?: DeliveryLocationSellingPriceEditPeriodDTO;
+  /** 成功時（パネルを閉じる）。 */
+  onSuccess: () => void;
+  /** キャンセル時（パネルを閉じる）。 */
+  onCancel: () => void;
+};
+
+const SUBMIT_LABEL: Record<PeriodFormMode, { idle: string; busy: string }> = {
+  new: { idle: "登録", busy: "登録中..." },
+  edit: { idle: "更新", busy: "更新中..." },
+  endDate: { idle: "適用終了", busy: "処理中..." },
+};
+
+/** モード別に送信先Action（宛先キーを bind）と実行時スキーマを選ぶ。 */
+function pickRuntime(
+  mode: PeriodFormMode,
+  deliveryLocationId: string,
+  productId: string,
+  deliveryLocationCode: string,
+  productCode: string
+) {
+  switch (mode) {
+    case "new":
+      return {
+        action: addPeriodAction.bind(
+          null,
+          deliveryLocationId,
+          productId,
+          deliveryLocationCode,
+          productCode
+        ),
+        schema: addPeriodSchema,
+      };
+    case "edit":
+      return {
+        action: updateFuturePeriodAction.bind(
+          null,
+          deliveryLocationId,
+          productId,
+          deliveryLocationCode,
+          productCode
+        ),
+        schema: updateFuturePeriodSchema,
+      };
+    case "endDate":
+      return {
+        action: endDatePeriodAction.bind(
+          null,
+          deliveryLocationId,
+          productId,
+          deliveryLocationCode,
+          productCode
+        ),
+        schema: endDatePeriodSchema,
+      };
+  }
+}
+
+export function PeriodForm({
+  deliveryLocationId,
+  productId,
+  deliveryLocationCode,
+  productCode,
+  version,
+  mode,
+  period,
+  onSuccess,
+  onCancel,
+}: Props) {
+  const runtime = pickRuntime(
+    mode,
+    deliveryLocationId,
+    productId,
+    deliveryLocationCode,
+    productCode
+  );
+
+  const defaultValue = {
+    version: version != null ? String(version) : undefined,
+    periodId: period?.periodId,
+    startDate: period?.start,
+    endDate: period?.end ?? undefined,
+    // 単価は10進文字列で運ぶ。整数入力欄の既定値は整数部のみを渡す（float を経由しない）。
+    price: period != null ? period.sellingPrice.split(".")[0] : undefined,
+  };
+
+  const { form, fields, isPending } = useServerForm({
+    action: runtime.action,
+    // 実行時はモード別スキーマ（安全＝ロック項目は契約に無い）。型は網羅スキーマで付ける。
+    schema: runtime.schema as unknown as typeof _periodFormFieldsSchema,
+    defaultValue,
+  });
+
+  // 成功時（redirectせず留まる設計・決定8）にパネルを閉じる。revalidate済みでRSCは最新。
+  useEffect(() => {
+    if (form.status === "success") onSuccess();
+  }, [form.status, onSuccess]);
+
+  const labels = SUBMIT_LABEL[mode];
+  const showFullFields = mode === "new" || mode === "edit";
+
+  return (
+    <div className="bg-white border rounded px-6 pt-5 pb-6 mt-4">
+      <h3 className="text-lg font-semibold mb-4 text-gray-700">
+        {mode === "new" && "適用期間の登録"}
+        {mode === "edit" && "適用期間の編集"}
+        {mode === "endDate" && "適用終了（終了日の設定）"}
+      </h3>
+
+      {form.errors && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+          role="alert"
+        >
+          <p className="font-bold">エラー</p>
+          {form.errors.map((error) => (
+            <p key={error}>{error}</p>
+          ))}
+        </div>
+      )}
+
+      <form {...getFormProps(form)} noValidate className="space-y-4">
+        {/* 上書きなしへの初回登録（version=null）では version を送らず BE に新規作成を選ばせる（#505）。 */}
+        {version != null && (
+          <input type="hidden" name={fields.version.name} value={String(version)} />
+        )}
+        {(mode === "edit" || mode === "endDate") && period != null && (
+          <input type="hidden" name={fields.periodId.name} value={period.periodId} />
+        )}
+
+        {/* 適用終了モードは開始日・単価を読み取り専用表示（ロック項目＝入力契約に含めない） */}
+        {mode === "endDate" && period != null && (
+          <dl className="grid grid-cols-2 gap-4 bg-gray-50 rounded p-4">
+            <div>
+              <dt className="text-sm font-bold text-gray-700">適用開始日</dt>
+              <dd className="mt-1 tabular-nums text-gray-900">{period.start}</dd>
+            </div>
+            <div>
+              <dt className="text-sm font-bold text-gray-700">納品先別販売単価</dt>
+              <dd className="mt-1 tabular-nums text-gray-900">
+                {formatYenFromDecimal(period.sellingPrice)}
+              </dd>
+            </div>
+          </dl>
+        )}
+
+        {showFullFields && (
+          <div>
+            <label
+              htmlFor={fields.startDate.id}
+              className="block text-gray-700 text-sm font-bold mb-2"
+            >
+              適用開始日
+            </label>
+            <input
+              {...getInputProps(fields.startDate, { type: "date" })}
+              disabled={isPending}
+              className="shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+            />
+            {fields.startDate.errors && (
+              <p className="text-red-500 text-xs mt-1" id={fields.startDate.errorId}>
+                {fields.startDate.errors[0]}
+              </p>
+            )}
+          </div>
+        )}
+
+        <div>
+          <label htmlFor={fields.endDate.id} className="block text-gray-700 text-sm font-bold mb-2">
+            適用終了日
+          </label>
+          <input
+            {...getInputProps(fields.endDate, { type: "date" })}
+            disabled={isPending}
+            className="shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+          />
+          {fields.endDate.errors ? (
+            <p className="text-red-500 text-xs mt-1" id={fields.endDate.errorId}>
+              {fields.endDate.errors[0]}
+            </p>
+          ) : (
+            <p className="text-gray-600 text-xs mt-1">
+              {mode === "endDate"
+                ? "この日から適用しなくなります（終了日は含みません）。"
+                : "未入力なら無期限。終了日はその日を含みません。"}
+            </p>
+          )}
+        </div>
+
+        {showFullFields && (
+          <div>
+            <label htmlFor={fields.price.id} className="block text-gray-700 text-sm font-bold mb-2">
+              納品先別販売単価（円）
+            </label>
+            <input
+              {...getInputProps(fields.price, { type: "number" })}
+              min={0}
+              step={1}
+              disabled={isPending}
+              className="shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+            />
+            {fields.price.errors ? (
+              <p className="text-red-500 text-xs mt-1" id={fields.price.errorId}>
+                {fields.price.errors[0]}
+              </p>
+            ) : (
+              <p className="text-gray-600 text-xs mt-1">0円以上の整数。</p>
+            )}
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={isPending}
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            {isPending ? labels.busy : labels.idle}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isPending}
+            className="bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:opacity-50"
+          >
+            取消
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PriceTimeline.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PriceTimeline.tsx
@@ -3,19 +3,20 @@ import type { PeriodStatus } from "../../../_shared/period-rules";
 import type { TimelineBar, TimelineLayout } from "../../../_shared/timeline-layout";
 
 /**
- * 適用期間タイムライン帯（#547・純プレゼンテーション・2レーン化）。
+ * 適用期間タイムライン帯（#547・純プレゼンテーション・3レーン）。
  *
- * computeTimelineLayout の算出結果（主 bars ＋ 従 secondaryBars を同一軸に載せた layout）を受けて、
- * 納品先別販売単価レーン（主・操作対象）と共通販売単価レーン（従・フォールバック・表示専用）を縦に積んで
- * 描画する。両レーンは同一の pct 写像に載るため、同じ日付は同じ横位置に揃い、上書き期間の外で何が適用される
- * か（＝共通へフォールバックする）を一目で対比できる。今日マーカー・軸ラベル・凡例は両レーンで共有する。
+ * computeTimelineLayout の算出結果（主 bars ＋ 従 secondaryBars[レーン] を同一軸に載せた layout）を受けて、
+ * 納品先別販売単価レーン（主・操作対象）に、得意先別・共通販売単価レーン（従・フォールバック・表示専用）を
+ * 縦に積んで描画する。3レーンは「納品先別 → 得意先別 → 共通」の3段フォールバックに対応し、同一の pct 写像に
+ * 載るため同じ日付は同じ横位置に揃い、上書きが無い期間に実際いくらが適用されるか（得意先別があればそれ、
+ * 無ければ共通）を一目で対比できる。今日マーカー・軸ラベル・凡例は全レーンで共有する。
  *
- * 従（共通）レーンは表示のみ（クリック・操作なし・淡色で従属的に描画）。共通が未設定でもレーンを空表示する
- * だけで、警告等の新 UI は作らない（共通層の保守問題であり、この画面の関心ではない・決定）。hooks を持たない
- * ため "use client" は付けない（client の PeriodDetailPanel から利用される）。
+ * 従（得意先別・共通）レーンは表示のみ（クリック・操作なし・淡色で従属的に描画）。各層が未設定でもレーンを
+ * 空表示するだけで、警告等の新 UI は作らない（各層の保守問題であり、この画面の関心ではない・決定）。hooks を
+ * 持たないため "use client" は付けない（client の PeriodDetailPanel から利用される）。
  *
- * 得意先別販売単価（`customer-selling-prices/[customerCd]/[productCd]/PriceTimeline.tsx`）の同型写像で、
- * 主レーンの宛先軸が得意先から納品先へ替わる（Step 3-2 で得意先別レーンを加えた3レーンへ拡張予定）。
+ * 得意先別販売単価（`customer-selling-prices/[customerCd]/[productCd]/PriceTimeline.tsx`）の2レーン版を
+ * 出発点に、フォールバックが1段深い（得意先別が挟まる）ぶん従レーンを2本へ拡張したもの。
  */
 
 /** 状態→帯のパレット（プロトの timeline bars と同一の配色）。 */
@@ -82,12 +83,51 @@ function SecondaryBar({ bar }: { bar: TimelineBar }) {
   );
 }
 
+/** 従レーン1本（ラベル＋トラック＋帯／空表示）。淡色・表示専用のフォールバック層を表す。 */
+function SecondaryLane({
+  label,
+  bars,
+  emptyText,
+}: {
+  label: string;
+  bars: TimelineBar[];
+  emptyText: string;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-16 shrink-0 text-[11px] font-medium text-gray-400">{label}</span>
+      <div data-testid="price-timeline-secondary-lane" className="relative my-1 h-[62px] flex-1">
+        <div className="absolute inset-x-0 top-[30px] h-0.5 bg-[#EAEDF0]" />
+        {bars.length > 0 ? (
+          bars.map((bar) => <SecondaryBar key={bar.periodId} bar={bar} />)
+        ) : (
+          <span className="absolute top-[20px] left-2 text-[10px] text-gray-400">{emptyText}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function PriceTimeline({ layout }: Props) {
   const { bars, todayPct, axisStart, axisEnd } = layout;
-  // 従レーンは1本（共通販売単価）。Step 3-2 で得意先別レーンを加えた3レーンへ拡張する。
-  const secondaryBars = layout.secondaryBars[0] ?? [];
+  // 従レーンは2本：[得意先別, 共通]（PeriodDetailPanel が渡す順＝secondaryLanes の順に対応）。
+  // 3段フォールバック（納品先別 → 得意先別 → 共通）の中間層・最下層をそれぞれ表示専用で重ねる。
+  const secondaryLanes = [
+    {
+      key: "customer",
+      label: "得意先別",
+      bars: layout.secondaryBars[0] ?? [],
+      emptyText: "得意先別の上書きなし",
+    },
+    {
+      key: "common",
+      label: "共通",
+      bars: layout.secondaryBars[1] ?? [],
+      emptyText: "共通販売単価は未設定",
+    },
+  ];
 
-  if (bars.length === 0 && secondaryBars.length === 0) {
+  if (bars.length === 0 && secondaryLanes.every((lane) => lane.bars.length === 0)) {
     return (
       <div
         data-testid="price-timeline"
@@ -103,7 +143,7 @@ export function PriceTimeline({ layout }: Props) {
       data-testid="price-timeline"
       className="mb-4 rounded border border-gray-200 bg-white px-6 py-4"
     >
-      {/* 主・従レーンを積む相対配置の親（今日マーカーを両レーンに跨いで載せる）。 */}
+      {/* 主・従レーンを積む相対配置の親（今日マーカーを全レーンに跨いで載せる）。 */}
       <div className="relative">
         {/* 納品先別レーン（主・操作対象）。 */}
         <div className="flex items-center gap-3">
@@ -116,25 +156,17 @@ export function PriceTimeline({ layout }: Props) {
           </div>
         </div>
 
-        {/* 共通レーン（従・淡色・表示専用のフォールバック層）。 */}
-        <div className="flex items-center gap-3">
-          <span className="w-16 shrink-0 text-[11px] font-medium text-gray-400">共通</span>
-          <div
-            data-testid="price-timeline-secondary-lane"
-            className="relative my-1 h-[62px] flex-1"
-          >
-            <div className="absolute inset-x-0 top-[30px] h-0.5 bg-[#EAEDF0]" />
-            {secondaryBars.length > 0 ? (
-              secondaryBars.map((bar) => <SecondaryBar key={bar.periodId} bar={bar} />)
-            ) : (
-              <span className="absolute top-[20px] left-2 text-[10px] text-gray-400">
-                共通販売単価は未設定
-              </span>
-            )}
-          </div>
-        </div>
+        {/* 得意先別・共通レーン（従・淡色・表示専用のフォールバック層）。 */}
+        {secondaryLanes.map((lane) => (
+          <SecondaryLane
+            key={lane.key}
+            label={lane.label}
+            bars={lane.bars}
+            emptyText={lane.emptyText}
+          />
+        ))}
 
-        {/* 参照日（今日）マーカー（両レーンを縦断）。左のレーンラベル幅ぶんインセットする。 */}
+        {/* 参照日（今日）マーカー（全レーンを縦断）。左のレーンラベル幅ぶんインセットする。 */}
         <div className="pointer-events-none absolute inset-y-0 left-[76px] right-0">
           <div
             data-testid="price-timeline-today"
@@ -156,7 +188,7 @@ export function PriceTimeline({ layout }: Props) {
         <span>{axisEnd}</span>
       </div>
 
-      {/* 凡例（色分けは両レーン共通。従レーンは淡色・破線＝表示専用の対比）。 */}
+      {/* 凡例（色分けは全レーン共通。従レーンは淡色・破線＝表示専用の対比）。 */}
       <div
         data-testid="price-timeline-legend"
         className="mt-3.5 flex flex-wrap items-center gap-4 text-[11px] text-gray-500"
@@ -175,7 +207,7 @@ export function PriceTimeline({ layout }: Props) {
         })}
         <span className="inline-flex items-center gap-1.5 text-gray-400">
           <span className="h-2.5 w-2.5 rounded-[3px] border border-dashed border-gray-400 opacity-60" />
-          共通（フォールバック・表示専用）
+          得意先別・共通（フォールバック・表示専用）
         </span>
       </div>
     </div>

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PriceTimeline.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PriceTimeline.tsx
@@ -1,0 +1,181 @@
+import type { CSSProperties } from "react";
+import type { PeriodStatus } from "../../../_shared/period-rules";
+import type { TimelineBar, TimelineLayout } from "../../../_shared/timeline-layout";
+
+/**
+ * 適用期間タイムライン帯（#547・純プレゼンテーション・2レーン化）。
+ *
+ * computeTimelineLayout の算出結果（主 bars ＋ 従 secondaryBars を同一軸に載せた layout）を受けて、
+ * 納品先別販売単価レーン（主・操作対象）と共通販売単価レーン（従・フォールバック・表示専用）を縦に積んで
+ * 描画する。両レーンは同一の pct 写像に載るため、同じ日付は同じ横位置に揃い、上書き期間の外で何が適用される
+ * か（＝共通へフォールバックする）を一目で対比できる。今日マーカー・軸ラベル・凡例は両レーンで共有する。
+ *
+ * 従（共通）レーンは表示のみ（クリック・操作なし・淡色で従属的に描画）。共通が未設定でもレーンを空表示する
+ * だけで、警告等の新 UI は作らない（共通層の保守問題であり、この画面の関心ではない・決定）。hooks を持たない
+ * ため "use client" は付けない（client の PeriodDetailPanel から利用される）。
+ *
+ * 得意先別販売単価（`customer-selling-prices/[customerCd]/[productCd]/PriceTimeline.tsx`）の同型写像で、
+ * 主レーンの宛先軸が得意先から納品先へ替わる（Step 3-2 で得意先別レーンを加えた3レーンへ拡張予定）。
+ */
+
+/** 状態→帯のパレット（プロトの timeline bars と同一の配色）。 */
+const STATUS_PALETTE: Record<PeriodStatus, { bg: string; border: string; fg: string }> = {
+  active: { bg: "#CDEAD6", border: "#8FCFA4", fg: "#1E7A3D" },
+  future: { bg: "#D6E2FB", border: "#A9C2F1", fg: "#2563EB" },
+  expired: { bg: "#E5E8EB", border: "#C7CCD2", fg: "#6B7280" },
+};
+
+/** 凡例の並び（現在有効／失効／将来・プロトの並び順）。 */
+const LEGEND_ITEMS: { status: PeriodStatus; label: string }[] = [
+  { status: "active", label: "現在有効" },
+  { status: "expired", label: "失効" },
+  { status: "future", label: "将来" },
+];
+
+type Props = {
+  layout: TimelineLayout;
+};
+
+/** 主レーンの帯1本（BE 算出状態で色分け・単価ラベル付き）。 */
+function PrimaryBar({ bar }: { bar: TimelineBar }) {
+  const palette = STATUS_PALETTE[bar.status];
+  const barStyle: CSSProperties = {
+    left: `${bar.leftPct}%`,
+    width: `${bar.widthPct}%`,
+    backgroundColor: palette.bg,
+    borderColor: palette.border,
+    color: palette.fg,
+  };
+  return (
+    <div
+      data-testid="price-timeline-bar"
+      className="absolute top-[18px] flex h-[26px] items-center justify-center overflow-hidden rounded-md border"
+      style={barStyle}
+    >
+      <span className="whitespace-nowrap px-1.5 text-[11px] font-bold tabular-nums">
+        {bar.priceLabel}
+      </span>
+    </div>
+  );
+}
+
+/** 従（共通）レーンの帯1本。淡色・破線・低不透明度で従属＝表示専用を表す。 */
+function SecondaryBar({ bar }: { bar: TimelineBar }) {
+  const palette = STATUS_PALETTE[bar.status];
+  const barStyle: CSSProperties = {
+    left: `${bar.leftPct}%`,
+    width: `${bar.widthPct}%`,
+    backgroundColor: palette.bg,
+    borderColor: palette.border,
+    color: palette.fg,
+  };
+  return (
+    <div
+      data-testid="price-timeline-secondary-bar"
+      className="absolute top-[18px] flex h-[26px] items-center justify-center overflow-hidden rounded-md border border-dashed opacity-60"
+      style={barStyle}
+    >
+      <span className="whitespace-nowrap px-1.5 text-[11px] font-medium tabular-nums">
+        {bar.priceLabel}
+      </span>
+    </div>
+  );
+}
+
+export function PriceTimeline({ layout }: Props) {
+  const { bars, secondaryBars, todayPct, axisStart, axisEnd } = layout;
+
+  if (bars.length === 0 && secondaryBars.length === 0) {
+    return (
+      <div
+        data-testid="price-timeline"
+        className="mb-4 rounded border border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm text-gray-500"
+      >
+        タイムラインに表示できる適用期間がありません。
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="price-timeline"
+      className="mb-4 rounded border border-gray-200 bg-white px-6 py-4"
+    >
+      {/* 主・従レーンを積む相対配置の親（今日マーカーを両レーンに跨いで載せる）。 */}
+      <div className="relative">
+        {/* 納品先別レーン（主・操作対象）。 */}
+        <div className="flex items-center gap-3">
+          <span className="w-16 shrink-0 text-[11px] font-bold text-gray-600">納品先別</span>
+          <div className="relative my-1 h-[62px] flex-1">
+            <div className="absolute inset-x-0 top-[30px] h-0.5 bg-[#EAEDF0]" />
+            {bars.map((bar) => (
+              <PrimaryBar key={bar.periodId} bar={bar} />
+            ))}
+          </div>
+        </div>
+
+        {/* 共通レーン（従・淡色・表示専用のフォールバック層）。 */}
+        <div className="flex items-center gap-3">
+          <span className="w-16 shrink-0 text-[11px] font-medium text-gray-400">共通</span>
+          <div
+            data-testid="price-timeline-secondary-lane"
+            className="relative my-1 h-[62px] flex-1"
+          >
+            <div className="absolute inset-x-0 top-[30px] h-0.5 bg-[#EAEDF0]" />
+            {secondaryBars.length > 0 ? (
+              secondaryBars.map((bar) => <SecondaryBar key={bar.periodId} bar={bar} />)
+            ) : (
+              <span className="absolute top-[20px] left-2 text-[10px] text-gray-400">
+                共通販売単価は未設定
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* 参照日（今日）マーカー（両レーンを縦断）。左のレーンラベル幅ぶんインセットする。 */}
+        <div className="pointer-events-none absolute inset-y-0 left-[76px] right-0">
+          <div
+            data-testid="price-timeline-today"
+            className="absolute inset-y-1 w-0.5 bg-red-600"
+            style={{ left: `${todayPct}%` }}
+          />
+          <div
+            className="absolute -top-1 -translate-x-1/2 whitespace-nowrap text-[10px] font-bold text-red-600"
+            style={{ left: `${todayPct}%` }}
+          >
+            今日
+          </div>
+        </div>
+      </div>
+
+      {/* 軸両端の日付ラベル（レーンラベル幅ぶんインセット）。 */}
+      <div className="ml-[76px] flex justify-between text-[11px] tabular-nums text-gray-400">
+        <span>{axisStart}</span>
+        <span>{axisEnd}</span>
+      </div>
+
+      {/* 凡例（色分けは両レーン共通。従レーンは淡色・破線＝表示専用の対比）。 */}
+      <div
+        data-testid="price-timeline-legend"
+        className="mt-3.5 flex flex-wrap items-center gap-4 text-[11px] text-gray-500"
+      >
+        {LEGEND_ITEMS.map((item) => {
+          const palette = STATUS_PALETTE[item.status];
+          return (
+            <span key={item.status} className="inline-flex items-center gap-1.5">
+              <span
+                className="h-2.5 w-2.5 rounded-[3px] border"
+                style={{ backgroundColor: palette.bg, borderColor: palette.border }}
+              />
+              {item.label}
+            </span>
+          );
+        })}
+        <span className="inline-flex items-center gap-1.5 text-gray-400">
+          <span className="h-2.5 w-2.5 rounded-[3px] border border-dashed border-gray-400 opacity-60" />
+          共通（フォールバック・表示専用）
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PriceTimeline.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/PriceTimeline.tsx
@@ -83,7 +83,9 @@ function SecondaryBar({ bar }: { bar: TimelineBar }) {
 }
 
 export function PriceTimeline({ layout }: Props) {
-  const { bars, secondaryBars, todayPct, axisStart, axisEnd } = layout;
+  const { bars, todayPct, axisStart, axisEnd } = layout;
+  // 従レーンは1本（共通販売単価）。Step 3-2 で得意先別レーンを加えた3レーンへ拡張する。
+  const secondaryBars = layout.secondaryBars[0] ?? [];
 
   if (bars.length === 0 && secondaryBars.length === 0) {
     return (

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/ReviseForm.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/ReviseForm.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { getFormProps, getInputProps } from "@conform-to/react";
+import { useEffect } from "react";
+import { useServerForm } from "@/app/_hooks/useServerForm";
+import { formatYenFromDecimal } from "../../../_shared/formatYen";
+import { revisePeriodAction } from "./actions";
+import { revisePeriodSchema } from "./schema";
+
+type Props = {
+  /** コマンド宛先キー（編集読みモデルが返す deliveryLocationId を bind）。 */
+  deliveryLocationId: string;
+  /** コマンド宛先キー（編集読みモデルが返す productId を bind）。 */
+  productId: string;
+  /** route／revalidate 用キー（編集読みモデルが返す deliveryLocationCode を bind）。 */
+  deliveryLocationCode: string;
+  /** route／revalidate 用キー（編集読みモデルが返す productCode を bind）。 */
+  productCode: string;
+  /** 集約ルートの楽観ロックversion（hidden で往復）。 */
+  version: number;
+  /** 現在有効行の単価（10進文字列）。方向ラベルの算出と現単価表示に使う（表示専用・改竄面に載せない）。 */
+  currentPrice: string;
+  /** 成功時（パネルを閉じる）。 */
+  onSuccess: () => void;
+  /** キャンセル時（パネルを閉じる）。 */
+  onCancel: () => void;
+};
+
+/** 入力中の新単価と現単価から改定方向を表示用に算出する（据え置きも許容＝拒否しない）。 */
+function directionLabel(
+  currentPrice: string,
+  rawNewPrice: string | undefined
+): { text: string; className: string } | null {
+  if (rawNewPrice == null || rawNewPrice === "") return null;
+  const next = Number(rawNewPrice);
+  const current = Number(currentPrice);
+  if (!Number.isFinite(next) || !Number.isFinite(current)) return null;
+  if (next > current) return { text: "値上げ", className: "text-red-600" };
+  if (next < current) return { text: "値下げ", className: "text-blue-600" };
+  return { text: "据え置き", className: "text-gray-600" };
+}
+
+/**
+ * 単価改定（ガイド付き・#474）専用フォーム。
+ *
+ * 「現在有効行の適用終了（終了日＝改定日）＋改定日開始の新規追加」を BE 単一コマンドが合成する操作の
+ * 入力ガワ。改定固有の最小入力契約（改定日＋新単価。version は hidden）を PeriodForm に混ぜず独立させる
+ * （現単価表示・方向ラベル・単一日付セマンティクスが汎用フォームと噛み合わないため）。現在有効行の特定は
+ * サーバーが参照日で行うため periodId は送らない。方向ラベルは表示専用で、据え置き（新＝現）も許容する。
+ *
+ * 得意先別販売単価（`customer-selling-prices/[customerCd]/[productCd]/ReviseForm.tsx`）の同型写像で、
+ * 宛先軸が得意先から納品先へ替わる点だけが異なる。
+ */
+export function ReviseForm({
+  deliveryLocationId,
+  productId,
+  deliveryLocationCode,
+  productCode,
+  version,
+  currentPrice,
+  onSuccess,
+  onCancel,
+}: Props) {
+  const { form, fields, isPending } = useServerForm({
+    action: revisePeriodAction.bind(
+      null,
+      deliveryLocationId,
+      productId,
+      deliveryLocationCode,
+      productCode
+    ),
+    schema: revisePeriodSchema,
+    defaultValue: { version: String(version), revisionDate: undefined, price: undefined },
+  });
+
+  // 成功時（redirectせず留まる設計）にパネルを閉じる。revalidate済みでRSCは最新。
+  useEffect(() => {
+    if (form.status === "success") onSuccess();
+  }, [form.status, onSuccess]);
+
+  const direction = directionLabel(currentPrice, fields.price.value);
+
+  return (
+    <div className="bg-white border rounded px-6 pt-5 pb-6 mt-4">
+      <h3 className="text-lg font-semibold mb-4 text-gray-700">
+        単価改定（改定日から新単価へ切替）
+      </h3>
+
+      {form.errors && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+          role="alert"
+        >
+          <p className="font-bold">エラー</p>
+          {form.errors.map((error) => (
+            <p key={error}>{error}</p>
+          ))}
+        </div>
+      )}
+
+      <form {...getFormProps(form)} noValidate className="space-y-4">
+        <input type="hidden" name={fields.version.name} value={String(version)} />
+
+        {/* 現単価は読み取り専用表示（改定の起点。入力契約には含めない）。 */}
+        <dl className="bg-gray-50 rounded p-4">
+          <dt className="text-sm font-bold text-gray-700">現在の納品先別販売単価</dt>
+          <dd className="mt-1 tabular-nums text-gray-900">{formatYenFromDecimal(currentPrice)}</dd>
+        </dl>
+
+        <div>
+          <label
+            htmlFor={fields.revisionDate.id}
+            className="block text-gray-700 text-sm font-bold mb-2"
+          >
+            改定日
+          </label>
+          <input
+            {...getInputProps(fields.revisionDate, { type: "date" })}
+            disabled={isPending}
+            className="shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+          />
+          {fields.revisionDate.errors ? (
+            <p className="text-red-500 text-xs mt-1" id={fields.revisionDate.errorId}>
+              {fields.revisionDate.errors[0]}
+            </p>
+          ) : (
+            <p className="text-gray-600 text-xs mt-1">
+              この日から新単価を適用します（改定日は明日以降。当日は含みます）。
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor={fields.price.id} className="block text-gray-700 text-sm font-bold mb-2">
+            改定後の納品先別販売単価（円）
+          </label>
+          <div className="flex items-center gap-3">
+            <input
+              {...getInputProps(fields.price, { type: "number" })}
+              min={0}
+              step={1}
+              disabled={isPending}
+              className="shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+            />
+            {direction && (
+              <span className={`text-sm font-bold ${direction.className}`}>{direction.text}</span>
+            )}
+          </div>
+          {fields.price.errors ? (
+            <p className="text-red-500 text-xs mt-1" id={fields.price.errorId}>
+              {fields.price.errors[0]}
+            </p>
+          ) : (
+            <p className="text-gray-600 text-xs mt-1">0円以上の整数。</p>
+          )}
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={isPending}
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            {isPending ? "改定中..." : "改定する"}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isPending}
+            className="bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:opacity-50"
+          >
+            取消
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/actions.ts
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/actions.ts
@@ -1,0 +1,188 @@
+"use server";
+
+import { verifyAdmin } from "@/app/_lib/verifyAuthentication";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { revalidatePath } from "next/cache";
+import { deleteDeliveryLocationSellingPricePeriodCommandFactory } from "@subdomains/pricing/application/factories/deleteDeliveryLocationSellingPricePeriodCommandFactory";
+import { editDeliveryLocationSellingPricePeriodCommandFactory } from "@subdomains/pricing/application/factories/editDeliveryLocationSellingPricePeriodCommandFactory";
+import { endDateDeliveryLocationSellingPricePeriodCommandFactory } from "@subdomains/pricing/application/factories/endDateDeliveryLocationSellingPricePeriodCommandFactory";
+import { registerDeliveryLocationSellingPricePeriodCommandFactory } from "@subdomains/pricing/application/factories/registerDeliveryLocationSellingPricePeriodCommandFactory";
+import { toJstCalendarDay } from "@server/shared/domain/values/toJstCalendarDay";
+import { handleCommandError } from "../../../_shared/error-handler";
+import {
+  addPeriodSchema,
+  deletePeriodSchema,
+  endDatePeriodSchema,
+  updateFuturePeriodSchema,
+} from "./schema";
+
+/**
+ * 納品先別販売単価 適用期間の操作別 Server Action（UC-3/4/5・#505 実BE接続）。
+ *
+ * いずれも parse → BE コマンド → catch → revalidate の薄いガワ。不変条件（開始日 ≥ 今日・重複禁止・
+ * 状態別権限）と楽観ロックは集約／コマンドが既存エラー型で throw し、`handleCommandError` が本番同形に
+ * ユーザ向け文言へ変換する。成功時は redirect せず、詳細＋一覧の両パスを revalidate して詳細に留まる。
+ * クライアント（PeriodForm）は submission の success を検知してパネルを閉じる。
+ *
+ * 得意先別販売単価（`customer-selling-prices/[customerCd]/[productCd]/actions.ts`）の同型写像で、宛先軸が
+ * 得意先から納品先へ替わる点だけが異なる（ADR-20260627-a5c）。宛先キー（コマンド宛先）と
+ * `deliveryLocationCode`/`productCode`（route／revalidate 用）は編集読みモデルが返した値を `.bind()` で渡す
+ * （フォーム改竄で別の納品先×商品を操作できないようにする）。価格は10進文字列で運ぶ（ADR-0022）。
+ * 参照日は各 action でサーバー生成して注入する（ADR-20260627-86b）。
+ */
+
+/** 成功後に詳細＋一覧の両パスを再検証する（一覧の現在有効単価・ステータスも動くため）。 */
+function revalidateBoth(deliveryLocationCode: string, productCode: string): void {
+  revalidatePath(`/delivery-location-selling-prices/${deliveryLocationCode}/${productCode}`);
+  revalidatePath("/delivery-location-selling-prices");
+}
+
+/** UC-3 適用期間の登録（上書きなし＝集約なしへの初回登録は version 省略＝新規作成）。 */
+export async function addPeriodAction(
+  deliveryLocationId: string,
+  productId: string,
+  deliveryLocationCode: string,
+  productCode: string,
+  _prevState: unknown,
+  formData: FormData
+) {
+  await verifyAdmin();
+
+  const submission = parseWithZod(formData, { schema: addPeriodSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const { version, startDate, endDate, price } = submission.value;
+
+  try {
+    await registerDeliveryLocationSellingPricePeriodCommandFactory().execute({
+      deliveryLocationId,
+      productId,
+      start: startDate,
+      end: endDate ?? null,
+      price: String(price),
+      referenceDate: toJstCalendarDay(new Date()),
+      expectedVersion: version,
+    });
+    revalidateBoth(deliveryLocationCode, productCode);
+  } catch (error) {
+    const result = handleCommandError(error);
+    const message = !result.success && result.error ? result.error : undefined;
+    return submission.reply({ formErrors: message ? [message] : [] });
+  }
+
+  return submission.reply();
+}
+
+/** UC-4 将来開始行の全項目編集。 */
+export async function updateFuturePeriodAction(
+  deliveryLocationId: string,
+  productId: string,
+  deliveryLocationCode: string,
+  productCode: string,
+  _prevState: unknown,
+  formData: FormData
+) {
+  await verifyAdmin();
+
+  const submission = parseWithZod(formData, { schema: updateFuturePeriodSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const { version, periodId, startDate, endDate, price } = submission.value;
+
+  try {
+    await editDeliveryLocationSellingPricePeriodCommandFactory().execute({
+      deliveryLocationId,
+      productId,
+      periodId,
+      start: startDate,
+      end: endDate ?? null,
+      price: String(price),
+      referenceDate: toJstCalendarDay(new Date()),
+      expectedVersion: version,
+    });
+    revalidateBoth(deliveryLocationCode, productCode);
+  } catch (error) {
+    const result = handleCommandError(error);
+    const message = !result.success && result.error ? result.error : undefined;
+    return submission.reply({ formErrors: message ? [message] : [] });
+  }
+
+  return submission.reply();
+}
+
+/** UC-4 適用終了(現在有効行に終了日を設定)。 */
+export async function endDatePeriodAction(
+  deliveryLocationId: string,
+  productId: string,
+  deliveryLocationCode: string,
+  productCode: string,
+  _prevState: unknown,
+  formData: FormData
+) {
+  await verifyAdmin();
+
+  const submission = parseWithZod(formData, { schema: endDatePeriodSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const { version, periodId, endDate } = submission.value;
+
+  try {
+    await endDateDeliveryLocationSellingPricePeriodCommandFactory().execute({
+      deliveryLocationId,
+      productId,
+      periodId,
+      endDate,
+      referenceDate: toJstCalendarDay(new Date()),
+      expectedVersion: version,
+    });
+    revalidateBoth(deliveryLocationCode, productCode);
+  } catch (error) {
+    const result = handleCommandError(error);
+    const message = !result.success && result.error ? result.error : undefined;
+    return submission.reply({ formErrors: message ? [message] : [] });
+  }
+
+  return submission.reply();
+}
+
+/** UC-5 未適用(将来開始)行の削除。 */
+export async function deletePeriodAction(
+  deliveryLocationId: string,
+  productId: string,
+  deliveryLocationCode: string,
+  productCode: string,
+  _prevState: unknown,
+  formData: FormData
+) {
+  await verifyAdmin();
+
+  const submission = parseWithZod(formData, { schema: deletePeriodSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const { version, periodId } = submission.value;
+
+  try {
+    await deleteDeliveryLocationSellingPricePeriodCommandFactory().execute({
+      deliveryLocationId,
+      productId,
+      periodId,
+      referenceDate: toJstCalendarDay(new Date()),
+      expectedVersion: version,
+    });
+    revalidateBoth(deliveryLocationCode, productCode);
+  } catch (error) {
+    const result = handleCommandError(error);
+    const message = !result.success && result.error ? result.error : undefined;
+    return submission.reply({ formErrors: message ? [message] : [] });
+  }
+
+  return submission.reply();
+}

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/actions.ts
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/actions.ts
@@ -7,12 +7,14 @@ import { deleteDeliveryLocationSellingPricePeriodCommandFactory } from "@subdoma
 import { editDeliveryLocationSellingPricePeriodCommandFactory } from "@subdomains/pricing/application/factories/editDeliveryLocationSellingPricePeriodCommandFactory";
 import { endDateDeliveryLocationSellingPricePeriodCommandFactory } from "@subdomains/pricing/application/factories/endDateDeliveryLocationSellingPricePeriodCommandFactory";
 import { registerDeliveryLocationSellingPricePeriodCommandFactory } from "@subdomains/pricing/application/factories/registerDeliveryLocationSellingPricePeriodCommandFactory";
+import { reviseDeliveryLocationSellingPricePeriodCommandFactory } from "@subdomains/pricing/application/factories/reviseDeliveryLocationSellingPricePeriodCommandFactory";
 import { toJstCalendarDay } from "@server/shared/domain/values/toJstCalendarDay";
 import { handleCommandError } from "../../../_shared/error-handler";
 import {
   addPeriodSchema,
   deletePeriodSchema,
   endDatePeriodSchema,
+  revisePeriodSchema,
   updateFuturePeriodSchema,
 } from "./schema";
 
@@ -138,6 +140,47 @@ export async function endDatePeriodAction(
       productId,
       periodId,
       endDate,
+      referenceDate: toJstCalendarDay(new Date()),
+      expectedVersion: version,
+    });
+    revalidateBoth(deliveryLocationCode, productCode);
+  } catch (error) {
+    const result = handleCommandError(error);
+    const message = !result.success && result.error ? result.error : undefined;
+    return submission.reply({ formErrors: message ? [message] : [] });
+  }
+
+  return submission.reply();
+}
+
+/**
+ * 単価改定（ガイド付き・#474）。現在有効行の適用終了（終了日＝改定日）＋改定日開始の新規追加を
+ * BE 単一コマンドが1ロード/1セーブで合成しアトミックに適用する。対象の現在有効行はコマンドが
+ * 参照日で特定するため periodId は送らない（決定2）。据え置き（新単価＝現単価）も許容する。
+ */
+export async function revisePeriodAction(
+  deliveryLocationId: string,
+  productId: string,
+  deliveryLocationCode: string,
+  productCode: string,
+  _prevState: unknown,
+  formData: FormData
+) {
+  await verifyAdmin();
+
+  const submission = parseWithZod(formData, { schema: revisePeriodSchema });
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  const { version, revisionDate, price } = submission.value;
+
+  try {
+    await reviseDeliveryLocationSellingPricePeriodCommandFactory().execute({
+      deliveryLocationId,
+      productId,
+      revisionDate,
+      price: String(price),
       referenceDate: toJstCalendarDay(new Date()),
       expectedVersion: version,
     });

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/page.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/page.tsx
@@ -1,0 +1,124 @@
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { isAdmin } from "@server/shared/auth";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import {
+  commonSellingPriceEditQueryFactory,
+  deliveryLocationSellingPriceEditQueryFactory,
+} from "@subdomains/pricing/application/factories/pricingQueryFactory";
+import { toJstCalendarDay } from "@server/shared/domain/values/toJstCalendarDay";
+import { Badge } from "@/app/_components/shadcnui/badge";
+import { PeriodDetailPanel } from "./PeriodDetailPanel";
+
+export default async function DeliveryLocationSellingPriceDetailPage({
+  params,
+}: {
+  params: Promise<{ deliveryLocationCd: string; productCd: string }>;
+}) {
+  const session = await verifySession();
+  const admin = isAdmin(session);
+  const { deliveryLocationCd, productCd } = await params;
+
+  // status 算出とタイムラインの今日マーカーを同一基準日に揃えるため、参照日を一度だけ求めて共有する。
+  const referenceDate = toJstCalendarDay(new Date());
+
+  // 納品先別（主）と共通販売単価（従＝タイムラインのフォールバックレーン）を並行取得する。
+  // 共通は同一商品コードで引ける既存の編集読みモデルを再利用し BE 追加実装ゼロ。商品が在れば非 null で、
+  // 上書き／設定なしでも periods は空配列を返す（#506 と同型）。
+  // 得意先別レーンは親得意先コードが detail 取得後に判明するため Step 3-2 で追加取得する（今は共通のみ）。
+  const [detail, commonDetail] = await Promise.all([
+    deliveryLocationSellingPriceEditQueryFactory().find({
+      deliveryLocationCode: deliveryLocationCd,
+      productCode: productCd,
+      referenceDate,
+    }),
+    commonSellingPriceEditQueryFactory().find({
+      productCode: productCd,
+      referenceDate,
+    }),
+  ]);
+  if (detail == null) {
+    notFound();
+  }
+
+  // 共通が null（商品不在）でも納品先別が在れば描画は続行する。従レーンは空扱い（フォールバックも無い）。
+  const commonPeriods = commonDetail?.periods ?? [];
+
+  return (
+    <div className="container mx-auto p-8">
+      <div className="mb-8">
+        {/* 戻り先は納品先選択済みの一覧（#548 が納品先をパスに持つため選択状態を保って戻せる）。 */}
+        <Link
+          href={`/delivery-location-selling-prices/${detail.deliveryLocationCode}`}
+          className="text-blue-600 hover:text-blue-800 hover:underline"
+        >
+          ← 納品先別販売単価一覧に戻る
+        </Link>
+      </div>
+
+      <div className="flex justify-between items-center mb-8">
+        <h1 className="text-3xl font-bold">納品先別販売単価</h1>
+      </div>
+
+      {/* 納品先情報（保守対象の宛先軸）。 */}
+      <div className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+        <h2 className="text-xl font-semibold mb-4 text-gray-500">納品先</h2>
+        <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <dt className="text-sm font-bold text-gray-700">納品先コード</dt>
+            <dd className="mt-1 text-gray-900">{detail.deliveryLocationCode}</dd>
+          </div>
+          <div>
+            <dt className="text-sm font-bold text-gray-700">納品先名</dt>
+            <dd className="mt-1 flex items-center gap-2 text-gray-900">
+              {detail.deliveryLocationName}
+              {!detail.deliveryLocationIsActive && <Badge variant="outline">無効</Badge>}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* 親得意先情報（文脈提示。納品先は親得意先の文脈が無いと意味を成さない・#546）。
+          有効フラグは保守の判断材料にならないため DTO が同梱せず、ここでもバッジは出さない。 */}
+      <div className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+        <h2 className="text-xl font-semibold mb-4 text-gray-500">得意先</h2>
+        <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <dt className="text-sm font-bold text-gray-700">得意先コード</dt>
+            <dd className="mt-1 text-gray-900">{detail.customerCode}</dd>
+          </div>
+          <div>
+            <dt className="text-sm font-bold text-gray-700">得意先名</dt>
+            <dd className="mt-1 text-gray-900">{detail.customerName}</dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* 商品情報 */}
+      <div className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
+        <h2 className="text-xl font-semibold mb-4 text-gray-500">商品</h2>
+        <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <dt className="text-sm font-bold text-gray-700">商品コード</dt>
+            <dd className="mt-1 text-gray-900">{detail.productCode}</dd>
+          </div>
+          <div>
+            <dt className="text-sm font-bold text-gray-700">商品名</dt>
+            <dd className="mt-1 flex items-center gap-2 text-gray-900">
+              {detail.productName}
+              {!detail.productIsActive && <Badge variant="outline">無効</Badge>}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* 適用期間明細＋操作（UC-2/3/4/5）。表示・操作はクライアント wrapper に委譲。 */}
+      <PeriodDetailPanel
+        detail={detail}
+        commonPeriods={commonPeriods}
+        isAdmin={admin}
+        referenceDate={referenceDate}
+      />
+    </div>
+  );
+}

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/page.tsx
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import {
   commonSellingPriceEditQueryFactory,
+  customerSellingPriceEditQueryFactory,
   deliveryLocationSellingPriceEditQueryFactory,
 } from "@subdomains/pricing/application/factories/pricingQueryFactory";
 import { toJstCalendarDay } from "@server/shared/domain/values/toJstCalendarDay";
@@ -22,10 +23,10 @@ export default async function DeliveryLocationSellingPriceDetailPage({
   // status 算出とタイムラインの今日マーカーを同一基準日に揃えるため、参照日を一度だけ求めて共有する。
   const referenceDate = toJstCalendarDay(new Date());
 
-  // 納品先別（主）と共通販売単価（従＝タイムラインのフォールバックレーン）を並行取得する。
-  // 共通は同一商品コードで引ける既存の編集読みモデルを再利用し BE 追加実装ゼロ。商品が在れば非 null で、
-  // 上書き／設定なしでも periods は空配列を返す（#506 と同型）。
-  // 得意先別レーンは親得意先コードが detail 取得後に判明するため Step 3-2 で追加取得する（今は共通のみ）。
+  // タイムラインは「納品先別 → 得意先別 → 共通」の3段フォールバックを主＋2従レーンで対比する。
+  // ①納品先別 detail と共通（商品コードのみで引ける）を並行取得する。共通は同一商品コードで引ける
+  // 既存の編集読みモデルを再利用し BE 追加実装ゼロ。商品が在れば非 null で、上書き／設定なしでも periods は
+  // 空配列を返す（#506 と同型）。
   const [detail, commonDetail] = await Promise.all([
     deliveryLocationSellingPriceEditQueryFactory().find({
       deliveryLocationCode: deliveryLocationCd,
@@ -41,8 +42,17 @@ export default async function DeliveryLocationSellingPriceDetailPage({
     notFound();
   }
 
-  // 共通が null（商品不在）でも納品先別が在れば描画は続行する。従レーンは空扱い（フォールバックも無い）。
+  // ②得意先別レーンは親得意先コードが detail 取得後に判明するため2段目で引く（detail 依存）。
+  // 得意先別が null（当該得意先×商品に得意先別集約が無い等）でも従レーンを空扱いで描画継続する。
+  const customerDetail = await customerSellingPriceEditQueryFactory().find({
+    customerCode: detail.customerCode,
+    productCode: productCd,
+    referenceDate,
+  });
+
+  // 共通・得意先別が null（商品不在等）でも納品先別が在れば描画は続行する。従レーンは空扱い。
   const commonPeriods = commonDetail?.periods ?? [];
+  const customerPeriods = customerDetail?.periods ?? [];
 
   return (
     <div className="container mx-auto p-8">
@@ -115,6 +125,7 @@ export default async function DeliveryLocationSellingPriceDetailPage({
       {/* 適用期間明細＋操作（UC-2/3/4/5）。表示・操作はクライアント wrapper に委譲。 */}
       <PeriodDetailPanel
         detail={detail}
+        customerPeriods={customerPeriods}
         commonPeriods={commonPeriods}
         isAdmin={admin}
         referenceDate={referenceDate}

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/schema.ts
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/schema.ts
@@ -87,7 +87,19 @@ export const deletePeriodSchema = z.object({
   periodId: z.string().min(1),
 });
 
+/**
+ * 単価改定（ガイド付き・#474）: 改定日（必須・実在日）＋ 新単価。
+ * 現在有効行はサーバー側で特定するため periodId は入力契約に含めない（改竄面を消す・決定2）。
+ * 改定日＝適用終了日＝新行開始日で本日以降であること・据え置き許容は BE コマンドが最終判定する。
+ */
+export const revisePeriodSchema = z.object({
+  version: versionInput,
+  revisionDate: dateInput,
+  price: priceInput,
+});
+
 export type AddPeriodFormInput = z.infer<typeof addPeriodSchema>;
 export type UpdateFuturePeriodFormInput = z.infer<typeof updateFuturePeriodSchema>;
 export type EndDatePeriodFormInput = z.infer<typeof endDatePeriodSchema>;
 export type DeletePeriodFormInput = z.infer<typeof deletePeriodSchema>;
+export type RevisePeriodFormInput = z.infer<typeof revisePeriodSchema>;

--- a/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/schema.ts
+++ b/src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/schema.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+/**
+ * 納品先別販売単価 適用期間の操作別バリデーションスキーマ（UC-3/4/5）。
+ *
+ * 単項目の形（必須・実在日・整数・非負）と、同一フォーム内で完結する交差検証
+ * （終了>開始）のみをここで担保する。集約横断の重複・状態別権限・楽観ロック競合・
+ * 適用終了の「本日以降」は BE コマンド（集約の不変条件）が最終判定する（#505）。
+ * 操作別に分けることで、現在有効行の開始日・単価を入力契約から外し改竄不能にする（決定3）。
+ *
+ * 得意先別販売単価（`customer-selling-prices/[customerCd]/[productCd]/schema.ts`）の同型写像で、宛先軸が
+ * 得意先から納品先へ替わる点だけが異なる（ADR-20260627-a5c）。
+ */
+
+/** `YYYY-MM-DD` かつ実在する暦日（2026-02-30 や 2026-13-01 を弾く）。 */
+const dateInput = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "日付を入力してください")
+  .refine((value) => {
+    const [y, m, d] = value.split("-").map(Number);
+    // Date.UTC で構築し UTC 成分で突合（タイムゾーンによる暦日ずれを避ける）。
+    const date = new Date(Date.UTC(y, m - 1, d));
+    return date.getUTCFullYear() === y && date.getUTCMonth() === m - 1 && date.getUTCDate() === d;
+  }, "存在しない日付です");
+
+/** 納品先別販売単価（0以上の整数。マスタ正規入力として0円を許容＝use-cases.md ルール3）。 */
+const priceInput = z.coerce
+  .number({ message: "単価を入力してください" })
+  .int("単価は整数で入力してください")
+  .min(0, "単価は0円以上で入力してください");
+
+/** 楽観ロックトークン（ADR-0039）。表示時の version を hidden で往復させる。 */
+const versionInput = z.coerce.number().int();
+
+/**
+ * 楽観ロックトークン（登録用・任意）。上書きなし（集約なし）の初回登録は version を持たないため
+ * 省略を許容する（BE の RegisterCommand が expectedVersion 省略時は create+insert を選ぶ・#505）。
+ * 既存集約へ期間を追加する場合のみ表示時 version を hidden で往復させ、存在時は楽観ロックが効く。
+ */
+const versionOptionalInput = z.coerce.number().int().optional();
+
+/** 開始日に対し終了日が後（厳密）であること。終了日 未指定（無期限）は許容。 */
+function endAfterStart(value: { startDate: string; endDate?: string }): boolean {
+  return value.endDate == null || value.startDate < value.endDate;
+}
+const END_AFTER_START_ISSUE = {
+  message: "適用終了日は適用開始日より後にしてください",
+  path: ["endDate"],
+};
+
+/** UC-3 登録: 開始日（必須）・終了日（任意・無期限可）・単価。version は新規モードで省略可。 */
+export const addPeriodSchema = z
+  .object({
+    version: versionOptionalInput,
+    startDate: dateInput,
+    // conform は空文字を undefined 化するため任意は optional にする（無期限＝終了日なし）。
+    endDate: dateInput.optional(),
+    price: priceInput,
+  })
+  .refine(endAfterStart, END_AFTER_START_ISSUE);
+
+/** UC-4 将来行の全項目編集: 対象 periodId ＋ 開始日・終了日・単価。 */
+export const updateFuturePeriodSchema = z
+  .object({
+    version: versionInput,
+    periodId: z.string().min(1),
+    startDate: dateInput,
+    endDate: dateInput.optional(),
+    price: priceInput,
+  })
+  .refine(endAfterStart, END_AFTER_START_ISSUE);
+
+/**
+ * UC-4 適用終了（end-dating）: 対象 periodId ＋ 終了日（必須）。
+ * 開始日・単価は入力契約に含めない（現在有効行のロック項目＝改竄不能）。
+ * 終了>開始（厳密）・本日以降はミューテータがストア上の真の開始日で最終判定する。
+ */
+export const endDatePeriodSchema = z.object({
+  version: versionInput,
+  periodId: z.string().min(1),
+  endDate: dateInput,
+});
+
+/** UC-5 削除: 対象 periodId のみ（＋楽観ロック version）。 */
+export const deletePeriodSchema = z.object({
+  version: versionInput,
+  periodId: z.string().min(1),
+});
+
+export type AddPeriodFormInput = z.infer<typeof addPeriodSchema>;
+export type UpdateFuturePeriodFormInput = z.infer<typeof updateFuturePeriodSchema>;
+export type EndDatePeriodFormInput = z.infer<typeof endDatePeriodSchema>;
+export type DeletePeriodFormInput = z.infer<typeof deletePeriodSchema>;


### PR DESCRIPTION
## Summary

納品先別販売単価の管理画面を実装。期間行の一覧・状態別操作の出し分けを行い、登録 / 将来行編集 / 適用終了 / 削除フォーム、改訂ウィザード（適用終了 + 新期間追加の合成）、タイムライン帯表示（得意先別・共通レーン並記）を 1 画面に集約した。操作は Server Action + zod スキーマで実装。タイムライン帯レイアウトは複数従レーンに一般化した。

Closes #547

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### delivery-location-selling-price-maintenance-screen.md

# Issue #547: 納品先別販売単価 管理画面（登録・編集・適用終了・削除 + 改訂ウィザード + タイムライン） — 実装計画

## Context

納品先別販売単価の価格決定は「**納品先別 → 得意先別 → 共通**」の3段フォールバック。親 #544 の分割のうち本イシューは **FE 管理画面**で、ある納品先 × 商品の適用期間行に対する登録・編集・適用終了・削除と、改訂ウィザード・タイムライン帯を1画面に含める。

BE は完成済み（書き込み #545/#550・読みモデル #546/#552）で、本イシューは **FE のみ**（BE に接続するだけ）。一覧画面 #548 は出荷済みで、そこから行クリックで本管理画面へ遷移する。得意先別 #507 とほぼ同型のため、`customer-selling-prices/[customerCd]/[productCd]/` を**ディレクトリごとコピー写像**し、宛先軸を「得意先→納品先」に差し替えるのが基本方針。唯一 #507 の単純写像で済まないのがタイムラインで、フォールバック層が1段深い（得意先別レーンが増える）ため従レーンが2本になる。

## 設計判断

### 得意先別 #507 の流用方針 — 判断不要（前例踏襲）
`customer-selling-prices/[customerCd]/[productCd]/` をディレクトリごとコピー写像し、`_shared` の原子（`authorityFor` / `computeTimelineLayout` / `formatYenFromDecimal` / `formatPeriod` / `handleCommandError`）は共有を続ける。ADR-20260627-a5c（型は集約ごとに独立複製し共有しない）と対称。BE factory も既に `DeliveryLocation` へ置換した同名構造で実装済み。

### ルート階層（2階層 vs 3階層） — 確定（#548 に追従）
**2階層 `/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]`**。出荷済みの #548 が `columns.tsx` で `href=/delivery-location-selling-prices/${deliveryLocationCode}/${productCode}`（customerCd を挟まない）と遷移リンクを組んでおり、本管理画面はその受け側。追従一択。

### タイムラインのフォールバック層 — 確定（ユーザー選択: 得意先別＋共通の2従レーン）
主レーン=納品先別（操作対象）、従レーン=得意先別＋共通（淡色・表示専用）の**3レーン**。3段フォールバックの「上書きが無い期間に実際いくらが適用されるか（得意先別があればそれ、無ければ共通）」を一目で対比できる。データは編集DTOの親 `customerCode` から得意先別を、`productCode` から共通を追加取得でき、BE 追加実装ゼロ。

### `computeTimelineLayout` の複数従レーン一般化方式 — 推奨 A
現状は主 + 従レーン**1本**（`secondaryPeriods: TimelinePeriod[]` → `secondaryBars: TimelineBar[]`）まで。従レーン2本には拡張が必要。
- **A（推奨）**: `secondaryPeriods` を従レーンの配列 `secondaryLanes: TimelinePeriod[][]` に一般化し、`secondaryBars: TimelineBar[][]` を返す。軸範囲は主＋全従レーンの和集合から算出。得意先別 #507 側は `[commonPeriods]` と配列でラップして渡す1行修正＋`PriceTimeline` の `secondaryBars` 消費を `secondaryBars[0]` に読み替える軽微修正。
- **B**: 第4引数 `tertiaryPeriods` を足し `tertiaryBars` を返す（2従レーン固定）。得意先別は第4引数省略で無修正。ただし「従レーン2本まで」を型に刻み、将来の拡張余地を狭める。
- 採用理由: #507 計画が予告した「**抽象化は納品先別（3例目）が出てから**」の実行タイミング。従レーン数を型で固定しない一般化が正しい方向。跨ぎ作業（#507 の2ファイル修正）は発生するが軽微で、純関数ゆえ TDD で既存の単レーン（共通単価・原価）・2レーン（得意先別）テスト GREEN を担保できる。

### 得意先別レーンの取得順 — detail 依存の2段取得
得意先別レーンを引くには親得意先コードが要り、これは納品先別の編集DTO（`detail`）取得後に判明する。よって `page.tsx` は「①納品先別 detail と共通（`productCode` のみで引ける）を `Promise.all`、②detail から得た `customerCode` で得意先別を引く」の2段。共通は最初から並行、得意先別のみ detail 依存。得意先別が null（商品不在等）でも従レーンを空扱いで描画継続（#507 の共通レーンと同じ堅牢性）。

### 「上書きなし」状態の画面表現 — 3段フォールバックに合わせた情報提供トーン
`version: null` + `periods` 空は異常ではなく正常な派生状態。文言は「**この納品先×商品の上書きはありません。価格決定は得意先別販売単価を、無ければ共通販売単価を適用します。**」（警告 UI なし）。タイムラインは上書きなしでも描画し、従レーン（得意先別・共通）のみが表示される。

### 戻りリンク — 納品先選択済み一覧へ戻す
#548 出荷済みかつ納品先選択状態をパスに持つため、`/delivery-location-selling-prices/${deliveryLocationCode}`（選択済み一覧）へ戻す。#507 が一覧トップに戻したのは #508 未出荷時の死リンク回避事情によるもので、本イシューは選択状態を保った戻りが可能。

### フォーム統一（#351）・権限 — 判断不要（前例踏襲）
`PeriodForm` の3モード（new/edit/endDate 単一フォーム切替・`pickRuntime` で action(bind)＋zod スキーマ選択・`version==null` で新規/既存分岐）写像で自動充足。権限は `authorityFor(status)`（`_shared/period-rules.ts`・集約非依存）× `isAdmin(session)` の踏襲。

## TDD 適用方針
- **新規純ロジックは `computeTimelineLayout` の複数従レーン一般化のみ** → red-green-refactor（Step 3-1）。`_shared/timeline-layout.test.ts` に前例あり。
- コピー写像部分（画面部品・actions・schema）はコンポーネントテスト前例がなく、挙動担保は別イシューの E2E に委ねる。写像部分にテストを新設する逸脱はしない。

## ステップ

コミットは Issue 方針（基本操作 → 改訂ウィザード → タイムライン）の順で刻む。

### Step 1: 基本操作（登録・編集・適用終了・削除）
- 対象ファイル（すべて `src/app/(features)/delivery-location-selling-prices/[deliveryLocationCd]/[productCd]/` 配下・新規写像）:
  - `page.tsx` — `deliveryLocationSellingPriceEditQueryFactory().find({ deliveryLocationCode, productCode, referenceDate })`。null → `notFound()`。ヘッダに納品先・親得意先・商品の identity（コード/名称/無効バッジ）を dl 表示。`isAdmin(session)` 算出。戻りリンクは `/delivery-location-selling-prices/${deliveryLocationCode}`。この Step では共通のみ従レーン取得（後述 PriceTimeline 先行作成）。
  - `PeriodDetailPanel.tsx` — 期間行を束ねる中核 client。`PanelMode`(closed/new/edit/endDate/revise/delete) を client state 保持、表示/タイムライントグル、`authorityFor` で行操作出し分け、`isAdmin` false でミューテーションUI非描画。
  - `PeriodForm.tsx` — new/edit/endDate 単一フォーム写像。宛先キーを `(deliveryLocationId, productId)`、route キーを `(deliveryLocationCode, productCode)` に差し替え。
  - `PeriodDeleteConfirm.tsx` — 行内2段階削除確認。
  - `PriceTimeline.tsx` — **この Step では #507 の2レーン版を写像**（主=納品先別 / 従=共通1本）で先行作成しビルド可能に保つ（PeriodDetailPanel がトグルで参照するため。Step 3-2 で3レーン化。#507 と同じ先行作成パターンを計画に織り込み逸脱化を回避）。
  - `actions.ts` — add / updateFuture / endDate / delete の4 action。`register`/`edit`/`endDate`/`delete` `DeliveryLocationSellingPricePeriodCommandFactory` に接続、宛先キーを `.bind()`。parse→command→`handleCommandError`→revalidate（詳細＋一覧、redirect せず留まる）。
  - `schema.ts` — `addPeriodSchema`/`updateFuturePeriodSchema`/`endDatePeriodSchema`/`deletePeriodSchema`。conform 空文字→undefined 規約に従い必須でない string は `.optional()`。
- 空状態文言: 「この納品先×商品の上書きはありません。価格決定は得意先別販売単価を、無ければ共通販売単価を適用します。」
- コミット: `feat: 納品先別販売単価 管理画面の基本操作（登録・編集・適用終了・削除） (#547)`

### Step 2: 改訂ウィザード
- 対象ファイル:
  - `ReviseForm.tsx`（新規写像・改定日＋新単価のみ、periodId 送らない。方向ラベル表示）
  - `actions.ts` / `schema.ts`（revise action + `revisePeriodSchema` 追記）
- `reviseDeliveryLocationSellingPricePeriodCommandFactory` に接続（合成＝適用終了+新期間は BE 単一コマンドがアトミック実行、FE では合成しない）。`PeriodDetailPanel` の `PanelMode` に `revise` 配線。
- コミット: `feat: 納品先別販売単価 改訂ウィザード (#547)`

### Step 3-1: `computeTimelineLayout` の複数従レーン一般化（TDD）
- 対象ファイル: `src/app/(features)/_shared/timeline-layout.ts` / `timeline-layout.test.ts`、および写像元 `customer-selling-prices/.../PriceTimeline.tsx`（`secondaryBars[0]` 読み替え）
- Red: 「主＋従レーン**複数**の和集合から軸範囲を決め、各従レーンを同一軸に載せる」テストを先に書く。
- Green: `secondaryLanes: TimelinePeriod[][]` へ一般化、`secondaryBars: TimelineBar[][]` を返す（採用A）。
- Refactor: 既存の単レーン（共通・原価）・得意先別（従1本→`[commonPeriods]`）呼び出しのテストが全て GREEN であることを確認。
- コミット: `feat: タイムライン帯レイアウトを複数従レーンに一般化 (#547)`

### Step 3-2: タイムライン（納品先別＋得意先別＋共通の3レーン）
- 対象ファイル: 当該 `PriceTimeline.tsx`（3レーン化）／`page.tsx`・`PeriodDetailPanel.tsx`（得意先別・共通 DTO の取得・受け渡し）
- `page.tsx`: 共通を初回 `Promise.all` で並行取得、detail の `customerCode` で `customerSellingPriceEditQueryFactory().find()` を追加取得。両従レーンを `PeriodDetailPanel` 経由で `PriceTimeline` に渡す。
- `PriceTimeline.tsx`: 主=納品先別、従1=得意先別、従2=共通の3レーン描画（従は淡色・破線・表示専用）。上書きなしでも描画。凡例に得意先別・共通のフォールバック表示を追記。
- コミット: `feat: 納品先別販売単価 タイムライン（得意先別・共通レーン並記） (#547)`

## 検証

- `pnpm test` — `timeline-layout.test.ts`（複数従レーン一般化の red-green＋既存レーン回帰 GREEN）。
- `pnpm lint` / `pnpm build` — 型チェック（写像元 #507 の `secondaryBars[0]` 修正含む全体ビルド）。
- 実機確認（verify-frontend / playwright MCP・要ログイン）: 一覧 #548 から行クリック遷移 → 管理画面表示 → 登録/編集/適用終了/削除/改訂の一連、上書きなし状態の文言、タイムライン3レーン（納品先別・得意先別・共通）の対比表示、戻りリンクが選択済み一覧に戻ること。
- E2E テストは別イシュー（納品先別 E2E があれば別途）。本イシューにコンポーネントテスト/E2E は新設しない。

</details>

## 計画からの逸脱

# Issue #547 実装 — 計画からの逸脱記録

## 1. 改訂（revise）系を Step 1 の PanelMode から Step 2 へ全面分離

### 元の計画内容
Step 1 の `PeriodDetailPanel.tsx` の記述で `PanelMode` を
`closed/new/edit/endDate/revise/delete` と列挙しており、`revise` 分岐が Step 1 に含まれるよう
読める。一方 Step 2 は「`PeriodDetailPanel` の `PanelMode` に `revise` 配線」とも書いており、
計画内で revise の配置 Step が自己矛盾していた。

### 実際の実装内容
revise を Step 1 から完全に除外し、Step 2 でまとめて配線した。
- Step 1: `PanelMode` は `closed/new/edit/endDate/delete`（revise なし）。`ReviseForm` 未作成、
  actions/schema に revise なし、「改定」ボタンなし。
- Step 2: `PanelMode` に `revise` を追加、`ReviseForm.tsx` 写像、revise action / `revisePeriodSchema`
  追加、「改定」ボタン＋ReviseForm JSX を配線。

### 逸脱の理由
CLAUDE.md「意味のあるまとまりでコミットし、各コミットを独立ビルド可能に保つ」に従うため。
Step 1 の PanelMode に `revise` を含めると `ReviseForm` の import が必要になり、Step 2 で作る
`ReviseForm.tsx` が未作成の時点でビルドが割れる。Issue 方針のコミット順（基本操作 → 改訂
ウィザード）とも整合し、Step 2 の「revise 配線」記述に寄せる形で解消した。挙動・最終成果物は
計画と同一で、Step 境界のみを明確化した。


---

Generated with [Claude Code](https://claude.ai/code)
