### PR TITLE
feat: 見積申請 FE（申請ボタン・確認モーダル・Server Actions）

### DIFF
--- a/docs/business/estimate/システム設計書(申請).md
+++ b/docs/business/estimate/システム設計書(申請).md
@@ -406,13 +406,16 @@ SubmitApplication(variationId)   … コマンド（永続化）
 
 ```
 PreviewResult =
-  | { kind: 'EXEMPT',    reason: EstimateExemptionReason }
-  | { kind: 'REQUIRED',  goalPosition, steps: [{ order, roleName, positionName }] }
-  | { kind: 'BLOCKED',   reason: 'NO_SUPERIOR_ROLE' | 'NO_APPROVER', detail }
+  | { kind: 'EXEMPT',    reason, reasonLabel }
+  | { kind: 'REQUIRED',  goalPositionId, goalPositionName, steps: [{ order, roleName, positionName }] }
+  | { kind: 'BLOCKED',   reason: 'NO_SUPERIOR_ROLE' | 'GOAL_UNREACHABLE' | 'NO_APPROVER', reasonLabel }
+  | { kind: 'INACTIVE',  label }
 ```
 
 - モーダルでは承認必要時に **チェーン全体**（課長 → 部長 → … ）を表示する（ADR-0002 の「フロー全体を可視化」を UI で実現）。
-- 申請不可（BLOCKED）は実行に進ませない。ADR-0002 の「承認者不在による停滞を未然に防ぐ」がここで効く。
+- 申請不可（BLOCKED）は実行に進ませない。ADR-0002 の「承認者不在による停滞を未然に防ぐ」がここで効く。BLOCKED の理由は 3 値（起点の上位役割なし `NO_SUPERIOR_ROLE` ／ゴール段階へ役割グラフが届かない `GOAL_UNREACHABLE` ／チェーン上に承認者不在 `NO_APPROVER`・§5.2）。
+- **INACTIVE**（対象バリエーションが無効・§3.4）は judge を走らせる前に返す独立分岐。`canApply` ゲート（§12・#493）が無効バリの申請ボタンを抑止するため、プレビューが INACTIVE に到達するのは「モーダル表示後に他操作で無効化された」レースであり、画面更新を促す文言を載せる。
+- 実行不可を含む全分岐の**表示文言は BE 所有**（ADR-0069）。EXEMPT は `reasonLabel`（免除理由 VO 由来）、BLOCKED は `reasonLabel`（`BLOCKED_REASON_LABELS` 由来）、INACTIVE は `label`（固定文言）を同梱し、モーダルは受け取った文言をそのまま描く（FE は状態語彙を再発明しない）。
 
 ### 6.3 SubmitApplication（コマンド）の分岐
 
@@ -502,7 +505,7 @@ PreviewResult =
 
 | # | クエリ | 備考 |
 | - | ------ | ---- |
-| AQ1 | `PreviewApplication(variationId)` | 確認モーダルの中身（EXEMPT / REQUIRED / BLOCKED）。副作用なし |
+| AQ1 | `PreviewApplication(variationId)` | 確認モーダルの中身（EXEMPT / REQUIRED / BLOCKED / INACTIVE・全分岐 BE 供給 label 同梱・§6.2）。副作用なし |
 | AQ2 | `GetApplicationDetail(applicationId)` | 申請＋承認ステップ一覧（進行状況・差戻理由・承認者） |
 | AQ3 | `SearchApprovalInbox(employeeId)` | 自分が承認すべき申請一覧 ＝ `AWAITING` ステップの `role_id` が自分の役割（`EmployeeRole`）に一致する申請を引く。**存在と権限ロジックのみ本書で定義し、一覧の表示項目・絞り込み・UI は別 issue で設計**する |
 

--- a/docs/claude-plans/issue-494/deviations.md
+++ b/docs/claude-plans/issue-494/deviations.md
@@ -60,3 +60,23 @@
   success/warning/info 相当の配色を補った。
 - **逸脱の理由**: shadcn Badge の variant は default/secondary/destructive/outline のみで、申請状態の 4 tone を
   表現できない。tone→className の写像を既存バッジ消費ファイルに co-locate した（網羅 switch＋never ガード）。
+
+## 自動レビュー＆修正（PR562・ラウンド1）での逸脱
+
+### ⑧ 修正の「①②先→③後」原則に対する指摘3+7の統合コミット
+- **元の計画（auto-review-fix スキル）**: ①correctness を先に直して落ち着かせてから、③cleanup を最後に当てる
+  （③が①②で触った箇所に被る事故を避けるため）。
+- **実際の実装**: 指摘3（①: getEstimateDetail が try/catch 外で reject 握り潰し）と指摘7（③: preview/submit の
+  共通プロローグ二重化）は**完全に同一の約8行**を対象とするため、`resolveApplicationContext` 抽出として1コミットに
+  統合した（`fix:`）。
+- **逸脱の理由**: 同一箇所を①→③の2段階で別コミットにすると、抽出で作り直す二度手間かつ競合事故を招く。原則の狙い
+  （被り事故の回避）はむしろ統合で満たされる。
+
+### ⑨ 指摘6「catch のエラー整形は `return handleCommandError(error)` と等価」は型レベルで不成立
+- **指摘内容**: catch 内の `errorMessage` 計算は死コードで `return handleCommandError(error)` に置換可能（③cleanup）。
+- **実際の対応**: `return handleCommandError(error)` は型が通らない。`handleCommandError` の戻り型は `ActionResult<void>`
+  で、`success:true` アームの `data:void` がジェネリック T（PreviewApplicationResultDTO 等）と不一致になるため。
+  元の冗長コードは失敗アームを組み直す**型ブリッジ**だった。`toActionError(error)` private ヘルパーに集約し、
+  失敗アーム（T 非依存）だけを返す形で重複を正しく解消した。
+- **逸脱の理由**: レビュー指摘の「等価」判断がジェネリック分散を見落としていた。挙動不変・単一ソース化という指摘の
+  意図は toActionError で達成しつつ、型健全性を保った。

--- a/docs/claude-plans/issue-494/deviations.md
+++ b/docs/claude-plans/issue-494/deviations.md
@@ -1,0 +1,62 @@
+# Issue #494 実装の逸脱記録
+
+計画（`estimate-application-fe-modal-and-actions.md`）および Issue #494 本文と、実際の実装との差分を記録する。
+大半は grill-with-docs でコード・ADR と突き合わせた結果、Issue 本文の陳腐化を是正したものであり、
+計画時点で合意済み。実装フェーズで計画からさらに逸脱した点は末尾に別記する。
+
+## Issue 本文 → 計画で確定した是正
+
+### ① `EstimateApplicationPersistError` の扱い（スコープ除外）
+- **元の計画（Issue 本文）**: submit のエラー経路として `EstimateApplicationPersistError` をハンドルする。
+- **実際の実装**: ハンドルしない（型自体が存在しない）。submit のエラーは `ConflictError` と正常 union の 2 分岐のみ。
+- **逸脱の理由**: ADR-20260626-dee の bump+insert 原子化により「bump 成功・insert 失敗」が発生し得なくなり、
+  本例外は #440 で撤去済み。Issue 本文は撤去以前の ADR-0068 記述に引きずられていた。存在しない型への
+  ハンドラはデッドコード＋コンパイルエラーになる。
+
+### ② 申請ボタンの無効化ゲート（`isVariationApplicable` 不新設）
+- **元の計画（Issue 本文）**: `isVariationApplicable`（`status === "ACTIVE"` を要求）を新設し `canApply=false` と併用。
+- **実際の実装**: `canApply` 単一ゲート。`isVariationApplicable` は新設しない。無効時のツールチップ文言だけ
+  手元の `variation.status` で選ぶ。
+- **逸脱の理由**: `VariationApplicationStateDTO.canApply` は既に「ACTIVE かつ 見積内に前進バリなし」と定義され
+  INACTIVE は false。`isVariationApplicable`（ACTIVE のみ）は canApply の部分再導出にすぎず、無効化式
+  `!isVariationApplicable || !canApply` は `!canApply` に潰れる。ADR-0069 が禁じる「FE による BE 状態語彙の
+  再発明（ドリフト源）」に該当。
+
+### ③ BLOCKED ラベルの単一ソース（ドメイン co-locate）
+- **元の計画（Issue 本文）**: `blockedMessage` を application-shared へ引き上げる。
+- **実際の実装**: `ApprovalChainBlockedReason` の隣（ドメイン層 `ApprovalChainBuilder.ts`）に
+  `BLOCKED_REASON_LABELS: Record<ApprovalChainBlockedReason, string>` を co-locate。
+- **逸脱の理由**: EXEMPT の label 源 `EstimateExemptionReason`（VO に code＋label 同梱）と対称にすべき
+  （ADR-0069 原則#2）。`ApprovalChainBlockedReason` は非永続の判別子ゆえ full-VO は過剰で `Record` の軽量 map。
+  Preview（reasonLabel）と Submit（業務例外 message）が同一ソースから引く。ユーザー向け文言から内部参照
+  「（§5.2）」を落とした。
+
+### ④ preview 消費のコンパイル時型証明（実モーダル内蔵）
+- **元の計画（Issue 本文）**: 独立した消費スタブファイルを新設する。
+- **実際の実装**: 実モーダル（`ApplicationConfirmDialog`）の `kind` 網羅 switch（never ガード付き default）に内蔵。
+- **逸脱の理由**: 独立スタブは実描画とドリフトしうる（スタブだけ緑でも実モーダルが網羅漏れ）。本 issue は実モーダルを
+  実装するので、その描画 switch 自体を証明にすれば drift 余地ゼロ。DTO に kind が増減すれば実モーダルが即コンパイル
+  エラーになり pre-push の `tsc --noEmit` が gate。
+
+### ⑤ submit 失敗リカバリ（バナー方式・auto-refresh しない）
+- **元の計画（Issue 本文）**: モーダル内で再プレビュー＋再確認、または `router.refresh()` で自動更新。
+- **実際の実装**: モーダル強制クローズ＋パネル上部の永続バナー（`role="alert"`）。`router.refresh()` は呼ばず、
+  更新タイミングはユーザーに委ねる。ConflictError / BusinessRuleViolationError 共通。
+- **逸脱の理由**: (1) preview は兄弟前進を見ない（4 分岐に「兄弟前進で申請不可」が無い）ため、素の再プレビューは
+  誤って再確認ボタンを出しループ・誤誘導する。(2) ユーザーがメモ等を編集中／文言をコピーしたい可能性があるため、
+  `router.refresh()` で画面状態を勝手に奪わない。パネルの canApply・バッジ・金額は古いままのため、バナーで
+  「最新ではない」と明示警告する。
+
+## 実装フェーズでの計画からの追加逸脱
+
+### ⑥ 確認モーダルコンポーネント名を `ApplicationConfirmDialog` に確定
+- **元の計画**: 「新規モーダルコンポーネント」（名称未定）。
+- **実際の実装**: `ApplicationConfirmDialog.tsx`。
+- **逸脱の理由**: 既存の自己完結ダイアログ命名（`ReviseForCustomerDialog`）に倣い、「確認モーダル」の役割を名に表した。
+
+### ⑦ バッジ色調ヘルパー `badgeToneClassName` を追加
+- **元の計画**: バッジは既存 stub（`variationApplicationStateBadge.ts`）を土台に肉付け。
+- **実際の実装**: 同ファイルに `badgeToneClassName`（tone → Tailwind クラス）を追加し、shadcn Badge に無い
+  success/warning/info 相当の配色を補った。
+- **逸脱の理由**: shadcn Badge の variant は default/secondary/destructive/outline のみで、申請状態の 4 tone を
+  表現できない。tone→className の写像を既存バッジ消費ファイルに co-locate した（網羅 switch＋never ガード）。

