### PR TITLE
feat: 見積申請詳細 承認・差戻・取下操作（FE）

### DIFF
--- a/docs/claude-plans/issue-575/application-detail-approve-reject-withdraw-fe.md
+++ b/docs/claude-plans/issue-575/application-detail-approve-reject-withdraw-fe.md
@@ -1,0 +1,116 @@
+# Issue #575: 見積申請詳細 承認・差戻・取下操作（FE） — 実装計画
+
+## 概要
+
+見積申請詳細画面（`/estimate-applications/[estimateNumber]/[variationNumber]`）に、承認・差戻・取下の操作 UI を配線する。BE コマンド（`ApproveStep` / `RejectStep` / `WithdrawApplication`）とファクトリ、参照 DTO（`operations.canApprove/canReject/canWithdraw`・`latestApplicationId`・`awaitingStepId`・`expectedVersion`・#573）は実装済みで、本 issue は FE（Server Action・ダイアログ・出し分け・成功/失敗表示・E2E）だけを担う。
+
+- 最終防衛は BE（役割メンバー検証・本人性検証・楽観ロック）。FE の出し分けは UX のためで役割メンバーシップ判定を複製しない（DTO の 3 フラグに従う）。
+- 資格の無い閲覧者には操作ボタンを一切出さず、純粋な閲覧画面として振る舞う。
+- TDD（red-green-refactor）で進める。単体/コンポーネントは Vitest、動線は Playwright。
+
+## 設計判断
+
+会話（/grill-with-docs）で確定済み。実装中に判断を追加しない。
+
+### Server Action の契約と成功時の画面更新
+- A. #562 申請ボタンモデル: redirect せず `ActionResult<T>` 返却、成功時 `router.refresh()` で同一 URL 再導出
+- B. 見積編集フォーム流: conform + redirect + `?reason=` フラッシュ
+- **採用: A**。閲覧/編集のモード遷移が無い単一ビューで、成功後に欲しい「チェーン状態・バッジ・ボタン再評価」は RSC 再実行（`router.refresh()`）で自然に再導出できる。兄弟の申請ボタンと契約を揃える。ADR-0068/0069 のパターンに乗る。
+- 承認は結果を区別するため `ActionResult` に判別子 `outcome: "APPROVED" | "STILL_PENDING"` を載せる。コマンドが返す `EstimateApplication.applicationStatus`（`deriveApplicationStatus`）から導出する。
+
+### 成功提示
+- sonner `toast.success(...)` を**直接**呼ぶ（`Toaster` はレイアウトで全画面マウント済み）。`?reason=` フラッシュ（redirect 連動）は使わず、新しい reason コードも増やさない。
+- 文言: 差戻「差し戻しました」／取下「取り下げました」は各 1 文言。**承認は途中/最終で区別**する:
+  - 途中承認（`STILL_PENDING`）: 「承認しました。次の承認ステップに進みました」
+  - 最終承認（`APPROVED`）: 「承認しました。この申請は承認済になりました」
+- 途中承認は refresh 後もバッジが「申請中」のままボタンだけ消えるため、文言で結果を言い切りユーザーの不安を消す。
+
+### 失敗提示（入力保護で分岐）
+- `handleCommandError` は ConflictError（楽観ロック競合）も BusinessRuleViolationError（役割非メンバー・非 PENDING 等）も区別せず `{success:false, error}` に畳む。今回はどちらも救済が「最新を読み直す」に収束するため区別不要。
+- **承認・取下（入力なし）**: 失敗時はダイアログを閉じ、エラートースト＋`router.refresh()` で真実へ。
+- **差戻（コメントあり）**: 失敗時は**ダイアログを開いたまま**、内部にエラー表示、入力済みコメントを温存、auto-refresh しない。
+- 理由: #494 の一律「強制クローズ＋永続バナー＋no-refresh」から意図的に外れる。この画面は守るべき外部フォームが無く（閲覧専用）、守るべき貴重な入力は差戻ダイアログ内の差戻理由（必須・最大 2000 字・ADR-0058）のみ。入力保護原則をその 1 箇所にだけ適用する。
+- ※この失敗ハンドリングの分岐（兄弟の申請ボタンと異なる失敗 UX にした理由）は ADR 化せず、コミットボディ／PR 説明に記載する（ユーザー判断）。
+
+### 差戻コメントの状態保持
+- コメントの `useState` は差戻ラッパー（トリガー＋Dialog を内包する常設クライアント部品）に持つ。`DialogContent` の内側に置くと Radix の unmount で消えるため、親に持たせる。
+- 閉じても消さない。**クリアは差戻成功時のみ**（成功で `canReject=false` になり操作ブロックごと自然消滅）。閉じて再度開いても入力が残る。`router.refresh()` をまたいでもクライアント状態は保持される。
+
+### 差戻コメントのバリデーション配置
+- A. 素の controlled textarea ＋ 薄い UX ガード（`maxLength={2000}`・文字数カウンタ・trim 後空で送信無効）。権威は VO `RejectionComment`（必須・1〜2000 字・trim）。すり抜けは `handleCommandError` 経由で表面化
+- B. conform + zod スキーマ
+- **採用: A**。VO が権威なので FE はミラーせず（ADR-0069）UX 補助に留める。`ApplicationConfirmDialog`（#562）の素 `useState` 前例に一致し、コメント状態保持も素直に成立する。
+
+### Server Action のシグネチャ
+- 承認/取下は estimateNumber からの estimateId 再解決が不要（対象は `stepId`／`applicationId` の identity で、BE が membership・本人性・version を再検証する）。
+- `approveStep(stepId, expectedVersion)` / `rejectStep(stepId, comment, expectedVersion)` / `withdrawApplication(applicationId, expectedVersion)`。operator は各 Action 内で `verifySession()` から解決（null は fail-fast）。
+
+### revalidate の単位
+- Server Action で `revalidatePath` は呼ばない。redirect しないので現ビューは `router.refresh()` で再導出、一覧・見積詳細は別ナビゲーションで dynamic 再クエリされる（#562 と同一方針）。
+
+### CONTEXT.md / ADR
+- CONTEXT.md 変更なし（今回の決定は FE/UX/実装判断で、新ドメイン用語の導入・鋭利化なし。途中承認/最終承認は既存概念の状況記述）。
+- ADR 起票なし（失敗ハンドリング分岐は可逆性が中程度のためコミット/PR 記載に留める・ユーザー判断）。
+
+### E2E のテストデータ
+- 既存表示フィクスチャ（N9905011〜15・申請者 EMP000003・承認待ち役割 営業課長/営業部長）は operator 中立に作られており、ログインユーザー（employee1=社長/employee2=営業本部長）が承認資格も本人でもないため操作成功動線に使えない。
+- **採用: 動線別の独立新フィクスチャ**を `seed-estimate-applications.ts` に追加し、主役 employee2（営業本部長）に紐づける。社長は常に頂点で途中承認を作れないため、中間役割の営業本部長を主役に、その上に社長ステップを置いて途中承認を成立させる。
+
+## ステップ
+
+### Step 1: 承認・差戻・取下の Server Action（契約テスト先行）
+- 対象ファイル:
+  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/actions.ts`（新規）
+  - 同ディレクトリ `actions.test.ts`（新規・契約テスト）
+- 作業内容:
+  - red: コマンドファクトリをモックし、契約を固定するテストを書く。
+    - operator を `verifySession()` から解決し各コマンドへ渡す（null は失敗）
+    - `expectedVersion` を client エコーのまま渡す（サーバで読み直さない・ADR-0068）
+    - `approveStep` は返却 `EstimateApplication.applicationStatus` が APPROVED なら `outcome:"APPROVED"`、それ以外は `"STILL_PENDING"` を `ActionResult` に載せる
+    - ConflictError / BusinessRuleViolationError を `handleCommandError` 経由で `{success:false, error}` に変換
+  - green: `"use server"` の 3 Action を実装。`approveStepCommandFactory` / `rejectStepCommandFactory` / `withdrawApplicationCommandFactory` を配線。差戻は comment を生文字列で渡す（VO は BE で構築）。redirect しない。
+- コミットメッセージ: `feat: 見積申請詳細 承認・差戻・取下のServer Action（FE）`
+  - ボディに「失敗ハンドリングを入力保護で分岐（承認/取下=refresh、差戻=ダイアログ保持）した理由。#494 の一律 force-close から外れる根拠＝閲覧専用画面で守るべき入力は差戻理由のみ」を記載。
+
+### Step 2: 操作ダイアログ（承認/取下 確認・差戻 コメント入力）＋コンポーネントテスト
+- 対象ファイル:
+  - 同ディレクトリ `_components/ApplicationOperations.tsx`（新規・常設クライアント部品。3 ダイアログと差戻コメント state を内包）
+  - `_components/ApplicationOperations.test.tsx`（新規）
+- 作業内容:
+  - red: コンポーネントテスト（Vitest + testing-library）。
+    - 承認/取下は確認ダイアログ（確定/キャンセル）
+    - 差戻は textarea・trim 後空で送信無効・`maxLength`・文字数カウンタ
+    - **差戻コメントを閉じて再度開いても保持**、成功時のみクリア
+    - 成功時 `toast.success` 呼び出し（承認は outcome で文言分岐）＋`router.refresh()`
+    - 失敗時: 承認/取下は閉じてエラートースト、差戻はダイアログ保持＋内部エラー＋コメント温存
+  - green: `ApplicationOperations` を実装。`operations`（3 フラグ・`latestApplicationId`・`awaitingStepId`・`expectedVersion`）と要約（確認文用の variationNumber）を props で受け、`canApprove/canReject/canWithdraw` でボタン出し分け。sonner を直接呼ぶ。
+- コミットメッセージ: `feat: 見積申請詳細 承認・差戻・取下の操作ダイアログ（FE）`
+
+### Step 3: 詳細ページへの操作ブロック配線
+- 対象ファイル:
+  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/page.tsx`
+- 作業内容:
+  - 要約ヘッダの後に `ApplicationOperations` を描画し、`detail.operations` と要約を渡す（現状 page は operations を描画していない）。
+  - 資格なし（3 フラグ全 false）ではボタンが出ないことを配線上担保。
+- コミットメッセージ: `feat: 見積申請詳細画面に操作ブロックを配線（FE）`
+
+### Step 4: E2E フィクスチャ追加＋操作動線 E2E
+- 対象ファイル:
+  - `prisma/seed-estimate-applications.ts`（動線別独立フィクスチャ 4 本を追加・N9905016〜・主役 EMP000002）
+  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/estimate-application-detail-operations.e2e.ts`（新規・storageState=user.json）
+- 作業内容:
+  - フィクスチャ:
+    1. 最終承認用: 単段・承認待ち=営業本部長
+    2. 途中承認用: 2 段（step1=営業本部長／step2=社長）
+    3. 差戻用: 承認待ち=営業本部長
+    4. 取下用: 申請者=EMP000002
+  - E2E（employee2 ログイン）:
+    - 承認して承認済になる（バッジ「承認済」＋成功トースト＋操作消滅）
+    - 途中承認（バッジ「申請中」のまま・自ステップ承認済・承認ボタン消滅＋「次の承認ステップに進みました」）
+    - 差戻（コメント入力→バッジ「差戻」＋差戻コメント表示＋成功トースト）
+    - 取下（バッジ「取下」＋取下記録＋成功トースト）
+    - 負: 既存 N9905015 を employee2 で開き操作ボタンが一切出ない（純粋閲覧）
+  - 競合/ガード拒否は E2E に載せない（フレーキー回避・単体に委譲）。
+- コミットメッセージ:
+  - `test: 見積申請詳細 操作動線のE2Eフィクスチャを追加`
+  - `test: 見積申請詳細 承認・差戻・取下の操作動線E2E`

--- a/prisma/seed-estimate-applications.ts
+++ b/prisma/seed-estimate-applications.ts
@@ -57,8 +57,21 @@ export const SEED_APPLICATION_ESTIMATE_NUMBERS = {
    * - attempt1 = 差戻（REJECTED・差戻コメント付き）＝過去履歴
    * - attempt2 = 多段チェーン（営業課長 承認済 → 営業部長 承認待ち）＝最新申請（PENDING）
    * 過去履歴・差戻コメント・多段ステップの状態・actorName を一度に配線検証する。
+   * 主役 employee2（営業本部長）は申請者でも承認待ち役割メンバーでもないため、この番号は
+   * 操作動線 E2E で「操作ボタンが一切出ない純粋閲覧」の負の検証台にも使う（#575）。
    */
   richMultiStep: "N9905015",
+
+  // --- 操作動線 E2E 用（#575・主役 employee2＝EMP000002＝営業本部長＝ROLE002）。 ---
+  // いずれも終端イベントの無い PENDING 申請で、plan の承認待ち役割と申請者だけが異なる。
+  /** 最終承認用（単段・承認待ち＝営業本部長）。employee2 が承認して APPROVED になる。 */
+  operationApprove: "N9905016",
+  /** 途中承認用（2 段・step1＝営業本部長 → step2＝社長）。employee2 が step1 を承認して途中承認。 */
+  operationMidApprove: "N9905017",
+  /** 差戻用（単段・承認待ち＝営業本部長）。employee2 がコメント付きで差し戻す。 */
+  operationReject: "N9905018",
+  /** 取下用（単段・申請者＝営業本部長・承認待ち＝社長）。employee2 が本人として取り下げる。 */
+  operationWithdraw: "N9905019",
 } as const;
 
 const TAX_RATE = new TaxRate(0.1);
@@ -81,6 +94,12 @@ type ApplicationSeedFk = {
   /** 多段チェーンの 2 段目役割（営業部長）。リッチフィクスチャの step2 に使う。 */
   secondRoleId: string;
   goalPositionId: string;
+  /** 操作動線 E2E の主役（EMP000002＝営業本部長）。取下フィクスチャの申請者にも使う。 */
+  protagonistId: string;
+  /** 営業本部長役割（ROLE002）。主役 employee2 が直接メンバーで、承認/差戻の承認待ち役割に使う。 */
+  headquartersRoleId: string;
+  /** 社長役割（ROLE001）。途中承認の 2 段目・取下フィクスチャの承認待ち役割に使う。 */
+  presidentRoleId: string;
 };
 
 /** 申請対象の単一バリエーション見積を組み立てる（NEW・CUSTOMER・1 明細）。 */
@@ -131,6 +150,41 @@ function twoStepPlan(fk: ApplicationSeedFk): ApprovalChainPlan {
   ]);
 }
 
+/** 承認待ち役割を差し替えられる汎用チェーン計画（操作動線 E2E 用・ゴール役職は表示に出ない）。 */
+function planWithRoles(fk: ApplicationSeedFk, roleIds: string[]): ApprovalChainPlan {
+  return ApprovalChainPlan.create(
+    new PositionId(fk.goalPositionId),
+    roleIds.map((id) => new RoleId(id))
+  );
+}
+
+/**
+ * 終端イベントの無い PENDING 申請を単体で投入する（操作動線 E2E 用・#575）。
+ *
+ * 申請者・承認待ち役割だけを差し替えて、承認/差戻/取下の各動線ごとに独立したバリエーションを作る。
+ * 操作の成否は主役 employee2（営業本部長）が「承認待ち役割の直接メンバーか」「申請者本人か」で決まる。
+ */
+async function seedPendingApplication(
+  prisma: PrismaClient,
+  fk: ApplicationSeedFk,
+  estimateNumber: string,
+  amount: number,
+  applicantEmployeeId: string,
+  roleIds: string[]
+): Promise<void> {
+  const estimate = buildEstimate(fk, estimateNumber, amount);
+  await prisma.estimate.create({ data: EstimateMapper.toEstimateCreateInput(estimate) });
+  const application = EstimateApplication.create({
+    variationId: estimate.variations[0].id,
+    attempt: 1,
+    applicantEmployeeId: new EmployeeId(applicantEmployeeId),
+    plan: planWithRoles(fk, roleIds),
+  });
+  await prisma.estimateApplication.create({
+    data: EstimateApplicationMapper.toCreateInput(application),
+  });
+}
+
 /**
  * 既存の作成済みマスタ（納品先・部署・個別商品・役割・役職・従業員）を参照して、代表状態を持つ
  * 見積申請フィクスチャを投入する。FK は E2E シードの決定的コード（EMP000003〜5・営業課長）に結び、
@@ -150,6 +204,10 @@ export async function seedEstimateApplications(prisma: PrismaClient): Promise<nu
   const awaitingRole = await prisma.role.findFirst({ where: { name: "営業課長" } });
   const secondRole = await prisma.role.findFirst({ where: { name: "営業部長" } });
   const goalPosition = await prisma.position.findFirst({ orderBy: { positionCd: "asc" } });
+  // 操作動線 E2E の主役と役割（#575）。employee2＝EMP000002＝営業本部長＝ROLE002 の直接メンバー。
+  const protagonist = await prisma.employee.findFirst({ where: { employeeCd: "EMP000002" } }); // 一般 ユーザ（営業本部長）
+  const headquartersRole = await prisma.role.findFirst({ where: { name: "営業本部長" } });
+  const presidentRole = await prisma.role.findFirst({ where: { name: "社長" } });
 
   if (
     !deliveryLocation ||
@@ -160,10 +218,13 @@ export async function seedEstimateApplications(prisma: PrismaClient): Promise<nu
     !exemptor ||
     !awaitingRole ||
     !secondRole ||
-    !goalPosition
+    !goalPosition ||
+    !protagonist ||
+    !headquartersRole ||
+    !presidentRole
   ) {
     throw new Error(
-      "seedEstimateApplications: 前提マスタ（納品先・部署・個別商品・EMP000003-5・役割 営業課長/営業部長・役職）が不足しています"
+      "seedEstimateApplications: 前提マスタ（納品先・部署・個別商品・EMP000002-5・役割 社長/営業本部長/営業部長/営業課長・役職）が不足しています"
     );
   }
 
@@ -179,6 +240,9 @@ export async function seedEstimateApplications(prisma: PrismaClient): Promise<nu
     awaitingRoleId: awaitingRole.id,
     secondRoleId: secondRole.id,
     goalPositionId: goalPosition.id,
+    protagonistId: protagonist.id,
+    headquartersRoleId: headquartersRole.id,
+    presidentRoleId: presidentRole.id,
   };
 
   const now = Date.now();
@@ -287,6 +351,51 @@ export async function seedEstimateApplications(prisma: PrismaClient): Promise<nu
   await prisma.estimateStepApproval.createMany({
     data: EstimateApplicationMapper.toStepApprovalCreateInputs(pendingChainApp),
   });
+
+  // --- 操作動線 E2E 用の 4 フィクスチャ（#575・主役 employee2＝営業本部長）。 ---
+  // いずれも PENDING（終端イベントなし）。承認待ち役割と申請者だけで employee2 の操作可否を切り替える。
+
+  // 1. 最終承認用: 単段・承認待ち＝営業本部長。employee2 が承認すると全ステップ承認済＝APPROVED。
+  await seedPendingApplication(
+    prisma,
+    fk,
+    SEED_APPLICATION_ESTIMATE_NUMBERS.operationApprove,
+    50000,
+    fk.applicantId,
+    [fk.headquartersRoleId]
+  );
+
+  // 2. 途中承認用: 2 段（step1＝営業本部長 → step2＝社長）。employee2 が step1 を承認しても
+  //    社長ステップが承認待ちで残り、申請は PENDING のまま（途中承認）。
+  await seedPendingApplication(
+    prisma,
+    fk,
+    SEED_APPLICATION_ESTIMATE_NUMBERS.operationMidApprove,
+    70000,
+    fk.applicantId,
+    [fk.headquartersRoleId, fk.presidentRoleId]
+  );
+
+  // 3. 差戻用: 単段・承認待ち＝営業本部長。employee2 がコメント付きで差し戻す。
+  await seedPendingApplication(
+    prisma,
+    fk,
+    SEED_APPLICATION_ESTIMATE_NUMBERS.operationReject,
+    90000,
+    fk.applicantId,
+    [fk.headquartersRoleId]
+  );
+
+  // 4. 取下用: 単段・申請者＝営業本部長（本人）・承認待ち＝社長（employee2 は非メンバー）。
+  //    employee2 は申請者本人として取下でき、承認/差戻ボタンは出ない。
+  await seedPendingApplication(
+    prisma,
+    fk,
+    SEED_APPLICATION_ESTIMATE_NUMBERS.operationWithdraw,
+    110000,
+    fk.protagonistId,
+    [fk.presidentRoleId]
+  );
 
   return Object.keys(SEED_APPLICATION_ESTIMATE_NUMBERS).length;
 }

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/__tests__/actions.test.ts
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/__tests__/actions.test.ts
@@ -1,0 +1,172 @@
+import { ConflictError } from "@server/shared/errors/ApplicationError";
+import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { approveStep, rejectStep, withdrawApplication } from "../actions";
+
+/**
+ * 見積申請詳細の操作 Server Action のマッピング契約テスト（#575・Step 1）。
+ *
+ * 「operator はセッション注入で client 入力を無視する」「stepId / applicationId は identity で
+ * BE が membership・本人性・version を再検証する」「expectedVersion は client エコーでサーバは
+ * 読み直さない（TOCTOU・ADR-0068）」を固定する。承認は返却集約の applicationStatus から
+ * outcome（最終承認 / 途中承認）を導出することも固定する。実 Prisma には触れず、Composition
+ * Root（factory）とセッションをモックして配線だけを検証する（applicationActions.test.ts と同型）。
+ */
+
+const verifySession = vi.fn();
+vi.mock("@/app/_lib/verifyAuthentication", () => ({
+  verifySession: () => verifySession(),
+}));
+
+const approveExecute = vi.fn();
+vi.mock("@subdomains/estimate/application/factories/approveStepCommandFactory", () => ({
+  approveStepCommandFactory: () => ({ execute: approveExecute }),
+}));
+
+const rejectExecute = vi.fn();
+vi.mock("@subdomains/estimate/application/factories/rejectStepCommandFactory", () => ({
+  rejectStepCommandFactory: () => ({ execute: rejectExecute }),
+}));
+
+const withdrawExecute = vi.fn();
+vi.mock("@subdomains/estimate/application/factories/withdrawApplicationCommandFactory", () => ({
+  withdrawApplicationCommandFactory: () => ({ execute: withdrawExecute }),
+}));
+
+const SESSION_EMPLOYEE_ID = "emp-session-001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifySession.mockResolvedValue({ user: { employeeId: SESSION_EMPLOYEE_ID } });
+});
+
+describe("approveStep", () => {
+  it("operator をセッション注入・stepId と expectedVersion を client エコーで渡す", async () => {
+    approveExecute.mockResolvedValue({ applicationStatus: { value: "PENDING" } });
+
+    await approveStep("step-1", 7);
+
+    expect(approveExecute).toHaveBeenCalledWith({
+      stepId: "step-1",
+      approverEmployeeId: SESSION_EMPLOYEE_ID,
+      expectedVersion: 7,
+    });
+  });
+
+  it("全ステップ承認済（applicationStatus=APPROVED）なら outcome:APPROVED を返す", async () => {
+    approveExecute.mockResolvedValue({ applicationStatus: { value: "APPROVED" } });
+
+    const result = await approveStep("step-1", 7);
+
+    expect(result).toEqual({ success: true, data: { outcome: "APPROVED" } });
+  });
+
+  it("まだ承認中（applicationStatus=PENDING）なら outcome:STILL_PENDING を返す", async () => {
+    approveExecute.mockResolvedValue({ applicationStatus: { value: "PENDING" } });
+
+    const result = await approveStep("step-1", 7);
+
+    expect(result).toEqual({ success: true, data: { outcome: "STILL_PENDING" } });
+  });
+
+  it("session.user.employeeId が null ならコマンドを呼ばずエラーメッセージを返す", async () => {
+    verifySession.mockResolvedValue({ user: { employeeId: null } });
+
+    const result = await approveStep("step-1", 7);
+
+    expect(approveExecute).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+  });
+
+  it("ConflictError は handleCommandError 経由でメッセージ化する", async () => {
+    approveExecute.mockRejectedValue(new ConflictError("他の操作で申請が更新されました"));
+
+    const result = await approveStep("step-1", 7);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("他の操作で申請が更新されました");
+    }
+  });
+
+  it("BusinessRuleViolationError は handleCommandError 経由でメッセージ化する", async () => {
+    approveExecute.mockRejectedValue(
+      new BusinessRuleViolationError("この操作を行う権限がありません")
+    );
+
+    const result = await approveStep("step-1", 7);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("この操作を行う権限がありません");
+    }
+  });
+});
+
+describe("rejectStep", () => {
+  it("operator をセッション注入・comment を生文字列で・expectedVersion を client エコーで渡す", async () => {
+    rejectExecute.mockResolvedValue({ applicationStatus: { value: "REJECTED" } });
+
+    const result = await rejectStep("step-1", "金額の根拠を明記してください", 7);
+
+    expect(rejectExecute).toHaveBeenCalledWith({
+      stepId: "step-1",
+      rejecterEmployeeId: SESSION_EMPLOYEE_ID,
+      comment: "金額の根拠を明記してください",
+      expectedVersion: 7,
+    });
+    expect(result).toEqual({ success: true });
+  });
+
+  it("ValidationError（空コメント等の VO すり抜け）は handleCommandError 経由でメッセージ化する", async () => {
+    rejectExecute.mockRejectedValue(new ConflictError("他の操作で申請が更新されました"));
+
+    const result = await rejectStep("step-1", "  ", 7);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("session.user.employeeId が null ならコマンドを呼ばずエラーメッセージを返す", async () => {
+    verifySession.mockResolvedValue({ user: { employeeId: null } });
+
+    const result = await rejectStep("step-1", "理由", 7);
+
+    expect(rejectExecute).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("withdrawApplication", () => {
+  it("operator をセッション注入・applicationId と expectedVersion を client エコーで渡す", async () => {
+    withdrawExecute.mockResolvedValue({ applicationStatus: { value: "WITHDRAWN" } });
+
+    const result = await withdrawApplication("app-1", 7);
+
+    expect(withdrawExecute).toHaveBeenCalledWith({
+      applicationId: "app-1",
+      operatorEmployeeId: SESSION_EMPLOYEE_ID,
+      expectedVersion: 7,
+    });
+    expect(result).toEqual({ success: true });
+  });
+
+  it("ConflictError（最終承認との競合等）は handleCommandError 経由でメッセージ化する", async () => {
+    withdrawExecute.mockRejectedValue(new ConflictError("他の操作で申請が更新されました"));
+
+    const result = await withdrawApplication("app-1", 7);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("他の操作で申請が更新されました");
+    }
+  });
+
+  it("session.user.employeeId が null ならコマンドを呼ばずエラーメッセージを返す", async () => {
+    verifySession.mockResolvedValue({ user: { employeeId: null } });
+
+    const result = await withdrawApplication("app-1", 7);
+
+    expect(withdrawExecute).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ApplicationOperations.test.tsx
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ApplicationOperations.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi, type Mock } from "vitest";
+import type { ApplicationOperationsView } from "@subdomains/estimate/application/queries/dto/EstimateApplicationDetailDTO";
+import { ApplicationOperations } from "./ApplicationOperations";
+import { approveStep, rejectStep, withdrawApplication } from "../actions";
+
+/**
+ * 操作ブロック（承認/取下 確認・差戻 コメント入力）のコンポーネントテスト（#575・Step 2）。
+ *
+ * DTO の 3 フラグでボタンを出し分け、確認/入力ダイアログの確定で Server Action を呼び、
+ * 成功トースト（承認は outcome で文言分岐）＋`router.refresh()`、失敗は入力保護で分岐
+ * （承認/取下=閉じて refresh、差戻=ダイアログ保持＋コメント温存）することを固定する。
+ */
+
+vi.mock("../actions", () => ({
+  approveStep: vi.fn(),
+  rejectStep: vi.fn(),
+  withdrawApplication: vi.fn(),
+}));
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+const mockApprove = approveStep as unknown as Mock;
+const mockReject = rejectStep as unknown as Mock;
+const mockWithdraw = withdrawApplication as unknown as Mock;
+
+/** 承認/差戻が可能な operations（承認待ちステップの役割メンバー視点）。 */
+const APPROVER_OPERATIONS: ApplicationOperationsView = {
+  canApprove: true,
+  canReject: true,
+  canWithdraw: false,
+  latestApplicationId: "app-1",
+  awaitingStepId: "step-1",
+  expectedVersion: 7,
+};
+
+/** 取下が可能な operations（申請者本人視点）。 */
+const WITHDRAWER_OPERATIONS: ApplicationOperationsView = {
+  canApprove: false,
+  canReject: false,
+  canWithdraw: true,
+  latestApplicationId: "app-1",
+  awaitingStepId: null,
+  expectedVersion: 7,
+};
+
+function renderOperations(
+  operations: ApplicationOperationsView = APPROVER_OPERATIONS,
+  variationNumber = 1
+) {
+  return render(
+    <ApplicationOperations operations={operations} variationNumber={variationNumber} />
+  );
+}
+
+describe("ApplicationOperations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("最終承認（outcome=APPROVED）は承認済の文言でトーストし router.refresh する", async () => {
+    const user = userEvent.setup();
+    mockApprove.mockResolvedValue({ success: true, data: { outcome: "APPROVED" } });
+    renderOperations();
+
+    await user.click(screen.getByRole("button", { name: "承認" }));
+    await user.click(await screen.findByRole("button", { name: "承認する" }));
+
+    expect(mockApprove).toHaveBeenCalledWith("step-1", 7);
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastSuccess.mock.calls[0][0]).toContain("承認済");
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled());
+  });
+
+  test("途中承認（outcome=STILL_PENDING）は次ステップに進んだ文言でトーストする", async () => {
+    const user = userEvent.setup();
+    mockApprove.mockResolvedValue({ success: true, data: { outcome: "STILL_PENDING" } });
+    renderOperations();
+
+    await user.click(screen.getByRole("button", { name: "承認" }));
+    await user.click(await screen.findByRole("button", { name: "承認する" }));
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastSuccess.mock.calls[0][0]).toContain("次の承認ステップ");
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled());
+  });
+
+  test("承認失敗はダイアログを閉じエラートースト＋refresh で真実へ寄せる", async () => {
+    const user = userEvent.setup();
+    mockApprove.mockResolvedValue({ success: false, error: "他の操作で申請が更新されました" });
+    renderOperations();
+
+    await user.click(screen.getByRole("button", { name: "承認" }));
+    await user.click(await screen.findByRole("button", { name: "承認する" }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("他の操作で申請が更新されました"));
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByRole("button", { name: "承認する" })).toBeNull());
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  test("差戻はコメントを渡して成功トースト＋refresh する", async () => {
+    const user = userEvent.setup();
+    mockReject.mockResolvedValue({ success: true });
+    renderOperations();
+
+    await user.click(screen.getByRole("button", { name: "差戻" }));
+    await user.type(await screen.findByLabelText("差戻理由"), "金額の根拠を明記してください");
+    await user.click(screen.getByRole("button", { name: "差し戻す" }));
+
+    expect(mockReject).toHaveBeenCalledWith("step-1", "金額の根拠を明記してください", 7);
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("差し戻しました"));
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled());
+  });
+
+  test("差戻理由が空（trim 後空）の間は差し戻すボタンが無効", async () => {
+    const user = userEvent.setup();
+    renderOperations();
+
+    await user.click(screen.getByRole("button", { name: "差戻" }));
+    expect(await screen.findByRole("button", { name: "差し戻す" })).toBeDisabled();
+
+    await user.type(screen.getByLabelText("差戻理由"), "   ");
+    expect(screen.getByRole("button", { name: "差し戻す" })).toBeDisabled();
+
+    await user.type(screen.getByLabelText("差戻理由"), "理由");
+    expect(screen.getByRole("button", { name: "差し戻す" })).toBeEnabled();
+  });
+
+  test("差戻失敗はダイアログを保持し内部エラーを出しコメントを温存する（refresh しない）", async () => {
+    const user = userEvent.setup();
+    mockReject.mockResolvedValue({ success: false, error: "他の操作で申請が更新されました" });
+    renderOperations();
+
+    await user.click(screen.getByRole("button", { name: "差戻" }));
+    await user.type(await screen.findByLabelText("差戻理由"), "根拠を明記してください");
+    await user.click(screen.getByRole("button", { name: "差し戻す" }));
+
+    await screen.findByRole("alert");
+    expect(screen.getByRole("alert")).toHaveTextContent("他の操作で申請が更新されました");
+    // ダイアログは開いたまま・コメントは温存・refresh しない。
+    expect(screen.getByLabelText("差戻理由")).toHaveValue("根拠を明記してください");
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  test("差戻ダイアログを閉じて再度開いても入力したコメントが残る", async () => {
+    const user = userEvent.setup();
+    renderOperations();
+
+    await user.click(screen.getByRole("button", { name: "差戻" }));
+    await user.type(await screen.findByLabelText("差戻理由"), "書きかけの理由");
+    // キャンセルで閉じる。
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+    // 再度開く。
+    await user.click(screen.getByRole("button", { name: "差戻" }));
+
+    expect(await screen.findByLabelText("差戻理由")).toHaveValue("書きかけの理由");
+  });
+
+  test("取下は確認後に成功トースト＋refresh する", async () => {
+    const user = userEvent.setup();
+    mockWithdraw.mockResolvedValue({ success: true });
+    renderOperations(WITHDRAWER_OPERATIONS);
+
+    await user.click(screen.getByRole("button", { name: "取下" }));
+    await user.click(await screen.findByRole("button", { name: "取り下げる" }));
+
+    expect(mockWithdraw).toHaveBeenCalledWith("app-1", 7);
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("取り下げました"));
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled());
+  });
+
+  test("資格なし（3 フラグ全 false）では操作ボタンを一切出さない", () => {
+    renderOperations({
+      canApprove: false,
+      canReject: false,
+      canWithdraw: false,
+      latestApplicationId: null,
+      awaitingStepId: null,
+      expectedVersion: null,
+    });
+
+    expect(screen.queryByRole("button", { name: "承認" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "差戻" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "取下" })).toBeNull();
+  });
+});

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ApplicationOperations.tsx
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/_components/ApplicationOperations.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/app/_components/shadcnui/dialog";
+import type { ApplicationOperationsView } from "@subdomains/estimate/application/queries/dto/EstimateApplicationDetailDTO";
+import { approveStep, rejectStep, withdrawApplication } from "../actions";
+
+/** 差戻理由の最大文字数（VO `RejectionComment` の MAX_LENGTH と一致・権威は VO・ADR-0069）。 */
+const REJECTION_COMMENT_MAX_LENGTH = 2000;
+
+type Props = {
+  /** 操作可否＋コマンド標的（app 層 Query が操作者を受けて合成・ADR-20260707-ae2）。 */
+  operations: ApplicationOperationsView;
+  /** 対象バリの案番号（確認文の表示用）。 */
+  variationNumber: number;
+};
+
+/**
+ * 見積申請詳細の操作ブロック（承認/差戻/取下・#575）。
+ *
+ * DTO の 3 フラグ（`canApprove`／`canReject`／`canWithdraw`）でボタンを出し分ける常設クライアント
+ * 部品。資格の無い閲覧者には 3 フラグが全 false で渡り、何も描画しない（純粋な閲覧画面）。承認/差戻は
+ * 同一述語（当該ステップの役割メンバー）で `awaitingStepId`＋`expectedVersion` を標的に、取下は
+ * `latestApplicationId`＋`expectedVersion` を標的に取る。FE の出し分けは UX のためで、最終防衛は BE
+ * （役割メンバー検証・本人性検証・楽観ロック）。
+ *
+ * 成功/失敗の提示方針:
+ * - 成功: sonner `toast.success` を直接呼び `router.refresh()` で RSC を再導出（#562 申請ボタンモデル）。
+ *   承認は outcome（最終承認/途中承認）で文言を分ける。
+ * - 失敗（入力保護で分岐）: 承認/取下（入力なし）はダイアログを閉じエラートースト＋refresh で真実へ。
+ *   差戻（コメントあり）はダイアログを保持し内部にエラー表示・入力を温存・refresh しない。
+ */
+export function ApplicationOperations({ operations, variationNumber }: Props) {
+  const {
+    canApprove,
+    canReject,
+    canWithdraw,
+    latestApplicationId,
+    awaitingStepId,
+    expectedVersion,
+  } = operations;
+
+  // 3 フラグ全 false（資格なし・免除・非 PENDING）では操作ブロックごと描画しない。
+  if (!canApprove && !canReject && !canWithdraw) {
+    return null;
+  }
+
+  return (
+    <section className="flex flex-wrap gap-3" aria-label="申請操作">
+      {canApprove && awaitingStepId !== null && expectedVersion !== null && (
+        <ApproveDialog
+          variationNumber={variationNumber}
+          stepId={awaitingStepId}
+          expectedVersion={expectedVersion}
+        />
+      )}
+      {canReject && awaitingStepId !== null && expectedVersion !== null && (
+        <RejectDialog
+          variationNumber={variationNumber}
+          stepId={awaitingStepId}
+          expectedVersion={expectedVersion}
+        />
+      )}
+      {canWithdraw && latestApplicationId !== null && expectedVersion !== null && (
+        <WithdrawDialog
+          variationNumber={variationNumber}
+          applicationId={latestApplicationId}
+          expectedVersion={expectedVersion}
+        />
+      )}
+    </section>
+  );
+}
+
+/** 承認の確認ダイアログ（確定/キャンセル・入力なし）。 */
+function ApproveDialog({
+  variationNumber,
+  stepId,
+  expectedVersion,
+}: {
+  variationNumber: number;
+  stepId: string;
+  expectedVersion: number;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isSubmitting, startSubmit] = useTransition();
+
+  function handleConfirm(): void {
+    startSubmit(async () => {
+      const result = await approveStep(stepId, expectedVersion);
+      if (result.success) {
+        setOpen(false);
+        // 途中承認は refresh 後もバッジが「申請中」のまま。文言で結果を言い切り不安を消す。
+        const message =
+          result.data?.outcome === "APPROVED"
+            ? "承認しました。この申請は承認済になりました"
+            : "承認しました。次の承認ステップに進みました";
+        toast.success(message);
+        router.refresh();
+      } else {
+        // 入力なしのため画面を最新へ寄せる（強制クローズ＋エラートースト＋refresh）。
+        setOpen(false);
+        toast.error(result.error ?? "承認に失敗しました");
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <TriggerButton
+        onClick={() => setOpen(true)}
+        className="bg-green-600 hover:bg-green-700"
+        label="承認"
+      />
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>承認の確認</DialogTitle>
+          <DialogDescription>第{variationNumber}案を承認します。よろしいですか？</DialogDescription>
+        </DialogHeader>
+        <ConfirmFooter
+          confirmLabel="承認する"
+          submittingLabel="承認中..."
+          isSubmitting={isSubmitting}
+          onConfirm={handleConfirm}
+          onCancel={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * 差戻のコメント入力ダイアログ。コメント `useState` は本コンポーネント本体（DialogContent の外）に
+ * 持つため、閉じて再度開いても入力が残る。差戻成功時は refresh → RSC 再評価で canReject=false となり
+ * 本コンポーネントごと unmount され、入力が自然にクリアされる（成功時のみクリア）。失敗時はダイアログ
+ * を保持し、コメントを温存する（入力保護・auto-refresh しない）。
+ */
+function RejectDialog({
+  variationNumber,
+  stepId,
+  expectedVersion,
+}: {
+  variationNumber: number;
+  stepId: string;
+  expectedVersion: number;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [comment, setComment] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, startSubmit] = useTransition();
+
+  // 権威は VO `RejectionComment`（必須・1〜2000字・trim）。FE はミラーせず UX ガードに留める。
+  const trimmedEmpty = comment.trim().length === 0;
+
+  function handleConfirm(): void {
+    setError(null);
+    startSubmit(async () => {
+      const result = await rejectStep(stepId, comment, expectedVersion);
+      if (result.success) {
+        // クローズしても comment は残すが、成功は refresh で操作ブロックごと消えるため気にしない。
+        setOpen(false);
+        toast.success("差し戻しました");
+        router.refresh();
+      } else {
+        // 入力保護: ダイアログを開いたまま内部にエラーを出し、コメントを温存する（refresh しない）。
+        setError(result.error ?? "差戻に失敗しました");
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <TriggerButton
+        onClick={() => setOpen(true)}
+        className="bg-orange-600 hover:bg-orange-700"
+        label="差戻"
+      />
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>差戻の確認</DialogTitle>
+          <DialogDescription>
+            第{variationNumber}案を差し戻します。差戻理由を入力してください。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1">
+          <textarea
+            aria-label="差戻理由"
+            value={comment}
+            maxLength={REJECTION_COMMENT_MAX_LENGTH}
+            onChange={(e) => setComment(e.target.value)}
+            rows={4}
+            className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            placeholder="差戻理由を入力（必須）"
+          />
+          <p className="text-right text-xs text-gray-500">
+            {comment.length} / {REJECTION_COMMENT_MAX_LENGTH}
+          </p>
+        </div>
+
+        {error && (
+          <div
+            className="rounded border border-red-400 bg-red-100 px-4 py-2 text-sm text-red-700"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        <ConfirmFooter
+          confirmLabel="差し戻す"
+          submittingLabel="差戻中..."
+          isSubmitting={isSubmitting}
+          confirmDisabled={trimmedEmpty}
+          onConfirm={handleConfirm}
+          onCancel={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** 取下の確認ダイアログ（確定/キャンセル・入力なし）。 */
+function WithdrawDialog({
+  variationNumber,
+  applicationId,
+  expectedVersion,
+}: {
+  variationNumber: number;
+  applicationId: string;
+  expectedVersion: number;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isSubmitting, startSubmit] = useTransition();
+
+  function handleConfirm(): void {
+    startSubmit(async () => {
+      const result = await withdrawApplication(applicationId, expectedVersion);
+      if (result.success) {
+        setOpen(false);
+        toast.success("取り下げました");
+        router.refresh();
+      } else {
+        setOpen(false);
+        toast.error(result.error ?? "取下に失敗しました");
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <TriggerButton
+        onClick={() => setOpen(true)}
+        className="bg-gray-600 hover:bg-gray-700"
+        label="取下"
+      />
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>取下の確認</DialogTitle>
+          <DialogDescription>
+            第{variationNumber}案を取り下げます。よろしいですか？
+          </DialogDescription>
+        </DialogHeader>
+        <ConfirmFooter
+          confirmLabel="取り下げる"
+          submittingLabel="取下中..."
+          isSubmitting={isSubmitting}
+          onConfirm={handleConfirm}
+          onCancel={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** 操作トリガー（各操作で色だけ変える共通ボタン）。 */
+function TriggerButton({
+  onClick,
+  className,
+  label,
+}: {
+  onClick: () => void;
+  className: string;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`${className} rounded px-4 py-1 text-sm font-bold text-white focus:outline-none focus:shadow-outline`}
+    >
+      {label}
+    </button>
+  );
+}
+
+/** 確認（確定）＋キャンセルのフッター（3 ダイアログ共用）。 */
+function ConfirmFooter({
+  confirmLabel,
+  submittingLabel,
+  isSubmitting,
+  confirmDisabled = false,
+  onConfirm,
+  onCancel,
+}: {
+  confirmLabel: string;
+  submittingLabel: string;
+  isSubmitting: boolean;
+  confirmDisabled?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="flex justify-end gap-3">
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={isSubmitting}
+        className="rounded bg-gray-300 px-4 py-2 font-bold text-gray-800 hover:bg-gray-400 focus:outline-none focus:shadow-outline disabled:cursor-not-allowed"
+      >
+        キャンセル
+      </button>
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={isSubmitting || confirmDisabled}
+        className="rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700 focus:outline-none focus:shadow-outline disabled:bg-gray-400 disabled:cursor-not-allowed"
+      >
+        {isSubmitting ? submittingLabel : confirmLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/actions.ts
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/actions.ts
@@ -1,0 +1,134 @@
+"use server";
+
+import { verifySession } from "@/app/_lib/verifyAuthentication";
+import { approveStepCommandFactory } from "@subdomains/estimate/application/factories/approveStepCommandFactory";
+import { rejectStepCommandFactory } from "@subdomains/estimate/application/factories/rejectStepCommandFactory";
+import { withdrawApplicationCommandFactory } from "@subdomains/estimate/application/factories/withdrawApplicationCommandFactory";
+import type { ActionResult } from "@shared/types/ActionResult";
+import { handleCommandError } from "../../../_shared/error-handler";
+
+/** 承認結果の判別子。最終承認（全ステップ承認済）か、途中承認（次ステップへ前進）か。 */
+export type ApproveOutcome = "APPROVED" | "STILL_PENDING";
+
+/** 操作者の従業員情報が取得できない場合の共通文言（前例: 申請の operator null）。 */
+const OPERATOR_UNRESOLVED_MESSAGE =
+  "操作者の従業員情報が取得できないため操作できません。管理者にお問い合わせください。";
+
+/**
+ * `handleCommandError` を ActionResult<T> の失敗アームへブリッジする（#494 と同型）。
+ *
+ * `handleCommandError` の戻り型 `ActionResult<void>` は成功アームの `data:void` がジェネリック T と
+ * 不一致になり `return handleCommandError(error)` が型不整合になる。失敗アーム（T 非依存）だけを
+ * 組み直して任意の ActionResult<T> に代入可能な形へ落とす。
+ */
+function toActionError(error: unknown): { success: false; error?: string } {
+  const result = handleCommandError(error);
+  return { success: false, error: result.success ? undefined : result.error };
+}
+
+/**
+ * 認証セッションから操作者の employeeId を解決する（null は操作不可）。
+ *
+ * 承認・差戻・取下いずれも client の operator を信頼せずセッションから注入する。BE が最終防衛
+ * （役割メンバー検証・本人性検証）を担うため、FE は「誰が操作しているか」をセッションで確定するだけ。
+ */
+async function resolveOperator(): Promise<
+  { success: true; operatorEmployeeId: string } | { success: false; error?: string }
+> {
+  const session = await verifySession();
+  const operatorEmployeeId = session.user.employeeId;
+  if (!operatorEmployeeId) {
+    return { success: false, error: OPERATOR_UNRESOLVED_MESSAGE };
+  }
+  return { success: true, operatorEmployeeId };
+}
+
+/**
+ * ステップ承認（§7.1・#575）の Server Action。
+ *
+ * operator は認証セッションの employeeId（null は操作不可）、stepId と expectedVersion は画面表示時に
+ * DTO（operations）から得た値を client エコーする。expectedVersion はサーバで読み直さない（TOCTOU
+ * 防御の関門トークン・ADR-0068）。成功時は返却集約の applicationStatus から outcome を導出して返す
+ * （最終承認=APPROVED / 途中承認=STILL_PENDING）。呼び出し元はこの判別子で成功トーストの文言を分ける。
+ * redirect はせず、画面更新は呼び出し元の `router.refresh()` に委ねる（#562 申請ボタンモデル）。
+ * 競合（ConflictError）・業務例外（BusinessRuleViolationError）は handleCommandError でメッセージ化する。
+ */
+export async function approveStep(
+  stepId: string,
+  expectedVersion: number
+): Promise<ActionResult<{ outcome: ApproveOutcome }>> {
+  const operator = await resolveOperator();
+  if (!operator.success) {
+    return operator;
+  }
+
+  try {
+    const application = await approveStepCommandFactory().execute({
+      stepId,
+      approverEmployeeId: operator.operatorEmployeeId,
+      expectedVersion,
+    });
+    const outcome: ApproveOutcome =
+      application.applicationStatus.value === "APPROVED" ? "APPROVED" : "STILL_PENDING";
+    return { success: true, data: { outcome } };
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+/**
+ * ステップ差戻（§7.2・#575）の Server Action。
+ *
+ * operator はセッション注入、stepId と expectedVersion は client エコー（ADR-0068）。comment は生文字列で
+ * 渡し、必須・1〜2000字・trim の権威は BE の VO `RejectionComment`（FE はミラーしない・ADR-0069）。
+ * すり抜けた不正コメントは ValidationError として handleCommandError 経由で表面化する。redirect しない。
+ */
+export async function rejectStep(
+  stepId: string,
+  comment: string,
+  expectedVersion: number
+): Promise<ActionResult> {
+  const operator = await resolveOperator();
+  if (!operator.success) {
+    return operator;
+  }
+
+  try {
+    await rejectStepCommandFactory().execute({
+      stepId,
+      rejecterEmployeeId: operator.operatorEmployeeId,
+      comment,
+      expectedVersion,
+    });
+    return { success: true };
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+/**
+ * 申請取下（§7.3・#575）の Server Action。
+ *
+ * operator はセッション注入、applicationId と expectedVersion は client エコー（ADR-0068）。本人性
+ * （申請者本人のみ取下可）の権威は BE のドメイン withdraw（集約内で完結）。redirect しない。
+ */
+export async function withdrawApplication(
+  applicationId: string,
+  expectedVersion: number
+): Promise<ActionResult> {
+  const operator = await resolveOperator();
+  if (!operator.success) {
+    return operator;
+  }
+
+  try {
+    await withdrawApplicationCommandFactory().execute({
+      applicationId,
+      operatorEmployeeId: operator.operatorEmployeeId,
+      expectedVersion,
+    });
+    return { success: true };
+  } catch (error) {
+    return toActionError(error);
+  }
+}

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/estimate-application-detail-operations.e2e.ts
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/estimate-application-detail-operations.e2e.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * 見積申請詳細画面の操作動線（承認・差戻・取下・#575）の E2E。
+ *
+ * 主役は employee2（EMP000002＝営業本部長＝ROLE002）。storageState を user.json に差し替えて
+ * ログインする（既定 project は admin.json＝社長のため）。seed-estimate-applications.ts の操作動線
+ * 専用フィクスチャ（N9905016〜19・いずれも PENDING）に対し、operations フラグ由来のボタン出し分けと
+ * 各操作の成功結末（バッジ遷移・成功トースト・操作ブロック消滅）を配線検証する。
+ *
+ * - N9905016: 単段・承認待ち＝営業本部長 → employee2 が承認して「承認済」。
+ * - N9905017: 2 段（営業本部長 → 社長）→ employee2 が step1 を承認して途中承認（申請中のまま）。
+ * - N9905018: 単段・承認待ち＝営業本部長 → employee2 がコメント付きで差し戻して「差戻」。
+ * - N9905019: 単段・申請者＝営業本部長・承認待ち＝社長 → employee2 が本人として取り下げて「取下」。
+ * - N9905015: employee2 は申請者でも承認待ち役割メンバーでもない → 操作ボタンが一切出ない純粋閲覧。
+ *
+ * 競合・ガード拒否（楽観ロック・非メンバー）はフレーキー回避のため単体に委譲し、ここには載せない。
+ * 各テストは互いに素なフィクスチャを 1 回だけ変更するため serial 化しない。
+ */
+
+// 主役 employee2 でログインする（営業本部長）。
+test.use({ storageState: "playwright/.auth/user.json" });
+
+const APPROVE = "N9905016";
+const MID_APPROVE = "N9905017";
+const REJECT = "N9905018";
+const WITHDRAW = "N9905019";
+const VIEW_ONLY = "N9905015";
+
+test.describe("見積申請詳細 操作動線", () => {
+  test("承認: 最終承認で「承認済」になり成功トースト＋操作ブロックが消える", async ({ page }) => {
+    await page.goto(`/estimate-applications/${APPROVE}/1`);
+    await expect(page.getByRole("heading", { name: "見積申請詳細" })).toBeVisible();
+
+    await page.getByRole("button", { name: "承認", exact: true }).click();
+    await page.getByRole("button", { name: "承認する" }).click();
+
+    // 成功トースト（最終承認の言い切り）＋恒久的な結末（バッジ「承認済」・承認ボタン消滅）。
+    await expect(page.getByText("この申請は承認済になりました")).toBeVisible();
+    await expect(page.getByText("承認済").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "承認", exact: true })).toHaveCount(0);
+  });
+
+  test("途中承認: 申請中のまま自ステップが承認され「次の承認ステップに進みました」", async ({
+    page,
+  }) => {
+    await page.goto(`/estimate-applications/${MID_APPROVE}/1`);
+    await expect(page.getByRole("button", { name: "承認", exact: true })).toBeVisible();
+
+    await page.getByRole("button", { name: "承認", exact: true }).click();
+    await page.getByRole("button", { name: "承認する" }).click();
+
+    // 途中承認: 文言で結果を言い切り、バッジは「申請中」のまま・承認ボタンは消える（社長が承認待ち）。
+    await expect(page.getByText("次の承認ステップに進みました")).toBeVisible();
+    await expect(page.getByText("申請中").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "承認", exact: true })).toHaveCount(0);
+  });
+
+  test("差戻: コメントを入力して差し戻すと「差戻」になりコメントが読める", async ({ page }) => {
+    await page.goto(`/estimate-applications/${REJECT}/1`);
+
+    await page.getByRole("button", { name: "差戻", exact: true }).click();
+    await page.getByLabel("差戻理由").fill("金額の内訳を再確認してください");
+    await page.getByRole("button", { name: "差し戻す" }).click();
+
+    await expect(page.getByText("差し戻しました")).toBeVisible();
+    await expect(page.getByText("差戻").first()).toBeVisible();
+    await expect(page.getByText("金額の内訳を再確認してください")).toBeVisible();
+    await expect(page.getByRole("button", { name: "差戻", exact: true })).toHaveCount(0);
+  });
+
+  test("取下: 申請者本人が取り下げると「取下」になり成功トースト", async ({ page }) => {
+    await page.goto(`/estimate-applications/${WITHDRAW}/1`);
+
+    await page.getByRole("button", { name: "取下", exact: true }).click();
+    await page.getByRole("button", { name: "取り下げる" }).click();
+
+    await expect(page.getByText("取り下げました")).toBeVisible();
+    await expect(page.getByText("取下").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "取下", exact: true })).toHaveCount(0);
+  });
+
+  test("負: 資格の無い閲覧者には操作ボタンが一切出ない（純粋閲覧）", async ({ page }) => {
+    await page.goto(`/estimate-applications/${VIEW_ONLY}/1`);
+    await expect(page.getByRole("heading", { name: "見積申請詳細" })).toBeVisible();
+
+    // employee2 は申請者（佐藤 太郎）でも承認待ち役割（営業部長）メンバーでもない。
+    await expect(page.getByRole("button", { name: "承認", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "差戻", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "取下", exact: true })).toHaveCount(0);
+  });
+});

--- a/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/page.tsx
+++ b/src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/page.tsx
@@ -3,6 +3,7 @@ import { verifySession } from "@/app/_lib/verifyAuthentication";
 import { getEstimateApplicationDetailQueryFactory } from "@subdomains/estimate/application/factories/getEstimateApplicationDetailQueryFactory";
 import { ApplicationCard } from "./_components/ApplicationCard";
 import { ApplicationDetailSummary } from "./_components/ApplicationDetailSummary";
+import { ApplicationOperations } from "./_components/ApplicationOperations";
 import { ExemptionRecord } from "./_components/ExemptionRecord";
 
 /**
@@ -17,6 +18,10 @@ import { ExemptionRecord } from "./_components/ExemptionRecord";
  *
  * NotFound（見積番号なし／バリエーション番号なし／申請も免除も無い）はクエリが null を返すため
  * `notFound()`（既存 estimates 詳細と同一パターン）。バリエーション番号が数値でない URL も同様。
+ *
+ * 操作 UI（承認・差戻・取下・#575）は要約ヘッダの後に `ApplicationOperations` として描画する。可否は
+ * DTO の `operations` 3 フラグに従い、資格の無い閲覧者には 3 フラグが全 false で渡り何も描画されない
+ * （純粋な閲覧画面）。最終防衛は BE（役割メンバー検証・本人性検証・楽観ロック）で、FE は UX の出し分け。
  */
 export default async function EstimateApplicationDetailPage({
   params,
@@ -55,6 +60,11 @@ export default async function EstimateApplicationDetailPage({
       <h1 className="text-3xl font-bold">見積申請詳細</h1>
 
       <ApplicationDetailSummary summary={detail.summary} />
+
+      <ApplicationOperations
+        operations={detail.operations}
+        variationNumber={detail.summary.variationNumber}
+      />
 
       {detail.kind === "EXEMPTED" ? (
         <ExemptionRecord exemption={detail.exemption} />


### PR DESCRIPTION
## Summary

見積申請詳細画面に承認・差戻・取下の操作 UI を配線しました。Server Action 3本（承認・差戻・取下）、確認/コメント入力ダイアログ、#573 の DTO（canApprove/canReject/canWithdraw）に従うボタン出し分け、楽観ロック競合・BE ガード拒否時のエラー表示、操作後の画面更新、および各動線の E2E テストを実装しています。

Closes #575

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### application-detail-approve-reject-withdraw-fe.md

# Issue #575: 見積申請詳細 承認・差戻・取下操作（FE） — 実装計画

## 概要

見積申請詳細画面（`/estimate-applications/[estimateNumber]/[variationNumber]`）に、承認・差戻・取下の操作 UI を配線する。BE コマンド（`ApproveStep` / `RejectStep` / `WithdrawApplication`）とファクトリ、参照 DTO（`operations.canApprove/canReject/canWithdraw`・`latestApplicationId`・`awaitingStepId`・`expectedVersion`・#573）は実装済みで、本 issue は FE（Server Action・ダイアログ・出し分け・成功/失敗表示・E2E）だけを担う。

- 最終防衛は BE（役割メンバー検証・本人性検証・楽観ロック）。FE の出し分けは UX のためで役割メンバーシップ判定を複製しない（DTO の 3 フラグに従う）。
- 資格の無い閲覧者には操作ボタンを一切出さず、純粋な閲覧画面として振る舞う。
- TDD（red-green-refactor）で進める。単体/コンポーネントは Vitest、動線は Playwright。

## 設計判断

会話（/grill-with-docs）で確定済み。実装中に判断を追加しない。

### Server Action の契約と成功時の画面更新
- A. #562 申請ボタンモデル: redirect せず `ActionResult<T>` 返却、成功時 `router.refresh()` で同一 URL 再導出
- B. 見積編集フォーム流: conform + redirect + `?reason=` フラッシュ
- **採用: A**。閲覧/編集のモード遷移が無い単一ビューで、成功後に欲しい「チェーン状態・バッジ・ボタン再評価」は RSC 再実行（`router.refresh()`）で自然に再導出できる。兄弟の申請ボタンと契約を揃える。ADR-0068/0069 のパターンに乗る。
- 承認は結果を区別するため `ActionResult` に判別子 `outcome: "APPROVED" | "STILL_PENDING"` を載せる。コマンドが返す `EstimateApplication.applicationStatus`（`deriveApplicationStatus`）から導出する。

### 成功提示
- sonner `toast.success(...)` を**直接**呼ぶ（`Toaster` はレイアウトで全画面マウント済み）。`?reason=` フラッシュ（redirect 連動）は使わず、新しい reason コードも増やさない。
- 文言: 差戻「差し戻しました」／取下「取り下げました」は各 1 文言。**承認は途中/最終で区別**する:
  - 途中承認（`STILL_PENDING`）: 「承認しました。次の承認ステップに進みました」
  - 最終承認（`APPROVED`）: 「承認しました。この申請は承認済になりました」
- 途中承認は refresh 後もバッジが「申請中」のままボタンだけ消えるため、文言で結果を言い切りユーザーの不安を消す。

### 失敗提示（入力保護で分岐）
- `handleCommandError` は ConflictError（楽観ロック競合）も BusinessRuleViolationError（役割非メンバー・非 PENDING 等）も区別せず `{success:false, error}` に畳む。今回はどちらも救済が「最新を読み直す」に収束するため区別不要。
- **承認・取下（入力なし）**: 失敗時はダイアログを閉じ、エラートースト＋`router.refresh()` で真実へ。
- **差戻（コメントあり）**: 失敗時は**ダイアログを開いたまま**、内部にエラー表示、入力済みコメントを温存、auto-refresh しない。
- 理由: #494 の一律「強制クローズ＋永続バナー＋no-refresh」から意図的に外れる。この画面は守るべき外部フォームが無く（閲覧専用）、守るべき貴重な入力は差戻ダイアログ内の差戻理由（必須・最大 2000 字・ADR-0058）のみ。入力保護原則をその 1 箇所にだけ適用する。
- ※この失敗ハンドリングの分岐（兄弟の申請ボタンと異なる失敗 UX にした理由）は ADR 化せず、コミットボディ／PR 説明に記載する（ユーザー判断）。

### 差戻コメントの状態保持
- コメントの `useState` は差戻ラッパー（トリガー＋Dialog を内包する常設クライアント部品）に持つ。`DialogContent` の内側に置くと Radix の unmount で消えるため、親に持たせる。
- 閉じても消さない。**クリアは差戻成功時のみ**（成功で `canReject=false` になり操作ブロックごと自然消滅）。閉じて再度開いても入力が残る。`router.refresh()` をまたいでもクライアント状態は保持される。

### 差戻コメントのバリデーション配置
- A. 素の controlled textarea ＋ 薄い UX ガード（`maxLength={2000}`・文字数カウンタ・trim 後空で送信無効）。権威は VO `RejectionComment`（必須・1〜2000 字・trim）。すり抜けは `handleCommandError` 経由で表面化
- B. conform + zod スキーマ
- **採用: A**。VO が権威なので FE はミラーせず（ADR-0069）UX 補助に留める。`ApplicationConfirmDialog`（#562）の素 `useState` 前例に一致し、コメント状態保持も素直に成立する。

### Server Action のシグネチャ
- 承認/取下は estimateNumber からの estimateId 再解決が不要（対象は `stepId`／`applicationId` の identity で、BE が membership・本人性・version を再検証する）。
- `approveStep(stepId, expectedVersion)` / `rejectStep(stepId, comment, expectedVersion)` / `withdrawApplication(applicationId, expectedVersion)`。operator は各 Action 内で `verifySession()` から解決（null は fail-fast）。

### revalidate の単位
- Server Action で `revalidatePath` は呼ばない。redirect しないので現ビューは `router.refresh()` で再導出、一覧・見積詳細は別ナビゲーションで dynamic 再クエリされる（#562 と同一方針）。

### CONTEXT.md / ADR
- CONTEXT.md 変更なし（今回の決定は FE/UX/実装判断で、新ドメイン用語の導入・鋭利化なし。途中承認/最終承認は既存概念の状況記述）。
- ADR 起票なし（失敗ハンドリング分岐は可逆性が中程度のためコミット/PR 記載に留める・ユーザー判断）。

### E2E のテストデータ
- 既存表示フィクスチャ（N9905011〜15・申請者 EMP000003・承認待ち役割 営業課長/営業部長）は operator 中立に作られており、ログインユーザー（employee1=社長/employee2=営業本部長）が承認資格も本人でもないため操作成功動線に使えない。
- **採用: 動線別の独立新フィクスチャ**を `seed-estimate-applications.ts` に追加し、主役 employee2（営業本部長）に紐づける。社長は常に頂点で途中承認を作れないため、中間役割の営業本部長を主役に、その上に社長ステップを置いて途中承認を成立させる。

## ステップ

### Step 1: 承認・差戻・取下の Server Action（契約テスト先行）
- 対象ファイル:
  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/actions.ts`（新規）
  - 同ディレクトリ `actions.test.ts`（新規・契約テスト）
