### PR TITLE
feat: 見積申請詳細画面 表示（FE）

### DIFF
--- a/docs/claude-plans/issue-574/deviations.md
+++ b/docs/claude-plans/issue-574/deviations.md
@@ -1,0 +1,17 @@
+# Issue #574 実装計画からの逸脱記録
+
+## 1. 整形ヘルパの共有化先ディレクトリ
+
+- **元の計画**: 共有位置を「`estimate-applications/_lib/labels.ts` 等（詳細と一覧の共通親）」と例示。
+- **実際の実装**: `src/app/(features)/estimate-applications/_shared/labels.ts` に移設。
+- **逸脱の理由**: 計画は「等」で正確な位置を未確定にしていた。既存リポジトリに機能ローカルな共有ヘルパの
+  イディオムとして `estimates/_shared/`（例: `setComponentExpansion.ts`）が存在するため、`_lib` ではなく
+  `_shared` サブフォルダに揃えた。global な `@/app/_lib` へは昇格せず、見積申請機能に閉じる方針は計画通り。
+
+## 2. 承認ステップ状態バッジの tone 割り当て（計画の空白を補完）
+
+- **元の計画**: Step 1 で「`ApprovalStepStatus` の全 code → tone をテスト化」と方針のみ規定し、各値の tone は未明示。
+- **実際の実装**: `NOT_STARTED=neutral / AWAITING=info / APPROVED=success / REJECTED=warning`。
+- **逸脱の理由**: 計画未確定の配色を、申請状態バッジ（`PENDING=info / APPROVED=success / REJECTED=warning /
+  WITHDRAWN=neutral`）およびバリエーション申請状態の既存 `badgeToneOf` と同じ色語彙で整合させた
+  （「緑=承認済・琥珀=差戻・青=進行中・灰=不活性」の共通語彙）。新規判断ではなく既存語彙への追従。

--- a/docs/claude-plans/issue-574/estimate-application-detail-screen.md
+++ b/docs/claude-plans/issue-574/estimate-application-detail-screen.md
@@ -1,0 +1,125 @@
+# Issue #574: 見積申請詳細画面 表示（FE） — 実装計画
+
+## 概要
+
+見積申請詳細画面（`/estimate-applications/[estimateNumber]/[variationNumber]`）の**表示部分**を実装する。承認・差戻・取下の操作系は後続 issue とし、本 issue は表示のみに閉じる。
+
+BE の参照クエリ（#573・`GetEstimateApplicationDetailQuery`）が既に完成しており、本画面はその読み取り DTO（`EstimateApplicationDetailDTO`）を **直 type-import で消費するだけ**の薄い RSC 構成になる（ADR-0069）。DTO は判別ユニオン（`APPLICATIONS` / `EXEMPTED`）で分岐を畳み込み済みで、FE 側に新しい型・新しい用語は生まれない。
+
+表示ブロック（概要設計 §3.1）:
+1. バリエーション要約ヘッダ（見積詳細へのリンク・申請状態バッジ）
+2. 最新申請の承認チェーン
+3. 過去の申請履歴（承認チェーン込み）
+4. 免除バリエーションの場合は免除記録
+
+TDD で進める（`/tdd`）。表示ロジックのうち純粋関数（`code→tone` 写像）は単体テスト先行、画面全体の配線は E2E で担保する（導出の全網羅は BE 単体テストに委ねる・ADR-0012）。
+
+## 設計判断
+
+### クエリ呼び出しと `operatorEmployeeId` の供給
+- `execute` は表示スコープ外の `operations` 合成のために `operatorEmployeeId: string`（非 null）を必須とする
+- 判断: `page.tsx`（RSC）で `session.user.employeeId` を渡す。`null` は「このシステムに存在しない前提」として `throw`（fail-fast、error 境界へ）
+- `operations`（承認可否）は本 issue では**描画しない**（操作 UI は後続 issue）
+- 理由: 既存 `resolveApplicationContext`（Server Action 側）と同じ「employeeId null は操作不可」の思想を RSC に踏襲。BE クエリを operator optional に変える案は、表示 issue のスコープを BE に広げるため不採用
+
+### NotFound の扱い
+- 判断: クエリが `null`（見積番号なし／バリエーション番号なし／申請も免除も無い）なら `notFound()`
+- 理由: 既存 `estimates/[estimateNumber]/page.tsx` と同一パターン
+
+### コンポーネント分割（全て RSC）
+- 判断: `page.tsx` で取得・notFound・`kind` 分岐。presentational は `ApplicationDetailSummary` / `ApplicationCard` / `ApprovalStepList` / `ExemptionRecord`
+- `ApplicationCard` は `latest` と `past[]` の各要素で**共用**（BE が両者を同型 `ApplicationView` にした意図に従う）
+- 理由: 操作 UI が無いため client 化の必然が無く、全 RSC にしておけば後続の操作 issue が「操作 UI だけを client island として足す」形で拡張できる
+
+### 状態バッジ（3種の状態を別扱い）
+- 画面に出る状態は3種: バリエーション申請状態（6値・要約ヘッダ）／申請状態（4値・申請カード）／承認ステップ状態（4値・チェーン各段）
+- 判断: 共通 tone 層（既存 `shared/variationApplicationStateBadge` の tone 語彙＋`tone→className`）を再利用し、`code→tone` 写像だけを状態 VO ごとに専用関数として持つ
+  - `VariationApplicationState` = 既存 `badgeToneOf` を流用
+  - `ApplicationStatus` / `ApprovalStepStatus` = 本画面 `_components` に新規（`never` ガードで網羅強制）
+- 理由: 3状態は別概念なので写像も別関数（VO に値が増えたら該当 switch だけ型エラー）。一方「緑=承認済」の色語彙は3重定義を避け tone 層で単一ソース化。新規2つは本画面専用のため shared へ昇格しない（labels.ts と同じ「機能固有は昇格しない」方針）
+
+### 承認ステップの表示形式
+- 判断: **テーブル6列**（順序 / 役割 / 状態バッジ / 承認者・差戻者 / 発生日時 / 差戻コメント）
+- 理由: `ApprovalStepView` の JSDoc が「均一テーブル UI に合わせ承認者/差戻者を `actorName` に畳み込み」と明記。DTO がテーブル前提で flat 化されている。ステッパーは畳み込みと齟齬。進行感は状態バッジの色で補える
+
+### 過去申請履歴の見せ方
+- 判断: 折りたたみ無し・attempt 降順（DTO が既にソート済み）で全件展開・`past` 空なら履歴ブロックごと非表示
+- 理由: §3.2 が「折りたたみ等の UI 詳細は後続 issue で決める」と明示委譲。折りたたみは client 状態を要し全 RSC 構成を崩す
+
+### 免除ブロックのレイアウト
+- 判断: 3行定義リスト（理由 label / 実施者 / 日時）。理由はテキスト（状態バッジは付けない）
+- 理由: 承認チェーンが無い枝で定義リストが情報形状に合う。免除の状態表現は要約ヘッダの「承認不要」バッジに一本化（同一の免除事実に表示を割らない・CONTEXT.md「承認免除」）
+
+### 整形ヘルパの配置
+- 判断: `formatDateTime` / `formatYen` / `SUBMISSION_TYPE_LABELS` を一覧・詳細で共有できる位置へ寄せる
+- 理由: 現在 `estimate-applications/_components/labels.ts` にあり、詳細でも使うため共有化
+
+### E2E とシード
+- 判断: 詳細画面用にリッチフィクスチャ `N9905015`（attempt2 多段チェーン＝課長承認済→部長承認待ち／attempt1 差戻コメント付き）を `seed-estimate-applications.ts` に追加
+- 理由: 既存シードは全て attempt1・単段チェーンで `past` が常に空。§3.2 が置く画面主目的（過去履歴・差戻コメントの参照）を E2E で検証できないため。リッチ1件で最新チェーンの複数ステップ状態・過去履歴ブロック・差戻コメント・actorName を一度に配線検証できる
+
+### ドキュメント更新
+- CONTEXT.md / ADR: **新規更新なし**（新用語なし・配色確定は ADR-0069 が FE issue へ委譲済み・operator 必須のねじれは ADR-20260707-ae2 が説明済み・残りは可逆でトレードオフ小）
+
+## ステップ
+
+### Step 1: 状態バッジの `code→tone` 写像（TDD・純粋関数）
+- 対象ファイル:
+  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/applicationStatusBadge.ts`（新規）
+  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/approvalStepStatusBadge.ts`（新規）
+  - 各 `.test.ts`
+- 作業内容:
+  - Red: `ApplicationStatus`（PENDING/APPROVED/REJECTED/WITHDRAWN）・`ApprovalStepStatus`（NOT_STARTED/AWAITING/APPROVED/REJECTED）の全 code → tone 期待をテスト化
+  - Green: 既存 `variationApplicationStateBadge` の `tone`/`tone→className` を import 再利用しつつ、`code→tone` を `never` ガード網羅 switch で実装
+  - Refactor: tone 語彙・className の重複が出れば shared 側の再利用に寄せる
+- コミットメッセージ: `feat: 見積申請詳細 状態バッジの code→tone 写像（申請状態・承認ステップ状態）`
+
+### Step 2: 整形ヘルパの共有化
+- 対象ファイル:
+  - `estimate-applications/_components/labels.ts`（移動元）
+  - 共有位置（`estimate-applications/_lib/labels.ts` 等・詳細と一覧の共通親）
+  - 一覧 `columns.tsx` の import 追随
+- 作業内容:
+  - `formatDateTime` / `formatYen` / `SUBMISSION_TYPE_LABELS` を共有位置へ移設
+  - 一覧側の import を更新し、既存 E2E がグリーンのままを確認
+- コミットメッセージ: `refactor: 見積申請の整形ヘルパを一覧・詳細で共有化`
+
+### Step 3: presentational コンポーネント（RSC）
+- 対象ファイル（`[estimateNumber]/[variationNumber]/_components/` 配下）:
+  - `ApplicationDetailSummary.tsx`（要約ヘッダ・見積詳細リンク・申請状態バッジ）
+  - `ApprovalStepList.tsx`（テーブル6列）
+  - `ApplicationCard.tsx`（`ApplicationView` を承認チェーン込みで・latest/past 共用）
+  - `ExemptionRecord.tsx`（3行定義リスト）
+- 作業内容:
+  - DTO の各 View 型を直 type-import して各ブロックを描画（ミラー型を作らない）
+  - null フィールド（`actorName`/`decidedAt`/`rejectionComment` 等）は空表示
+- コミットメッセージ: `feat: 見積申請詳細の表示コンポーネント（要約・承認チェーン・免除記録）`
+
+### Step 4: page.tsx（RSC・データ取得と分岐）
+- 対象ファイル:
+  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/page.tsx`（新規）
+- 作業内容:
+  - `params` の `variationNumber` を数値パース、`verifySession()` + `employeeId` null ガード（throw）
+  - `getEstimateApplicationDetailQueryFactory().execute(...)` 実行、`null` は `notFound()`
+  - `summary` は常に `ApplicationDetailSummary` へ。`kind` で APPLICATIONS（latest + past）/ EXEMPTED（exemption）を出し分け
+  - 過去履歴は attempt 降順で全件展開・`past` 空なら履歴ブロック非表示
+- コミットメッセージ: `feat: 見積申請詳細画面のページ（取得・notFound・kind 分岐）`
+
+### Step 5: E2E 用リッチフィクスチャの追加
+- 対象ファイル:
+  - `prisma/seed-estimate-applications.ts`
+- 作業内容:
+  - `N9905015`: attempt1 = 差戻（REJECTED・差戻コメント付き）、attempt2 = 多段チェーン（課長承認済→部長承認待ち）を追加
+  - 既知従業員（承認者/差戻者/申請者）で actorName を弁別可能にする
+- コミットメッセージ: `test: 見積申請詳細 E2E 用のリッチフィクスチャ（差戻→再申請＋多段チェーン）を追加`
+
+### Step 6: E2E（4シナリオ）
+- 対象ファイル:
+  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/estimate-application-detail.e2e.ts`（新規）
+- 作業内容:
+  - ① APPLICATIONS（`N9905015`）: 要約ヘッダ・見積詳細リンク href・最新チェーンのステップ状態・過去履歴の差戻コメント
+  - ② EXEMPTED（`N9905013`）: 免除記録（理由/実施者/日時）＋要約ヘッダ「承認不要」バッジ
+  - ③ NotFound: 申請も免除も無いバリエーション（または存在しない自然キー）→ 404
+  - ④ 一覧→詳細: 一覧行の見積番号リンクを実クリックして詳細へ着地
+  - read-only のため非 serial
+- コミットメッセージ: `test: 見積申請詳細画面の表示 E2E（APPLICATIONS/EXEMPTED/NotFound/一覧遷移）`