--- a/docs/claude-plans/issue-494/estimate-application-fe-modal-and-actions.md
+++ b/docs/claude-plans/issue-494/estimate-application-fe-modal-and-actions.md
@@ -1,0 +1,111 @@
+# Issue #494: 見積申請 FE（申請ボタン・確認モーダル・Server Actions） — 実装計画
+
+## 概要
+
+見積詳細画面（S2）にバリエーション申請 UI を実装する。申請ボタン → 確認モーダル（プレビュー）→ 実行のフロー（仕様書 §6）を、#491 で合意した BE 契約（ADR-0069）を直 type-import で消費して配線する。あわせて、モーダルが消費する当事者として `PreviewApplicationResultDTO` の小さな是正（BLOCKED/INACTIVE の label 同梱）を本 issue で行う。
+
+grill-with-docs セッションでコード・ADR と突き合わせた結果、Issue 本文から複数の是正（主に `EstimateApplicationPersistError` の撤去済み事実の反映、ボタン無効化ゲートの単一化）が確定した。詳細は「設計判断」に記載し、完了時に `deviations.md` へ記録する。
+
+CONTEXT.md は新規用語が生じないため変更しない（「見積申請」は既に「申請」の _Avoid_ に収録済み。申請対象はバリエーションであり、新設物はバリエーション申請の語彙で統一する）。新規 ADR も起票しない（リカバリ方針は局所的な FE UX で、コンポーネントの doc コメント＋PR に記録する）。
+
+## 設計判断
+
+### `EstimateApplicationPersistError` の扱い
+- A. Issue 本文どおりエラー経路として処理する
+- B. スコープから除外する
+- **確定: B**。ADR-20260626-dee の bump+insert 原子化により「bump 成功・insert 失敗」が発生し得なくなり、本例外は撤去済み（コードベースに存在しない）。submit のエラーは `ConflictError` と正常 union の 2 分岐のみ。存在しない型へのハンドラはデッドコード＋コンパイルエラーになる。Issue 本文は #440 撤去以前の記述に引きずられた陳腐化。
+
+### 申請ボタンの無効化ゲート
+- A. Issue 本文どおり `isVariationApplicable`（`status === "ACTIVE"` を要求）を新設し、`canApply=false` と併用
+- B. `canApply` 単一ゲート。`isVariationApplicable` は新設しない
+- **確定: B**。`VariationApplicationStateDTO.canApply` は既に「ACTIVE かつ 見積内に前進バリなし」と定義され INACTIVE は false。`isVariationApplicable`（ACTIVE のみ）は canApply の部分再導出にすぎず、無効化式 `!isVariationApplicable || !canApply` は `!canApply` に潰れる。ADR-0069 が禁じる「FE による BE 状態語彙の再発明（ドリフト源）」に該当。tooltip 文言の出し分けは手元の `variation.status` で足りる（INACTIVE →「無効なバリエーションは申請できません」／ACTIVE かつ !canApply →「既に前進しているバリエーションがあります」）。
+
+### BLOCKED ラベルの単一ソース
+- A. Issue 本文どおり `blockedMessage` を application-shared へ引き上げ
+- B. code 定義に隣接した `BLOCKED_REASON_LABELS` map をドメインに co-locate
+- **確定: B**。EXEMPT の label 源 `EstimateExemptionReason` は VO に code＋label を同梱（ADR-0069 原則#2）。BLOCKED も対称にすべき。`ApprovalChainBlockedReason` は非永続の判別子なので full-VO は過剰、`Record<ApprovalChainBlockedReason, string>` の軽量 map を `ApprovalChainBuilder` 隣に co-locate。`PreviewApplicationQuery`（reasonLabel）と `SubmitApplicationCommand`（error message）が同一ソースから引く。ユーザー向け label からは内部参照「（§5.2）」を落とす。
+
+### INACTIVE の自己記述
+- A. DTO に BE 供給の `label` を追加
+- B. FE 固定定数で描画（DTO は `{kind:"INACTIVE"}` のまま）
+- **確定: A**。モーダルの実行不可分岐（BLOCKED.reasonLabel / INACTIVE.label）の表示文言を全て BE 所有に統一。INACTIVE は code 集合を持たない単一 kind なので `reason` は持たず `label` 単体（VO/map 不要、`PreviewApplicationQuery` が固定のレース自覚文言を載せる）。
+
+### preview 消費のコンパイル時型証明
+- A. Issue 本文どおり独立した消費スタブファイルを新設
+- B. 実モーダルの `kind` 網羅 switch（never ガード付き default）に内蔵
+- **確定: B**。独立スタブは実描画とドリフトしうる（スタブだけ緑でも実モーダルが網羅漏れ）。本 issue は実モーダルを実装するので、その描画 switch 自体を証明にすれば drift 余地ゼロ。DTO に kind が増減すれば実モーダルが即コンパイルエラー、pre-push の `tsc --noEmit` が gate。
+
+### submit 失敗リカバリ
+- A. モーダル内で再プレビュー＋再確認
+- B. モーダル強制クローズ＋パネル上部の永続バナー（auto-refresh しない）
+- **確定: B**。理由（1）preview は兄弟前進を見ない（4 分岐に「兄弟前進で申請不可」が無い）ため、素の再プレビューは誤って再確認ボタンを出しループ・誤誘導する。（2）ユーザーがメモ等を編集中／文言をコピーしたい可能性があるため、`router.refresh()` で画面状態を勝手に奪わない。よって ConflictError / BusinessRuleViolationError 共通で、モーダルを強制クローズしパネル上部へ永続バナー（`handleCommandError` の message ＋「内容を確認・必要な情報を控えてから F5 か一覧へ戻って更新」）を出し、更新タイミングはユーザーに委ねる。auto-refresh は呼ばない。バナー表示中も申請ボタンは押下可のまま（無駄な再試行はバナーで自明、強制はしない）。トレードオフ: パネルの canApply・バッジ・金額は古いまま表示され続けるため、バナーで「最新ではない」と明示警告する。
+
+### operator（session.user.employeeId）が null の場合
+- 既存「null は複製不可」前例踏襲のため判断不要。preview / submit 両アクションに null ガードを置きメッセージを返す（「申請者の従業員情報が取得できないため申請できません。管理者にお問い合わせください。」）。前段のボタン抑止はしない。preview の null エラーはモーダル内メッセージ＋閉じる（状態変化ではない前提条件エラーなのでバナー導線に乗せない）。
+
+### Server Actions のマッピング
+- 既存パターン踏襲のため判断不要。operator は `session.user.employeeId` から注入、`estimateId` は `estimateNumber` から `getEstimateDetailQueryFactory` で再解決、`variationId`(UUID) は client エコー、`version` は submit のみ client エコー・サーバで読み直さない（TOCTOU・ADR-0068）。
+
+### §6.2 仕様書の是正範囲
+- **確定**: BLOCKED を実装の 3 値（`NO_SUPERIOR_ROLE`/`GOAL_UNREACHABLE`/`NO_APPROVER`）に更新＋欠落している INACTIVE 分岐を追加＋ EXEMPT/BLOCKED/INACTIVE が BE 供給 label を持つことを明記。submit 失敗リカバリの UX は FE 実装詳細のため仕様書には含めない。
+
+## ステップ
+
+### Step 1: BLOCKED ラベルのドメイン単一ソース化
+- 対象ファイル: `src/server/subdomains/estimate/domain/services/approval/ApprovalChainBuilder.ts`（or 隣接ファイル）、`src/server/subdomains/estimate/application/commands/SubmitApplicationCommand.ts`
+- 作業内容:
+  - `ApprovalChainBlockedReason` の隣に `BLOCKED_REASON_LABELS: Record<ApprovalChainBlockedReason, string>` を co-locate（ユーザー向け文言・「（§5.2）」は含めない）
+  - `SubmitApplicationCommand` の private `blockedMessage` を撤去し、error message を map から引く
+- コミットメッセージ: `refactor: BLOCKED理由ラベルをドメインのBLOCKED_REASON_LABELSへ単一ソース化`
+
+### Step 2: PreviewApplicationResultDTO の是正（BLOCKED.reasonLabel / INACTIVE.label）
+- 対象ファイル: `src/server/subdomains/estimate/application/queries/dto/PreviewApplicationResultDTO.ts`、`src/server/subdomains/estimate/application/queries/PreviewApplicationQuery.ts`、（既存テスト）`.../queries/__tests__/PreviewApplicationQuery.test.ts`
+- 作業内容:
+  - DTO の BLOCKED に `reasonLabel`、INACTIVE に `label` を追加
+  - `PreviewApplicationQuery` が BLOCKED 時に `BLOCKED_REASON_LABELS` から reasonLabel を、INACTIVE 時に固定のレース自覚 label を populate
+  - Query テストを新フィールドに追随
+- コミットメッセージ: `feat: 申請プレビューDTOのBLOCKED/INACTIVE分岐を自己記述化（reasonLabel/label同梱）`
+
+### Step 3: Server Actions（previewApplication / submitApplication）
+- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/actions.ts`、（必要なら）対応スキーマ
+- 作業内容:
+  - operator を session 注入（null ガード＋メッセージ）、`estimateId` を estimateNumber から再解決、`variationId` client エコー、`version` は submit のみ client エコー
+  - preview は `PreviewApplicationResultDTO` を返す（or ActionResult ラップ）、submit は `handleCommandError` で ConflictError/BusinessRuleViolationError を message 化
+- コミットメッセージ: `feat: 申請プレビュー・申請実行のServer Actionsを追加`
+
+### Step 4: action マッピング契約テスト
+- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/__tests__/`（既存前例に倣う）
+- 作業内容:
+  - operator がセッション注入され client 入力を無視する / `estimateId` が estimateNumber から再解決される / `version` が client エコーされサーバで読み直されない、を固定
+- コミットメッセージ: `test: 申請Server Actionのマッピング契約テストを追加`
+
+### Step 5: 確認モーダルコンポーネント
+- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/`（新規モーダルコンポーネント）
+- 作業内容:
+  - open 時に previewApplication を呼び、`kind` を網羅 switch（never ガード）で描画（EXEMPT/REQUIRED/BLOCKED/INACTIVE）＝コンパイル時消費証明を内蔵
+  - REQUIRED はチェーン全体（課長→部長(最終)）＋金額（`VariationDTO.finalTotal`）を表示し確認ボタン、BLOCKED/INACTIVE は文言のみで確認を出さない、EXEMPT は理由 label ＋確認
+  - submit 成功は既存流儀で閉じてパネル更新、失敗（ConflictError/BusinessRuleViolationError）は VariationPanel へコールバックして強制クローズ
+  - operator null の preview エラーはモーダル内メッセージ＋閉じる
+- コミットメッセージ: `feat: 見積申請の確認モーダル（プレビュー分岐描画）を追加`
+
+### Step 6: VariationPanel への申請ボタン・バッジ・失敗バナー配線
+- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx`、`page.tsx`、`variationApplicationStateBadge.ts` 周辺、`variationEditable.ts`（必要な範囲）
+- 作業内容:
+  - `page.tsx` で `GetVariationApplicationStates` を取得し `VariationPanel` へ渡す（variationId で `VariationDTO` と join）
+  - 申請ボタンを常に表示、無効化は `canApply` 単一ゲート、tooltip は `variation.status` で文言選択（`isVariationApplicable` は新設しない）
+  - バリエーション別バッジに `applicationState.label` を表示（既存 stub を土台に肉付け）
+  - submit 失敗時の永続バナー state を VariationPanel に lift（パネル上部・`role="alert"`・auto-refresh なし・申請ボタンは押下可）
+- コミットメッセージ: `feat: 見積詳細に申請ボタン・申請状態バッジ・競合バナーを配線`
+
+### Step 7: 仕様書 §6.2 の是正
+- 対象ファイル: `docs/business/estimate/システム設計書(申請).md`
+- 作業内容:
+  - BLOCKED を 3 値に更新、INACTIVE 分岐を追加、EXEMPT/BLOCKED/INACTIVE が BE 供給 label を持つことを明記
+- コミットメッセージ: `docs: 申請設計書§6.2をpreview契約の実態（3値BLOCKED・INACTIVE・label）に追随`
+
+### Step 8: E2E ＋ 逸脱記録
+- 対象ファイル: 見積詳細の E2E spec、`docs/claude-plans/issue-494/deviations.md`
+- 作業内容:
+  - 申請→preview→確認→submit を実 DB（seed）で承認必要・承認免除の両経路、INACTIVE のボタン前段無効化＋tooltip を検証
+  - deviations.md に本計画の逸脱（PersistError 除外／isVariationApplicable 不新設／BLOCKED ラベルのドメイン配置／preview 証明の実モーダル内蔵／リカバリのバナー方式）を記録
+- コミットメッセージ: `test: 見積申請フローのE2Eテストを追加`

--- a/docs/claude-plans/issue-494/r1-fix-plan.md
+++ b/docs/claude-plans/issue-494/r1-fix-plan.md
@@ -1,0 +1,53 @@
+# Issue #494 PR562 自動レビュー＆修正 ラウンド1 修正計画
+
+`/code-review medium` → judge 評価で採用された指摘の修正方針。採用①②=3件（全て①）、採用③=3件。
+
+## ① correctness bug
+
+### 指摘3（採用・High）getEstimateDetail が try/catch 外で reject 握り潰し
+- file:line: `actions.ts:396,437`（previewApplication / submitApplication）
+- 問題: `getEstimateDetailQueryFactory().execute()` が try の外。インフラ例外時に ActionResult を返さず reject。モーダル側（`ApplicationConfirmDialog` handleOpen/handleSubmit）は try/catch なしで await するため、preview は「取得しています…」固着、submit は失敗バナー導線もクローズも発火せず握り潰し。
+- 修正方針: **指摘7（③）と統合**。共通プロローグを private 関数 `resolveApplicationContext(estimateNumber)` に抽出し、その中で `getEstimateDetail` を try/catch で囲み `handleCommandError` で ActionResult 化する。preview/submit は `const ctx = await resolveApplicationContext(...); if (!ctx.success) return ctx;` で使う。
+- 影響範囲: `actions.ts` のみ（レイヤまたぎなし）。
+- 想定テスト: 既存 `applicationActions.test.ts` が緑のまま。getEstimateDetail reject 時に `{success:false}` を返すことを追加検証しうる（既存テスト構造に合わせる）。
+
+### 指摘1（採用・Low）網羅 switch default がオブジェクトを return しクラッシュ
+- file:line: `ApplicationConfirmDialog.tsx:231-235`
+- 問題: default が `return _exhaustive`（=preview オブジェクト自体）。実行時の版スキューで未知 kind 受信時に React が「Objects are not valid as a React child」で描画クラッシュ。
+- 修正方針: `const _exhaustive: never = preview;`（コンパイル時網羅証明・逸脱④の意図）は残し、`return _exhaustive;` を `return null;` に変更。実行時は何も描かない（安全側）。コメントを実行時挙動込みで更新。
+- 影響範囲: 当該ファイルのみ。
+- 想定テスト: 既存 `ApplicationConfirmDialog.test.tsx` 緑のまま。
+
+### 指摘4（採用・Low）申請成功時に applyFailure バナー未クリア
+- file:line: `VariationPanel.tsx:97,291` + `ApplicationConfirmDialog.tsx:96-98`
+- 問題: submit 成功は `setOpen(false)+router.refresh()` のみで applyFailure（client useState）を消さない。「失敗→再申請成功」後もバナー『最新ではない』が残る誤表示。
+- 修正方針: `onSubmitFailure` と対称に optional な `onSubmitSuccess?: () => void` を Props に追加。ダイアログ success 分岐で `onSubmitSuccess?.()` を `router.refresh()` 前に呼ぶ。`VariationPanel` で `onSubmitSuccess={() => setApplyFailure(null)}` を渡す。
+- 影響範囲: 2 ファイル（同一 feature、公開シグネチャは optional 追加で後方互換）。
+- 想定テスト: `ApplicationConfirmDialog.test.tsx` に「成功時 onSubmitSuccess が呼ばれる」を追加しうる。
+
+## ③ cleanup
+
+### 指摘7（採用・③／指摘3と統合）共通プロローグ二重化 → private 関数抽出
+- 上記指摘3の修正で `resolveApplicationContext` を private 抽出することで同時解消。
+- ③採用根拠: 挙動不変（verifySession→operator ガード→estimateId 解決の順・文言同一）、同一ファイル内 private 関数抽出（③規約で明示可）、公開シグネチャ不変、局所。
+
+### 指摘6（採用・③）catch 内 errorMessage 計算がデッドコード
+- file:line: `actions.ts:409-411,451-453`
+- 修正方針: `const errorResult = ...; const errorMessage = ...; return {success:false, error:errorMessage}` を `return handleCommandError(error)` に置換。
+- ③採用根拠: handleCommandError は全分岐で `{success:false, error:非空}` を返すため恒等・挙動不変（console.error 副作用も内包保持）、同一ファイル2箇所の局所置換、公開シグネチャ不変。
+
+### 指摘8（採用・③）全件 Map 索引を active 1キーしか読まない
+- file:line: `VariationPanel.tsx:100-103,107`
+- 修正方針: `useMemo`+`new Map(...)` を削除し、`activeApplicationState` を `applicationStates.find((s) => s.variationId === active.variationId)` で直接引く。
+- ③採用根拠: 未発見時 undefined も同値で挙動不変、単一ファイル数行、公開シグネチャ不変、設計判断不要。
+
+## 計画からの逸脱（記録予定）
+- CLAUDE.md 系の「①②を先に、③を最後に」原則に対し、指摘3(①)と指摘7(③)は**完全に同一の8行**を対象とするため分割せず1コミットに統合する。分割はむしろ二度手間＋競合事故を招くため。→ deviations.md に追記。
+
+## コミット分割
+1. `fix:` 指摘3+7 統合（resolveApplicationContext 抽出＋getEstimateDetail を try 内へ）
+2. `fix:` 指摘4（onSubmitSuccess でバナークリア）
+3. `fix:` 指摘1（switch default を null 化）
+4. `refactor:` 指摘6（catch デッドコード除去）
+5. `refactor:` 指摘8（useMemo Map → find）
+- 計画ファイル自体は `docs:`。

