### PR TITLE
feat: 従業員登録・更新画面に担当役割の設定UIを追加する（FE＋e2e）

### DIFF
--- a/docs/claude-plans/issue-568/assigned-role-select-ui-fe.md
+++ b/docs/claude-plans/issue-568/assigned-role-select-ui-fe.md
@@ -1,0 +1,99 @@
+# Issue #568: 従業員登録・更新画面に担当役割の設定UIを追加する（FE＋e2e） — 実装計画
+
+## 概要
+
+#565（担当役割割当BE）のフロントエンド＋e2e。従業員の登録・更新フォームに **担当役割セレクト**（全役割のドロップダウン・任意選択／解除可）を追加する。更新時は `EmployeeDTO.assignedRoleId` を preselect し、本人が旧役割の唯一メンバーである場合に **承認者不在ワーニング**（非ブロッキング）を反応的に表示する。BE 契約（`CreateEmployeeInput.roleId?` / `UpdateEmployeeInput.roleId?` / `EmployeeDTO.assignedRoleId: string | null` / `RoleQueryService.isSoleMember` / `findAll`）は #565 で確定済み。
+
+**実装方式は TDD（red-green-refactor）を前提**とする。各ステップは失敗するテスト（コンポーネントテスト or e2e）を先に書き、実装で green にする流れで進める。
+
+**リリース順序ハザード**: #565（PR #570）は「roleId 未指定＝解除」の意味論を持つため、本 #568 の FE（roleId フォーム欄）と **同時出荷が必須**。本計画の e2e Step（回帰テスト）がその唯一の網。
+
+## 設計判断
+
+### 役割セレクトの供給方式
+- A1. `RoleSelectField` サーバスロットを新設（`DepartmentSelectField` に倣う）
+- A2. `page.tsx` が `findAll` で全役割を取得し `{id,name}[]` を props でクライアントフォームへ渡す
+- **採用: A2**。承認者不在ワーニングの反応性はフォームが値を所有していると最も堅牢。issue 本文「page.tsx で役割一覧を供給」とも一致。部署のスロット方式は「反応性不要」前提で選ばれたもので、roleId が要件的に異なることは正当な逸脱。
+
+### 役割セレクトの描画配線
+- 共通 `SelectField`（生 select・onChange 非公開）を再利用
+- 権限セレクトと同じ `<select {...getSelectProps(fields.roleId)}>` インライン描画
+- **採用: getSelectProps インライン**。`fields.roleId.value` を反応的に読む要件に対し、repo 内で実証済みなのは conform 配線フィールド（`getInputProps`/`getSelectProps`、`ReviseForm` 先例）のみ。生 select の反応性は未実証のため賭けない。先頭に `<option value="">（担当役割なし）</option>`、以降 `name` のみをラベルに `map`。
+
+### roleId スキーマの型
+- `employeeBaseSchema` に `roleId: z.string().optional()` を追加（create/update 両方が extend するため1箇所で足りる）
+- `min(1)`・uuid 検証は付けない。conform が空文字を undefined 化する（[[conform-empty-string-to-undefined]]）ため `.optional()` 必須。空選択＝解除が BE の「未指定＝解除」と一致。存在検証はセレクトの選択肢が制約し、改竄は BE の `new RoleId()` が弾く（`departmentId` も schema では uuid 検証しない既存方針と整合）。
+
+### 承認者不在ワーニングのデータフロー
+- `[employeeCd]/page.tsx` で現在の `assignedRoleId` に対し `isSoleMember` を **1回スナップショット** → `isSoleMemberOfCurrentRole: boolean` をフォームへ。`assignedRoleId==null` ならクエリせず false。
+- クライアントは `assignedRoleId != null && isSoleMemberOfCurrentRole && fields.roleId.value !== assignedRoleId` で反応的に表示。
+- スナップショットで十分（非ブロッキング警告。陳腐化しても最終整合は承認時 `NO_APPROVER` が担保）。変更・解除どちらも「本人が旧役割から抜ける」点で同じなので条件は「値が元と異なる」の一本。
+
+### ワーニング UI
+- 琥珀色（`bg-yellow-50` `border-yellow-400` `text-yellow-800`）、`role="status"` `aria-live="polite"`（エラーの `role="alert"` とは別扱い）。
+- 旧役割名を供給された一覧（id→name）から解決して明示。文言例:「⚠️ この従業員は現在「{旧役割名}」の唯一の担当者です。担当役割を変更・解除しても更新はできますが、この役割の承認が承認者不在になる可能性があります。」
+- 非ブロッキング（更新ボタンを無効化しない・フォームエラーにしない）。値が元に戻れば消える。
+
+### 権限（authorization）
+- 担当役割セレクトも既存フィールドと同じ `disabled={isPending || !canUpdate}`（owner も自分の担当役割を編集可）。
+- 担当役割だけ admin 限定にせず兄弟フィールド（特に既に owner 編集可の権限セレクト）と統一。自己エスカレーション懸念は権限セレクトにも既存で存在するため横断的な別課題。
+
+### 役割オプションの表示
+- ラベルは `role.name` のみ、並び順は `roleCd` 昇順。役割名が既に役職を内包し、`DepartmentSelectField`（name 単独＋cd 昇順）の先例と揃う。
+
+### e2e のテストデータ（シード追加なし）
+- (A)回帰は破棄可能な `EMP999901` チェーンを拡張、(B)警告は既存の唯一メンバー `EMP000004`（ROLE004）で非保存検証。DB 不変フィクスチャ（`EMP999001` 等）を汚さない。
+
+### スコープ外
+- 一覧の担当役割列は **#578** に分離（#567 で上位役割列も同時検討。名前解決方式が ADR-0013 と #565 判断の緊張点）。
+
+### ADR / CONTEXT
+- ADR 起票なし（各決定は FE/UI で可逆、非ブロッキング理由・#565 同時出荷理由は既に issue/CONTEXT に記録済み）。
+- CONTEXT.md 更新なし（導入したのは UI アフォーダンスで新規ドメイン用語ではない）。
+
+## ステップ
+
+### Step 1: スキーマに roleId を追加
+- 対象ファイル: `src/app/(features)/employees/_shared/schema.ts`
+- 作業内容:
+  - TDD: `employeeBaseSchema` の `roleId` について、未指定・空文字・有効値のパース結果を検証するスキーマテストを先に書く（conform 経路の空文字→undefined を意識）
+  - `employeeBaseSchema` に `roleId: z.string().optional()` を追加
+- コミットメッセージ: `feat: 従業員フォームスキーマに担当役割(roleId)を追加`
+
+### Step 2: 登録フォームに担当役割セレクトを追加
+- 対象ファイル: `src/app/(features)/employees/new/page.tsx`, `new/EmployeeCreateForm.tsx`, `new/EmployeeCreateForm.test.tsx`, `new/actions.ts`
+- 作業内容:
+  - TDD: `EmployeeCreateForm.test.tsx` に「担当役割セレクトが表示され、（担当役割なし）を含む役割オプションが並ぶ」テストを追加（red）
+  - `new/page.tsx` で `PrismaRoleQueryService.findAll({ orderBy: { field: "roleCd", direction: "asc" } })` を取得し `{id,name}[]` を `EmployeeCreateForm` に渡す
+  - `EmployeeCreateForm` に `getSelectProps(fields.roleId)` インラインの担当役割セレクト（先頭に空オプション「（担当役割なし）」）を追加
+  - `actions.ts` の `createEmployee` で `submission.value.roleId` を Command に受け渡し
+- コミットメッセージ: `feat: 従業員登録画面に担当役割セレクトを追加`
+
+### Step 3: 更新フォームに担当役割セレクトと preselect を追加
+- 対象ファイル: `src/app/(features)/employees/[employeeCd]/page.tsx`, `[employeeCd]/EmployeeUpdateForm.tsx`, `[employeeCd]/EmployeeUpdateForm.test.tsx`, `[employeeCd]/actions.ts`
+- 作業内容:
+  - TDD: `EmployeeUpdateForm.test.tsx` に「`assignedRoleId` が preselect される／`canUpdate=false` で disabled」テストを追加（red）
+  - `Employee` prop 型に `assignedRoleId: string | null` を追加、`page.tsx` から DTO 経由で供給、役割一覧も供給
+  - `EmployeeUpdateForm` に担当役割セレクト（`getSelectProps`・`defaultValue.roleId = assignedRoleId ?? ""`・`disabled={isPending || !canUpdate}`）を追加
+  - `updateEmployee` actions で `roleId` を Command に受け渡し
+- コミットメッセージ: `feat: 従業員更新画面に担当役割セレクトとpreselectを追加`
+
+### Step 4: 承認者不在ワーニングを追加
+- 対象ファイル: `src/app/(features)/employees/[employeeCd]/page.tsx`, `[employeeCd]/EmployeeUpdateForm.tsx`, `[employeeCd]/EmployeeUpdateForm.test.tsx`
+- 作業内容:
+  - TDD: `EmployeeUpdateForm.test.tsx` に「唯一メンバーがセレクトを変更/解除すると警告表示、元に戻すと消える／唯一メンバーでなければ出ない」テストを追加（red）
+  - `page.tsx` で `assignedRoleId != null` のとき `RoleQueryService.isSoleMember(assignedRoleId, employeeId)` を1回呼び `isSoleMemberOfCurrentRole` をフォームへ渡す
+  - `EmployeeUpdateForm` に反応的ワーニング（琥珀色・`role="status"`・旧役割名解決・非ブロッキング）を追加
+- コミットメッセージ: `feat: 担当役割の承認者不在ワーニング(非ブロッキング)を追加`
+
+### Step 5: e2e 回帰テスト（役割残存）を追加
+- 対象ファイル: `src/app/(features)/employees/employees-crud.e2e.ts`
+- 作業内容:
+  - `EMP999901` の serial チェーンを拡張：作成時に担当役割セレクトで1つ選択 → 更新で名前のみ変更・保存 → 保存後の編集フォームで担当役割セレクトが選択済み残存を assert（リリースハザード F1 の唯一の網）
+- コミットメッセージ: `test: 役割保有従業員の編集で担当役割が残存するe2e回帰を追加`
+
+### Step 6: e2e 承認者不在ワーニング表示テストを追加
+- 対象ファイル: `src/app/(features)/employees/employees-crud.e2e.ts`
+- 作業内容:
+  - `EMP000004`（ROLE004 唯一メンバー）の編集画面でセレクトを解除／別役割へ変更 → 警告表示を assert → 保存しない（DB 不変を維持）
+- コミットメッセージ: `test: 担当役割の承認者不在ワーニング表示のe2eを追加`