--- a/docs/claude-plans/issue-574/r1-fix-plan.md
+++ b/docs/claude-plans/issue-574/r1-fix-plan.md
@@ -1,0 +1,53 @@
+# Issue #574 auto-review-fix ラウンド1 修正計画
+
+## 対象指摘（judge 採用・いずれも ①correctness）
+
+| バケツ | severity(参考) | file:line | 問題 |
+|---|---|---|---|
+| ①correctness | High | `page.tsx:28-30` | `Number()` が int32 超の整数文字列（例 `"9999999999"`）を通し、Prisma `Int`(int4) 列への where で throw → `error.tsx` 不在のため `notFound()`(404) でなく **500** |
+| ①correctness | Low | `page.tsx:28-30` | `Number()` が非正規10進文字列（`"0x1"`/`"1.0"`/`" 1"`/`"+1"`）を受理し bogus URL が 404 でなく **200** 描画 |
+
+両者は「`variationNumber` 入力バリデーションの緩さ」という単一原因。1コミットで両方解消する。
+
+## 修正方針
+
+`page.tsx` の `variationNumber` パースブロックを差し替える:
+
+```ts
+// Before
+const variationNumberValue = Number(variationNumber);
+if (!Number.isInteger(variationNumberValue)) {
+  notFound();
+}
+
+// After
+// URL セグメントは常に文字列。厳格な10進整数（先頭ゼロ/符号/小数/16進/空白を弾く）かつ
+// int4 範囲内のみ受理し、それ以外は notFound()。範囲外・非正規を Prisma に到達させないことで
+// 500 を避け、業務範囲外（存在しない番号）は既存のクエリ null → notFound に委ねる。
+const variationNumberValue = Number(variationNumber);
+if (
+  !/^[1-9][0-9]*$/.test(variationNumber) ||
+  variationNumberValue > 2_147_483_647
+) {
+  notFound();
+}
+```
+
+- `/^[1-9][0-9]*$/`: 1始まりの正の10進整数のみ受理（`0`・先頭ゼロ・`0x1`・`1.0`・`+1`・` 1` を全て弾く）→ 指摘B解消。
+- `> 2_147_483_647`（int4 上限）超を弾く → Prisma に範囲外値を渡さない → 指摘A解消。
+- 業務上の上限（1〜99）はパース層で二重に持たず、存在しない番号はクエリ null → `notFound()` の既存設計に委ねる（DB/ドメイン制約の変更でパース層が乖離するのを防ぐ）。
+
+## 影響範囲
+
+- `page.tsx` のパースブロックのみ。BE クエリ（#573）・コンポーネント・DTO には触れない。
+- 既存の正常系（`/N9905015/1` 等）は挙動不変。
+
+## 想定テスト
+
+- `pnpm test`（既存単体は本箇所に依存しないが緑を確認）。
+- `pnpm lint`。
+- E2E（NotFound シナリオ）は既存の「存在しない見積番号 → 404」で担保済み。パースの範囲/正規性は入力早期棄却の局所修正であり、E2E 追加は本ラウンドのスコープ外（残課題として報告）。
+
+## DDD 層配置
+
+- 入力バリデーション（URL セグメントの数値正規化・範囲）は presentation 層（RSC page.tsx）の責務。BE クエリを変更しないため層違反なし。

