### PR TITLE
docs: auto-review-fix の Phase 1 レビュー結果を PR に確実に記録する

### DIFF
--- a/.claude/skills/auto-review-fix/SKILL.md
+++ b/.claude/skills/auto-review-fix/SKILL.md
@@ -70,7 +70,7 @@ ls docs/claude-plans/issue-{番号}/
 
 ## ループ本体（最大 3 ラウンド）
 
-以下の Phase 1〜5 を、**終了条件に達するまで**繰り返す。ラウンド番号を `R`（1 始まり）とする。
+以下の Phase 1 → 1.5 → 2〜5 を、**終了条件に達するまで**繰り返す。ラウンド番号を `R`（1 始まり）とする。
 
 ### 終了条件（いずれか満たしたら停止）
 
@@ -84,12 +84,36 @@ ls docs/claude-plans/issue-{番号}/
 
 ### Phase 1: レビュー（組み込み `/code-review` を確実に使う）
 
-**`Skill` ツールで `code-review` スキルを起動する（`skill: code-review`、`args: {深さ} --comment`）。** ここはメイン文脈で実行する（`Skill` ツールはサブエージェント内では起動できないため）。
+**`Skill` ツールで `code-review` スキルを起動する（`skill: code-review`、`args: {深さ} {base}...HEAD`）。** ここはメイン文脈で実行する（`Skill` ツールはサブエージェント内では起動できないため）。
 
-- **`--comment` を付ける**: レビュー結果を PR に残すため。生の `/code-review` 指摘が PR の記録として残る。
+- **/code-review は「検出専用」として使う**（PR への記録は Phase 1.5 に一本化する）。`--comment` は **付けない**: インライン投稿はアンカー不能分が黙って落ちる不確実な経路であり、Phase 1.5 のトップレベル投稿と重複するため。
+- **レビュー対象を PR の ref 範囲に固定する（`{base}...HEAD`）**: `{base}` は PR のベースブランチ（通常 `develop`。Phase 0.2 の `gh pr view --json baseRefName` で確認し、`develop` でなければそれを使う）。
+  - 理由: `/code-review` の既定スコープは「upstream より先行しているコミット＋未コミット変更」であり、push 直後やトラッキング設定次第で **レビューした diff が PR の diff と食い違う**。ref 範囲形式は upstream 設定に依らず「その PR が持つコミット差分」をレビューするため、スコープが PR と一致する。未コミット変更（PR に無い）を拾う事故も防ぐ。
 - `--fix` は **付けない**（評価前に勝手に直させない）。修正は評価（judge）を通ったバケツ①②③だけに限定する。
-- findings はセッション内にも表示されるので、それを次の評価ステージへ渡す。
-- `/code-review` が指摘ゼロを返したら「収束」。Phase 6 へ。
+- **findings はセッション内に必ず表示される**ので、それを丸ごと控えて Phase 1.5・Phase 2 へ渡す。判定と記録の一次情報は **この セッション findings**。
+
+### Phase 1.5: findings の記録（トップレベル投稿）と Phase 2 ゲート
+
+**生 findings を auto-review-fix 側（メイン文脈）が決定的に PR へ記録する。** これを通してからでないと Phase 2 に進まない。
+
+1. **findings 0 件の判定（収束ゲート）**: Phase 1 のセッション findings が空（`/code-review` が指摘ゼロ）なら「収束」。**Phase 2 に進まず Phase 6 へ**。
+2. **findings ≥1 件なら、生 findings をトップレベルコメントとして必ず投稿する**（行アンカー不要なので 100% 残る）:
+
+```bash
+gh pr comment {PR番号} --body "$(cat <<'EOF'
+## 🔍 /code-review 生レビュー ラウンド {R}（深さ {深さ} / 対象 {base}...HEAD）
+
+Phase 1 の `/code-review` が返した指摘（judge 評価前の一次情報）:
+
+- [severity参考:{severity}] {file:line} {問題}
+EOF
+)"
+```
+
+3. 投稿の成否を確認する（`gh pr comment` の終了コード）。**投稿できなければ Phase 2 に進まない**（原因を記録して停止する）。
+4. 投稿できたら、そのセッション findings を持って Phase 2 へ。
+
+> これにより「Phase 1 の結果が PR に載らないまま Phase 2 に進む」が構造的に起きなくなる。PR には「Phase 1.5 の生レビュー（トップレベル）」「Phase 2 の judge 判定」の 2 層が記録として残る。
 
 ### Phase 2: 評価（fresh subagent で妥当性を judge）— **鵜呑みにしない**
 
@@ -100,7 +124,7 @@ ls docs/claude-plans/issue-{番号}/
 
 judge サブエージェントへのプロンプトに以下を**すべて**渡す:
 
-1. **`/code-review` の指摘リスト**（Phase 1 の出力そのまま）
+1. **`/code-review` の指摘リスト**（**Phase 1 のセッション findings をそのまま**。Phase 1.5 でトップレベル投稿したものと同一の一次情報。PR のインラインコメントを読み直すのではなく、この findings を判定材料にする）
 2. **実装の変更内容**: `git diff develop..HEAD`
 3. **計画ファイルの中身**: `docs/claude-plans/issue-{番号}/*.md`（`deviations.md` 含む。無い場合はその旨）
 4. 下記「バケツ分類基準」と「③ cleanup の採用基準」


### PR DESCRIPTION
## 背景・課題

`auto-review-fix` で **Phase 1 の `/code-review` 結果が PR にコメントされないまま Phase 2 に進む**ことが多かった。

### 原因（ドキュメント確認済み）

組み込み `/code-review` の仕様に起因する2点:

1. **`--comment` はインライン投稿のみ**: PR の diff 行にアンカーできた指摘しか投稿されず、アンカー不能な指摘は黙って落ちる。一方 findings はセッションに全部出るため「PRコメントなし × Phase 2 続行」が成立していた。
2. **既定スコープのズレ**: 既定の対象は「upstream より先行コミット＋未コミット変更」で、push 直後やトラッキング設定次第で **レビューした diff が PR の diff と食い違う**。

## 対応

| 変更 | 内容 |
|---|---|
| **スコープ固定** | Phase 1 の対象を `{base}...HEAD`（通常 `develop...HEAD`）の ref 範囲に固定。upstream 設定に依らず PR 差分と一致させる |
| **記録の一本化** | `--comment` を撤去。`/code-review` は検出専用（セッション findings を返すだけ）に |
| **Phase 1.5 新設** | 生 findings を **トップレベル `gh pr comment`** で決定的に記録（行アンカー不要で必ず残る） |
| **進行ゲート** | Phase 1.5 を通すまで Phase 2 に進ませない。findings 0 は収束で Phase 6、投稿失敗は停止 |
| **judge 入力の明確化** | judge の一次情報は PR コメントではなく**セッション findings**と明示 |

## 設計判断

記録を `/code-review` の副作用（`--comment`）に委ねず、auto-review-fix 側の `gh pr comment` に一本化した。理由: 投稿経路を1本にすると「記録は必ず Phase 1.5 が担保する」という不変条件が単純になり、進行ゲートを検証可能にできるため。

PR に残る記録は「生レビュー（Phase 1.5）」「judge 判定（Phase 2）」の2層に単純化される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)