--- a/docs/claude-plans/issue-568/r1-fix-plan.md
+++ b/docs/claude-plans/issue-568/r1-fix-plan.md
@@ -1,0 +1,28 @@
+# Issue #568 auto-review-fix ラウンド1 修正計画
+
+`/code-review medium` → judge 評価で **採用①②=1件 / 採用③=1件** を修正対象とする。却下④（4件）は Phase 6 サマリで報告のみ。
+
+## 対象1: ① correctness — Create フォームの defaultValue が担当役割をサイレントに消す
+
+- バケツ: ① correctness / severity(参考): High
+- file:line: `src/app/(features)/employees/new/EmployeeCreateForm.tsx:150`
+- 問題: `<select {...getSelectProps(fields.roleId)} defaultValue="">` の spread 後 `defaultValue=""` が、サーバ検証エラー再描画時に conform が再投入する submitted 値を上書きし、選択済み担当役割が「（担当役割なし）」に戻る。ユーザーが役割を選択→他項目の検証エラーで再描画→再送信すると役割なしで作成されるデータ不整合。
+- 修正方針: `defaultValue=""` を削除し、conform の再投入（getSelectProps 由来の defaultValue）に委ねる。先頭に `<option value="">（担当役割なし）</option>` があるため初期未選択の挙動は不変。更新フォーム（EmployeeUpdateForm.tsx）が既に inline defaultValue を付けていない流儀に統一する。
+- 影響範囲: 単一 select 要素のみ。初期描画は先頭 option により value="" のまま（挙動不変）。エラー再描画時のみ挙動が正される。
+- 想定テスト: `EmployeeCreateForm.test.tsx` の既存「担当役割セレクトが表示され…既定値 ""」テストが緑のまま。回帰確認は `pnpm test` 全体。
+
+## 対象2: ③ efficiency — page.tsx の逐次 await を並列化
+
+- バケツ: ③ efficiency / severity(参考): Low
+- file:line: `src/app/(features)/employees/[employeeCd]/page.tsx:29-41`
+- 採用根拠(③): 挙動不変（findAll と isSoleMember は独立した読み取りクエリ）・設計判断不要（Promise.all への機械的変換・置き場所は同一関数内に一意）・局所的（単一関数・シグネチャ不変・レイヤ非越境）。
+- 問題: `findAll` を await 完了後に `isSoleMember` を await しており DB 往復が直列。isSoleMember は roles に非依存。
+- 修正方針: `Promise.all([findAll(...), employee.assignedRoleId ? isSoleMember(...) : Promise.resolve(false)])` で並列化。roles の map 整形は Promise.all 後に行う。
+- 影響範囲: `[employeeCd]/page.tsx` の Page 関数内のみ。返り値・props は不変。
+- 想定テスト: page はサーバコンポーネントで単体テスト無し。挙動不変のため `pnpm test`（既存 EmployeeUpdateForm テスト）緑＋ `pnpm lint` で担保。
+
+## 修正順
+
+1. 先に ① EmployeeCreateForm.tsx（`fix:`）
+2. 次に ③ page.tsx（`refactor:`）
+3. 計画ファイル自体は `docs:`

--- a/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.test.tsx
+++ b/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.test.tsx
@@ -63,6 +63,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -84,6 +85,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -100,6 +102,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -115,6 +118,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -128,6 +132,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -144,6 +149,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -160,6 +166,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -173,6 +180,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -186,10 +194,127 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={false}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
       expect(screen.getByLabelText("担当役割")).toBeDisabled();