- 作業内容:
  - red: コマンドファクトリをモックし、契約を固定するテストを書く。
    - operator を `verifySession()` から解決し各コマンドへ渡す（null は失敗）
    - `expectedVersion` を client エコーのまま渡す（サーバで読み直さない・ADR-0068）
    - `approveStep` は返却 `EstimateApplication.applicationStatus` が APPROVED なら `outcome:"APPROVED"`、それ以外は `"STILL_PENDING"` を `ActionResult` に載せる
    - ConflictError / BusinessRuleViolationError を `handleCommandError` 経由で `{success:false, error}` に変換
  - green: `"use server"` の 3 Action を実装。`approveStepCommandFactory` / `rejectStepCommandFactory` / `withdrawApplicationCommandFactory` を配線。差戻は comment を生文字列で渡す（VO は BE で構築）。redirect しない。
- コミットメッセージ: `feat: 見積申請詳細 承認・差戻・取下のServer Action（FE）`
  - ボディに「失敗ハンドリングを入力保護で分岐（承認/取下=refresh、差戻=ダイアログ保持）した理由。#494 の一律 force-close から外れる根拠＝閲覧専用画面で守るべき入力は差戻理由のみ」を記載。

### Step 2: 操作ダイアログ（承認/取下 確認・差戻 コメント入力）＋コンポーネントテスト
- 対象ファイル:
  - 同ディレクトリ `_components/ApplicationOperations.tsx`（新規・常設クライアント部品。3 ダイアログと差戻コメント state を内包）
  - `_components/ApplicationOperations.test.tsx`（新規）