--- a/prisma/seed-estimates.ts
+++ b/prisma/seed-estimates.ts
@@ -52,6 +52,12 @@ export const SEED_ESTIMATE_NUMBERS = {
   reviseSource: "N9905006",
   /** S7 無効化/有効化（C5）の E2E 用（V1・V2 とも ACTIVE。トグルで状態を往復させる）。 */
   s7Toggle: "N9905007",
+  /** 申請（承認免除・#494）の E2E 用（税込10万円未満＝BELOW_THRESHOLD→EXEMPT）。 */
+  applyExempt: "N9905008",
+  /** 申請（承認必要・#494）の E2E 用（税込10万〜100万＝ゴール課長→REQUIRED）。 */
+  applyRequired: "N9905009",
+  /** 申請ボタン出し分け（#494）の E2E 用（V1 ACTIVE＝申請可・V2 INACTIVE＝申請不可）。 */
+  applyInactive: "N9905010",
 } as const;
 
 /** 見積が参照する FK マスタ（呼び出し側 seed の作成済みデータから解決した ID）。 */
@@ -273,6 +279,69 @@ function buildS7ToggleEstimate(fk: EstimateSeedFk) {
 }
 
 /**
+ * 申請（承認免除）E2E 用の見積（#494）。V1 は ACTIVE・税込 5.5 万円（< 10 万＝BELOW_THRESHOLD）。
+ * プレビューは operator の上位役割に依らず EXEMPT を返す（judge が chain 構築前に免除確定）。
+ */
+function buildApplyExemptEstimate(fk: EstimateSeedFk) {
+  return EstimateFactory.create({
+    ...header(fk),
+    estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.applyExempt),
+    variations: [
+      {
+        variationNumber: 1,
+        submissionType: SubmissionType.CUSTOMER,
+        items: [mkItem(fk.productAId, 1, "免除対象明細", 1, 50000)],
+      },
+    ],
+  });
+}
+
+/**
+ * 申請（承認必要）E2E 用の見積（#494）。V1 は ACTIVE・税込 33 万円（10 万〜100 万＝ゴール課長）。
+ * プレビューは REQUIRED を返す。E2E は operator=user（営業本部長・上位=社長）で実行し、起点＝社長が
+ * ゴール段階（課長）以上のため 1 段のチェーンが組める（社長は承認者を持つ）。
+ */
+function buildApplyRequiredEstimate(fk: EstimateSeedFk) {
+  return EstimateFactory.create({
+    ...header(fk),
+    estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.applyRequired),
+    variations: [
+      {
+        variationNumber: 1,
+        submissionType: SubmissionType.CUSTOMER,
+        items: [mkItem(fk.productAId, 1, "承認必要明細", 1, 300000)],
+      },
+    ],
+  });
+}
+
+/**
+ * 申請ボタン出し分け E2E 用の見積（#494）。V1 ACTIVE（申請可）・V2 INACTIVE（申請不可）。
+ * submit はせず、INACTIVE バリの申請ボタン無効化＋ツールチップだけを read-only で観測する。
+ */
+function buildApplyInactiveEstimate(fk: EstimateSeedFk) {
+  const estimate = EstimateFactory.create({
+    ...header(fk),
+    estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.applyInactive),
+    variations: [
+      {
+        variationNumber: 1,
+        submissionType: SubmissionType.CUSTOMER,
+        items: [mkItem(fk.productAId, 1, "申請可明細", 1, 50000)],
+      },
+      {
+        variationNumber: 2,
+        submissionType: SubmissionType.DELIVERY_LOCATION,
+        items: [mkItem(fk.productBId, 1, "無効バリ明細", 1, 60000)],
+      },
+    ],
+  });
+  // V2 を無効化（申請ボタンが canApply=false で無効になることの確認用）。
+  estimate.deactivateVariation(estimate.variations[1].id);
+  return estimate;
+}
+
+/**
  * S5 セット群編集 E2E 用の NEW 見積（ADR-0047）。構成2件のセット群1つ＋通常明細1件。非改訂 ACTIVE。
  * 群ヘッダは SET 商品、構成は個別商品（productA/B）。表示位置・金額は構成から導出される。
  */
@@ -343,6 +412,9 @@ export async function seedEstimates(prisma: PrismaClient): Promise<number> {
     buildRepairSeedEstimate(fk),
     buildReviseSourceEstimate(fk),
     buildS7ToggleEstimate(fk),
+    buildApplyExemptEstimate(fk),
+    buildApplyRequiredEstimate(fk),
+    buildApplyInactiveEstimate(fk),
   ];
   for (const estimate of estimates) {
     // 上記はセット群なし → 所属交差表の createMany は不要。

--- a/src/app/(features)/estimates/[estimateNumber]/ApplicationConfirmDialog.test.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/ApplicationConfirmDialog.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi, type Mock } from "vitest";
+import { ApplicationConfirmDialog } from "./ApplicationConfirmDialog";
+import { previewApplication, submitApplication } from "./actions";
+
+vi.mock("./actions", () => ({
+  previewApplication: vi.fn(),
+  submitApplication: vi.fn(),
+}));
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+const mockPreview = previewApplication as unknown as Mock;
+const mockSubmit = submitApplication as unknown as Mock;
+
+const baseProps = {
+  estimateNumber: "EST-1",
+  variationId: "v1",
+  variationNumber: 1,
+  version: 7,
+  finalTotal: 330000,
+  canApply: true,
+  variationStatus: "ACTIVE",
+  onSubmitFailure: vi.fn(),
+};
+
+const REQUIRED_PREVIEW = {
+  success: true as const,
+  data: {
+    kind: "REQUIRED" as const,
+    goalPositionId: "pos-9",
+    goalPositionName: "部長",
+    steps: [
+      { order: 1, roleName: "営業一課長", positionName: "課長" },
+      { order: 2, roleName: "営業部長", positionName: "部長" },
+    ],
+  },
+};
+
+function renderDialog(overrides: Partial<typeof baseProps> = {}) {
+  return render(<ApplicationConfirmDialog {...baseProps} {...overrides} />);
+}
+
+describe("ApplicationConfirmDialog（申請プレビュー→確認）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("申請ボタンを押すと preview を呼び REQUIRED の承認チェーンと金額と確認ボタンを表示する", async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue(REQUIRED_PREVIEW);
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "申請" }));
+
+    expect(mockPreview).toHaveBeenCalledWith("EST-1", "v1");
+    await screen.findByText(/営業一課長（課長）/);
+    expect(screen.getByText(/営業部長（部長）/)).toBeInTheDocument();
+    expect(screen.getByText(/330,000円/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "申請する" })).toBeInTheDocument();
+  });
+
+  test("EXEMPT は免除理由 label と確認ボタンを表示する", async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue({
+      success: true,
+      data: { kind: "EXEMPT", reason: "BELOW_THRESHOLD", reasonLabel: "10万円未満" },
+    });
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "申請" }));
+
+    await screen.findByText(/10万円未満/);
+    expect(screen.getByRole("button", { name: "申請する" })).toBeInTheDocument();
+  });
+
+  test("BLOCKED は reasonLabel を表示し確認ボタンを出さない", async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue({
+      success: true,
+      data: {
+        kind: "BLOCKED",
+        reason: "NO_SUPERIOR_ROLE",
+        reasonLabel: "申請者に上位役割が設定されていないため申請できません",
+      },
+    });
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "申請" }));
+
+    await screen.findByText(/申請者に上位役割が設定されていないため申請できません/);
+    expect(screen.queryByRole("button", { name: "申請する" })).toBeNull();
+    expect(screen.getByRole("button", { name: "閉じる" })).toBeInTheDocument();
+  });
+
+  test("INACTIVE は label を表示し確認ボタンを出さない", async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue({
+      success: true,
+      data: {
+        kind: "INACTIVE",
+        label: "このバリエーションは無効化されています。画面を更新して最新の状態をご確認ください。",
+      },
+    });
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "申請" }));
+
+    await screen.findByText(/無効化されています/);
+    expect(screen.queryByRole("button", { name: "申請する" })).toBeNull();
+  });
+
+  test("申請するを押すと submit を version エコーで呼び、成功でモーダルを閉じ router.refresh する", async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue(REQUIRED_PREVIEW);
+    mockSubmit.mockResolvedValue({
+      success: true,
+      data: {
+        kind: "ApplicationSubmitted",
+        applicationId: "a1",
+        finalApprovalPositionId: "p1",
+        attempt: 1,
+      },
+    });
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "申請" }));
+    await user.click(await screen.findByRole("button", { name: "申請する" }));
+
+    expect(mockSubmit).toHaveBeenCalledWith("EST-1", "v1", 7);
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByRole("button", { name: "申請する" })).toBeNull());
+  });
+
+  test("submit 失敗は onSubmitFailure にメッセージを渡しモーダルを閉じる（refresh しない）", async () => {
+    const user = userEvent.setup();
+    const onSubmitFailure = vi.fn();
+    mockPreview.mockResolvedValue(REQUIRED_PREVIEW);
+    mockSubmit.mockResolvedValue({ success: false, error: "他の操作で見積が更新されました" });
+    renderDialog({ onSubmitFailure });
+
+    await user.click(screen.getByRole("button", { name: "申請" }));
+    await user.click(await screen.findByRole("button", { name: "申請する" }));
+
+    await waitFor(() =>
+      expect(onSubmitFailure).toHaveBeenCalledWith("他の操作で見積が更新されました")
+    );
+    expect(mockRefresh).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByRole("button", { name: "申請する" })).toBeNull());
+  });
+
+  test("preview 失敗（operator 未取得等）はモーダル内にメッセージを出す", async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue({
+      success: false,
+      error: "申請者の従業員情報が取得できないため申請できません。管理者にお問い合わせください。",
+    });
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "申請" }));
+
+    await screen.findByText(/申請者の従業員情報が取得できない/);
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  test("canApply=false ではトリガーが無効化され状態に応じたツールチップを持つ", () => {
+    const { rerender } = renderDialog({ canApply: false, variationStatus: "INACTIVE" });
+    const button = screen.getByRole("button", { name: "申請" });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("title", "無効なバリエーションは申請できません");
+
+    rerender(<ApplicationConfirmDialog {...baseProps} canApply={false} variationStatus="ACTIVE" />);
+    expect(screen.getByRole("button", { name: "申請" })).toHaveAttribute(
+      "title",
+      "既に前進しているバリエーションがあるため申請できません（1見積1前進）"
+    );
+  });
+});

--- a/src/app/(features)/estimates/[estimateNumber]/ApplicationConfirmDialog.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/ApplicationConfirmDialog.tsx
@@ -33,6 +33,11 @@ type Props = {
    * パネル上部の永続バナーで「最新ではない」旨を告知させる（auto-refresh しない・#494）。
    */
   onSubmitFailure: (message: string) => void;
+  /**
+   * submit 成功時にパネルへ通知するコールバック。直前の失敗で立った永続バナーを消すために使う
+   * （「失敗→再申請成功」でバナーが残り続ける誤表示を防ぐ・#494・自動レビュー R1）。
+   */
+  onSubmitSuccess?: () => void;
 };
 
 /** トリガー無効時のツールチップ文言（無効化は canApply 単一ゲート・文言だけ状態で選ぶ）。 */