--- a/prisma/seed-estimate-applications.ts
+++ b/prisma/seed-estimate-applications.ts
@@ -24,6 +24,7 @@ import { EstimateApplicationMapper } from "@subdomains/estimate/infrastructure/m
 import { EstimateApprovalExemptionMapper } from "@subdomains/estimate/infrastructure/mappers/approval/EstimateApprovalExemptionMapper";
 import { ApprovalChainPlan } from "@subdomains/estimate/domain/values/approval/ApprovalChainPlan";
 import { EstimateExemptionReason } from "@subdomains/estimate/domain/values/approval/EstimateExemptionReason";
+import { RejectionComment } from "@subdomains/estimate/domain/values/approval/RejectionComment";
 import { CustomerId } from "@subdomains/customer/domain/values/CustomerId";
 import { DeliveryLocationId } from "@subdomains/delivery-location/domain/values/DeliveryLocationId";
 import { DepartmentId } from "@subdomains/department/domain/values/DepartmentId";
@@ -51,6 +52,13 @@ export const SEED_APPLICATION_ESTIMATE_NUMBERS = {
   exempted: "N9905013",
   /** WITHDRAWN かつ INACTIVE（V1 無効・取下済＝includeInactive の検証台）。 */
   withdrawnInactive: "N9905014",
+  /**
+   * 詳細画面用リッチフィクスチャ（V1 ACTIVE）。同一バリエーションに 2 申請を積む:
+   * - attempt1 = 差戻（REJECTED・差戻コメント付き）＝過去履歴
+   * - attempt2 = 多段チェーン（営業課長 承認済 → 営業部長 承認待ち）＝最新申請（PENDING）
+   * 過去履歴・差戻コメント・多段ステップの状態・actorName を一度に配線検証する。
+   */
+  richMultiStep: "N9905015",
 } as const;
 
 const TAX_RATE = new TaxRate(0.1);
@@ -70,6 +78,8 @@ type ApplicationSeedFk = {
   approverId: string;
   exemptorId: string;
   awaitingRoleId: string;
+  /** 多段チェーンの 2 段目役割（営業部長）。リッチフィクスチャの step2 に使う。 */
+  secondRoleId: string;
   goalPositionId: string;
 };
 
@@ -113,6 +123,14 @@ function singleStepPlan(fk: ApplicationSeedFk): ApprovalChainPlan {
   ]);
 }
 