- 作業内容:
  - red: コンポーネントテスト（Vitest + testing-library）。
    - 承認/取下は確認ダイアログ（確定/キャンセル）
    - 差戻は textarea・trim 後空で送信無効・`maxLength`・文字数カウンタ
    - **差戻コメントを閉じて再度開いても保持**、成功時のみクリア
    - 成功時 `toast.success` 呼び出し（承認は outcome で文言分岐）＋`router.refresh()`
    - 失敗時: 承認/取下は閉じてエラートースト、差戻はダイアログ保持＋内部エラー＋コメント温存
  - green: `ApplicationOperations` を実装。`operations`（3 フラグ・`latestApplicationId`・`awaitingStepId`・`expectedVersion`）と要約（確認文用の variationNumber）を props で受け、`canApprove/canReject/canWithdraw` でボタン出し分け。sonner を直接呼ぶ。
- コミットメッセージ: `feat: 見積申請詳細 承認・差戻・取下の操作ダイアログ（FE）`

### Step 3: 詳細ページへの操作ブロック配線
- 対象ファイル:
  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/page.tsx`
- 作業内容:
  - 要約ヘッダの後に `ApplicationOperations` を描画し、`detail.operations` と要約を渡す（現状 page は operations を描画していない）。
  - 資格なし（3 フラグ全 false）ではボタンが出ないことを配線上担保。
- コミットメッセージ: `feat: 見積申請詳細画面に操作ブロックを配線（FE）`

### Step 4: E2E フィクスチャ追加＋操作動線 E2E
- 対象ファイル:
  - `prisma/seed-estimate-applications.ts`（動線別独立フィクスチャ 4 本を追加・N9905016〜・主役 EMP000002）
  - `src/app/(features)/estimate-applications/[estimateNumber]/[variationNumber]/estimate-application-detail-operations.e2e.ts`（新規・storageState=user.json）
- 作業内容:
  - フィクスチャ:
    1. 最終承認用: 単段・承認待ち=営業本部長
    2. 途中承認用: 2 段（step1=営業本部長／step2=社長）
    3. 差戻用: 承認待ち=営業本部長
    4. 取下用: 申請者=EMP000002
  - E2E（employee2 ログイン）:
    - 承認して承認済になる（バッジ「承認済」＋成功トースト＋操作消滅）
    - 途中承認（バッジ「申請中」のまま・自ステップ承認済・承認ボタン消滅＋「次の承認ステップに進みました」）
    - 差戻（コメント入力→バッジ「差戻」＋差戻コメント表示＋成功トースト）
    - 取下（バッジ「取下」＋取下記録＋成功トースト）
    - 負: 既存 N9905015 を employee2 で開き操作ボタンが一切出ない（純粋閲覧）
  - 競合/ガード拒否は E2E に載せない（フレーキー回避・単体に委譲）。
- コミットメッセージ:
  - `test: 見積申請詳細 操作動線のE2Eフィクスチャを追加`
  - `test: 見積申請詳細 承認・差戻・取下の操作動線E2E`

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

---

Generated with [Claude Code](https://claude.ai/code)