@@ -68,6 +73,7 @@ export function ApplicationConfirmDialog({
   canApply,
   variationStatus,
   onSubmitFailure,
+  onSubmitSuccess,
 }: Props) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -95,6 +101,8 @@ export function ApplicationConfirmDialog({
       const result = await submitApplication(estimateNumber, variationId, version);
       if (result.success) {
         setOpen(false);
+        // 直前の失敗で立った永続バナーを消す（成功でパネルは最新化される・#494・R1）。
+        onSubmitSuccess?.();
         router.refresh();
       } else {
         // 競合・業務例外は強制クローズしてパネルのバナーへ委譲する（画面全体をユーザーに確認させる）。
@@ -229,9 +237,11 @@ function PreviewBody({
         </div>
       );
     default: {
-      // 網羅漏れ（DTO に kind が増えた等）をコンパイル時に検出する（ADR-0069）。
+      // 網羅漏れ（DTO に kind が増えた等）をコンパイル時に検出する（ADR-0069）。実行時に版スキュー等で
+      // 未知 kind が届いても、オブジェクトを React child として返さず null を描く（描画クラッシュ防止・R1）。
       const _exhaustive: never = preview;
-      return _exhaustive;
+      void _exhaustive;
+      return null;
     }
   }
 }

--- a/src/app/(features)/estimates/[estimateNumber]/ApplicationConfirmDialog.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/ApplicationConfirmDialog.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/app/_components/shadcnui/dialog";
+import type { PreviewApplicationResultDTO } from "@subdomains/estimate/application/queries/dto/PreviewApplicationResultDTO";
+import { formatYen } from "../_shared/labels";
+import { previewApplication, submitApplication } from "./actions";
+
+type Props = {
+  /** 見積番号（Server Action の束縛・estimateId 再解決に使う）。 */
+  estimateNumber: string;
+  /** 申請対象バリエーション ID。 */
+  variationId: string;
+  /** 申請対象の案番号（確認文の表示用）。 */
+  variationNumber: number;
+  /** 親集約の楽観ロックトークン（ADR-0039）。submit へ client エコーする（version 関門・ADR-0068）。 */
+  version: number;
+  /** 申請対象バリの税込合計（REQUIRED 表示用・ADR-0055 のゴール判定と同じ税込最終合計）。 */
+  finalTotal: number;
+  /** 申請可能か（ACTIVE かつ 見積内に前進バリなし・ADR-0069）。トリガーの活性を制御する。 */
+  canApply: boolean;
+  /** 対象バリの状態（トリガー無効時のツールチップ文言選択に使う。DTO 再発明はしない）。 */
+  variationStatus: string;
+  /**
+   * submit 失敗（競合・業務例外）時にパネルへ持ち上げるコールバック。モーダルは強制クローズし、
+   * パネル上部の永続バナーで「最新ではない」旨を告知させる（auto-refresh しない・#494）。
+   */
+  onSubmitFailure: (message: string) => void;
+};
+
+/** トリガー無効時のツールチップ文言（無効化は canApply 単一ゲート・文言だけ状態で選ぶ）。 */
+function disabledReason(variationStatus: string): string {
+  return variationStatus !== "ACTIVE"
+    ? "無効なバリエーションは申請できません"
+    : "既に前進しているバリエーションがあるため申請できません（1見積1前進）";
+}
+
+/**
+ * 見積申請の確認モーダル（S2・§6.2/§6.3・#494）。
+ *
+ * 操作行の「申請」ボタン（トリガー）とモーダルを内包する自己完結コンポーネント。開くと
+ * {@link previewApplication} を副作用なしで呼び、結果 `kind` を網羅 switch で描く。この switch 自体が
+ * `PreviewApplicationResultDTO` のコンパイル時消費証明を兼ね、DTO に kind が増減すれば never ガードで
+ * 型エラーになる（独立スタブとのドリフトを排す・ADR-0069）。
+ *
+ * - REQUIRED: 承認チェーン（起点→ゴール順）と税込合計を示し「申請する」で {@link submitApplication}。
+ * - EXEMPT: 免除理由 label を示し「申請する」（免除の記録も単一ジェスチャ・ADR-0037/0038）。
+ * - BLOCKED / INACTIVE: BE 供給の文言のみ描き、確認ボタンは出さない（申請できないため）。
+ * - submit 成功はモーダルを閉じ `router.refresh()` でパネル（バッジ・canApply）を最新化する。
+ * - submit 失敗（ConflictError / BusinessRuleViolationError）は強制クローズし onSubmitFailure へ
+ *   メッセージを渡す。パネルは古い表示のままなので、バナーで更新を促す（auto-refresh しない・#494）。
+ * - operator 情報が引けない等の preview エラーは前提条件エラーのためモーダル内に文言を出すに留め、
+ *   バナー導線には乗せない。
+ */
+export function ApplicationConfirmDialog({
+  estimateNumber,
+  variationId,
+  variationNumber,
+  version,
+  finalTotal,
+  canApply,
+  variationStatus,
+  onSubmitFailure,
+}: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [preview, setPreview] = useState<PreviewApplicationResultDTO | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [isPreviewing, startPreview] = useTransition();
+  const [isSubmitting, startSubmit] = useTransition();
+
+  function handleOpen(): void {
+    setPreview(null);
+    setPreviewError(null);
+    setOpen(true);
+    startPreview(async () => {
+      const result = await previewApplication(estimateNumber, variationId);
+      if (result.success) {
+        setPreview(result.data ?? null);
+      } else {
+        setPreviewError(result.error ?? "プレビューの取得に失敗しました");
+      }
+    });
+  }
+
+  function handleSubmit(): void {
+    startSubmit(async () => {
+      const result = await submitApplication(estimateNumber, variationId, version);
+      if (result.success) {
+        setOpen(false);
+        router.refresh();
+      } else {
+        // 競合・業務例外は強制クローズしてパネルのバナーへ委譲する（画面全体をユーザーに確認させる）。
+        setOpen(false);
+        onSubmitFailure(result.error ?? "申請に失敗しました");
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        disabled={!canApply}
+        title={canApply ? undefined : disabledReason(variationStatus)}
+        className="bg-purple-600 hover:bg-purple-700 text-white text-sm font-bold py-1 px-4 rounded focus:outline-none focus:shadow-outline disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        申請
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>申請の確認</DialogTitle>
+            <DialogDescription>
+              第{variationNumber}案を申請します。内容を確認してください。
+            </DialogDescription>
+          </DialogHeader>
+
+          {isPreviewing && <p className="text-gray-600 py-4">プレビューを取得しています...</p>}
+
+          {previewError && (
+            <div
+              className="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded text-sm"
+              role="alert"
+            >
+              {previewError}
+            </div>
+          )}
+
+          {preview && (
+            <PreviewBody
+              preview={preview}
+              finalTotal={finalTotal}
+              isSubmitting={isSubmitting}
+              onSubmit={handleSubmit}
+              onCancel={() => setOpen(false)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+/** preview の kind を網羅描画する（never ガードで DTO 消費をコンパイル時に証明する・ADR-0069）。 */
+function PreviewBody({
+  preview,
+  finalTotal,
+  isSubmitting,
+  onSubmit,
+  onCancel,
+}: {
+  preview: PreviewApplicationResultDTO;
+  finalTotal: number;
+  isSubmitting: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  switch (preview.kind) {
+    case "REQUIRED":
+      return (
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-sm font-bold text-gray-700 mb-2">承認チェーン</h3>
+            <ol className="space-y-1">
+              {preview.steps.map((step) => (
+                <li key={step.order} className="text-gray-900">
+                  {`${step.order}. ${step.roleName}（${step.positionName}）`}
+                </li>
+              ))}
+            </ol>
+            <p className="text-sm text-gray-600 mt-2">最終承認職位: {preview.goalPositionName}</p>
+          </div>
+          <p className="text-right text-lg font-bold text-gray-900">{formatYen(finalTotal)}</p>
+          <ConfirmFooter
+            confirmLabel="申請する"
+            isSubmitting={isSubmitting}
+            onSubmit={onSubmit}
+            onCancel={onCancel}
+          />
+        </div>
+      );
+    case "EXEMPT":
+      return (
+        <div className="space-y-4">
+          <p className="bg-green-50 border border-green-300 text-green-800 text-sm px-3 py-2 rounded">
+            この申請は承認不要です（理由: {preview.reasonLabel}
+            ）。申請すると承認免除として記録されます。
+          </p>
+          <ConfirmFooter
+            confirmLabel="申請する"
+            isSubmitting={isSubmitting}
+            onSubmit={onSubmit}
+            onCancel={onCancel}
+          />
+        </div>
+      );
+    case "BLOCKED":
+      return (
+        <div className="space-y-4">
+          <div
+            className="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded text-sm"
+            role="alert"
+          >
+            {preview.reasonLabel}
+          </div>
+          <CloseOnlyFooter onCancel={onCancel} />
+        </div>
+      );
+    case "INACTIVE":
+      return (
+        <div className="space-y-4">
+          <div
+            className="bg-yellow-100 border border-yellow-400 text-yellow-800 px-4 py-2 rounded text-sm"
+            role="alert"
+          >
+            {preview.label}
+          </div>
+          <CloseOnlyFooter onCancel={onCancel} />
+        </div>
+      );
+    default: {
+      // 網羅漏れ（DTO に kind が増えた等）をコンパイル時に検出する（ADR-0069）。
+      const _exhaustive: never = preview;
+      return _exhaustive;
+    }
+  }
+}
+
+/** 確認（申請する）＋キャンセルのフッター（EXEMPT / REQUIRED 共用）。 */
+function ConfirmFooter({
+  confirmLabel,
+  isSubmitting,
+  onSubmit,
+  onCancel,
+}: {
+  confirmLabel: string;
+  isSubmitting: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="flex gap-3 justify-end">
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={isSubmitting}
+        className="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:cursor-not-allowed"
+      >
+        キャンセル
+      </button>
+      <button
+        type="button"
+        onClick={onSubmit}
+        disabled={isSubmitting}
+        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+      >
+        {isSubmitting ? "申請中..." : confirmLabel}
+      </button>
+    </div>
+  );
+}
+
+/** 申請できない分岐（BLOCKED / INACTIVE）の「閉じる」だけのフッター。 */
+function CloseOnlyFooter({ onCancel }: { onCancel: () => void }) {
+  return (
+    <div className="flex justify-end">
+      <button
+        type="button"
+        onClick={onCancel}
+        className="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+      >
+        閉じる
+      </button>
+    </div>
+  );
+}

--- a/src/app/(features)/estimates/[estimateNumber]/VariationPanel.test.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationPanel.test.tsx
@@ -5,10 +5,11 @@ import type {
   LineDTO,
   VariationDTO,
 } from "@subdomains/estimate/application/queries/dto/EstimateDetailDTO";
+import type { VariationApplicationStateDTO } from "@subdomains/estimate/application/queries/dto/VariationApplicationStateDTO";
 import { VariationPanel } from "./VariationPanel";
-import { addVariation } from "./actions";
+import { addVariation, previewApplication, submitApplication } from "./actions";
 
-// Server Action をモック（VariationCreateForm / VariationEditForm が依存）。
+// Server Action をモック（VariationCreateForm / VariationEditForm / ApplicationConfirmDialog が依存）。
 vi.mock("./actions", () => ({
   addVariation: vi.fn(),
   updateVariationContent: vi.fn(),
@@ -16,9 +17,31 @@ vi.mock("./actions", () => ({
   updateVariationAdjustment: vi.fn(),
   activateVariation: vi.fn(),
   deactivateVariation: vi.fn(),
+  previewApplication: vi.fn(),
+  submitApplication: vi.fn(),
+}));
+
+// ApplicationConfirmDialog が submit 成功時に router.refresh() を呼ぶためモックする。
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
 }));
 
 const mockAddVariation = addVariation as unknown as Mock;
+const mockPreview = previewApplication as unknown as Mock;
+const mockSubmit = submitApplication as unknown as Mock;
+
+/** テスト用 申請状態 DTO ビルダ（既定: 未申請・申請可）。 */
+function appState(
+  variationId: string,
+  overrides: Partial<VariationApplicationStateDTO> = {}
+): VariationApplicationStateDTO {
+  return {
+    variationId,
+    applicationState: { code: "NONE", label: "未申請" },
+    canApply: true,
+    ...overrides,
+  };
+}
 
 /** テスト用 LineDTO ビルダ（改訂列なし＝編集可・複製可）。 */
 function line(overrides: Partial<LineDTO> = {}): LineDTO {
@@ -66,13 +89,20 @@ function variation(overrides: Partial<VariationDTO> = {}): VariationDTO {
   };
 }
 
-/** VariationPanel の共通 props（バリエーション群だけ差し替える）。 */
-function renderPanel(variations: VariationDTO[]) {
+/** VariationPanel の共通 props（バリエーション群だけ差し替える）。申請状態は既定で全件申請可。 */
+function renderPanel(
+  variations: VariationDTO[],
+  applicationStates?: VariationApplicationStateDTO[]
+) {
   return render(
     <VariationPanel
       estimateNumber="EST-0001"
       version={1}
       variations={variations}
+      applicationStates={
+        applicationStates ??
+        variations.map((v) => appState(v.variationId, { canApply: v.status === "ACTIVE" }))
+      }
       taxRate={0.1}
       taxRoundingType="ROUND_DOWN"
       hasRevision={false}
@@ -189,13 +219,16 @@ describe("VariationPanel（改訂先の部分編集・#390）", () => {
     const { rerender } = renderPanel([variation({ revisionRole: "NONE" })]);
     expect(screen.queryByRole("button", { name: "価格を調整" })).toBeNull();
 
+    const revisionSource = variation({
+      revisionRole: "REVISION_SOURCE",
+      submissionType: "DELIVERY_LOCATION",
+    });
     rerender(
       <VariationPanel
         estimateNumber="EST-0001"
         version={1}
-        variations={[
-          variation({ revisionRole: "REVISION_SOURCE", submissionType: "DELIVERY_LOCATION" }),
-        ]}
+        variations={[revisionSource]}
+        applicationStates={[appState(revisionSource.variationId)]}
         taxRate={0.1}
         taxRoundingType="ROUND_DOWN"
         hasRevision={false}
@@ -215,5 +248,61 @@ describe("VariationPanel（改訂先の部分編集・#390）", () => {
     expect(screen.getByLabelText("単価（通常明細）")).toBeInTheDocument();
     // 合計粗利が表示される。
     expect(screen.getByLabelText("合計粗利")).toBeInTheDocument();
+  });
+});
+
+describe("VariationPanel（申請ボタン・状態バッジ・失敗バナー・#494）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("申請ボタンを常に表示し、canApply=false のバリでは無効化する", () => {
+    const v = variation({ variationId: "v1", status: "ACTIVE" });
+    renderPanel([v], [appState("v1", { canApply: false })]);
+
+    const applyButton = screen.getByRole("button", { name: "申請" });
+    expect(applyButton).toBeInTheDocument();
+    expect(applyButton).toBeDisabled();
+  });
+
+  test("canApply=true のバリでは申請ボタンが活性", () => {
+    const v = variation({ variationId: "v1", status: "ACTIVE" });
+    renderPanel([v], [appState("v1", { canApply: true })]);
+
+    expect(screen.getByRole("button", { name: "申請" })).toBeEnabled();
+  });
+
+  test("アクティブなバリの申請状態 label をバッジ表示する", () => {
+    const v = variation({ variationId: "v1", status: "ACTIVE" });
+    renderPanel(
+      [v],
+      [appState("v1", { applicationState: { code: "PENDING", label: "申請中" }, canApply: false })]
+    );
+
+    expect(screen.getByText("申請中")).toBeInTheDocument();
+  });
+
+  test("submit 失敗でパネル上部に永続バナーを表示し、refresh はしない", async () => {
+    const user = userEvent.setup();
+    const v = variation({ variationId: "v1", status: "ACTIVE" });
+    mockPreview.mockResolvedValue({
+      success: true,
+      data: {
+        kind: "REQUIRED",
+        goalPositionId: "p9",
+        goalPositionName: "部長",
+        steps: [{ order: 1, roleName: "営業一課長", positionName: "課長" }],
+      },
+    });
+    mockSubmit.mockResolvedValue({ success: false, error: "他の操作で見積が更新されました" });
+    renderPanel([v], [appState("v1", { canApply: true })]);
+
+    await user.click(screen.getByRole("button", { name: "申請" }));
+    await user.click(await screen.findByRole("button", { name: "申請する" }));
+
+    const banner = await screen.findByRole("alert");
+    expect(banner).toHaveTextContent("他の操作で見積が更新されました");
+    // モーダルは強制クローズされる（確認ボタンが消える）。
+    await waitFor(() => expect(screen.queryByRole("button", { name: "申請する" })).toBeNull());
   });
 });

--- a/src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Badge } from "@/app/_components/shadcnui/badge";
 import type { VariationDTO } from "@subdomains/estimate/application/queries/dto/EstimateDetailDTO";
 import type { VariationApplicationStateDTO } from "@subdomains/estimate/application/queries/dto/VariationApplicationStateDTO";
@@ -96,15 +96,13 @@ export function VariationPanel({
   // submit 失敗（競合・業務例外）の永続バナー（#494）。auto-refresh せずユーザーに画面確認を委ねる。
   const [applyFailure, setApplyFailure] = useState<string | null>(null);
 
-  // variationId → 申請状態 の索引（申請ボタンの canApply とバッジ label を join で引く・#493）。
-  const applicationStateById = useMemo(
-    () => new Map(applicationStates.map((state) => [state.variationId, state])),
-    [applicationStates]
-  );
-
   const allInactive = variations.every((v) => v.status !== "ACTIVE");
   const active = variations[activeIndex];
-  const activeApplicationState = active ? applicationStateById.get(active.variationId) : undefined;
+  // active バリの申請状態を join で引く（canApply とバッジ label に使う・#493）。読み出しは active の
+  // 1 キーのみのため全件 Map 索引は作らず find で直接引く（自動レビュー R1）。
+  const activeApplicationState = active
+    ? applicationStates.find((state) => state.variationId === active.variationId)
+    : undefined;
 
   function selectVariation(index: number): void {
     if (index === activeIndex) return;

--- a/src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx
@@ -289,6 +289,7 @@ export function VariationPanel({
                   canApply={activeApplicationState?.canApply ?? false}
                   variationStatus={active.status}
                   onSubmitFailure={setApplyFailure}
+                  onSubmitSuccess={() => setApplyFailure(null)}
                 />
                 <button
                   type="button"

--- a/src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Badge } from "@/app/_components/shadcnui/badge";
 import type { VariationDTO } from "@subdomains/estimate/application/queries/dto/EstimateDetailDTO";
+import type { VariationApplicationStateDTO } from "@subdomains/estimate/application/queries/dto/VariationApplicationStateDTO";
 import { SUBMISSION_TYPE_LABELS, formatYen } from "../_shared/labels";
+import { ApplicationConfirmDialog } from "./ApplicationConfirmDialog";
+import { badgeToneClassName, badgeToneOf } from "./variationApplicationStateBadge";
 import { LineTable } from "./components/LineTable";
 import {
   isVariationAdjustable,
@@ -28,6 +31,11 @@ type Props = {
   /** 集約ルートの楽観ロックトークン（ADR-0039）。編集フォームへ往復させる。 */
   version: number;
   variations: VariationDTO[];
+  /**
+   * バリエーション別 申請状態（#493・#494）。申請ボタンの出し分け（canApply）とバッジ（label）を
+   * 駆動する。variationId で {@link VariationDTO} と join する（INACTIVE 含む全件・variationNumber 昇順）。
+   */
+  applicationStates: VariationApplicationStateDTO[];
   /** 消費税率（金額プレビュー用・見積時点スナップショット）。 */
   taxRate: number;
   /** 税端数区分（金額プレビュー用）。 */
@@ -70,6 +78,7 @@ export function VariationPanel({
   estimateNumber,
   version,
   variations,
+  applicationStates,
   taxRate,
   taxRoundingType,
   hasRevision,
@@ -84,9 +93,18 @@ export function VariationPanel({
   const [activeRowId, setActiveRowId] = useState<string | null>(null);
   // 閲覧／編集（C4）／新規追加・複製（C3）を 1 つの判別共用体で排他管理する（計画§起点）。
   const [mode, setMode] = useState<PanelMode>({ kind: "view" });
+  // submit 失敗（競合・業務例外）の永続バナー（#494）。auto-refresh せずユーザーに画面確認を委ねる。
+  const [applyFailure, setApplyFailure] = useState<string | null>(null);
+
+  // variationId → 申請状態 の索引（申請ボタンの canApply とバッジ label を join で引く・#493）。
+  const applicationStateById = useMemo(
+    () => new Map(applicationStates.map((state) => [state.variationId, state])),
+    [applicationStates]
+  );
 
   const allInactive = variations.every((v) => v.status !== "ACTIVE");
   const active = variations[activeIndex];
+  const activeApplicationState = active ? applicationStateById.get(active.variationId) : undefined;
 
   function selectVariation(index: number): void {
     if (index === activeIndex) return;
@@ -117,6 +135,30 @@ export function VariationPanel({
 
   return (
     <div>
+      {/* 申請失敗（競合・業務例外）の永続バナー（#494）。パネルの canApply・バッジ・金額は古いままの
+          ため「最新ではない」と明示し、更新タイミングはユーザーに委ねる（auto-refresh しない）。 */}
+      {applyFailure && (
+        <div
+          role="alert"
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4 flex items-start justify-between gap-4"
+        >
+          <p>
+            {applyFailure}
+            <br />
+            この画面の表示は最新ではありません。必要な情報を控えたうえで、一覧に戻るか F5 で画面を
+            更新してください。
+          </p>
+          <button
+            type="button"
+            onClick={() => setApplyFailure(null)}
+            className="shrink-0 text-red-700 hover:text-red-900 font-bold"
+            aria-label="バナーを閉じる"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
       {/* 全無効警告（presentation 導出。DTO に専用フラグは持たせない） */}
       {allInactive && (
         <div
@@ -163,6 +205,17 @@ export function VariationPanel({
             <span className="text-sm text-gray-600">
               {active.status === "ACTIVE" ? "● 有効" : "○ 無効"}
             </span>
+            {/* 申請状態バッジ（label は VO 単一ソース・ADR-0069。tone は code から導出）。 */}
+            {activeApplicationState && (
+              <Badge
+                variant="outline"
+                className={badgeToneClassName(
+                  badgeToneOf(activeApplicationState.applicationState.code)
+                )}
+              >
+                {activeApplicationState.applicationState.label}
+              </Badge>
+            )}
             {mode.kind === "view" && (
               <div className="ml-auto flex gap-2">
                 {isVariationEditable(active) && (
@@ -224,6 +277,19 @@ export function VariationPanel({
                     hasRevision={hasRevision}
                   />
                 )}
+                {/* 申請（S2・§6・#494）。ボタンは常時表示し、無効化は canApply 単一ゲート。
+                    activeApplicationState が無いのは申請状態の取得漏れ（バグ）だが、UI は防御的に
+                    「申請不可」で描く（canApply=false）。 */}
+                <ApplicationConfirmDialog
+                  estimateNumber={estimateNumber}
+                  variationId={active.variationId}
+                  variationNumber={active.variationNumber}
+                  version={version}
+                  finalTotal={active.finalTotal}
+                  canApply={activeApplicationState?.canApply ?? false}
+                  variationStatus={active.status}
+                  onSubmitFailure={setApplyFailure}
+                />
                 <button
                   type="button"
                   onClick={startNew}

--- a/src/app/(features)/estimates/[estimateNumber]/__tests__/applicationActions.test.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/__tests__/applicationActions.test.ts
@@ -1,0 +1,148 @@
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { previewApplication, submitApplication } from "../actions";
+
+/**
+ * 申請 Server Action のマッピング契約テスト（#494・Step 4）。
+ *
+ * 「operator はセッション注入で client 入力を無視する」「estimateId は estimateNumber から
+ * 再解決する」「version は client エコーでサーバは読み直さない（TOCTOU・ADR-0068）」を固定する。
+ * 実 Prisma には触れず、Composition Root（factory）とセッションをモックして配線だけを検証する。
+ */
+
+const verifySession = vi.fn();
+vi.mock("@/app/_lib/verifyAuthentication", () => ({
+  verifySession: () => verifySession(),
+}));
+
+const getEstimateDetail = vi.fn();
+vi.mock("@subdomains/estimate/application/factories/estimateQueryFactory", () => ({
+  getEstimateDetailQueryFactory: () => ({ execute: getEstimateDetail }),
+}));
+
+const previewExecute = vi.fn();
+vi.mock("@subdomains/estimate/application/factories/previewApplicationQueryFactory", () => ({
+  previewApplicationQueryFactory: () => ({ execute: previewExecute }),
+}));
+
+const submitExecute = vi.fn();
+vi.mock("@subdomains/estimate/application/factories/submitApplicationCommandFactory", () => ({
+  submitApplicationCommandFactory: () => ({ execute: submitExecute }),
+}));
+
+const SESSION_EMPLOYEE_ID = "emp-session-001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifySession.mockResolvedValue({ user: { employeeId: SESSION_EMPLOYEE_ID } });
+  getEstimateDetail.mockResolvedValue({ estimateId: "est-resolved-001", version: 999 });
+});
+
+describe("previewApplication", () => {
+  it("operator をセッションから注入し estimateId を estimateNumber から再解決する", async () => {
+    previewExecute.mockResolvedValue({
+      kind: "EXEMPT",
+      reason: "BELOW_THRESHOLD",
+      reasonLabel: "10万円未満",
+    });
+
+    const result = await previewApplication("N0001", "var-1");
+
+    expect(getEstimateDetail).toHaveBeenCalledWith({ estimateNumber: "N0001" });
+    expect(previewExecute).toHaveBeenCalledWith({
+      estimateId: "est-resolved-001",
+      variationId: "var-1",
+      operatorEmployeeId: SESSION_EMPLOYEE_ID,
+    });
+    expect(result).toEqual({
+      success: true,
+      data: { kind: "EXEMPT", reason: "BELOW_THRESHOLD", reasonLabel: "10万円未満" },
+    });
+  });
+
+  it("session.user.employeeId が null ならクエリを呼ばずエラーメッセージを返す", async () => {
+    verifySession.mockResolvedValue({ user: { employeeId: null } });
+
+    const result = await previewApplication("N0001", "var-1");
+
+    expect(previewExecute).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("申請者");
+    }
+  });
+
+  it("見積が見つからなければエラーメッセージを返す", async () => {
+    getEstimateDetail.mockResolvedValue(null);
+
+    const result = await previewApplication("N0001", "var-1");
+
+    expect(previewExecute).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("submitApplication", () => {
+  it("operator をセッション注入・estimateId を再解決し version は client 値をそのまま渡す", async () => {
+    submitExecute.mockResolvedValue({
+      kind: "ApplicationSubmitted",
+      applicationId: "app-1",
+      finalApprovalPositionId: "pos-1",
+      attempt: 1,
+    });
+
+    const result = await submitApplication("N0001", "var-1", 7);
+
+    expect(getEstimateDetail).toHaveBeenCalledWith({ estimateNumber: "N0001" });
+    // version はサーバの DTO(version:999)ではなく client エコー値 7 を渡す（TOCTOU・ADR-0068）。
+    expect(submitExecute).toHaveBeenCalledWith({
+      estimateId: "est-resolved-001",
+      variationId: "var-1",
+      operatorEmployeeId: SESSION_EMPLOYEE_ID,
+      version: 7,
+    });
+    expect(result).toEqual({
+      success: true,
+      data: {
+        kind: "ApplicationSubmitted",
+        applicationId: "app-1",
+        finalApprovalPositionId: "pos-1",
+        attempt: 1,
+      },
+    });
+  });
+
+  it("ConflictError は handleCommandError 経由でメッセージ化する", async () => {
+    submitExecute.mockRejectedValue(new ConflictError("他の操作で見積が更新されました"));
+
+    const result = await submitApplication("N0001", "var-1", 7);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("他の操作で見積が更新されました");
+    }
+  });
+
+  it("BusinessRuleViolationError は handleCommandError 経由でメッセージ化する", async () => {
+    submitExecute.mockRejectedValue(
+      new BusinessRuleViolationError("既に前進しているバリエーションがあります（1見積1前進）")
+    );
+
+    const result = await submitApplication("N0001", "var-1", 7);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("既に前進しているバリエーションがあります（1見積1前進）");
+    }
+  });
+
+  it("session.user.employeeId が null ならコマンドを呼ばずエラーメッセージを返す", async () => {
+    verifySession.mockResolvedValue({ user: { employeeId: null } });
+
+    const result = await submitApplication("N0001", "var-1", 7);
+
+    expect(submitExecute).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/app/(features)/estimates/[estimateNumber]/actions.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/actions.ts
@@ -4,6 +4,8 @@ import { verifySession } from "@/app/_lib/verifyAuthentication";
 import { parseWithZod } from "@conform-to/zod/v4";
 import { REDIRECT_REASON } from "@shared/constants/redirect-reasons";
 import { getEstimateDetailQueryFactory } from "@subdomains/estimate/application/factories/estimateQueryFactory";
+import { previewApplicationQueryFactory } from "@subdomains/estimate/application/factories/previewApplicationQueryFactory";
+import { submitApplicationCommandFactory } from "@subdomains/estimate/application/factories/submitApplicationCommandFactory";
 import { updateEstimateCommandFactory } from "@subdomains/estimate/application/factories/updateEstimateCommandFactory";
 import { updateVariationCommandFactory } from "@subdomains/estimate/application/factories/updateVariationCommandFactory";
 import { updateVariationMemosCommandFactory } from "@subdomains/estimate/application/factories/updateVariationMemosCommandFactory";
@@ -20,6 +22,9 @@ import type { UpdateVariationMemosInput } from "@subdomains/estimate/application
 import type { AddVariationInput } from "@subdomains/estimate/application/commands/AddVariationCommand";
 import type { ReviseForCustomerInput } from "@subdomains/estimate/application/commands/ReviseForCustomerCommand";
 import type { AdjustRevisedVariationInput } from "@subdomains/estimate/application/commands/AdjustRevisedVariationCommand";
+import type { SubmitApplicationResult } from "@subdomains/estimate/application/commands/SubmitApplicationCommand";
+import type { PreviewApplicationResultDTO } from "@subdomains/estimate/application/queries/dto/PreviewApplicationResultDTO";
+import type { ActionResult } from "@shared/types/ActionResult";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { handleCommandError } from "../../_shared/error-handler";
@@ -361,6 +366,92 @@ export async function updateVariationContent(
 
   revalidatePath(`/estimates/${estimateNumber}`);
   redirect(`/estimates/${estimateNumber}?reason=${REDIRECT_REASON.ESTIMATE_UPDATED}`);
+}
+
+/** 申請者の従業員情報が取得できない場合の共通文言（前例: 複製の作成者 null）。 */
+const OPERATOR_UNRESOLVED_MESSAGE =
+  "申請者の従業員情報が取得できないため申請できません。管理者にお問い合わせください。";
+
+/**
+ * 見積申請のプレビュー（S2・確認モーダル用・§6.2・#494）の Server Action。
+ *
+ * 確認モーダルを開いた時点で呼ばれる副作用なしの読み取り。フォーム送信ではないため conform を
+ * 通さず plain 引数を取り、`PreviewApplicationResultDTO` を {@link ActionResult} で包んで返す。
+ * operator は認証セッションの employeeId（null は申請不可）、estimateId は estimateNumber から DTO
+ * 再解決（client を信頼しない）、variationId は client エコー。preview は version を取らない
+ * （version 関門は submit 専任・ADR-0068）。BLOCKED/INACTIVE は業務例外ではなく preview の正常結果
+ * のため、これらは success:true の DTO として返す（モーダルが文言を描く・ADR-0069）。
+ */
+export async function previewApplication(
+  estimateNumber: string,
+  variationId: string
+): Promise<ActionResult<PreviewApplicationResultDTO>> {
+  const session = await verifySession();
+
+  const operatorEmployeeId = session.user.employeeId;
+  if (!operatorEmployeeId) {
+    return { success: false, error: OPERATOR_UNRESOLVED_MESSAGE };
+  }
+
+  const dto = await getEstimateDetailQueryFactory().execute({ estimateNumber });
+  if (!dto) {
+    return { success: false, error: "見積が見つかりません" };
+  }
+
+  try {
+    const preview = await previewApplicationQueryFactory().execute({
+      estimateId: dto.estimateId,
+      variationId,
+      operatorEmployeeId,
+    });
+    return { success: true, data: preview };
+  } catch (error) {
+    const errorResult = handleCommandError(error);
+    const errorMessage = !errorResult.success && errorResult.error ? errorResult.error : undefined;
+    return { success: false, error: errorMessage };
+  }
+}
+
+/**
+ * 見積申請の実行（S2・確認モーダルの確定・§6.3・#494・ADR-0068）の Server Action。
+ *
+ * operator は認証セッションの employeeId（null は申請不可）、estimateId は estimateNumber から DTO
+ * 再解決。version は preview 時に client が読んだ楽観ロックトークンをそのままエコーし、サーバでは
+ * 読み直さない（TOCTOU 防御の関門トークン・ADR-0068）。成功結末（申請 or 免除）は union を
+ * {@link ActionResult} で包んで返し、競合（ConflictError）・業務例外（BusinessRuleViolationError）は
+ * handleCommandError でメッセージ化する。redirect はせず、成功時のパネル更新・失敗時のバナー表示は
+ * 呼び出し元（VariationPanel）に委ねる（画面状態をユーザーから奪わない・#494）。
+ */
+export async function submitApplication(
+  estimateNumber: string,
+  variationId: string,
+  version: number
+): Promise<ActionResult<SubmitApplicationResult>> {
+  const session = await verifySession();
+
+  const operatorEmployeeId = session.user.employeeId;
+  if (!operatorEmployeeId) {
+    return { success: false, error: OPERATOR_UNRESOLVED_MESSAGE };
+  }
+
+  const dto = await getEstimateDetailQueryFactory().execute({ estimateNumber });
+  if (!dto) {
+    return { success: false, error: "見積が見つかりません" };
+  }
+
+  try {
+    const result = await submitApplicationCommandFactory().execute({
+      estimateId: dto.estimateId,
+      variationId,
+      operatorEmployeeId,
+      version,
+    });
+    return { success: true, data: result };
+  } catch (error) {
+    const errorResult = handleCommandError(error);
+    const errorMessage = !errorResult.success && errorResult.error ? errorResult.error : undefined;
+    return { success: false, error: errorMessage };
+  }
 }
 
 /**

--- a/src/app/(features)/estimates/[estimateNumber]/actions.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/actions.ts
@@ -373,6 +373,50 @@ const OPERATOR_UNRESOLVED_MESSAGE =
   "申請者の従業員情報が取得できないため申請できません。管理者にお問い合わせください。";
 
 /**
+ * `handleCommandError` を ActionResult<T> の失敗アームへブリッジする（#494・自動レビュー R1）。
+ *
+ * `handleCommandError` の戻り型は `ActionResult<void>` で、`success:true` アームの `data:void` が
+ * ジェネリック T と不一致になり `return handleCommandError(error)` は型が通らない。失敗アーム
+ * （T 非依存）だけを組み直して任意の ActionResult<T> に代入可能な形へ落とす。
+ */
+function toActionError(error: unknown): { success: false; error?: string } {
+  const result = handleCommandError(error);
+  return { success: false, error: result.success ? undefined : result.error };
+}
+
+/**
+ * 申請系 Server Action（preview / submit）の共通前処理を解決する（#494）。
+ *
+ * 認証セッションの operator（null は申請不可）と、estimateNumber から再解決した estimateId
+ * （client を信頼しない）を返す。`getEstimateDetail` はインフラ例外で reject しうるため try/catch で
+ * 囲み ActionResult 化する。呼び出し元は plain await でモーダルへ resolve する契約のため、ここで
+ * reject を漏らすと失敗導線（バナー・エラー文言）を握り潰す（#494・自動レビュー R1）。
+ */
+async function resolveApplicationContext(
+  estimateNumber: string
+): Promise<
+  | { success: true; operatorEmployeeId: string; estimateId: string }
+  | { success: false; error?: string }
+> {
+  const session = await verifySession();
+
+  const operatorEmployeeId = session.user.employeeId;
+  if (!operatorEmployeeId) {
+    return { success: false, error: OPERATOR_UNRESOLVED_MESSAGE };
+  }
+
+  try {
+    const dto = await getEstimateDetailQueryFactory().execute({ estimateNumber });
+    if (!dto) {
+      return { success: false, error: "見積が見つかりません" };
+    }
+    return { success: true, operatorEmployeeId, estimateId: dto.estimateId };
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+/**
  * 見積申請のプレビュー（S2・確認モーダル用・§6.2・#494）の Server Action。
  *
  * 確認モーダルを開いた時点で呼ばれる副作用なしの読み取り。フォーム送信ではないため conform を
@@ -386,29 +430,20 @@ export async function previewApplication(
   estimateNumber: string,
   variationId: string
 ): Promise<ActionResult<PreviewApplicationResultDTO>> {
-  const session = await verifySession();
-
-  const operatorEmployeeId = session.user.employeeId;
-  if (!operatorEmployeeId) {
-    return { success: false, error: OPERATOR_UNRESOLVED_MESSAGE };
-  }
-
-  const dto = await getEstimateDetailQueryFactory().execute({ estimateNumber });
-  if (!dto) {
-    return { success: false, error: "見積が見つかりません" };
+  const ctx = await resolveApplicationContext(estimateNumber);
+  if (!ctx.success) {
+    return ctx;
   }
 
   try {
     const preview = await previewApplicationQueryFactory().execute({
-      estimateId: dto.estimateId,
+      estimateId: ctx.estimateId,
       variationId,
-      operatorEmployeeId,
+      operatorEmployeeId: ctx.operatorEmployeeId,
     });
     return { success: true, data: preview };
   } catch (error) {
-    const errorResult = handleCommandError(error);
-    const errorMessage = !errorResult.success && errorResult.error ? errorResult.error : undefined;
-    return { success: false, error: errorMessage };
+    return toActionError(error);
   }
 }
 
@@ -427,30 +462,21 @@ export async function submitApplication(
   variationId: string,
   version: number
 ): Promise<ActionResult<SubmitApplicationResult>> {
-  const session = await verifySession();
-
-  const operatorEmployeeId = session.user.employeeId;
-  if (!operatorEmployeeId) {
-    return { success: false, error: OPERATOR_UNRESOLVED_MESSAGE };
-  }
-
-  const dto = await getEstimateDetailQueryFactory().execute({ estimateNumber });
-  if (!dto) {
-    return { success: false, error: "見積が見つかりません" };
+  const ctx = await resolveApplicationContext(estimateNumber);
+  if (!ctx.success) {
+    return ctx;
   }
 
   try {
     const result = await submitApplicationCommandFactory().execute({
-      estimateId: dto.estimateId,
+      estimateId: ctx.estimateId,
       variationId,
-      operatorEmployeeId,
+      operatorEmployeeId: ctx.operatorEmployeeId,
       version,
     });
     return { success: true, data: result };
   } catch (error) {
-    const errorResult = handleCommandError(error);
-    const errorMessage = !errorResult.success && errorResult.error ? errorResult.error : undefined;
-    return { success: false, error: errorMessage };
+    return toActionError(error);
   }
 }
 

--- a/src/app/(features)/estimates/[estimateNumber]/page.tsx
+++ b/src/app/(features)/estimates/[estimateNumber]/page.tsx
@@ -3,6 +3,7 @@ import { REDIRECT_REASON } from "@shared/constants/redirect-reasons";
 import { getActiveDepartmentsQueryFactory } from "@subdomains/department/application/factories/departmentQueryFactory";
 import {
   getEstimateDetailQueryFactory,
+  getVariationApplicationStatesQueryFactory,
   resolveEffectiveTaxRateQueryFactory,
 } from "@subdomains/estimate/application/factories/estimateQueryFactory";
 import { notFound } from "next/navigation";
@@ -43,9 +44,11 @@ export default async function EstimateDetailPage({
   // 部署プルダウン（編集フォーム・複製モーダル用・有効な部署のみ Q6）と既定日付の有効税率
   // （複製モーダルの read-only 初期値）は互いに独立なため並列解決する（詳細はホットパスで
   // 逐次 I/O を避ける）。
-  const [departments, initialTaxRate] = await Promise.all([
+  // 申請状態（#493・#494）も見積 ID が定まれば独立に読めるため同じ並列束で解決する。
+  const [departments, initialTaxRate, applicationStates] = await Promise.all([
     getActiveDepartmentsQueryFactory().execute({}),
     resolveEffectiveTaxRateQueryFactory().execute({ date: fromDateInputValue(today) }),
+    getVariationApplicationStatesQueryFactory().execute({ estimateId: estimate.estimateId }),
   ]);
   const departmentOptions = departments.map((d) => ({ id: d.id, name: d.name }));
 
@@ -78,6 +81,7 @@ export default async function EstimateDetailPage({
         estimateNumber={estimate.estimateNumber}
         version={estimate.version}
         variations={estimate.variations}
+        applicationStates={applicationStates}
         taxRate={estimate.taxRate}
         taxRoundingType={estimate.taxRoundingType}
         hasRevision={estimate.hasRevision}

--- a/src/app/(features)/estimates/[estimateNumber]/variationApplicationStateBadge.ts
+++ b/src/app/(features)/estimates/[estimateNumber]/variationApplicationStateBadge.ts
@@ -43,6 +43,24 @@ export function badgeToneOf(
   }
 }
 
+/** バッジ色調を Tailwind クラスへ写す（shadcn Badge に success/warning/info variant が無いため）。 */
+export function badgeToneClassName(tone: VariationApplicationStateBadgeTone): string {
+  switch (tone) {
+    case "neutral":
+      return "bg-gray-100 text-gray-700 border-gray-300";
+    case "info":
+      return "bg-blue-100 text-blue-800 border-blue-300";
+    case "success":
+      return "bg-green-100 text-green-800 border-green-300";
+    case "warning":
+      return "bg-amber-100 text-amber-800 border-amber-300";
+    default: {
+      const _exhaustive: never = tone;
+      return _exhaustive;
+    }
+  }
+}
+
 /** DTO の全フィールド（variationId / applicationState.code / label / canApply）を読む消費例。 */
 export type VariationApplicationStateBadge = {
   variationId: string;

--- a/src/app/(features)/estimates/estimates-application.e2e.ts
+++ b/src/app/(features)/estimates/estimates-application.e2e.ts
@@ -1,0 +1,87 @@
+import { type Page, expect, test } from "@playwright/test";
+
+/**
+ * 見積申請（S2・§6・#494）の E2E。操作行「申請」→ 確認モーダル（プレビュー）→ 実行のフローを、
+ * 承認免除（EXEMPT）・承認必要（REQUIRED）の両経路と、INACTIVE バリの申請ボタン無効化＋ツールチップで
+ * 検証する。
+ *
+ * 認証は user 固定ユーザー（EMP000002・営業本部長）で実行する。申請の operator はログインセッションの
+ * employeeId で、その上位役割（営業本部長 → 社長）が承認チェーンの起点になる。既定の admin（社長）は
+ * 上位役割を持たず REQUIRED が BLOCKED になるため、上位を持つ user に切り替える（§5.1）。
+ *
+ * 検証範囲（ADR-0012・UI 観測可能な範囲。申請/免除レコードの DB 直接参照はドメイン/アプリの
+ * ユニットテスト済みとして扱い、ここでは画面の状態遷移で観測する）:
+ * - (1) 税込10万円未満は EXEMPT。「承認不要」＋免除理由 label を出し、申請→承認不要バッジへ遷移する
+ * - (2) 税込10万〜100万は REQUIRED。承認チェーンを出し、申請→申請中バッジへ遷移する
+ * - (3) INACTIVE バリの申請ボタンは無効（canApply=false）でツールチップを持つ／ACTIVE バリは活性
+ */
+
+// user 固定ユーザー（営業本部長・上位=社長）で実行する。operator の起点役割が要るため admin では不可。
+test.use({ storageState: "playwright/.auth/user.json" });
+
+const EN = {
+  exempt: "N9905008",
+  required: "N9905009",
+  inactive: "N9905010",
+} as const;
+
+async function waitForDetailReady(page: Page, estimateNumber: string) {
+  await expect(page.getByRole("heading", { level: 1, name: estimateNumber })).toBeVisible();
+}
+
+async function selectVariationTab(page: Page, variationNumber: number) {
+  await page.getByRole("tab", { name: `バリエーション${variationNumber}` }).click();
+}
+
+test("税込10万円未満は承認不要（EXEMPT）で、申請すると承認不要バッジへ遷移する", async ({
+  page,
+}) => {
+  await page.goto(`/estimates/${EN.exempt}`);
+  await waitForDetailReady(page, EN.exempt);
+
+  // 操作行の「申請」トリガーから確認モーダルを開く。
+  await page.getByRole("button", { name: "申請", exact: true }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+
+  // 承認不要（BELOW_THRESHOLD）: 免除理由 label と「申請する」ボタンが出る。
+  await expect(page.getByText("10万円未満")).toBeVisible();
+  await page.getByRole("button", { name: "申請する" }).click();
+
+  // 申請後、承認不要（EXEMPTED）バッジへ遷移し、再申請できない（canApply=false）。
+  await expect(page.getByText("承認不要", { exact: true })).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole("button", { name: "申請", exact: true })).toBeDisabled();
+});
+
+test("税込10万〜100万は承認必要（REQUIRED）で、申請すると申請中バッジへ遷移する", async ({
+  page,
+}) => {
+  await page.goto(`/estimates/${EN.required}`);
+  await waitForDetailReady(page, EN.required);
+
+  await page.getByRole("button", { name: "申請", exact: true }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+
+  // 承認必要: 承認チェーンの見出しと「申請する」ボタンが出る（具体役職名はチェーン構成に依存するため
+  // 構造だけを観測する）。
+  await expect(page.getByText("承認チェーン")).toBeVisible();
+  await page.getByRole("button", { name: "申請する" }).click();
+
+  // 申請後、申請中（PENDING）バッジへ遷移し、再申請できない（canApply=false）。
+  await expect(page.getByText("申請中", { exact: true })).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole("button", { name: "申請", exact: true })).toBeDisabled();
+});
+
+test("INACTIVE バリの申請ボタンは無効でツールチップを持ち、ACTIVE バリは活性", async ({ page }) => {
+  await page.goto(`/estimates/${EN.inactive}`);
+  await waitForDetailReady(page, EN.inactive);
+
+  // V2（INACTIVE）: 申請ボタンは無効化され、無効理由のツールチップを持つ。
+  await selectVariationTab(page, 2);
+  const inactiveApply = page.getByRole("button", { name: "申請", exact: true });
+  await expect(inactiveApply).toBeDisabled();
+  await expect(inactiveApply).toHaveAttribute("title", "無効なバリエーションは申請できません");
+
+  // V1（ACTIVE・未申請）: 申請ボタンは活性。
+  await selectVariationTab(page, 1);
+  await expect(page.getByRole("button", { name: "申請", exact: true })).toBeEnabled();
+});

--- a/src/server/subdomains/estimate/application/commands/SubmitApplicationCommand.ts
+++ b/src/server/subdomains/estimate/application/commands/SubmitApplicationCommand.ts
@@ -13,7 +13,7 @@ import {
 import { EstimateRepository } from "@subdomains/estimate/domain/repositories/EstimateRepository";
 import { EstimateApplicationRepository } from "@subdomains/estimate/domain/repositories/approval/EstimateApplicationRepository";
 import { EstimateApprovalExemptionRepository } from "@subdomains/estimate/domain/repositories/approval/EstimateApprovalExemptionRepository";
-import { type ApprovalChainBlockedReason } from "@subdomains/estimate/domain/services/approval/ApprovalChainBuilder";
+import { BLOCKED_REASON_LABELS } from "@subdomains/estimate/domain/services/approval/ApprovalChainBuilder";
 import { AdvancingVariationPolicy } from "@subdomains/estimate/domain/policies/approval/AdvancingVariationPolicy";
 import { EstimateVariationId } from "@subdomains/estimate/domain/values/EstimateVariationId";
 import { VariationApplicationState } from "@subdomains/estimate/domain/values/approval/VariationApplicationState";
@@ -37,17 +37,6 @@ export type SubmitApplicationResult =
       attempt: number;
     }
   | { kind: "ApprovalExempted"; exemptionId: string; reason: string };
-
-function blockedMessage(reason: ApprovalChainBlockedReason): string {
-  switch (reason) {
-    case "NO_SUPERIOR_ROLE":
-      return "申請者に上位役割が設定されていないため申請できません（§5.2）";
-    case "GOAL_UNREACHABLE":
-      return "必要な承認職位まで組織が届かないため申請できません（§5.2）";
-    case "NO_APPROVER":
-      return "承認対象役割に承認者が存在しないため申請できません（§5.2）";
-  }
-}
 
 /**
  * 見積申請コマンド（version 関門で「1見積1前進」を直列化・ADR-0068・ADR-20260626-dee・#417・§6.3）
@@ -99,7 +88,7 @@ export class SubmitApplicationCommand {
 
     // 4. BLOCKED は Preview にとっては正常結果だが、Submit は境界で業務例外へ昇格する。
     if (result.kind === "BLOCKED") {
-      throw new BusinessRuleViolationError(blockedMessage(result.reason));
+      throw new BusinessRuleViolationError(BLOCKED_REASON_LABELS[result.reason]);
     }
 
     // 5-6. version 関門と挿入を単一トランザクションで原子化する（atomic submit・ADR-20260626-dee）。

--- a/src/server/subdomains/estimate/application/queries/PreviewApplicationQuery.ts
+++ b/src/server/subdomains/estimate/application/queries/PreviewApplicationQuery.ts
@@ -4,6 +4,7 @@ import { PositionQueryService } from "@subdomains/position/application/queries/P
 import { ProductQueryService } from "@subdomains/product/application/queries/ProductQueryService";
 import { RoleQueryService } from "@subdomains/role/application/queries/RoleQueryService";
 import { EstimateRepository } from "@subdomains/estimate/domain/repositories/EstimateRepository";
+import { BLOCKED_REASON_LABELS } from "@subdomains/estimate/domain/services/approval/ApprovalChainBuilder";
 import { assembleApprovalChain } from "../shared/approval/assembleApprovalChain";
 import { loadApprovalChainInputs } from "../shared/approval/loadApprovalChainInputs";
 import {
@@ -49,7 +50,12 @@ export class PreviewApplicationQuery {
     // `targetVariationIsActive` を判定の起点に置き、judge＋チェーン組立ての前に弾く。これを
     // 怠ると Preview だけが INACTIVE でも EXEMPT/REQUIRED を見せ、Submit と可否が食い違う（#442）。
     if (!loaded.targetVariationIsActive) {
-      return { kind: "INACTIVE" };
+      // canApply ゲートが INACTIVE を弾くため、ここへ到達する＝表示後に無効化されたレース。
+      // ユーザーに画面更新を促す固定文言を BE から載せる（表示文言は BE 所有・ADR-0069）。
+      return {
+        kind: "INACTIVE",
+        label: "このバリエーションは無効化されています。画面を更新して最新の状態をご確認ください。",
+      };
     }
 
     const result = assembleApprovalChain(loaded.assemblerInput);
@@ -58,7 +64,11 @@ export class PreviewApplicationQuery {
       return { kind: "EXEMPT", reason: result.reason.value, reasonLabel: result.reason.label };
     }
     if (result.kind === "BLOCKED") {
-      return { kind: "BLOCKED", reason: result.reason };
+      return {
+        kind: "BLOCKED",
+        reason: result.reason,
+        reasonLabel: BLOCKED_REASON_LABELS[result.reason],
+      };
     }
 
     // REQUIRED: 役割 ID 列を表示名へ解決する（起点→ゴール順）。

--- a/src/server/subdomains/estimate/application/queries/__tests__/PreviewApplicationQuery.test.ts
+++ b/src/server/subdomains/estimate/application/queries/__tests__/PreviewApplicationQuery.test.ts
@@ -131,7 +131,11 @@ describe("PreviewApplicationQuery", () => {
       operatorEmployeeId: ids.estimate.employeeId,
     });
 
-    expect(result).toEqual({ kind: "BLOCKED", reason: "NO_SUPERIOR_ROLE" });
+    expect(result).toEqual({
+      kind: "BLOCKED",
+      reason: "NO_SUPERIOR_ROLE",
+      reasonLabel: "申請者に上位役割が設定されていないため申請できません",
+    });
   });
 
   it("INACTIVE バリエーションは judge を走らせず INACTIVE を返す（Submit と可否一致）", async () => {
@@ -150,7 +154,10 @@ describe("PreviewApplicationQuery", () => {
     });
 
     // Submit（無効なバリエーションには申請できない）と可否が一致する。
-    expect(result).toEqual({ kind: "INACTIVE" });
+    expect(result).toEqual({
+      kind: "INACTIVE",
+      label: "このバリエーションは無効化されています。画面を更新して最新の状態をご確認ください。",
+    });
 
     // 副作用なし（クエリのため申請行・免除行を作らない）。
     const applications = await prisma.estimateApplication.count({ where: { variationId } });

--- a/src/server/subdomains/estimate/application/queries/dto/PreviewApplicationResultDTO.ts
+++ b/src/server/subdomains/estimate/application/queries/dto/PreviewApplicationResultDTO.ts
@@ -20,6 +20,11 @@ export type PreviewApplicationStepDTO = {
  * `INACTIVE` はチェーン構築以前の「バリエーション状態」の事実で、`BLOCKED`（承認チェーンが
  * 組めない業務理由）とは原因が異なるため専用 kind に分ける。Submit が `targetVariationIsActive`
  * を判定の起点に置くのと同じく、Preview も judge を走らせる前にこれを返す（#442）。
+ *
+ * 実行不可の3分岐（EXEMPT は確認可・BLOCKED/INACTIVE は不可）の表示文言はすべて BE 所有とし、
+ * モーダルは受け取った label をそのまま描く（ADR-0069）。`BLOCKED` は理由 code に対応する
+ * `reasonLabel`（{@link BLOCKED_REASON_LABELS} 由来）、`INACTIVE` は code 集合を持たない単一 kind
+ * ゆえ `reason` を持たず固定の `label` 単体を載せる。
  */
 export type PreviewApplicationResultDTO =
   | { kind: "EXEMPT"; reason: string; reasonLabel: string }
@@ -29,5 +34,5 @@ export type PreviewApplicationResultDTO =
       goalPositionName: string;
       steps: PreviewApplicationStepDTO[];
     }
-  | { kind: "BLOCKED"; reason: ApprovalChainBlockedReason }
-  | { kind: "INACTIVE" };
+  | { kind: "BLOCKED"; reason: ApprovalChainBlockedReason; reasonLabel: string }
+  | { kind: "INACTIVE"; label: string };

--- a/src/server/subdomains/estimate/domain/services/approval/ApprovalChainBuilder.ts
+++ b/src/server/subdomains/estimate/domain/services/approval/ApprovalChainBuilder.ts
@@ -51,6 +51,20 @@ export type ApprovalChainBuildInput = {
 export type ApprovalChainBlockedReason = "NO_SUPERIOR_ROLE" | "GOAL_UNREACHABLE" | "NO_APPROVER";
 
 /**
+ * BLOCKED 理由のユーザー向け表示文言（単一ソース・ADR-0069 原則#2）。
+ *
+ * EXEMPT の label 源が VO（{@link EstimateExemptionReason}）に code＋label を同梱するのと対称に、
+ * BLOCKED も理由 code の隣で文言を持つ。`ApprovalChainBlockedReason` は永続化されない判別子のため
+ * full-VO は過剰で、`Record` の軽量 map で足りる。Preview（reasonLabel）と Submit（業務例外 message）が
+ * ともにここから引き、文言のドリフトを防ぐ。内部参照（§記号）はユーザー向け文言には載せない。
+ */
+export const BLOCKED_REASON_LABELS: Record<ApprovalChainBlockedReason, string> = {
+  NO_SUPERIOR_ROLE: "申請者に上位役割が設定されていないため申請できません",
+  GOAL_UNREACHABLE: "必要な承認職位まで組織が届かないため申請できません",
+  NO_APPROVER: "承認対象役割に承認者が存在しないため申請できません",
+};
+
+/**
  * 承認チェーン構築の結果（判別共用体）。
  *
  * `BUILT` は構築済みの VO 計画を持ち、`BLOCKED` は構築不能の業務理由を持つ。組織グラフの

--- a/src/server/subdomains/estimate/domain/services/approval/__tests__/ApprovalChainBuilder.test.ts
+++ b/src/server/subdomains/estimate/domain/services/approval/__tests__/ApprovalChainBuilder.test.ts
@@ -2,7 +2,12 @@ import { InvalidArgumentError } from "@server/shared/errors/DomainError";
 import { PositionId } from "@subdomains/position/domain/values/PositionId";
 import { RoleId } from "@subdomains/role/domain/values/RoleId";
 import { describe, expect, it } from "vitest";
-import { ApprovalChainBuilder, type ApprovalChainOrgRole } from "../ApprovalChainBuilder";
+import {
+  ApprovalChainBuilder,
+  BLOCKED_REASON_LABELS,
+  type ApprovalChainBlockedReason,
+  type ApprovalChainOrgRole,
+} from "../ApprovalChainBuilder";
 import { ApprovalGoalTier } from "../../../values/approval/ApprovalGoalTier";
 
 /** 上位リンクで連なる役割ノード列を作る（index 昇順で下位→上位）。tiers の順に役職段階を割り当てる。 */
@@ -162,6 +167,26 @@ describe("ApprovalChainBuilder", () => {
           snapshot: { applicantSuperiorRoleId: RoleId.generate(), roles },
         })
       ).toThrow(InvalidArgumentError);
+    });
+  });
+
+  describe("BLOCKED_REASON_LABELS（ユーザー向け文言の単一ソース）", () => {
+    const REASONS: ApprovalChainBlockedReason[] = [
+      "NO_SUPERIOR_ROLE",
+      "GOAL_UNREACHABLE",
+      "NO_APPROVER",
+    ];
+
+    it("全ての BLOCKED 理由に対しユーザー向け文言を持つ", () => {
+      for (const reason of REASONS) {
+        expect(BLOCKED_REASON_LABELS[reason]).toBeTruthy();
+      }
+    });
+
+    it("ユーザー向け文言に内部参照（§記号）を含めない", () => {
+      for (const reason of REASONS) {
+        expect(BLOCKED_REASON_LABELS[reason]).not.toContain("§");
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

見積詳細画面（S2）に見積申請 UI を配線。申請ボタン（VariationPanel）→確認モーダル（EXEMPT/REQUIRED/BLOCKED/INACTIVE 分岐）→ Server Actions（previewApplication/submitApplication）の申請フローを実装。BE 契約（ADR-0069）を直 type-import で消費し、モーダル消費のため PreviewApplicationResultDTO に BLOCKED reasonLabel / INACTIVE label を同梱する preview 是正も実施。action マッピング契約テストと E2E を追加。

Closes #494

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### estimate-application-fe-modal-and-actions.md

# Issue #494: 見積申請 FE（申請ボタン・確認モーダル・Server Actions） — 実装計画

## 概要

見積詳細画面（S2）にバリエーション申請 UI を実装する。申請ボタン → 確認モーダル（プレビュー）→ 実行のフロー（仕様書 §6）を、#491 で合意した BE 契約（ADR-0069）を直 type-import で消費して配線する。あわせて、モーダルが消費する当事者として `PreviewApplicationResultDTO` の小さな是正（BLOCKED/INACTIVE の label 同梱）を本 issue で行う。

grill-with-docs セッションでコード・ADR と突き合わせた結果、Issue 本文から複数の是正（主に `EstimateApplicationPersistError` の撤去済み事実の反映、ボタン無効化ゲートの単一化）が確定した。詳細は「設計判断」に記載し、完了時に `deviations.md` へ記録する。

CONTEXT.md は新規用語が生じないため変更しない（「見積申請」は既に「申請」の _Avoid_ に収録済み。申請対象はバリエーションであり、新設物はバリエーション申請の語彙で統一する）。新規 ADR も起票しない（リカバリ方針は局所的な FE UX で、コンポーネントの doc コメント＋PR に記録する）。

## 設計判断

### `EstimateApplicationPersistError` の扱い
- A. Issue 本文どおりエラー経路として処理する
- B. スコープから除外する
- **確定: B**。ADR-20260626-dee の bump+insert 原子化により「bump 成功・insert 失敗」が発生し得なくなり、本例外は撤去済み（コードベースに存在しない）。submit のエラーは `ConflictError` と正常 union の 2 分岐のみ。存在しない型へのハンドラはデッドコード＋コンパイルエラーになる。Issue 本文は #440 撤去以前の記述に引きずられた陳腐化。

### 申請ボタンの無効化ゲート
- A. Issue 本文どおり `isVariationApplicable`（`status === "ACTIVE"` を要求）を新設し、`canApply=false` と併用
- B. `canApply` 単一ゲート。`isVariationApplicable` は新設しない
- **確定: B**。`VariationApplicationStateDTO.canApply` は既に「ACTIVE かつ 見積内に前進バリなし」と定義され INACTIVE は false。`isVariationApplicable`（ACTIVE のみ）は canApply の部分再導出にすぎず、無効化式 `!isVariationApplicable || !canApply` は `!canApply` に潰れる。ADR-0069 が禁じる「FE による BE 状態語彙の再発明（ドリフト源）」に該当。tooltip 文言の出し分けは手元の `variation.status` で足りる（INACTIVE →「無効なバリエーションは申請できません」／ACTIVE かつ !canApply →「既に前進しているバリエーションがあります」）。

### BLOCKED ラベルの単一ソース
- A. Issue 本文どおり `blockedMessage` を application-shared へ引き上げ
- B. code 定義に隣接した `BLOCKED_REASON_LABELS` map をドメインに co-locate
- **確定: B**。EXEMPT の label 源 `EstimateExemptionReason` は VO に code＋label を同梱（ADR-0069 原則#2）。BLOCKED も対称にすべき。`ApprovalChainBlockedReason` は非永続の判別子なので full-VO は過剰、`Record<ApprovalChainBlockedReason, string>` の軽量 map を `ApprovalChainBuilder` 隣に co-locate。`PreviewApplicationQuery`（reasonLabel）と `SubmitApplicationCommand`（error message）が同一ソースから引く。ユーザー向け label からは内部参照「（§5.2）」を落とす。

### INACTIVE の自己記述
- A. DTO に BE 供給の `label` を追加
- B. FE 固定定数で描画（DTO は `{kind:"INACTIVE"}` のまま）
- **確定: A**。モーダルの実行不可分岐（BLOCKED.reasonLabel / INACTIVE.label）の表示文言を全て BE 所有に統一。INACTIVE は code 集合を持たない単一 kind なので `reason` は持たず `label` 単体（VO/map 不要、`PreviewApplicationQuery` が固定のレース自覚文言を載せる）。

### preview 消費のコンパイル時型証明
- A. Issue 本文どおり独立した消費スタブファイルを新設
- B. 実モーダルの `kind` 網羅 switch（never ガード付き default）に内蔵
- **確定: B**。独立スタブは実描画とドリフトしうる（スタブだけ緑でも実モーダルが網羅漏れ）。本 issue は実モーダルを実装するので、その描画 switch 自体を証明にすれば drift 余地ゼロ。DTO に kind が増減すれば実モーダルが即コンパイルエラー、pre-push の `tsc --noEmit` が gate。

### submit 失敗リカバリ
- A. モーダル内で再プレビュー＋再確認
- B. モーダル強制クローズ＋パネル上部の永続バナー（auto-refresh しない）
- **確定: B**。理由（1）preview は兄弟前進を見ない（4 分岐に「兄弟前進で申請不可」が無い）ため、素の再プレビューは誤って再確認ボタンを出しループ・誤誘導する。（2）ユーザーがメモ等を編集中／文言をコピーしたい可能性があるため、`router.refresh()` で画面状態を勝手に奪わない。よって ConflictError / BusinessRuleViolationError 共通で、モーダルを強制クローズしパネル上部へ永続バナー（`handleCommandError` の message ＋「内容を確認・必要な情報を控えてから F5 か一覧へ戻って更新」）を出し、更新タイミングはユーザーに委ねる。auto-refresh は呼ばない。バナー表示中も申請ボタンは押下可のまま（無駄な再試行はバナーで自明、強制はしない）。トレードオフ: パネルの canApply・バッジ・金額は古いまま表示され続けるため、バナーで「最新ではない」と明示警告する。

### operator（session.user.employeeId）が null の場合
- 既存「null は複製不可」前例踏襲のため判断不要。preview / submit 両アクションに null ガードを置きメッセージを返す（「申請者の従業員情報が取得できないため申請できません。管理者にお問い合わせください。」）。前段のボタン抑止はしない。preview の null エラーはモーダル内メッセージ＋閉じる（状態変化ではない前提条件エラーなのでバナー導線に乗せない）。

### Server Actions のマッピング
- 既存パターン踏襲のため判断不要。operator は `session.user.employeeId` から注入、`estimateId` は `estimateNumber` から `getEstimateDetailQueryFactory` で再解決、`variationId`(UUID) は client エコー、`version` は submit のみ client エコー・サーバで読み直さない（TOCTOU・ADR-0068）。

### §6.2 仕様書の是正範囲
- **確定**: BLOCKED を実装の 3 値（`NO_SUPERIOR_ROLE`/`GOAL_UNREACHABLE`/`NO_APPROVER`）に更新＋欠落している INACTIVE 分岐を追加＋ EXEMPT/BLOCKED/INACTIVE が BE 供給 label を持つことを明記。submit 失敗リカバリの UX は FE 実装詳細のため仕様書には含めない。

## ステップ

### Step 1: BLOCKED ラベルのドメイン単一ソース化
- 対象ファイル: `src/server/subdomains/estimate/domain/services/approval/ApprovalChainBuilder.ts`（or 隣接ファイル）、`src/server/subdomains/estimate/application/commands/SubmitApplicationCommand.ts`
- 作業内容:
  - `ApprovalChainBlockedReason` の隣に `BLOCKED_REASON_LABELS: Record<ApprovalChainBlockedReason, string>` を co-locate（ユーザー向け文言・「（§5.2）」は含めない）
  - `SubmitApplicationCommand` の private `blockedMessage` を撤去し、error message を map から引く
- コミットメッセージ: `refactor: BLOCKED理由ラベルをドメインのBLOCKED_REASON_LABELSへ単一ソース化`

### Step 2: PreviewApplicationResultDTO の是正（BLOCKED.reasonLabel / INACTIVE.label）
- 対象ファイル: `src/server/subdomains/estimate/application/queries/dto/PreviewApplicationResultDTO.ts`、`src/server/subdomains/estimate/application/queries/PreviewApplicationQuery.ts`、（既存テスト）`.../queries/__tests__/PreviewApplicationQuery.test.ts`
- 作業内容:
  - DTO の BLOCKED に `reasonLabel`、INACTIVE に `label` を追加
  - `PreviewApplicationQuery` が BLOCKED 時に `BLOCKED_REASON_LABELS` から reasonLabel を、INACTIVE 時に固定のレース自覚 label を populate
  - Query テストを新フィールドに追随
- コミットメッセージ: `feat: 申請プレビューDTOのBLOCKED/INACTIVE分岐を自己記述化（reasonLabel/label同梱）`

### Step 3: Server Actions（previewApplication / submitApplication）
- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/actions.ts`、（必要なら）対応スキーマ
- 作業内容:
  - operator を session 注入（null ガード＋メッセージ）、`estimateId` を estimateNumber から再解決、`variationId` client エコー、`version` は submit のみ client エコー
  - preview は `PreviewApplicationResultDTO` を返す（or ActionResult ラップ）、submit は `handleCommandError` で ConflictError/BusinessRuleViolationError を message 化
- コミットメッセージ: `feat: 申請プレビュー・申請実行のServer Actionsを追加`

### Step 4: action マッピング契約テスト
- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/__tests__/`（既存前例に倣う）
- 作業内容:
  - operator がセッション注入され client 入力を無視する / `estimateId` が estimateNumber から再解決される / `version` が client エコーされサーバで読み直されない、を固定
- コミットメッセージ: `test: 申請Server Actionのマッピング契約テストを追加`

### Step 5: 確認モーダルコンポーネント
- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/`（新規モーダルコンポーネント）
- 作業内容:
  - open 時に previewApplication を呼び、`kind` を網羅 switch（never ガード）で描画（EXEMPT/REQUIRED/BLOCKED/INACTIVE）＝コンパイル時消費証明を内蔵
  - REQUIRED はチェーン全体（課長→部長(最終)）＋金額（`VariationDTO.finalTotal`）を表示し確認ボタン、BLOCKED/INACTIVE は文言のみで確認を出さない、EXEMPT は理由 label ＋確認
  - submit 成功は既存流儀で閉じてパネル更新、失敗（ConflictError/BusinessRuleViolationError）は VariationPanel へコールバックして強制クローズ
  - operator null の preview エラーはモーダル内メッセージ＋閉じる
- コミットメッセージ: `feat: 見積申請の確認モーダル（プレビュー分岐描画）を追加`

### Step 6: VariationPanel への申請ボタン・バッジ・失敗バナー配線
- 対象ファイル: `src/app/(features)/estimates/[estimateNumber]/VariationPanel.tsx`、`page.tsx`、`variationApplicationStateBadge.ts` 周辺、`variationEditable.ts`（必要な範囲）
- 作業内容:
  - `page.tsx` で `GetVariationApplicationStates` を取得し `VariationPanel` へ渡す（variationId で `VariationDTO` と join）
  - 申請ボタンを常に表示、無効化は `canApply` 単一ゲート、tooltip は `variation.status` で文言選択（`isVariationApplicable` は新設しない）
  - バリエーション別バッジに `applicationState.label` を表示（既存 stub を土台に肉付け）
  - submit 失敗時の永続バナー state を VariationPanel に lift（パネル上部・`role="alert"`・auto-refresh なし・申請ボタンは押下可）
- コミットメッセージ: `feat: 見積詳細に申請ボタン・申請状態バッジ・競合バナーを配線`

### Step 7: 仕様書 §6.2 の是正
- 対象ファイル: `docs/business/estimate/システム設計書(申請).md`
- 作業内容:
  - BLOCKED を 3 値に更新、INACTIVE 分岐を追加、EXEMPT/BLOCKED/INACTIVE が BE 供給 label を持つことを明記
- コミットメッセージ: `docs: 申請設計書§6.2をpreview契約の実態（3値BLOCKED・INACTIVE・label）に追随`

### Step 8: E2E ＋ 逸脱記録
- 対象ファイル: 見積詳細の E2E spec、`docs/claude-plans/issue-494/deviations.md`
- 作業内容:
  - 申請→preview→確認→submit を実 DB（seed）で承認必要・承認免除の両経路、INACTIVE のボタン前段無効化＋tooltip を検証
  - deviations.md に本計画の逸脱（PersistError 除外／isVariationApplicable 不新設／BLOCKED ラベルのドメイン配置／preview 証明の実モーダル内蔵／リカバリのバナー方式）を記録
- コミットメッセージ: `test: 見積申請フローのE2Eテストを追加`

</details>

## 計画からの逸脱

# Issue #494 実装の逸脱記録

計画（`estimate-application-fe-modal-and-actions.md`）および Issue #494 本文と、実際の実装との差分を記録する。
大半は grill-with-docs でコード・ADR と突き合わせた結果、Issue 本文の陳腐化を是正したものであり、
計画時点で合意済み。実装フェーズで計画からさらに逸脱した点は末尾に別記する。

## Issue 本文 → 計画で確定した是正

### ① `EstimateApplicationPersistError` の扱い（スコープ除外）
- **元の計画（Issue 本文）**: submit のエラー経路として `EstimateApplicationPersistError` をハンドルする。
- **実際の実装**: ハンドルしない（型自体が存在しない）。submit のエラーは `ConflictError` と正常 union の 2 分岐のみ。
- **逸脱の理由**: ADR-20260626-dee の bump+insert 原子化により「bump 成功・insert 失敗」が発生し得なくなり、
  本例外は #440 で撤去済み。Issue 本文は撤去以前の ADR-0068 記述に引きずられていた。存在しない型への
  ハンドラはデッドコード＋コンパイルエラーになる。

### ② 申請ボタンの無効化ゲート（`isVariationApplicable` 不新設）
- **元の計画（Issue 本文）**: `isVariationApplicable`（`status === "ACTIVE"` を要求）を新設し `canApply=false` と併用。
- **実際の実装**: `canApply` 単一ゲート。`isVariationApplicable` は新設しない。無効時のツールチップ文言だけ
  手元の `variation.status` で選ぶ。
- **逸脱の理由**: `VariationApplicationStateDTO.canApply` は既に「ACTIVE かつ 見積内に前進バリなし」と定義され
  INACTIVE は false。`isVariationApplicable`（ACTIVE のみ）は canApply の部分再導出にすぎず、無効化式
  `!isVariationApplicable || !canApply` は `!canApply` に潰れる。ADR-0069 が禁じる「FE による BE 状態語彙の
  再発明（ドリフト源）」に該当。

### ③ BLOCKED ラベルの単一ソース（ドメイン co-locate）
- **元の計画（Issue 本文）**: `blockedMessage` を application-shared へ引き上げる。
- **実際の実装**: `ApprovalChainBlockedReason` の隣（ドメイン層 `ApprovalChainBuilder.ts`）に
  `BLOCKED_REASON_LABELS: Record<ApprovalChainBlockedReason, string>` を co-locate。
- **逸脱の理由**: EXEMPT の label 源 `EstimateExemptionReason`（VO に code＋label 同梱）と対称にすべき
  （ADR-0069 原則#2）。`ApprovalChainBlockedReason` は非永続の判別子ゆえ full-VO は過剰で `Record` の軽量 map。
  Preview（reasonLabel）と Submit（業務例外 message）が同一ソースから引く。ユーザー向け文言から内部参照
  「（§5.2）」を落とした。

### ④ preview 消費のコンパイル時型証明（実モーダル内蔵）
- **元の計画（Issue 本文）**: 独立した消費スタブファイルを新設する。
- **実際の実装**: 実モーダル（`ApplicationConfirmDialog`）の `kind` 網羅 switch（never ガード付き default）に内蔵。
- **逸脱の理由**: 独立スタブは実描画とドリフトしうる（スタブだけ緑でも実モーダルが網羅漏れ）。本 issue は実モーダルを
  実装するので、その描画 switch 自体を証明にすれば drift 余地ゼロ。DTO に kind が増減すれば実モーダルが即コンパイル
  エラーになり pre-push の `tsc --noEmit` が gate。

### ⑤ submit 失敗リカバリ（バナー方式・auto-refresh しない）
- **元の計画（Issue 本文）**: モーダル内で再プレビュー＋再確認、または `router.refresh()` で自動更新。
- **実際の実装**: モーダル強制クローズ＋パネル上部の永続バナー（`role="alert"`）。`router.refresh()` は呼ばず、
  更新タイミングはユーザーに委ねる。ConflictError / BusinessRuleViolationError 共通。
- **逸脱の理由**: (1) preview は兄弟前進を見ない（4 分岐に「兄弟前進で申請不可」が無い）ため、素の再プレビューは
  誤って再確認ボタンを出しループ・誤誘導する。(2) ユーザーがメモ等を編集中／文言をコピーしたい可能性があるため、
  `router.refresh()` で画面状態を勝手に奪わない。パネルの canApply・バッジ・金額は古いままのため、バナーで
  「最新ではない」と明示警告する。

## 実装フェーズでの計画からの追加逸脱

### ⑥ 確認モーダルコンポーネント名を `ApplicationConfirmDialog` に確定
- **元の計画**: 「新規モーダルコンポーネント」（名称未定）。
- **実際の実装**: `ApplicationConfirmDialog.tsx`。
- **逸脱の理由**: 既存の自己完結ダイアログ命名（`ReviseForCustomerDialog`）に倣い、「確認モーダル」の役割を名に表した。

### ⑦ バッジ色調ヘルパー `badgeToneClassName` を追加
- **元の計画**: バッジは既存 stub（`variationApplicationStateBadge.ts`）を土台に肉付け。
- **実際の実装**: 同ファイルに `badgeToneClassName`（tone → Tailwind クラス）を追加し、shadcn Badge に無い
  success/warning/info 相当の配色を補った。
- **逸脱の理由**: shadcn Badge の variant は default/secondary/destructive/outline のみで、申請状態の 4 tone を
  表現できない。tone→className の写像を既存バッジ消費ファイルに co-locate した（網羅 switch＋never ガード）。


---

Generated with [Claude Code](https://claude.ai/code)