+    });
+  });
+
+  describe("承認者不在ワーニング（非ブロッキング）", () => {
+    // 唯一メンバー（isSoleMemberOfCurrentRole=true）が現在の担当役割「開発部長」(role-2) から
+    // 抜けるケース。旧役割名を明示した警告を反応的に表示する。
+    const soleMemberEmployee = { ...mockEmployee, assignedRoleId: "role-2" };
+
+    test("初期状態（現在の役割のまま）では警告は表示されない", () => {
+      render(
+        <EmployeeUpdateForm
+          employee={soleMemberEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={true}
+        />
+      );
+
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    test("唯一メンバーが別の担当役割へ変更すると旧役割名入りの警告が表示される", async () => {
+      const user = userEvent.setup();
+      render(
+        <EmployeeUpdateForm
+          employee={soleMemberEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={true}
+        />
+      );
+
+      await user.selectOptions(screen.getByLabelText("担当役割"), "role-1");
+
+      const warning = await screen.findByRole("status");
+      expect(warning).toBeInTheDocument();
+      // 旧役割名を明示
+      expect(warning).toHaveTextContent("開発部長");
+    });
+
+    test("唯一メンバーが担当役割を解除しても警告が表示される", async () => {
+      const user = userEvent.setup();
+      render(
+        <EmployeeUpdateForm
+          employee={soleMemberEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={true}
+        />
+      );
+
+      await user.selectOptions(screen.getByLabelText("担当役割"), "");
+
+      expect(await screen.findByRole("status")).toBeInTheDocument();
+    });
+
+    test("変更後に元の担当役割へ戻すと警告は消える", async () => {
+      const user = userEvent.setup();
+      render(
+        <EmployeeUpdateForm
+          employee={soleMemberEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={true}
+        />
+      );
+
+      await user.selectOptions(screen.getByLabelText("担当役割"), "role-1");
+      expect(await screen.findByRole("status")).toBeInTheDocument();
+
+      await user.selectOptions(screen.getByLabelText("担当役割"), "role-2");
+      await waitFor(() => {
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      });
+    });
+
+    test("唯一メンバーでなければ担当役割を変更しても警告は出ない", async () => {
+      const user = userEvent.setup();
+      render(
+        <EmployeeUpdateForm
+          employee={soleMemberEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
+        />
+      );
+
+      await user.selectOptions(screen.getByLabelText("担当役割"), "role-1");
+
+      await waitFor(() => {
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      });
+    });
+
+    test("担当役割が未設定の従業員では変更しても警告は出ない", async () => {
+      const user = userEvent.setup();
+      render(
+        <EmployeeUpdateForm
+          employee={{ ...mockEmployee, assignedRoleId: null }}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
+        />
+      );
+
+      await user.selectOptions(screen.getByLabelText("担当役割"), "role-1");
+
+      await waitFor(() => {
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -201,6 +326,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -214,6 +340,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -227,6 +354,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -244,6 +372,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={false}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -257,6 +386,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={false}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -270,6 +400,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={false}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -288,6 +419,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -312,6 +444,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -334,6 +467,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -357,6 +491,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -402,6 +537,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -441,6 +577,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 
@@ -476,6 +613,7 @@ describe("EmployeeUpdateForm", () => {
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
           roleOptions={mockRoleOptions}
+          isSoleMemberOfCurrentRole={false}
         />
       );
 

--- a/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.test.tsx
+++ b/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.test.tsx
@@ -27,6 +27,7 @@ const mockEmployee = {
   employeeCd: "EMP000001",
   departmentId: "dept-1",
   role: USER_ROLES.USER,
+  assignedRoleId: null,
   version: 3,
 };
 
@@ -38,6 +39,12 @@ const mockDepartmentSelectSlot = (
     <option value="dept-2">開発部</option>
   </select>
 );
+
+// 担当役割オプションのモック（page.tsx が findAll で取得し {id,name}[] を供給）
+const mockRoleOptions = [
+  { id: "role-1", name: "営業課長" },
+  { id: "role-2", name: "開発部長" },
+];
 
 describe("EmployeeUpdateForm", () => {
   beforeEach(() => {
@@ -55,6 +62,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -75,6 +83,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -90,6 +99,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -104,6 +114,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -116,11 +127,69 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
       expect(screen.getByRole("option", { name: "一般ユーザー" })).toBeInTheDocument();
       expect(screen.getByRole("option", { name: "管理者" })).toBeInTheDocument();
+    });
+  });
+
+  describe("担当役割セレクト", () => {
+    test("担当役割セレクトが表示され、（担当役割なし）を含む役割オプションが並ぶ", () => {
+      render(
+        <EmployeeUpdateForm
+          employee={mockEmployee}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
+
+      expect(screen.getByLabelText("担当役割")).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "（担当役割なし）" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "営業課長" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "開発部長" })).toBeInTheDocument();
+    });
+
+    test("assignedRoleId が現在の担当役割として preselect される", () => {
+      render(
+        <EmployeeUpdateForm
+          employee={{ ...mockEmployee, assignedRoleId: "role-2" }}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
+
+      expect(screen.getByLabelText("担当役割")).toHaveValue("role-2");
+    });
+
+    test("担当役割が未設定なら空選択（担当役割なし）が初期値", () => {
+      render(
+        <EmployeeUpdateForm
+          employee={{ ...mockEmployee, assignedRoleId: null }}
+          canUpdate={true}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
+
+      expect(screen.getByLabelText("担当役割")).toHaveValue("");
+    });
+
+    test("canUpdate=false のとき担当役割セレクトは無効になる", () => {
+      render(
+        <EmployeeUpdateForm
+          employee={{ ...mockEmployee, assignedRoleId: "role-2" }}
+          canUpdate={false}
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
+
+      expect(screen.getByLabelText("担当役割")).toBeDisabled();
     });
   });
 
@@ -131,6 +200,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -143,6 +213,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -155,6 +226,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -171,6 +243,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={false}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -183,6 +256,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={false}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -195,6 +269,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={false}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -212,6 +287,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -235,6 +311,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -256,6 +333,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -278,6 +356,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -322,6 +401,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -360,6 +440,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 
@@ -394,6 +475,7 @@ describe("EmployeeUpdateForm", () => {
           employee={mockEmployee}
           canUpdate={true}
           departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
         />
       );
 

--- a/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.tsx
+++ b/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.tsx
@@ -14,6 +14,8 @@ type Employee = {
   employeeCd: string;
   departmentId: string;
   role: UserRole | null;
+  /** 現在の担当役割ID（EmployeeRole から導出、役割なし＝課員は null）。編集画面の preselect に用いる */
+  assignedRoleId: string | null;
   /** 楽観ロックトークン（ADR-0039）。編集画面表示時の値をフォームで往復させる */
   version: number;
 };
@@ -23,9 +25,16 @@ type Props = {
   canUpdate: boolean;
   /** 部署選択フィールド（Server Component を slot として受け取る） */
   departmentSelectSlot: React.ReactNode;
+  /** 担当役割の選択肢（page.tsx が findAll で取得し roleCd 昇順で供給） */
+  roleOptions: { id: string; name: string }[];
 };
 
-export function EmployeeUpdateForm({ employee, canUpdate, departmentSelectSlot }: Props) {
+export function EmployeeUpdateForm({
+  employee,
+  canUpdate,
+  departmentSelectSlot,
+  roleOptions,
+}: Props) {
   // LEARN: bind()でemployeeCdを事前にバインド(server-action-bind-vs-formdata.md)
   const updateEmployeeWithEmployeeCd = updateEmployee.bind(null, employee.employeeCd);
 
@@ -37,6 +46,8 @@ export function EmployeeUpdateForm({ employee, canUpdate, departmentSelectSlot }
       email: employee.email,
       departmentId: employee.departmentId,
       role: employee.role ?? USER_ROLES.USER,
+      // 現在の担当役割を preselect。null（役割なし）は空文字で解除選択にマップ
+      roleId: employee.assignedRoleId ?? "",
       version: String(employee.version),
     },
   });
@@ -138,6 +149,31 @@ export function EmployeeUpdateForm({ employee, canUpdate, departmentSelectSlot }
           {fields.role.errors && (
             <p className="text-red-500 text-xs mt-1" id={fields.role.errorId}>
               {fields.role.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor={fields.roleId.id} className="block text-gray-700 text-sm font-bold mb-2">
+            担当役割
+          </label>
+          {/* preselect は conform の defaultValue.roleId が担う。承認者不在ワーニングの
+              反応性のため権限セレクトと同じく getSelectProps 配線でフォームに値を所有させる。 */}
+          <select
+            {...getSelectProps(fields.roleId)}
+            disabled={isPending || !canUpdate}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+          >
+            <option value="">（担当役割なし）</option>
+            {roleOptions.map((role) => (
+              <option key={role.id} value={role.id}>
+                {role.name}
+              </option>
+            ))}
+          </select>
+          {fields.roleId.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.roleId.errorId}>
+              {fields.roleId.errors[0]}
             </p>
           )}
         </div>

--- a/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.tsx
+++ b/src/app/(features)/employees/[employeeCd]/EmployeeUpdateForm.tsx
@@ -27,6 +27,11 @@ type Props = {
   departmentSelectSlot: React.ReactNode;
   /** 担当役割の選択肢（page.tsx が findAll で取得し roleCd 昇順で供給） */
   roleOptions: { id: string; name: string }[];
+  /**
+   * 現在の担当役割において本人が唯一のメンバーか（page.tsx で1回スナップショット・#565 isSoleMember）。
+   * 担当役割なし（assignedRoleId==null）のときは false。承認者不在ワーニングの反応表示に使う。
+   */
+  isSoleMemberOfCurrentRole: boolean;
 };
 
 export function EmployeeUpdateForm({
@@ -34,6 +39,7 @@ export function EmployeeUpdateForm({
   canUpdate,
   departmentSelectSlot,
   roleOptions,
+  isSoleMemberOfCurrentRole,
 }: Props) {
   // LEARN: bind()でemployeeCdを事前にバインド(server-action-bind-vs-formdata.md)
   const updateEmployeeWithEmployeeCd = updateEmployee.bind(null, employee.employeeCd);
@@ -51,6 +57,15 @@ export function EmployeeUpdateForm({
       version: String(employee.version),
     },
   });
+
+  // 承認者不在ワーニングの反応判定（非ブロッキング）:
+  // 本人が現在の担当役割の唯一メンバーで、かつセレクトの値が現在値から変わった（変更 or 解除）とき表示。
+  // fields.roleId.value を反応的に読むため conform 配線の getSelectProps が前提。
+  // スナップショット（isSoleMemberOfCurrentRole）で十分：陳腐化しても最終整合は承認時の NO_APPROVER が担保。
+  const currentRoleId = employee.assignedRoleId;
+  const willLeaveCurrentRole =
+    currentRoleId != null && isSoleMemberOfCurrentRole && fields.roleId.value !== currentRoleId;
+  const currentRoleName = roleOptions.find((role) => role.id === currentRoleId)?.name;
 
   return (
     <div className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-8">
@@ -175,6 +190,17 @@ export function EmployeeUpdateForm({
             <p className="text-red-500 text-xs mt-1" id={fields.roleId.errorId}>
               {fields.roleId.errors[0]}
             </p>
+          )}
+          {/* 承認者不在ワーニング（非ブロッキング）。エラーの role="alert" とは別扱いの role="status"。 */}
+          {willLeaveCurrentRole && (
+            <div
+              role="status"
+              aria-live="polite"
+              className="mt-2 rounded border border-yellow-400 bg-yellow-50 px-4 py-3 text-sm text-yellow-800"
+            >
+              ⚠️ この従業員は現在「{currentRoleName}
+              」の唯一の担当者です。担当役割を変更・解除しても更新はできますが、この役割の承認が承認者不在になる可能性があります。
+            </div>
           )}
         </div>
 

--- a/src/app/(features)/employees/[employeeCd]/actions.ts
+++ b/src/app/(features)/employees/[employeeCd]/actions.ts
@@ -33,7 +33,7 @@ export async function updateEmployee(employeeCd: string, prevState: unknown, for
     return submission.reply();
   }
 
-  const { name, email, role, departmentId, version } = submission.value;
+  const { name, email, role, departmentId, version, roleId } = submission.value;
 
   // employeeCdからidを取得（version は再取得値ではなくフォーム由来の値を使う。
   // 再取得値を使うと常に最新 version でチェックが素通りし、編集ウィンドウを守れない / ADR-0039）
@@ -61,6 +61,7 @@ export async function updateEmployee(employeeCd: string, prevState: unknown, for
       employeeCd,
       departmentId,
       role,
+      roleId,
       expectedVersion: version,
     });
 

--- a/src/app/(features)/employees/[employeeCd]/page.tsx
+++ b/src/app/(features)/employees/[employeeCd]/page.tsx
@@ -32,6 +32,12 @@ export default async function Page({ params }: { params: Promise<{ employeeCd: s
   });
   const roleOptions = roles.map((role) => ({ id: role.id, name: role.name }));
 
+  // 承認者不在ワーニング用に、現在の担当役割で本人が唯一メンバーかを1回スナップショット（#565 isSoleMember）。
+  // 担当役割なし（assignedRoleId==null）ならクエリせず false。
+  const isSoleMemberOfCurrentRole = employee.assignedRoleId
+    ? await roleQueryService.isSoleMember(employee.assignedRoleId, employee.id)
+    : false;
+
   return (
     <div className="container mx-auto p-8">
       <h1 className="text-3xl font-bold mb-8">従業員管理</h1>
@@ -41,6 +47,7 @@ export default async function Page({ params }: { params: Promise<{ employeeCd: s
         employee={employee}
         canUpdate={canUpdate}
         roleOptions={roleOptions}
+        isSoleMemberOfCurrentRole={isSoleMemberOfCurrentRole}
         departmentSelectSlot={
           <DepartmentSelectField
             name="departmentId"

--- a/src/app/(features)/employees/[employeeCd]/page.tsx
+++ b/src/app/(features)/employees/[employeeCd]/page.tsx
@@ -3,6 +3,7 @@ import { DepartmentSelectField } from "@/app/_components/form";
 import { isAdmin, isOwner } from "@server/shared/auth";
 import { GetEmployeeByEmployeeCdQuery } from "@subdomains/employee/application/queries/GetEmployeeByEmployeeCdQuery";
 import { PrismaEmployeeQueryService } from "@subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService";
+import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
 import { notFound } from "next/navigation";
 import { EmployeeDeleteForm } from "./EmployeeDeleteForm";
 import { EmployeeUpdateForm } from "./EmployeeUpdateForm";
@@ -24,6 +25,13 @@ export default async function Page({ params }: { params: Promise<{ employeeCd: s
   const canUpdate = isAdmin(session) || isOwner(session, employee.id);
   const canDelete = isAdmin(session);
 
+  // 担当役割の選択肢を供給（A2・roleCd 昇順）
+  const roleQueryService = new PrismaRoleQueryService();
+  const roles = await roleQueryService.findAll({
+    orderBy: { field: "roleCd", direction: "asc" },
+  });
+  const roleOptions = roles.map((role) => ({ id: role.id, name: role.name }));
+
   return (
     <div className="container mx-auto p-8">
       <h1 className="text-3xl font-bold mb-8">従業員管理</h1>
@@ -32,6 +40,7 @@ export default async function Page({ params }: { params: Promise<{ employeeCd: s
       <EmployeeUpdateForm
         employee={employee}
         canUpdate={canUpdate}
+        roleOptions={roleOptions}
         departmentSelectSlot={
           <DepartmentSelectField
             name="departmentId"

--- a/src/app/(features)/employees/[employeeCd]/page.tsx
+++ b/src/app/(features)/employees/[employeeCd]/page.tsx
@@ -25,18 +25,19 @@ export default async function Page({ params }: { params: Promise<{ employeeCd: s
   const canUpdate = isAdmin(session) || isOwner(session, employee.id);
   const canDelete = isAdmin(session);
 
-  // 担当役割の選択肢を供給（A2・roleCd 昇順）
+  // 担当役割の選択肢供給（A2・roleCd 昇順）と、承認者不在ワーニング用の唯一メンバー判定
+  // （#565 isSoleMember）は互いに独立した読み取りクエリなので並列に発行する。
+  // 担当役割なし（assignedRoleId==null）なら isSoleMember はクエリせず false。
   const roleQueryService = new PrismaRoleQueryService();
-  const roles = await roleQueryService.findAll({
-    orderBy: { field: "roleCd", direction: "asc" },
-  });
+  const [roles, isSoleMemberOfCurrentRole] = await Promise.all([
+    roleQueryService.findAll({
+      orderBy: { field: "roleCd", direction: "asc" },
+    }),
+    employee.assignedRoleId
+      ? roleQueryService.isSoleMember(employee.assignedRoleId, employee.id)
+      : Promise.resolve(false),
+  ]);
   const roleOptions = roles.map((role) => ({ id: role.id, name: role.name }));
-
-  // 承認者不在ワーニング用に、現在の担当役割で本人が唯一メンバーかを1回スナップショット（#565 isSoleMember）。
-  // 担当役割なし（assignedRoleId==null）ならクエリせず false。
-  const isSoleMemberOfCurrentRole = employee.assignedRoleId
-    ? await roleQueryService.isSoleMember(employee.assignedRoleId, employee.id)
-    : false;
 
   return (
     <div className="container mx-auto p-8">

--- a/src/app/(features)/employees/_shared/schema.conform.test.ts
+++ b/src/app/(features)/employees/_shared/schema.conform.test.ts
@@ -1,0 +1,64 @@
+import { parseWithZod } from "@conform-to/zod/v4";
+import { describe, expect, it } from "vitest";
+import { USER_ROLES } from "@server/shared/auth/types";
+import { employeeBaseSchema } from "./schema";
+
+/**
+ * employeeBaseSchema の roleId（担当役割）を conform parseWithZod 経路で固定するテスト。
+ *
+ * 検証する契約（#568）:
+ * - roleId は任意選択。有効値を選べば submission.value.roleId に保存される
+ * - 空選択（空文字）は conform が undefined 化する（[[conform-empty-string-to-undefined]]）。
+ *   これが BE の「roleId 未指定＝担当役割の解除」意味論と一致する
+ * - roleId を送らなくても他フィールドが揃えば success（任意フィールド）
+ */
+
+/** name/email/role の必須3項目を満たす最小 FormData（roleId は overrides で付与）。 */
+function buildFormData(overrides: Record<string, string> = {}): FormData {
+  const base: Record<string, string> = {
+    name: "山田太郎",
+    email: "yamada@example.com",
+    role: USER_ROLES.USER,
+  };
+  const merged = { ...base, ...overrides };
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(merged)) {
+    fd.set(k, v);
+  }
+  return fd;
+}
+
+describe("employeeBaseSchema の roleId（conform parseWithZod 経路）", () => {
+  it("担当役割を選ぶと submission.value.roleId に保存される", () => {
+    const submission = parseWithZod(buildFormData({ roleId: "role-1" }), {
+      schema: employeeBaseSchema,
+    });
+
+    if (submission.status !== "success") {
+      throw new Error(`status=${submission.status} reply=${JSON.stringify(submission.reply())}`);
+    }
+    expect(submission.value.roleId).toBe("role-1");
+  });
+
+  it("担当役割を空選択（空文字）にすると undefined になる（＝解除の意味論）", () => {
+    const submission = parseWithZod(buildFormData({ roleId: "" }), {
+      schema: employeeBaseSchema,
+    });
+
+    if (submission.status !== "success") {
+      throw new Error(`status=${submission.status} reply=${JSON.stringify(submission.reply())}`);
+    }
+    expect(submission.value.roleId).toBeUndefined();
+  });
+
+  it("roleId を送らなくても他フィールドが揃えば success（任意フィールド）", () => {
+    const submission = parseWithZod(buildFormData(), {
+      schema: employeeBaseSchema,
+    });
+
+    if (submission.status !== "success") {
+      throw new Error(`status=${submission.status} reply=${JSON.stringify(submission.reply())}`);
+    }
+    expect(submission.value.roleId).toBeUndefined();
+  });
+});

--- a/src/app/(features)/employees/_shared/schema.ts
+++ b/src/app/(features)/employees/_shared/schema.ts
@@ -20,6 +20,10 @@ export const employeeBaseSchema = z.object({
   role: z.enum([USER_ROLES.ADMIN, USER_ROLES.USER], {
     error: "権限を選択してください",
   }),
+  // 担当役割ID（任意）。空選択＝解除で BE の「未指定＝解除」意味論と一致する。
+  // conform が空文字を undefined 化するため .optional() が必須（[[conform-empty-string-to-undefined]]）。
+  // 存在検証はセレクトの選択肢が制約し、改竄は BE の new RoleId() が弾く（departmentId と同方針）。
+  roleId: z.string().optional(),
 });
 
 /**

--- a/src/app/(features)/employees/employees-crud.e2e.ts
+++ b/src/app/(features)/employees/employees-crud.e2e.ts
@@ -6,10 +6,16 @@ import { expect, test } from "@playwright/test";
  */
 const TEST_EMPLOYEE_CD = "EMP999901";
 const TEST_EMAIL = "e2e-create-test@example.com";
+// 担当役割の残存回帰で使う役割名（roleCd 昇順の先頭 ROLE001）。
+// Step6 の警告テスト（ROLE004/EMP000004）と非干渉で、EMP999901 は本チェーン末尾で削除される。
+const TEST_ROLE_NAME = "社長";
 
 test.describe("従業員CRUD（管理者）", () => {
   // 作成→更新→削除の順で実行（同一テストデータを使い回すため serial で順序保証）
   test.describe.serial("作成・更新・削除テスト", () => {
+    // 作成時に選んだ担当役割の value を後続の更新テストへ引き継ぐ（serial で同一 worker）。
+    let assignedRoleValue = "";
+
     test("管理者が新規従業員を作成できる", async ({ page }) => {
       // 一覧画面から新規登録画面に遷移
       await page.goto("/employees");
@@ -24,6 +30,12 @@ test.describe("従業員CRUD（管理者）", () => {
       await page.getByLabel("所属部署").selectOption({ index: 1 }); // 最初の部署を選択
       await page.getByLabel("パスワード").fill("testpass123");
       // 権限はデフォルト「一般ユーザー」のまま
+
+      // 担当役割を選択（残存回帰の起点）。選んだ value を後続テストへ引き継ぐ
+      const roleSelect = page.getByLabel("担当役割");
+      await roleSelect.selectOption({ label: TEST_ROLE_NAME });
+      assignedRoleValue = await roleSelect.inputValue();
+      expect(assignedRoleValue).not.toBe("");
 
       // 登録実行
       await page.getByRole("button", { name: "登録" }).click();
@@ -53,7 +65,10 @@ test.describe("従業員CRUD（管理者）", () => {
       // 従業員コードが読み取り専用であること
       await expect(page.locator("#employeeCd-display")).toBeDisabled();
 
-      // 複数フィールドを変更して更新
+      // 作成時に選んだ担当役割が preselect されている（残存回帰の前提）
+      await expect(page.getByLabel("担当役割")).toHaveValue(assignedRoleValue);
+
+      // 複数フィールドを変更して更新（担当役割セレクトには一切触れない）
       const nameField = page.getByLabel("名前");
       await nameField.clear();
       await nameField.fill("E2E更新テスト");
@@ -72,6 +87,10 @@ test.describe("従業員CRUD（管理者）", () => {
       // 変更が反映されていること
       await expect(nameField).toHaveValue("E2E更新テスト");
       await expect(emailField).toHaveValue("e2e-updated@example.com");
+
+      // リリースハザード F1 の網: 担当役割を送っていない更新でも役割が消えず残存すること。
+      // （#565 BE は「roleId 未指定＝解除」。フォームが roleId を往復し損ねると保存後に空になる）
+      await expect(page.getByLabel("担当役割")).toHaveValue(assignedRoleValue);
     });
 
     test("管理者が従業員を削除できる", async ({ page }) => {
@@ -125,6 +144,31 @@ test.describe("従業員CRUD（管理者）", () => {
     await page.goto("/employees/EMP000003");
 
     await expect(page.getByRole("button", { name: "削除" })).toBeVisible();
+  });
+
+  test("役割の唯一メンバーが担当役割を変更すると承認者不在ワーニングが表示される", async ({
+    page,
+  }) => {
+    // EMP000004 は ROLE004「開発部長」の唯一メンバー（seed-e2e）。DB は変更せず表示のみ検証する。
+    await page.goto("/employees/EMP000004");
+    await expect(page.getByText("従業員変更")).toBeVisible();
+
+    const roleSelect = page.getByLabel("担当役割");
+    // 現在の担当役割「開発部長」が preselect され、初期状態では警告は出ていない
+    await expect(roleSelect.locator("option:checked")).toHaveText("開発部長");
+    await expect(page.getByRole("status")).not.toBeVisible();
+
+    // 担当役割を解除（（担当役割なし））すると旧役割名入りの警告が反応的に表示される
+    await roleSelect.selectOption({ label: "（担当役割なし）" });
+    const warning = page.getByRole("status");
+    await expect(warning).toBeVisible();
+    await expect(warning).toContainText("開発部長");
+
+    // 元の担当役割へ戻すと警告は消える（非ブロッキング・反応的）
+    await roleSelect.selectOption({ label: "開発部長" });
+    await expect(page.getByRole("status")).not.toBeVisible();
+
+    // 保存はしない（DB 不変フィクスチャを維持）
   });
 
   test("存在しない従業員コードで404が表示される", async ({ page }) => {

--- a/src/app/(features)/employees/new/EmployeeCreateForm.test.tsx
+++ b/src/app/(features)/employees/new/EmployeeCreateForm.test.tsx
@@ -21,6 +21,12 @@ const mockDepartmentSelectSlot = (
   </select>
 );
 
+// 担当役割オプションのモック（page.tsx が findAll で取得し {id,name}[] を供給）
+const mockRoleOptions = [
+  { id: "role-1", name: "営業課長" },
+  { id: "role-2", name: "開発部長" },
+];
+
 describe("EmployeeCreateForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -30,7 +36,12 @@ describe("EmployeeCreateForm", () => {
 
   describe("レンダリングテスト", () => {
     test("全てのフォームフィールドが表示される", () => {
-      render(<EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />);
+      render(
+        <EmployeeCreateForm
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
 
       // 各フィールドのラベルが表示されていることを確認
       expect(screen.getByLabelText("名前")).toBeInTheDocument();
@@ -45,7 +56,12 @@ describe("EmployeeCreateForm", () => {
     });
 
     test("権限のセレクトボックスにオプションが表示される", () => {
-      render(<EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />);
+      render(
+        <EmployeeCreateForm
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
 
       const roleSelect = screen.getByLabelText("権限");
       expect(roleSelect).toHaveValue(USER_ROLES.USER); // デフォルト値
@@ -56,16 +72,46 @@ describe("EmployeeCreateForm", () => {
     });
 
     test("従業員コードの入力ヒントが表示される", () => {
-      render(<EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />);
+      render(
+        <EmployeeCreateForm
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
 
       expect(screen.getByText("形式: EMP + 6桁の数字（例: EMP000001）")).toBeInTheDocument();
+    });
+
+    test("担当役割セレクトが表示され、（担当役割なし）を含む役割オプションが並ぶ", () => {
+      render(
+        <EmployeeCreateForm
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
+
+      // 担当役割セレクト本体
+      const roleIdSelect = screen.getByLabelText("担当役割");
+      expect(roleIdSelect).toBeInTheDocument();
+      // 未選択（＝担当役割なし）が既定値
+      expect(roleIdSelect).toHaveValue("");
+
+      // 先頭の解除用オプション + 供給された役割名（name のみ）が並ぶ
+      expect(screen.getByRole("option", { name: "（担当役割なし）" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "営業課長" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "開発部長" })).toBeInTheDocument();
     });
   });
 
   describe("入力テスト", () => {
     test("ユーザーがフォームに値を入力できる", async () => {
       const user = userEvent.setup();
-      render(<EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />);
+      render(
+        <EmployeeCreateForm
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
 
       // 各フィールドに値を入力
       const nameInput = screen.getByLabelText("名前");
@@ -87,7 +133,12 @@ describe("EmployeeCreateForm", () => {
 
     test("権限を変更できる", async () => {
       const user = userEvent.setup();
-      render(<EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />);
+      render(
+        <EmployeeCreateForm
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
 
       const roleSelect = screen.getByLabelText("権限");
 
@@ -102,7 +153,12 @@ describe("EmployeeCreateForm", () => {
   describe("サブミットテスト", () => {
     test("フォームを送信するとcreateEmployeeが呼び出される", async () => {
       const user = userEvent.setup();
-      render(<EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />);
+      render(
+        <EmployeeCreateForm
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
 
       // 必須フィールドに値を入力
       await user.type(screen.getByLabelText("名前"), "山田太郎");
@@ -124,7 +180,12 @@ describe("EmployeeCreateForm", () => {
 
     test("送信されたFormDataに正しい値が含まれている", async () => {
       const user = userEvent.setup();
-      render(<EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />);
+      render(
+        <EmployeeCreateForm
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
 
       // 必須フィールドに値を入力
       await user.type(screen.getByLabelText("名前"), "山田太郎");
@@ -168,7 +229,12 @@ describe("EmployeeCreateForm", () => {
         initialValue: {},
       });
 
-      render(<EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />);
+      render(
+        <EmployeeCreateForm
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
 
       // 必須フィールドに値を入力
       await user.type(screen.getByLabelText("名前"), "山田太郎");
@@ -206,7 +272,12 @@ describe("EmployeeCreateForm", () => {
         },
       });
 
-      render(<EmployeeCreateForm departmentSelectSlot={mockDepartmentSelectSlot} />);
+      render(
+        <EmployeeCreateForm
+          departmentSelectSlot={mockDepartmentSelectSlot}
+          roleOptions={mockRoleOptions}
+        />
+      );
 
       // HTML5バリデーションを通過する有効な値を入力
       // （サーバーサイドでエラーを返すシナリオ）

--- a/src/app/(features)/employees/new/EmployeeCreateForm.tsx
+++ b/src/app/(features)/employees/new/EmployeeCreateForm.tsx
@@ -145,10 +145,12 @@ export function EmployeeCreateForm({ departmentSelectSlot, roleOptions }: Props)
             担当役割
           </label>
           {/* 任意選択。空選択＝担当役割なし。承認者不在ワーニングの反応性のため
-              権限セレクトと同じく conform 配線（getSelectProps）でフォームに値を所有させる。 */}
+              権限セレクトと同じく conform 配線（getSelectProps）でフォームに値を所有させる。
+              初期未選択は先頭の <option value=""> が担う。inline defaultValue は付けない
+              （spread 後の defaultValue が conform のエラー再描画時の再投入を上書きし、
+              選択済みの担当役割をサイレントに消すため。更新フォームと同じ流儀に統一）。 */}
           <select
             {...getSelectProps(fields.roleId)}
-            defaultValue=""
             disabled={isPending}
             className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
           >

--- a/src/app/(features)/employees/new/EmployeeCreateForm.tsx
+++ b/src/app/(features)/employees/new/EmployeeCreateForm.tsx
@@ -8,9 +8,11 @@ import { createEmployeeSchema } from "./schema";
 type Props = {
   /** 部署選択フィールド（Server Component を slot として受け取る） */
   departmentSelectSlot: React.ReactNode;
+  /** 担当役割の選択肢（page.tsx が findAll で取得し roleCd 昇順で供給） */
+  roleOptions: { id: string; name: string }[];
 };
 
-export function EmployeeCreateForm({ departmentSelectSlot }: Props) {
+export function EmployeeCreateForm({ departmentSelectSlot, roleOptions }: Props) {
   const { form, fields, isPending } = useServerForm({
     action: createEmployee,
     schema: createEmployeeSchema,
@@ -134,6 +136,32 @@ export function EmployeeCreateForm({ departmentSelectSlot }: Props) {
           {fields.role.errors && (
             <p className="text-red-500 text-xs mt-1" id={fields.role.errorId}>
               {fields.role.errors[0]}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor={fields.roleId.id} className="block text-gray-700 text-sm font-bold mb-2">
+            担当役割
+          </label>
+          {/* 任意選択。空選択＝担当役割なし。承認者不在ワーニングの反応性のため
+              権限セレクトと同じく conform 配線（getSelectProps）でフォームに値を所有させる。 */}
+          <select
+            {...getSelectProps(fields.roleId)}
+            defaultValue=""
+            disabled={isPending}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:bg-gray-100"
+          >
+            <option value="">（担当役割なし）</option>
+            {roleOptions.map((role) => (
+              <option key={role.id} value={role.id}>
+                {role.name}
+              </option>
+            ))}
+          </select>
+          {fields.roleId.errors && (
+            <p className="text-red-500 text-xs mt-1" id={fields.roleId.errorId}>
+              {fields.roleId.errors[0]}
             </p>
           )}
         </div>

--- a/src/app/(features)/employees/new/actions.ts
+++ b/src/app/(features)/employees/new/actions.ts
@@ -26,7 +26,7 @@ export async function createEmployee(prevState: unknown, formData: FormData) {
     return submission.reply();
   }
 
-  const { name, email, employeeCd, role, password, departmentId } = submission.value;
+  const { name, email, employeeCd, role, password, departmentId, roleId } = submission.value;
 
   try {
     // DIはファクトリで解決（インフラ層への依存をserver/側に閉じ込める）
@@ -40,6 +40,7 @@ export async function createEmployee(prevState: unknown, formData: FormData) {
       departmentId,
       role,
       password,
+      roleId,
     });
 
     revalidatePath("/employees");

--- a/src/app/(features)/employees/new/page.tsx
+++ b/src/app/(features)/employees/new/page.tsx
@@ -1,8 +1,17 @@
 import Link from "next/link";
 import { DepartmentSelectField } from "@/app/_components/form";
+import { PrismaRoleQueryService } from "@subdomains/role/infrastructure/queries/PrismaRoleQueryService";
 import { EmployeeCreateForm } from "./EmployeeCreateForm";
 
-export default function EmployeeNewPage() {
+export default async function EmployeeNewPage() {
+  // 担当役割の選択肢を供給（承認者不在ワーニングの反応性のためフォームに値を所有させる方針・A2）。
+  // ラベルは name のみ、roleCd 昇順（DepartmentSelectField と同方針）。
+  const roleQueryService = new PrismaRoleQueryService();
+  const roles = await roleQueryService.findAll({
+    orderBy: { field: "roleCd", direction: "asc" },
+  });
+  const roleOptions = roles.map((role) => ({ id: role.id, name: role.name }));
+
   return (
     <div className="container mx-auto p-8">
       <div className="mb-8">
@@ -16,6 +25,7 @@ export default function EmployeeNewPage() {
       {/* 作成フォーム */}
       <EmployeeCreateForm
         departmentSelectSlot={<DepartmentSelectField name="departmentId" id="departmentId" />}
+        roleOptions={roleOptions}
       />
 
       <div className="mt-4">


### PR DESCRIPTION
## Summary

#565（担当役割割当BE）のフロントエンド＋e2e。従業員登録・更新フォームに担当役割セレクト（任意選択／解除可）を追加し、更新画面では `EmployeeDTO.assignedRoleId` を preselect で復元する。
担当役割を変更・解除する際、本人が旧役割の唯一メンバーの場合は非ブロッキングの承認者不在ワーニングを表示（更新自体はブロックしない）。`employees-crud.e2e.ts` に残存回帰とワーニング表示のe2eを追加。

Closes #568

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### assigned-role-select-ui-fe.md

# Issue #568: 従業員登録・更新画面に担当役割の設定UIを追加する（FE＋e2e） — 実装計画

## 概要

#565（担当役割割当BE）のフロントエンド＋e2e。従業員の登録・更新フォームに **担当役割セレクト**（全役割のドロップダウン・任意選択／解除可）を追加する。更新時は `EmployeeDTO.assignedRoleId` を preselect し、本人が旧役割の唯一メンバーである場合に **承認者不在ワーニング**（非ブロッキング）を反応的に表示する。BE 契約（`CreateEmployeeInput.roleId?` / `UpdateEmployeeInput.roleId?` / `EmployeeDTO.assignedRoleId: string | null` / `RoleQueryService.isSoleMember` / `findAll`）は #565 で確定済み。

**実装方式は TDD（red-green-refactor）を前提**とする。各ステップは失敗するテスト（コンポーネントテスト or e2e）を先に書き、実装で green にする流れで進める。

**リリース順序ハザード**: #565（PR #570）は「roleId 未指定＝解除」の意味論を持つため、本 #568 の FE（roleId フォーム欄）と **同時出荷が必須**。本計画の e2e Step（回帰テスト）がその唯一の網。

## 設計判断

### 役割セレクトの供給方式
- A1. `RoleSelectField` サーバスロットを新設（`DepartmentSelectField` に倣う）
- A2. `page.tsx` が `findAll` で全役割を取得し `{id,name}[]` を props でクライアントフォームへ渡す
- **採用: A2**。承認者不在ワーニングの反応性はフォームが値を所有していると最も堅牢。issue 本文「page.tsx で役割一覧を供給」とも一致。部署のスロット方式は「反応性不要」前提で選ばれたもので、roleId が要件的に異なることは正当な逸脱。

### 役割セレクトの描画配線
- 共通 `SelectField`（生 select・onChange 非公開）を再利用
- 権限セレクトと同じ `<select {...getSelectProps(fields.roleId)}>` インライン描画
- **採用: getSelectProps インライン**。`fields.roleId.value` を反応的に読む要件に対し、repo 内で実証済みなのは conform 配線フィールド（`getInputProps`/`getSelectProps`、`ReviseForm` 先例）のみ。生 select の反応性は未実証のため賭けない。先頭に `<option value="">（担当役割なし）</option>`、以降 `name` のみをラベルに `map`。

### roleId スキーマの型
- `employeeBaseSchema` に `roleId: z.string().optional()` を追加（create/update 両方が extend するため1箇所で足りる）
- `min(1)`・uuid 検証は付けない。conform が空文字を undefined 化する（[[conform-empty-string-to-undefined]]）ため `.optional()` 必須。空選択＝解除が BE の「未指定＝解除」と一致。存在検証はセレクトの選択肢が制約し、改竄は BE の `new RoleId()` が弾く（`departmentId` も schema では uuid 検証しない既存方針と整合）。

### 承認者不在ワーニングのデータフロー
- `[employeeCd]/page.tsx` で現在の `assignedRoleId` に対し `isSoleMember` を **1回スナップショット** → `isSoleMemberOfCurrentRole: boolean` をフォームへ。`assignedRoleId==null` ならクエリせず false。
- クライアントは `assignedRoleId != null && isSoleMemberOfCurrentRole && fields.roleId.value !== assignedRoleId` で反応的に表示。
- スナップショットで十分（非ブロッキング警告。陳腐化しても最終整合は承認時 `NO_APPROVER` が担保）。変更・解除どちらも「本人が旧役割から抜ける」点で同じなので条件は「値が元と異なる」の一本。

### ワーニング UI
- 琥珀色（`bg-yellow-50` `border-yellow-400` `text-yellow-800`）、`role="status"` `aria-live="polite"`（エラーの `role="alert"` とは別扱い）。
- 旧役割名を供給された一覧（id→name）から解決して明示。文言例:「⚠️ この従業員は現在「{旧役割名}」の唯一の担当者です。担当役割を変更・解除しても更新はできますが、この役割の承認が承認者不在になる可能性があります。」
- 非ブロッキング（更新ボタンを無効化しない・フォームエラーにしない）。値が元に戻れば消える。

### 権限（authorization）
- 担当役割セレクトも既存フィールドと同じ `disabled={isPending || !canUpdate}`（owner も自分の担当役割を編集可）。
- 担当役割だけ admin 限定にせず兄弟フィールド（特に既に owner 編集可の権限セレクト）と統一。自己エスカレーション懸念は権限セレクトにも既存で存在するため横断的な別課題。

### 役割オプションの表示
- ラベルは `role.name` のみ、並び順は `roleCd` 昇順。役割名が既に役職を内包し、`DepartmentSelectField`（name 単独＋cd 昇順）の先例と揃う。

### e2e のテストデータ（シード追加なし）
- (A)回帰は破棄可能な `EMP999901` チェーンを拡張、(B)警告は既存の唯一メンバー `EMP000004`（ROLE004）で非保存検証。DB 不変フィクスチャ（`EMP999001` 等）を汚さない。

### スコープ外
- 一覧の担当役割列は **#578** に分離（#567 で上位役割列も同時検討。名前解決方式が ADR-0013 と #565 判断の緊張点）。

### ADR / CONTEXT
- ADR 起票なし（各決定は FE/UI で可逆、非ブロッキング理由・#565 同時出荷理由は既に issue/CONTEXT に記録済み）。
- CONTEXT.md 更新なし（導入したのは UI アフォーダンスで新規ドメイン用語ではない）。

## ステップ

### Step 1: スキーマに roleId を追加
- 対象ファイル: `src/app/(features)/employees/_shared/schema.ts`
- 作業内容:
  - TDD: `employeeBaseSchema` の `roleId` について、未指定・空文字・有効値のパース結果を検証するスキーマテストを先に書く（conform 経路の空文字→undefined を意識）
  - `employeeBaseSchema` に `roleId: z.string().optional()` を追加
- コミットメッセージ: `feat: 従業員フォームスキーマに担当役割(roleId)を追加`

### Step 2: 登録フォームに担当役割セレクトを追加
- 対象ファイル: `src/app/(features)/employees/new/page.tsx`, `new/EmployeeCreateForm.tsx`, `new/EmployeeCreateForm.test.tsx`, `new/actions.ts`
- 作業内容:
  - TDD: `EmployeeCreateForm.test.tsx` に「担当役割セレクトが表示され、（担当役割なし）を含む役割オプションが並ぶ」テストを追加（red）
  - `new/page.tsx` で `PrismaRoleQueryService.findAll({ orderBy: { field: "roleCd", direction: "asc" } })` を取得し `{id,name}[]` を `EmployeeCreateForm` に渡す
  - `EmployeeCreateForm` に `getSelectProps(fields.roleId)` インラインの担当役割セレクト（先頭に空オプション「（担当役割なし）」）を追加
  - `actions.ts` の `createEmployee` で `submission.value.roleId` を Command に受け渡し
- コミットメッセージ: `feat: 従業員登録画面に担当役割セレクトを追加`

### Step 3: 更新フォームに担当役割セレクトと preselect を追加
- 対象ファイル: `src/app/(features)/employees/[employeeCd]/page.tsx`, `[employeeCd]/EmployeeUpdateForm.tsx`, `[employeeCd]/EmployeeUpdateForm.test.tsx`, `[employeeCd]/actions.ts`
- 作業内容:
  - TDD: `EmployeeUpdateForm.test.tsx` に「`assignedRoleId` が preselect される／`canUpdate=false` で disabled」テストを追加（red）
  - `Employee` prop 型に `assignedRoleId: string | null` を追加、`page.tsx` から DTO 経由で供給、役割一覧も供給
  - `EmployeeUpdateForm` に担当役割セレクト（`getSelectProps`・`defaultValue.roleId = assignedRoleId ?? ""`・`disabled={isPending || !canUpdate}`）を追加
  - `updateEmployee` actions で `roleId` を Command に受け渡し
- コミットメッセージ: `feat: 従業員更新画面に担当役割セレクトとpreselectを追加`

### Step 4: 承認者不在ワーニングを追加
- 対象ファイル: `src/app/(features)/employees/[employeeCd]/page.tsx`, `[employeeCd]/EmployeeUpdateForm.tsx`, `[employeeCd]/EmployeeUpdateForm.test.tsx`
- 作業内容:
  - TDD: `EmployeeUpdateForm.test.tsx` に「唯一メンバーがセレクトを変更/解除すると警告表示、元に戻すと消える／唯一メンバーでなければ出ない」テストを追加（red）
  - `page.tsx` で `assignedRoleId != null` のとき `RoleQueryService.isSoleMember(assignedRoleId, employeeId)` を1回呼び `isSoleMemberOfCurrentRole` をフォームへ渡す
  - `EmployeeUpdateForm` に反応的ワーニング（琥珀色・`role="status"`・旧役割名解決・非ブロッキング）を追加
- コミットメッセージ: `feat: 担当役割の承認者不在ワーニング(非ブロッキング)を追加`

### Step 5: e2e 回帰テスト（役割残存）を追加
- 対象ファイル: `src/app/(features)/employees/employees-crud.e2e.ts`
- 作業内容:
  - `EMP999901` の serial チェーンを拡張：作成時に担当役割セレクトで1つ選択 → 更新で名前のみ変更・保存 → 保存後の編集フォームで担当役割セレクトが選択済み残存を assert（リリースハザード F1 の唯一の網）
- コミットメッセージ: `test: 役割保有従業員の編集で担当役割が残存するe2e回帰を追加`

### Step 6: e2e 承認者不在ワーニング表示テストを追加
- 対象ファイル: `src/app/(features)/employees/employees-crud.e2e.ts`
- 作業内容:
  - `EMP000004`（ROLE004 唯一メンバー）の編集画面でセレクトを解除／別役割へ変更 → 警告表示を assert → 保存しない（DB 不変を維持）
- コミットメッセージ: `test: 担当役割の承認者不在ワーニング表示のe2eを追加`

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

---

Generated with [Claude Code](https://claude.ai/code)