+/** 2 段の承認チェーン計画（step1＝営業課長 → step2＝営業部長）。詳細画面の多段表示検証用。 */
+function twoStepPlan(fk: ApplicationSeedFk): ApprovalChainPlan {
+  return ApprovalChainPlan.create(new PositionId(fk.goalPositionId), [
+    new RoleId(fk.awaitingRoleId),
+    new RoleId(fk.secondRoleId),
+  ]);
+}
+
 /**
  * 既存の作成済みマスタ（納品先・部署・個別商品・役割・役職・従業員）を参照して、代表状態を持つ
  * 見積申請フィクスチャを投入する。FK は E2E シードの決定的コード（EMP000003〜5・営業課長）に結び、
@@ -130,6 +148,7 @@ export async function seedEstimateApplications(prisma: PrismaClient): Promise<nu
   const approver = await prisma.employee.findFirst({ where: { employeeCd: "EMP000004" } }); // 鈴木 次郎
   const exemptor = await prisma.employee.findFirst({ where: { employeeCd: "EMP000005" } }); // 高橋 三郎
   const awaitingRole = await prisma.role.findFirst({ where: { name: "営業課長" } });
+  const secondRole = await prisma.role.findFirst({ where: { name: "営業部長" } });
   const goalPosition = await prisma.position.findFirst({ orderBy: { positionCd: "asc" } });
 
   if (
@@ -140,10 +159,11 @@ export async function seedEstimateApplications(prisma: PrismaClient): Promise<nu
     !approver ||
     !exemptor ||
     !awaitingRole ||
+    !secondRole ||
     !goalPosition
   ) {
     throw new Error(
-      "seedEstimateApplications: 前提マスタ（納品先・部署・個別商品・EMP000003-5・役割 営業課長・役職）が不足しています"
+      "seedEstimateApplications: 前提マスタ（納品先・部署・個別商品・EMP000003-5・役割 営業課長/営業部長・役職）が不足しています"
     );
   }
 
@@ -157,6 +177,7 @@ export async function seedEstimateApplications(prisma: PrismaClient): Promise<nu
     approverId: approver.id,
     exemptorId: exemptor.id,
     awaitingRoleId: awaitingRole.id,
+    secondRoleId: secondRole.id,
     goalPositionId: goalPosition.id,
   };
 
@@ -227,6 +248,45 @@ export async function seedEstimateApplications(prisma: PrismaClient): Promise<nu
   if (withdrawalInput) {
     await prisma.estimateApplicationWithdrawal.create({ data: withdrawalInput });
   }
+
+  // --- リッチ（詳細画面用・同一バリエーションに attempt1 差戻 → attempt2 多段 PENDING） ---
+  const richEstimate = buildEstimate(fk, SEED_APPLICATION_ESTIMATE_NUMBERS.richMultiStep, 120000);
+  await prisma.estimate.create({ data: EstimateMapper.toEstimateCreateInput(richEstimate) });
+  const richVariationId = richEstimate.variations[0].id;
+
+  // attempt1: 単段チェーンを営業課長が差し戻す（差戻コメント付き＝過去履歴で読む対象）。
+  const rejectedApp = EstimateApplication.create({
+    variationId: richVariationId,
+    attempt: 1,
+    applicantEmployeeId: new EmployeeId(fk.applicantId),
+    plan: singleStepPlan(fk),
+  });
+  rejectedApp.reject(
+    rejectedApp.steps[0].id,
+    new EmployeeId(fk.approverId),
+    new RejectionComment("金額の根拠資料を添付してください")
+  );
+  await prisma.estimateApplication.create({
+    data: { ...EstimateApplicationMapper.toCreateInput(rejectedApp), createdAt: daysAgo(4) },
+  });
+  await prisma.estimateStepRejection.createMany({
+    data: EstimateApplicationMapper.toStepRejectionCreateInputs(rejectedApp),
+  });
+
+  // attempt2: 2 段チェーン（営業課長 → 営業部長）。課長のみ承認済＝部長が承認待ちの PENDING。
+  const pendingChainApp = EstimateApplication.create({
+    variationId: richVariationId,
+    attempt: 2,
+    applicantEmployeeId: new EmployeeId(fk.applicantId),
+    plan: twoStepPlan(fk),
+  });
+  pendingChainApp.approve(pendingChainApp.steps[0].id, new EmployeeId(fk.approverId));
+  await prisma.estimateApplication.create({
+    data: { ...EstimateApplicationMapper.toCreateInput(pendingChainApp), createdAt: daysAgo(2) },
+  });
+  await prisma.estimateStepApproval.createMany({
+    data: EstimateApplicationMapper.toStepApprovalCreateInputs(pendingChainApp),
+  });
 
   return Object.keys(SEED_APPLICATION_ESTIMATE_NUMBERS).length;
 }

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ApplicationCard.tsx
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ApplicationCard.tsx
@@ -1,0 +1,52 @@
+import { Badge } from "@/app/_components/shadcnui/badge";
+import { badgeToneClassName } from "@/app/_components/shared/variationApplicationStateBadge";
+import { type ApplicationView } from "@subdomains/estimate/application/queries/dto/EstimateApplicationDetailDTO";
+import { formatDateTime } from "../../../_shared/labels";
+import { applicationStatusBadgeToneOf } from "./applicationStatusBadge";
+import { ApprovalStepList } from "./ApprovalStepList";
+
+/**
+ * 申請 1 件のカード（最新・過去で共用・§3.1-2/3）。申請メタ（申請者・申請日時・attempt・最終承認
+ * 役職・申請状態バッジ）と承認チェーン（{@link ApprovalStepList}）を束ねる。取下済みの申請は取下記録
+ * （取下者・取下日時）を添える。
+ *
+ * BE が最新（`latest`）と過去（`past[]`）を同型 `ApplicationView` にした意図に従い、両者を本カードで
+ * 共用する（プレゼン層でミラー分岐を作らない・ADR-0069）。
+ */
+export function ApplicationCard({ application }: { application: ApplicationView }) {
+  return (
+    <section className="bg-white shadow-md rounded p-6 space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <h3 className="text-base font-semibold text-gray-700">申請 #{application.attempt}</h3>
+          <Badge
+            variant="outline"
+            className={badgeToneClassName(applicationStatusBadgeToneOf(application.status.code))}
+          >
+            {application.status.label}
+          </Badge>
+        </div>
+      </div>
+
+      <dl className="grid grid-cols-[8rem_1fr] gap-y-2 text-sm">
+        <dt className="font-bold text-gray-600">申請者</dt>
+        <dd className="text-gray-800">{application.applicantName}</dd>
+        <dt className="font-bold text-gray-600">申請日時</dt>
+        <dd className="text-gray-800">{formatDateTime(application.appliedAt)}</dd>
+        <dt className="font-bold text-gray-600">最終承認役職</dt>
+        <dd className="text-gray-800">{application.finalApprovalPositionName}</dd>
+      </dl>
+
+      {application.withdrawal !== null && (
+        <dl className="grid grid-cols-[8rem_1fr] gap-y-2 text-sm bg-gray-50 rounded p-3">
+          <dt className="font-bold text-gray-600">取下者</dt>
+          <dd className="text-gray-800">{application.withdrawal.withdrawnByName}</dd>
+          <dt className="font-bold text-gray-600">取下日時</dt>
+          <dd className="text-gray-800">{formatDateTime(application.withdrawal.withdrawnAt)}</dd>
+        </dl>
+      )}
+
+      <ApprovalStepList steps={application.steps} />
+    </section>
+  );
+}

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ApplicationDetailSummary.tsx
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ApplicationDetailSummary.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { Badge } from "@/app/_components/shadcnui/badge";
+import {
+  badgeToneClassName,
+  badgeToneOf,
+} from "@/app/_components/shared/variationApplicationStateBadge";
+import { type ApplicationDetailSummaryView } from "@subdomains/estimate/application/queries/dto/EstimateApplicationDetailDTO";
+import { SUBMISSION_TYPE_LABELS, formatYen } from "../../../_shared/labels";
+
+/**
+ * バリエーション要約ヘッダ（§3.1-1）。見積番号（見積詳細へのリンク）・バリエーション番号・
+ * 得意先/納品先・提出区分・税込合計・バリエーション申請状態バッジを示す。明細の全内容は見積詳細に
+ * 委ね、本画面には複製しない。
+ *
+ * 申請状態バッジは共通 tone 層（`badgeToneOf`／`badgeToneClassName`）を一覧と共有し、label は VO 単一
+ * ソース（ADR-0069）。見積詳細リンクは既存の業務キー URL `/estimates/[estimateNumber]` へ張る。
+ */
+export function ApplicationDetailSummary({ summary }: { summary: ApplicationDetailSummaryView }) {
+  return (
+    <section className="bg-white shadow-md rounded p-6">
+      <div className="flex items-center justify-between gap-4 mb-4">
+        <div className="flex items-center gap-3">
+          <Link
+            href={`/estimates/${summary.estimateNumber}`}
+            className="text-2xl font-bold text-blue-600 hover:text-blue-800 hover:underline"
+          >
+            {summary.estimateNumber}
+          </Link>
+          <span className="text-lg text-gray-500">バリ {summary.variationNumber}</span>
+        </div>
+        <Badge
+          variant="outline"
+          className={badgeToneClassName(badgeToneOf(summary.applicationState.code))}
+        >
+          {summary.applicationState.label}
+        </Badge>
+      </div>
+
+      <dl className="grid grid-cols-[8rem_1fr] gap-y-2 text-sm">
+        <dt className="font-bold text-gray-600">得意先</dt>
+        <dd className="text-gray-800">{summary.customerName}</dd>
+        <dt className="font-bold text-gray-600">納品先</dt>
+        <dd className="text-gray-800">{summary.deliveryLocationName}</dd>
+        <dt className="font-bold text-gray-600">提出区分</dt>
+        <dd className="text-gray-800">
+          {SUBMISSION_TYPE_LABELS[summary.submissionType] ?? summary.submissionType}
+        </dd>
+        <dt className="font-bold text-gray-600">税込合計</dt>
+        <dd className="text-gray-800">{formatYen(summary.finalTotal)}</dd>
+      </dl>
+    </section>
+  );
+}

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ApprovalStepList.tsx
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ApprovalStepList.tsx
@@ -1,0 +1,52 @@
+import { Badge } from "@/app/_components/shadcnui/badge";
+import { badgeToneClassName } from "@/app/_components/shared/variationApplicationStateBadge";
+import { type ApprovalStepView } from "@subdomains/estimate/application/queries/dto/EstimateApplicationDetailDTO";
+import { formatDateTime } from "../../../_shared/labels";
+import { approvalStepStatusBadgeToneOf } from "./approvalStepStatusBadge";
+
+/**
+ * 承認チェーン（テーブル6列・§3.6）。1 行＝1 承認ステップ（stepOrder 昇順）。
+ *
+ * DTO が均一テーブル前提で flat 化（承認者/差戻者を `actorName` に畳み込み）しているため、
+ * ステッパーではなくテーブルで受ける。進行感は状態バッジの色（AWAITING=info / APPROVED=success /
+ * REJECTED=warning）で補う。未決フィールド（actorName / decidedAt / rejectionComment の null）は「—」。
+ */
+export function ApprovalStepList({ steps }: { steps: ApprovalStepView[] }) {
+  return (
+    <div className="overflow-x-auto border rounded">
+      <table className="w-full text-sm text-left whitespace-nowrap">
+        <thead className="bg-gray-50 border-b">
+          <tr>
+            <th className="px-3 py-2 font-bold text-gray-700 text-right">順序</th>
+            <th className="px-3 py-2 font-bold text-gray-700">役割</th>
+            <th className="px-3 py-2 font-bold text-gray-700">状態</th>
+            <th className="px-3 py-2 font-bold text-gray-700">承認者・差戻者</th>
+            <th className="px-3 py-2 font-bold text-gray-700">発生日時</th>
+            <th className="px-3 py-2 font-bold text-gray-700">差戻コメント</th>
+          </tr>
+        </thead>
+        <tbody>
+          {steps.map((step) => (
+            <tr key={step.order} className="border-b">
+              <td className="px-3 py-2 text-right">{step.order}</td>
+              <td className="px-3 py-2">{step.roleName}</td>
+              <td className="px-3 py-2">
+                <Badge
+                  variant="outline"
+                  className={badgeToneClassName(approvalStepStatusBadgeToneOf(step.status.code))}
+                >
+                  {step.status.label}
+                </Badge>
+              </td>
+              <td className="px-3 py-2">{step.actorName ?? "—"}</td>
+              <td className="px-3 py-2">
+                {step.decidedAt !== null ? formatDateTime(step.decidedAt) : "—"}
+              </td>
+              <td className="px-3 py-2 whitespace-pre-wrap">{step.rejectionComment ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ExemptionRecord.tsx
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ExemptionRecord.tsx
@@ -1,0 +1,23 @@
+import { type ExemptionView } from "@subdomains/estimate/application/queries/dto/EstimateApplicationDetailDTO";
+import { formatDateTime } from "../../../_shared/labels";
+
+/**
+ * 免除記録（EXEMPTED 枝・§3.1-4）。承認チェーンの代わりに免除の事実（理由・実施者・日時）を
+ * 3 行定義リストで示す。免除の状態表現（「承認不要」バッジ）は要約ヘッダに一本化するため、
+ * 理由はテキストで出し状態バッジは付けない（同一の免除事実に表示を割らない・CONTEXT「承認免除」）。
+ */
+export function ExemptionRecord({ exemption }: { exemption: ExemptionView }) {
+  return (
+    <section className="bg-white shadow-md rounded p-6">
+      <h2 className="text-lg font-semibold text-gray-700 mb-4">免除記録</h2>
+      <dl className="grid grid-cols-[8rem_1fr] gap-y-2 text-sm">
+        <dt className="font-bold text-gray-600">免除理由</dt>
+        <dd className="text-gray-800">{exemption.reason.label}</dd>
+        <dt className="font-bold text-gray-600">実施者</dt>
+        <dd className="text-gray-800">{exemption.exemptedByName}</dd>
+        <dt className="font-bold text-gray-600">免除日時</dt>
+        <dd className="text-gray-800">{formatDateTime(exemption.exemptedAt)}</dd>
+      </dl>
+    </section>
+  );
+}

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/applicationStatusBadge.test.ts
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/applicationStatusBadge.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { applicationStatusBadgeToneOf } from "./applicationStatusBadge";
+
+/**
+ * 申請状態（4値・{@link ApplicationStatusCode}）→ バッジ色調の写像。
+ * バリエーション申請状態の重なる4値（badgeToneOf）と同じ色語彙で揃える。
+ */
+describe("applicationStatusBadgeToneOf", () => {
+  it("PENDING（申請中）は info", () => {
+    expect(applicationStatusBadgeToneOf("PENDING")).toBe("info");
+  });
+
+  it("APPROVED（承認済）は success", () => {
+    expect(applicationStatusBadgeToneOf("APPROVED")).toBe("success");
+  });
+
+  it("REJECTED（差戻）は warning", () => {
+    expect(applicationStatusBadgeToneOf("REJECTED")).toBe("warning");
+  });
+
+  it("WITHDRAWN（取下）は neutral", () => {
+    expect(applicationStatusBadgeToneOf("WITHDRAWN")).toBe("neutral");
+  });
+});

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/applicationStatusBadge.ts
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/applicationStatusBadge.ts
@@ -1,0 +1,28 @@
+import { type VariationApplicationStateBadgeTone as BadgeTone } from "@/app/_components/shared/variationApplicationStateBadge";
+import { type ApplicationStatusCode } from "@subdomains/estimate/domain/values/approval/ApplicationStatus";
+
+/**
+ * 申請状態（4値・§3.6）→ バッジ色調の写像（見積申請詳細・#574）。
+ *
+ * 色調の語彙（tone）と `tone→className` は共通 tone 層（`shared/variationApplicationStateBadge`）を
+ * 単一ソースとして再利用し、本ファイルは「申請状態 code → tone」の写像だけを持つ。バリエーション
+ * 申請状態の重なる4値（`badgeToneOf`）と同じ配色に揃える（同じ状態は同じ色・ADR-0069 の語彙単一化）。
+ *
+ * `default` の `never` ガードで全 code 網羅をコンパイル時に強制する（VO に値が増えたらここが型エラー）。
+ */
+export function applicationStatusBadgeToneOf(code: ApplicationStatusCode): BadgeTone {
+  switch (code) {
+    case "PENDING":
+      return "info";
+    case "APPROVED":
+      return "success";
+    case "REJECTED":
+      return "warning";
+    case "WITHDRAWN":
+      return "neutral";
+    default: {
+      const _exhaustive: never = code;
+      return _exhaustive;
+    }
+  }
+}

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/approvalStepStatusBadge.test.ts
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/approvalStepStatusBadge.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { approvalStepStatusBadgeToneOf } from "./approvalStepStatusBadge";
+
+/**
+ * 承認ステップ状態（4値・{@link ApprovalStepStatusCode}）→ バッジ色調の写像。
+ * 申請状態と別概念のため別関数だが、色語彙（tone）は共通層で単一ソース化する。
+ */
+describe("approvalStepStatusBadgeToneOf", () => {
+  it("NOT_STARTED（未着手）は neutral", () => {
+    expect(approvalStepStatusBadgeToneOf("NOT_STARTED")).toBe("neutral");
+  });
+
+  it("AWAITING（承認待ち）は info", () => {
+    expect(approvalStepStatusBadgeToneOf("AWAITING")).toBe("info");
+  });
+
+  it("APPROVED（承認済）は success", () => {
+    expect(approvalStepStatusBadgeToneOf("APPROVED")).toBe("success");
+  });
+
+  it("REJECTED（差戻）は warning", () => {
+    expect(approvalStepStatusBadgeToneOf("REJECTED")).toBe("warning");
+  });
+});

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/approvalStepStatusBadge.ts
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/approvalStepStatusBadge.ts
@@ -1,0 +1,29 @@
+import { type VariationApplicationStateBadgeTone as BadgeTone } from "@/app/_components/shared/variationApplicationStateBadge";
+import { type ApprovalStepStatusCode } from "@subdomains/estimate/domain/values/approval/ApprovalStepStatus";
+
+/**
+ * 承認ステップ状態（4値・§3.6）→ バッジ色調の写像（見積申請詳細のチェーン各段・#574）。
+ *
+ * 申請状態とは別概念（主語がステップ）なので写像も別関数として持つが、色調の語彙（tone）と
+ * `tone→className` は共通 tone 層（`shared/variationApplicationStateBadge`）を単一ソースとして再利用する。
+ * 進行中（AWAITING）を info・完了（APPROVED）を success・差戻（REJECTED）を warning・未着手を neutral とし、
+ * 申請状態バッジと同じ配色語彙で揃える。
+ *
+ * `default` の `never` ガードで全 code 網羅をコンパイル時に強制する（VO に値が増えたらここが型エラー）。
+ */
+export function approvalStepStatusBadgeToneOf(code: ApprovalStepStatusCode): BadgeTone {
+  switch (code) {
+    case "NOT_STARTED":
+      return "neutral";
+    case "AWAITING":
+      return "info";
+    case "APPROVED":
+      return "success";
+    case "REJECTED":
+      return "warning";
+    default: {
+      const _exhaustive: never = code;
+      return _exhaustive;
+    }
+  }
+}

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/estimate-application-detail.e2e.ts
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/estimate-application-detail.e2e.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * 見積申請詳細画面（/estimate-applications/[estimateNumber]/[variationNumber]・#574）の E2E。
+ *
+ * seed-estimate-applications.ts のフィクスチャに対し、表示ブロック（要約ヘッダ・最新申請の承認
+ * チェーン・過去履歴の差戻コメント・免除記録）と一覧からの遷移・NotFound を配線検証する。
+ * - N9905015: attempt1 差戻（過去履歴）＋ attempt2 多段チェーン（営業課長 承認済 → 営業部長 承認待ち）
+ * - N9905013: 承認免除（EXEMPTED）
+ *
+ * 導出状態の網羅は BE 単体（#573 クエリテスト・§3.6 導出）に委ね、ここは画面配線の担保に集中する
+ * （ADR-0012）。read-only のため非 serial。
+ */
+const RICH = "N9905015";
+const EXEMPTED = "N9905013";
+const NONEXISTENT = "N9999999";
+
+test.describe("見積申請詳細", () => {
+  test("APPLICATIONS: 要約・見積詳細リンク・最新チェーン・過去の差戻コメントが読める", async ({
+    page,
+  }) => {
+    await page.goto(`/estimate-applications/${RICH}/1`);
+
+    await expect(page.getByRole("heading", { name: "見積申請詳細" })).toBeVisible();
+
+    // 要約ヘッダ: 見積番号は見積詳細（業務キー URL）へリンク・申請状態は最新=PENDING の「申請中」。
+    await expect(page.getByRole("link", { name: RICH })).toHaveAttribute(
+      "href",
+      `/estimates/${RICH}`
+    );
+    await expect(page.getByText("申請中").first()).toBeVisible();
+
+    // 最新申請（attempt2）: 申請者と多段チェーンの各ステップ状態・承認者を弁別する。
+    await expect(page.getByRole("heading", { name: "最新の申請" })).toBeVisible();
+    await expect(page.getByText("佐藤 太郎").first()).toBeVisible();
+
+    // step1 営業課長=承認済（承認者 鈴木 次郎）、step2 営業部長=承認待ち。
+    const latestStep1 = page
+      .locator("tr")
+      .filter({ hasText: "営業課長" })
+      .filter({ hasText: "承認済" });
+    await expect(latestStep1).toContainText("鈴木 次郎");
+    const latestStep2 = page.locator("tr").filter({ hasText: "営業部長" });
+    await expect(latestStep2).toContainText("承認待ち");
+
+    // 過去履歴（attempt1）: 差戻ステップと差戻コメントが読める（画面主目的）。
+    await expect(page.getByRole("heading", { name: "過去の申請履歴" })).toBeVisible();
+    const pastRejected = page
+      .locator("tr")
+      .filter({ hasText: "営業課長" })
+      .filter({ hasText: "差戻" });
+    await expect(pastRejected).toContainText("鈴木 次郎");
+    await expect(page.getByText("金額の根拠資料を添付してください")).toBeVisible();
+  });
+
+  test("EXEMPTED: 免除記録（理由・実施者）と要約ヘッダの「承認不要」バッジが読める", async ({
+    page,
+  }) => {
+    await page.goto(`/estimate-applications/${EXEMPTED}/1`);
+
+    await expect(page.getByRole("heading", { name: "見積申請詳細" })).toBeVisible();
+    await expect(page.getByText("承認不要").first()).toBeVisible();
+
+    // 免除記録: 理由 label（10万円未満）・実施者（高橋 三郎）。承認チェーン枝は出ない。
+    await expect(page.getByRole("heading", { name: "免除記録" })).toBeVisible();
+    await expect(page.getByText("10万円未満")).toBeVisible();
+    await expect(page.getByText("高橋 三郎")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "最新の申請" })).toHaveCount(0);
+  });
+
+  test("NotFound: 存在しない見積番号で 404 になる", async ({ page }) => {
+    const response = await page.goto(`/estimate-applications/${NONEXISTENT}/1`);
+    expect(response?.status()).toBe(404);
+  });
+
+  test("一覧→詳細: 見積番号リンクをクリックして詳細へ着地する", async ({ page }) => {
+    await page.goto(`/estimate-applications?estimateNumber=${RICH}`);
+    await expect(page.getByRole("heading", { name: "見積申請一覧" })).toBeVisible();
+    await expect(page.locator("table tbody tr").first()).toBeVisible();
+
+    await page.getByRole("link", { name: RICH }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/estimate-applications/${RICH}/1`));
+    await expect(page.getByRole("heading", { name: "見積申請詳細" })).toBeVisible();
+  });
+});

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/page.tsx
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/page.tsx
@@ -1,0 +1,76 @@
+import { notFound } from "next/navigation";
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { getEstimateApplicationDetailQueryFactory } from "@subdomains/estimate/application/factories/getEstimateApplicationDetailQueryFactory";
+import { ApplicationCard } from "./_components/ApplicationCard";
+import { ApplicationDetailSummary } from "./_components/ApplicationDetailSummary";
+import { ExemptionRecord } from "./_components/ExemptionRecord";
+
+/**
+ * 見積申請詳細画面（/estimate-applications/[estimateNumber]/[variationNumber]・#574）
+ *
+ * 薄い RSC。バリエーションの自然キー（見積番号＋バリエーション番号）で参照クエリ（#573）を引き、
+ * 判別ユニオン DTO を `kind` で出し分けて表示ブロック（要約ヘッダ・申請カード・免除記録）へ渡す。
+ *
+ * クエリは操作可否合成のため操作者（ログイン社員）を必須とする。本システムに employeeId を持たない
+ * 閲覧者はいない前提のため、null は fail-fast で throw する（error 境界へ）。ただし操作 UI（承認・
+ * 差戻・取下）は後続 issue のため、本画面では `operations` を描画しない（表示のみ）。
+ *
+ * NotFound（見積番号なし／バリエーション番号なし／申請も免除も無い）はクエリが null を返すため
+ * `notFound()`（既存 estimates 詳細と同一パターン）。バリエーション番号が数値でない URL も同様。
+ */
+export default async function EstimateApplicationDetailPage({
+  params,
+}: {
+  params: Promise<{ estimateNumber: string; variationNumber: string }>;
+}) {
+  const { estimateNumber, variationNumber } = await params;
+
+  const variationNumberValue = Number(variationNumber);
+  if (!Number.isInteger(variationNumberValue)) {
+    notFound();
+  }
+
+  const session = await verifySession();
+  const operatorEmployeeId = session.user.employeeId;
+  if (operatorEmployeeId === null) {
+    // 本システムに従業員未紐付けの閲覧者は存在しない前提。到達したら異常系として fail-fast。
+    throw new Error("従業員に紐付かないユーザーは見積申請詳細を参照できません");
+  }
+
+  const detail = await getEstimateApplicationDetailQueryFactory().execute({
+    estimateNumber,
+    variationNumber: variationNumberValue,
+    operatorEmployeeId,
+  });
+  if (detail === null) {
+    notFound();
+  }
+
+  return (
+    <div className="container mx-auto p-8 space-y-6">
+      <h1 className="text-3xl font-bold">見積申請詳細</h1>
+
+      <ApplicationDetailSummary summary={detail.summary} />
+
+      {detail.kind === "EXEMPTED" ? (
+        <ExemptionRecord exemption={detail.exemption} />
+      ) : (
+        <>
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-gray-700">最新の申請</h2>
+            <ApplicationCard application={detail.latest} />
+          </section>
+
+          {detail.past.length > 0 && (
+            <section className="space-y-3">
+              <h2 className="text-xl font-semibold text-gray-700">過去の申請履歴</h2>
+              {detail.past.map((application) => (
+                <ApplicationCard key={application.applicationId} application={application} />
+              ))}
+            </section>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/page.tsx
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/page.tsx
@@ -25,8 +25,12 @@ export default async function EstimateApplicationDetailPage({
 }) {
   const { estimateNumber, variationNumber } = await params;
 
+  // URL セグメントは常に文字列。厳格な 10 進整数（1 始まりの正の数のみ・先頭ゼロ/符号/小数/16 進/
+  // 空白を弾く）かつ int4 範囲内のみ受理し、それ以外は notFound()。範囲外・非正規値を Prisma の
+  // `Int`(int4) 列 where に到達させないことで 500 を避ける。業務上の上限（1〜99）はここで二重に
+  // 持たず、存在しない番号はクエリの null → notFound() に委ねる（DB/ドメイン制約と乖離させない）。
   const variationNumberValue = Number(variationNumber);
-  if (!Number.isInteger(variationNumberValue)) {
+  if (!/^[1-9][0-9]*$/.test(variationNumber) || variationNumberValue > 2_147_483_647) {
     notFound();
   }
 

--- a/src/app/(features)/estimate-applications/_components/columns.tsx
+++ b/src/app/(features)/estimate-applications/_components/columns.tsx
@@ -8,7 +8,7 @@ import {
   badgeToneOf,
 } from "@/app/_components/shared/variationApplicationStateBadge";
 import type { EstimateApplicationSummaryDTO } from "@subdomains/estimate/application/queries/dto/EstimateApplicationSummaryDTO";
-import { SUBMISSION_TYPE_LABELS, formatDateTime, formatYen } from "./labels";
+import { SUBMISSION_TYPE_LABELS, formatDateTime, formatYen } from "../_shared/labels";
 
 /**
  * 見積申請一覧の 1 行（presentation 用）。BE の読み取り DTO をそのまま行に用いる

--- a/src/app/(features)/estimate-applications/_shared/labels.ts
+++ b/src/app/(features)/estimate-applications/_shared/labels.ts
@@ -1,7 +1,10 @@
 /**
- * 見積申請一覧（/estimate-applications）の表示ラベル・整形ヘルパ（presentation 専用）。
- * この機能に閉じた小さな写像として持つ（日付・バッジのような複数画面共有部品は _lib へ昇格済みだが、
- * これらは本一覧固有のため昇格しない）。
+ * 見積申請（一覧 `/estimate-applications` と詳細 `[estimateNumber]/[variationNumber]`）で共有する
+ * 表示ラベル・整形ヘルパ（presentation 専用）。
+ *
+ * 一覧・詳細の共通親（`estimate-applications/`）直下の `_shared` に置き、両画面で同じ提出区分ラベル・
+ * 金額/日時整形を単一ソースにする。見積申請機能に閉じるため global（`_lib`）へは昇格しない
+ * （機能固有は昇格しない方針）。
  */
 
 /** 提出区分（バリエーションの submissionType・ADR-0045）。 */
@@ -15,7 +18,7 @@ export function formatYen(amount: number): string {
   return `${amount.toLocaleString("ja-JP")}円`;
 }
 
-/** 申請日時を JST の「2026/07/01 13:45」形式に整形する。 */
+/** 日時を JST の「2026/07/01 13:45」形式に整形する。 */
 export function formatDateTime(date: Date): string {
   return date.toLocaleString("ja-JP", {
     timeZone: "Asia/Tokyo",


### PR DESCRIPTION
## Summary

見積申請詳細画面（表示）を実装。バリエーション要約ヘッダ・最新申請の承認チェーン・過去の申請履歴・免除記録の各ブロックを `/estimate-applications/[estimateNumber]/[variationNumber]` に表示し、一覧（#572）からの遷移を接続。申請状態/承認ステップ状態のバッジ写像・整形ヘルパの共有化・表示 E2E（APPLICATIONS/EXEMPTED/NotFound/一覧遷移）を追加。

Closes #574

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### estimate-application-detail-screen.md

# Issue #574: 見積申請詳細画面 表示（FE） — 実装計画

## 概要

見積申請詳細画面（`/estimate-applications/[estimateNumber]/[variationNumber]`）の**表示部分**を実装する。承認・差戻・取下の操作系は後続 issue とし、本 issue は表示のみに閉じる。

BE の参照クエリ（#573・`GetEstimateApplicationDetailQuery`）が既に完成しており、本画面はその読み取り DTO（`EstimateApplicationDetailDTO`）を **直 type-import で消費するだけ**の薄い RSC 構成になる（ADR-0069）。DTO は判別ユニオン（`APPLICATIONS` / `EXEMPTED`）で分岐を畳み込み済みで、FE 側に新しい型・新しい用語は生まれない。

表示ブロック（概要設計 §3.1）:
1. バリエーション要約ヘッダ（見積詳細へのリンク・申請状態バッジ）
2. 最新申請の承認チェーン
3. 過去の申請履歴（承認チェーン込み）
4. 免除バリエーションの場合は免除記録

TDD で進める（`/tdd`）。表示ロジックのうち純粋関数（`code→tone` 写像）は単体テスト先行、画面全体の配線は E2E で担保する（導出の全網羅は BE 単体テストに委ねる・ADR-0012）。

## 設計判断

### クエリ呼び出しと `operatorEmployeeId` の供給
- `execute` は表示スコープ外の `operations` 合成のために `operatorEmployeeId: string`（非 null）を必須とする
- 判断: `page.tsx`（RSC）で `session.user.employeeId` を渡す。`null` は「このシステムに存在しない前提」として `throw`（fail-fast、error 境界へ）
- `operations`（承認可否）は本 issue では**描画しない**（操作 UI は後続 issue）
- 理由: 既存 `resolveApplicationContext`（Server Action 側）と同じ「employeeId null は操作不可」の思想を RSC に踏襲。BE クエリを operator optional に変える案は、表示 issue のスコープを BE に広げるため不採用

### NotFound の扱い
- 判断: クエリが `null`（見積番号なし／バリエーション番号なし／申請も免除も無い）なら `notFound()`
- 理由: 既存 `estimates/[estimateNumber]/page.tsx` と同一パターン

### コンポーネント分割（全て RSC）
- 判断: `page.tsx` で取得・notFound・`kind` 分岐。presentational は `ApplicationDetailSummary` / `ApplicationCard` / `ApprovalStepList` / `ExemptionRecord`
- `ApplicationCard` は `latest` と `past[]` の各要素で**共用**（BE が両者を同型 `ApplicationView` にした意図に従う）
- 理由: 操作 UI が無いため client 化の必然が無く、全 RSC にしておけば後続の操作 issue が「操作 UI だけを client island として足す」形で拡張できる

### 状態バッジ（3種の状態を別扱い）
- 画面に出る状態は3種: バリエーション申請状態（6値・要約ヘッダ）／申請状態（4値・申請カード）／承認ステップ状態（4値・チェーン各段）
- 判断: 共通 tone 層（既存 `shared/variationApplicationStateBadge` の tone 語彙＋`tone→className`）を再利用し、`code→tone` 写像だけを状態 VO ごとに専用関数として持つ
  - `VariationApplicationState` = 既存 `badgeToneOf` を流用
  - `ApplicationStatus` / `ApprovalStepStatus` = 本画面 `_components` に新規（`never` ガードで網羅強制）
- 理由: 3状態は別概念なので写像も別関数（VO に値が増えたら該当 switch だけ型エラー）。一方「緑=承認済」の色語彙は3重定義を避け tone 層で単一ソース化。新規2つは本画面専用のため shared へ昇格しない（labels.ts と同じ「機能固有は昇格しない」方針）

### 承認ステップの表示形式
- 判断: **テーブル6列**（順序 / 役割 / 状態バッジ / 承認者・差戻者 / 発生日時 / 差戻コメント）
- 理由: `ApprovalStepView` の JSDoc が「均一テーブル UI に合わせ承認者/差戻者を `actorName` に畳み込み」と明記。DTO がテーブル前提で flat 化されている。ステッパーは畳み込みと齟齬。進行感は状態バッジの色で補える

### 過去申請履歴の見せ方
- 判断: 折りたたみ無し・attempt 降順（DTO が既にソート済み）で全件展開・`past` 空なら履歴ブロックごと非表示
- 理由: §3.2 が「折りたたみ等の UI 詳細は後続 issue で決める」と明示委譲。折りたたみは client 状態を要し全 RSC 構成を崩す

### 免除ブロックのレイアウト
- 判断: 3行定義リスト（理由 label / 実施者 / 日時）。理由はテキスト（状態バッジは付けない）
- 理由: 承認チェーンが無い枝で定義リストが情報形状に合う。免除の状態表現は要約ヘッダの「承認不要」バッジに一本化（同一の免除事実に表示を割らない・CONTEXT.md「承認免除」）

### 整形ヘルパの配置
- 判断: `formatDateTime` / `formatYen` / `SUBMISSION_TYPE_LABELS` を一覧・詳細で共有できる位置へ寄せる
- 理由: 現在 `estimate-applications/_components/labels.ts` にあり、詳細でも使うため共有化

### E2E とシード
- 判断: 詳細画面用にリッチフィクスチャ `N9905015`（attempt2 多段チェーン＝課長承認済→部長承認待ち／attempt1 差戻コメント付き）を `seed-estimate-applications.ts` に追加
- 理由: 既存シードは全て attempt1・単段チェーンで `past` が常に空。§3.2 が置く画面主目的（過去履歴・差戻コメントの参照）を E2E で検証できないため。リッチ1件で最新チェーンの複数ステップ状態・過去履歴ブロック・差戻コメント・actorName を一度に配線検証できる

### ドキュメント更新
- CONTEXT.md / ADR: **新規更新なし**（新用語なし・配色確定は ADR-0069 が FE issue へ委譲済み・operator 必須のねじれは ADR-20260707-ae2 が説明済み・残りは可逆でトレードオフ小）

## ステップ

### Step 1: 状態バッジの `code→tone` 写像（TDD・純粋関数）
- 対象ファイル:
  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/applicationStatusBadge.ts`（新規）
  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/approvalStepStatusBadge.ts`（新規）
  - 各 `.test.ts`
- 作業内容:
  - Red: `ApplicationStatus`（PENDING/APPROVED/REJECTED/WITHDRAWN）・`ApprovalStepStatus`（NOT_STARTED/AWAITING/APPROVED/REJECTED）の全 code → tone 期待をテスト化
  - Green: 既存 `variationApplicationStateBadge` の `tone`/`tone→className` を import 再利用しつつ、`code→tone` を `never` ガード網羅 switch で実装
  - Refactor: tone 語彙・className の重複が出れば shared 側の再利用に寄せる
- コミットメッセージ: `feat: 見積申請詳細 状態バッジの code→tone 写像（申請状態・承認ステップ状態）`

### Step 2: 整形ヘルパの共有化
- 対象ファイル:
  - `estimate-applications/_components/labels.ts`（移動元）
  - 共有位置（`estimate-applications/_lib/labels.ts` 等・詳細と一覧の共通親）
  - 一覧 `columns.tsx` の import 追随
- 作業内容:
  - `formatDateTime` / `formatYen` / `SUBMISSION_TYPE_LABELS` を共有位置へ移設
  - 一覧側の import を更新し、既存 E2E がグリーンのままを確認
- コミットメッセージ: `refactor: 見積申請の整形ヘルパを一覧・詳細で共有化`

### Step 3: presentational コンポーネント（RSC）
- 対象ファイル（`[estimateNumber]/[variationNumber]/_components/` 配下）:
  - `ApplicationDetailSummary.tsx`（要約ヘッダ・見積詳細リンク・申請状態バッジ）
  - `ApprovalStepList.tsx`（テーブル6列）
  - `ApplicationCard.tsx`（`ApplicationView` を承認チェーン込みで・latest/past 共用）
  - `ExemptionRecord.tsx`（3行定義リスト）
- 作業内容:
  - DTO の各 View 型を直 type-import して各ブロックを描画（ミラー型を作らない）
  - null フィールド（`actorName`/`decidedAt`/`rejectionComment` 等）は空表示
- コミットメッセージ: `feat: 見積申請詳細の表示コンポーネント（要約・承認チェーン・免除記録）`

### Step 4: page.tsx（RSC・データ取得と分岐）
- 対象ファイル:
  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/page.tsx`（新規）
- 作業内容:
  - `params` の `variationNumber` を数値パース、`verifySession()` + `employeeId` null ガード（throw）
  - `getEstimateApplicationDetailQueryFactory().execute(...)` 実行、`null` は `notFound()`
  - `summary` は常に `ApplicationDetailSummary` へ。`kind` で APPLICATIONS（latest + past）/ EXEMPTED（exemption）を出し分け
  - 過去履歴は attempt 降順で全件展開・`past` 空なら履歴ブロック非表示
- コミットメッセージ: `feat: 見積申請詳細画面のページ（取得・notFound・kind 分岐）`

### Step 5: E2E 用リッチフィクスチャの追加
- 対象ファイル:
  - `prisma/seed-estimate-applications.ts`
- 作業内容:
  - `N9905015`: attempt1 = 差戻（REJECTED・差戻コメント付き）、attempt2 = 多段チェーン（課長承認済→部長承認待ち）を追加
  - 既知従業員（承認者/差戻者/申請者）で actorName を弁別可能にする
- コミットメッセージ: `test: 見積申請詳細 E2E 用のリッチフィクスチャ（差戻→再申請＋多段チェーン）を追加`

### Step 6: E2E（4シナリオ）
- 対象ファイル:
  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/estimate-application-detail.e2e.ts`（新規）
- 作業内容:
  - ① APPLICATIONS（`N9905015`）: 要約ヘッダ・見積詳細リンク href・最新チェーンのステップ状態・過去履歴の差戻コメント
  - ② EXEMPTED（`N9905013`）: 免除記録（理由/実施者/日時）＋要約ヘッダ「承認不要」バッジ
  - ③ NotFound: 申請も免除も無いバリエーション（または存在しない自然キー）→ 404
  - ④ 一覧→詳細: 一覧行の見積番号リンクを実クリックして詳細へ着地
  - read-only のため非 serial
- コミットメッセージ: `test: 見積申請詳細画面の表示 E2E（APPLICATIONS/EXEMPTED/NotFound/一覧遷移）`

</details>

## 計画からの逸脱

# Issue #574 実装計画からの逸脱記録

## 1. 整形ヘルパの共有化先ディレクトリ

- **元の計画**: 共有位置を「`estimate-applications/_lib/labels.ts` 等（詳細と一覧の共通親）」と例示。
- **実際の実装**: `src/app/(features)/estimate-applications/_shared/labels.ts` に移設。
- **逸脱の理由**: 計画は「等」で正確な位置を未確定にしていた。既存リポジトリに機能ローカルな共有ヘルパの
  イディオムとして `estimates/_shared/`（例: `setComponentExpansion.ts`）が存在するため、`_lib` ではなく
  `_shared` サブフォルダに揃えた。global な `@/app/_lib` へは昇格せず、見積申請機能に閉じる方針は計画通り。

## 2. 承認ステップ状態バッジの tone 割り当て（計画の空白を補完）

- **元の計画**: Step 1 で「`ApprovalStepStatus` の全 code → tone をテスト化」と方針のみ規定し、各値の tone は未明示。
- **実際の実装**: `NOT_STARTED=neutral / AWAITING=info / APPROVED=success / REJECTED=warning`。
- **逸脱の理由**: 計画未確定の配色を、申請状態バッジ（`PENDING=info / APPROVED=success / REJECTED=warning /
  WITHDRAWN=neutral`）およびバリエーション申請状態の既存 `badgeToneOf` と同じ色語彙で整合させた
  （「緑=承認済・琥珀=差戻・青=進行中・灰=不活性」の共通語彙）。新規判断ではなく既存語彙への追従。


---

Generated with [Claude Code](https://claude.ai/code)
