### PR TITLE
feat: 従業員一覧に担当役割（＋上位役割）の列を追加する

### DIFF
--- a/docs/claude-plans/issue-578/employee-list-role-columns.md
+++ b/docs/claude-plans/issue-578/employee-list-role-columns.md
@@ -1,0 +1,78 @@
+# Issue #578: 従業員一覧に担当役割（＋上位役割）の列を追加する — 実装計画
+
+## Context
+
+従業員一覧（`/employees`）には現在、担当役割・上位役割の列が無い。#565 は登録・更新フォーム文脈でのみ役割を扱い、一覧DTO（`EmployeeDTO`）には「役割名はフォーム供給の一覧から解決する」という理由で**役割名を意図的に載せなかった**。
+
+#578 が初めて**一覧表示要件**を持ち込むため、役割名の解決方式を決める必要があった。ここに ADR-0013（一覧DTOにリレーション先の名前をJOINで載せる）と #565 の非搭載判断の緊張関係がある。
+
+**ユーザー決定**:
+- 役割名解決方式 = **案B（DTOにJOIN）**。ADR-0013 の標準パターンに統一（既存 `departmentName` と同方式）。#565 の非搭載判断は「表示要件が無かった時点の判断」として上書きする。
+- 列スコープ = **担当役割列＋上位役割列の両方**。#567（`EmployeeSuperiorRole` 抽出・上位役割の読み取り時導出）は**CLOSED＝完了済み**で、導出ロジック（`findSuperiorRoleId`）・子表が確定しているため、上位役割列を本イシューで同時実装できる。
+
+**目標**: 従業員一覧に「担当役割」「上位役割」列を追加し、案Bで名前を解決。E2Eで表示を検証する。
+
+## 設計判断
+
+### 役割名の解決方式（Issueの核心 decision）
+- A. 一覧 `page.tsx` で全役割を取得し `Map<id,name>` を組んでFE側で解決（list DTO 不変）
+- B. `EmployeeDTO` に `assignedRoleName` / `superiorRoleName` を JOIN して載せる
+- **決定: B**（ユーザー選択）。ADR-0013 準拠、`departmentName` と一貫、変更がQueryServiceに局所化。#565 のDTOコメント（「役割名はフォーム供給の一覧から解決するため持たない」）は表示要件の発生に伴い更新する。
+
+### 上位役割名の導出方式
+- 表示する「上位役割」= 従業員の上位役割（承認起点＝`findSuperiorRoleId` と同じ導出分岐）。担当役割あり→その役割の上位役割名、課員→明示 `EmployeeSuperiorRole` の役割名、どちらも無→null。
+- `findSuperiorRoleId`（ID専用・承認消費点）とは別に、`toDTO` 内で JOIN 済み行から**名前を導出**する。
+  - A. `toDTO` にインライン導出（2分岐）
+  - B. 共通ヘルパーへ抽出
+  - **推奨: A（インライン）**。`findSuperiorRoleId` は別クエリ・ID返却でデータ形状が異なり、既存コードも `explicitSuperiorRoleId` に「承認起点の導出とは別読み」と明記済み。表示用と承認用の分離という既存方針に沿う。導出は2分岐と小さく、共通化の便益が薄い。
+
+### 役割なし（null）の表示
+- 担当役割なし（課員）／上位役割なし（社長）は列に `-` を表示。ADR-0013 が許容する departments の `-` 慣習に合わせる。`columns.tsx` の cell レンダラで `?? "-"`。
+
+### #567 との整合
+- 本イシューで案Bを採用。上位役割列も同じ案Bで実装するため、#567 と方式が揃う（列デザインの二度手間なし）。
+
+## ステップ
+
+### Step 1: BE — 一覧DTOに担当役割名・上位役割名を載せる（案B）
+- 対象ファイル:
+  - `src/server/subdomains/employee/application/queries/dto/EmployeeDTO.ts`
+  - `src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts`
+  - `src/server/subdomains/employee/infrastructure/queries/__tests__/PrismaEmployeeQueryService.assignedRoleId.test.ts`（等、既存テストパターンに倣い新規 or 追記）
+- 作業内容:
+  - `EmployeeDTO` に `assignedRoleName: string | null` と `superiorRoleName: string | null` を追加。`assignedRoleId` のコメントを「名前は一覧表示のため `assignedRoleName` に載せる／フォームの現在値復元はIDを使う」に更新。
+  - `getSelectFields()` を拡張:
+    - `employeeRoles.select` に `role: { select: { name: true, superiorRole: { select: { name: true } } } }`
+    - `superiorRole.select`（EmployeeSuperiorRole）に `role: { select: { name: true } }`
+  - `toDTO()` の引数型と本体を拡張:
+    - `assignedRoleName = employee.employeeRoles[0]?.role.name ?? null`
+    - `superiorRoleName`: 担当役割あり → `employeeRoles[0].role.superiorRole?.name ?? null`／課員 → `employee.superiorRole?.role?.name ?? null`（`findSuperiorRoleId` L74-81 と同分岐）
+  - 単体テスト: 役割持ち（担当名＝役割名、上位名＝役割の上位役割名）・課員（担当 null、上位＝明示役割名）・社長（担当名あり、上位 null）の3系統を検証。既存 `*.assignedRoleId.test.ts` / `*.explicitSuperiorRoleId.test.ts` のパターン踏襲。
+- コミットメッセージ: `feat: 従業員一覧DTOに担当役割名・上位役割名を載せる（案B/ADR-0013）`
+
+### Step 2: FE — 一覧に担当役割・上位役割の列を追加
+- 対象ファイル: `src/app/(features)/employees/_components/columns.tsx`
+- 作業内容:
+  - 「部署」列の後（または「権限」列の前）に列を2つ追加:
+    - `{ accessorKey: "assignedRoleName", header: "担当役割", cell: ({ row }) => row.original.assignedRoleName ?? "-" }`
+    - `{ accessorKey: "superiorRoleName", header: "上位役割", cell: ({ row }) => row.original.superiorRoleName ?? "-" }`
+  - `page.tsx` は変更不要（DTOをそのまま流す＝ADR-0013 の狙い）。
+- コミットメッセージ: `feat: 従業員一覧に担当役割・上位役割の列を追加（FE）`
+
+### Step 3: E2E — 列表示アサーション追加
+- 対象ファイル: `src/app/(features)/employees/employees-list.e2e.ts`
+- 作業内容:
+  - ヘッダー名からカラム位置を動的特定する既存パターン（「権限で検索できる」テスト L61-64 参照）に倣い、`EMP000004`（担当=開発部長／上位=営業本部長）で両列に役割名が出ることを検証するテストを追加。
+  - 課員 `EMP000006`（担当=`-`／上位=営業課長）で null 表示と明示上位役割の表示も検証（余力あれば1テストに含める）。
+  - 対象コードで検索して1行に絞り、`td:nth-child(担当役割列index)` / `td:nth-child(上位役割列index)` のテキストをアサート。
+- コミットメッセージ: `test: 従業員一覧の担当役割・上位役割列のE2Eアサーションを追加`
+
+## 検証
+
+- `pnpm test`（単体）: Step 1 の QueryService 導出テストが通ること。事前に schema 変更は無いため `pnpm test:setup` 不要。
+- `pnpm lint` / 型チェック: DTO 追加フィールドの型整合。
+- `pnpm e2e -- employees-list`（該当specのみ。全体はCIに任せる）: 追加した列アサーションが通ること。事前に `pnpm e2e:seed` でシード最新化。
+- 任意: `verify-frontend`（dev server + playwright MCP）で `/employees` を開き、担当役割・上位役割列と `-` 表示を目視確認。
+
+## 補足
+- E2Eフィクスチャ（`prisma/seed-e2e.ts`）の役割階層: ROLE004(開発部長)→上位 ROLE002(営業本部長)、ROLE005(営業課長)→上位 ROLE003(営業部長)、ROLE001(社長)→上位 null。課員 EMP000006(DEPT001)→明示上位 ROLE005(営業課長)。既存データで両列を検証可能、シード変更は不要。

--- a/docs/claude-plans/issue-578/refactor-employee-select-single-source.md
+++ b/docs/claude-plans/issue-578/refactor-employee-select-single-source.md
@@ -1,0 +1,79 @@
+# Issue #578 追加リファクタ: EmployeeDTO の select を単一真実源化する（TDD）
+
+## Context
+
+`/code-review`（PR #594）で `PrismaEmployeeQueryService` の **select 形状の二重管理**が指摘された（verify: CONFIRMED）。
+
+- `getSelectFields()`（L144-188）が `as const` で「引く列」を定義する一方、`toDTO()` の引数型（L193-208）が **同じ行形状を手書きで再宣言**している。
+- 本 PR（役割名列追加）はこの重複を `role.name` / `role.superiorRole.name` / `superiorRole.role.name` の追加ぶん **両所へ手で広げた**。
+- リポジトリには `Prisma.*GetPayload<{ include/select: typeof CONST }>` で select 定数から行型を機械導出する規約が9箇所（`EmployeeMapper.ts:14`、`PrismaEstimateQueryService.ts:51,72` ほか）に定着しており、**このファイルだけが手書き型の例外**。
+
+**問題の本質**: select と手書き型が独立に編集できるため、片方だけ変更すると型が実データとズレても `tsc` が検出できない（例: select から `superiorRole.role` を消しても手書き型に残れば、実行時 `undefined.name` でクラッシュするのにコンパイルは通る）。
+
+**ユーザー決定（このPRで対応）**:
+- `EMPLOYEE_SELECT` をモジュールレベル定数に切り出し、`satisfies Prisma.EmployeeSelect` を付す。
+- `toDTO` の引数型を `Prisma.EmployeeGetPayload<{ select: typeof EMPLOYEE_SELECT }>` の導出型に置換（手書き型を廃止）。
+- `getSelectFields()` は「引数なし・状態なし（`this` 不使用）・固定値を返すだけ」の無意味な中間層になるため **削除**し、呼び出し3箇所を定数直参照に置換する（規約の手本 `PrismaEstimateQueryService` もラッパーメソッドを持たず定数を直接参照している。構造まで規約に揃える）。
+
+**ゴール**: select を単一の真実源にし、以後の列追加が1箇所の編集で型まで追従する状態にする。ランタイム挙動は不変。
+
+## 設計判断
+
+### 配置: `EMPLOYEE_SELECT` はモジュールスコープ定数
+- 手本の `ESTIMATE_SUMMARY_INCLUDE`（`PrismaEstimateQueryService.ts:61`）と同じく、クラス外のモジュールスコープに `satisfies Prisma.EmployeeSelect` 付きで定義する。
+- 理由: `GetPayload<{ select: typeof CONST }>` は `typeof` で定数の型を取るため、定数がモジュールスコープにあると型導出が素直（private メソッド戻り値の `ReturnType` 経由より読みやすく、規約と一致）。
+
+### `getSelectFields()` は削除する（中間層の除去）
+- 現状の `getSelectFields()` は引数なし・`this` 不使用・分岐なしで固定 `select` を返すだけ。定数のエイリアス以上の意味を持たず、呼び出しごとにリテラルを再生成するぶん僅かに無駄。
+- 呼び出しは `findById`(L21) / `findByEmployeeCd`(L30) / `search`(L42) の3箇所のみ。すべて `select: this.getSelectFields()` → `select: EMPLOYEE_SELECT` に置換して削除する。
+- 理由: 手本の QueryService もラッパーメソッドを持たない。中間層を残すと「定数 vs メソッド」の二重の入口ができ、規約から外れる。
+
+### `findSuperiorRoleId` は対象外（非スコープ）
+- `findSuperiorRoleId`(L51-82) は承認起点導出のため **独自の select**（`role.superiorRoleId` と `superiorRole.roleId` のみ）を持ち、`getSelectFields()` を使っていない。役割・データ形状が異なる別読み（ADR-20260707-k4e）で、本リファクタの対象外。触らない。
+
+### DTO 形状・挙動は不変
+- `EmployeeDTO`（application 層）は変更しない。変えるのは infrastructure 層の型の**導出方法**だけで、`toDTO` が返す値・各フィールドの意味は不変。
+
+## TDD 方針（red-green-refactor の解釈）
+
+純粋な型リファクタ（挙動不変）のため、「失敗するランタイムテストを新規作成」は不自然。代わりに **既存の統合テストを回帰安全網として固定**し、**このリファクタが塞ぐ"型安全の穴"を `tsc` で可視化**する形で red-green-refactor を回す。
+
+### RED（安全網の確認 ＋ 現状の穴の可視化）
+1. **回帰安全網の緑を先に確認**: 変更前に下記4テストが緑であることを実行して確認（ベースライン固定）。
+   - `PrismaEmployeeQueryService.roleNames.test.ts`（担当役割あり／明示上位課員／上位なし役割持ち／両方なし／search経路 の5 it）
+   - `PrismaEmployeeQueryService.assignedRoleId.test.ts`
+   - `PrismaEmployeeQueryService.explicitSuperiorRoleId.test.ts`
+   - `PrismaEmployeeQueryService.findSuperiorRoleId.test.ts`
+2. **型安全の穴を RED として可視化**（一時的・コミットしない）: 現状の `toDTO` 手書き型 or `getSelectFields` の select を **わざと片方だけ1フィールドズラす**（例: select から `superiorRole.role.name` を消す／手書き型に余分なフィールドを足す）。`pnpm tsc --noEmit` が **通ってしまう**ことを確認する（＝現状は型が守っていない ＝ これが直したい欠陥＝RED）。確認後、ズラしを元に戻す。
+
+### GREEN（リファクタ実装）
+3. `EMPLOYEE_SELECT` をモジュール定数化（`satisfies Prisma.EmployeeSelect`）。
+4. `type EmployeeRow = Prisma.EmployeeGetPayload<{ select: typeof EMPLOYEE_SELECT }>` を定義し、`toDTO(employee: EmployeeRow)` に置換（手書き型を削除）。
+5. `getSelectFields()` を削除し、3箇所の `select: this.getSelectFields()` を `select: EMPLOYEE_SELECT` に置換。
+6. **回帰安全網が緑のまま**であることを再確認（`pnpm test`）＝挙動不変の担保。
+7. **穴が塞がったことを確認（GREEN）**: 手順2と同じズラしを再度入れると、今度は `pnpm tsc --noEmit` が **落ちる**ことを確認（＝ select と行型が単一真実源で連動）。確認後ズラしを戻す。
+
+### REFACTOR
+8. コメント整理（`getSelectFields` の JSDoc を `EMPLOYEE_SELECT` へ移設・簡潔化）、`pnpm lint`。挙動・型に影響しない仕上げのみ。
+
+## ステップ / コミット計画
+
+意味のあるまとまりでコミットする（一括コミットしない）。
+
+- **Step 0（この計画）**: `docs:` — 本計画ファイル。
+- **Step 1（GREEN本体）**: `refactor:` — `EMPLOYEE_SELECT` 定数化＋`GetPayload` 導出型で `toDTO` 置換＋`getSelectFields` 削除＋呼び出し3箇所置換。
+  - コミットボディに設計判断を記載: 「select 定数をモジュールスコープに配置し `getSelectFields` メソッドを削除。理由: select を単一真実源化し、手本の `PrismaEstimateQueryService`（定数直参照・ラッパーメソッドなし）と構造を揃えるため。手書き行型は `GetPayload` 導出に置換し二重管理を解消」。
+- **Step 2（任意・REFACTOR）**: 同 `refactor:` に含めてよい（コメント整理が軽微なら Step 1 に同梱）。
+
+## 検証
+
+- `pnpm test`: 上記4テストが緑（挙動不変の回帰確認）。schema 変更なしのため `pnpm test:setup` 不要。
+- `pnpm tsc --noEmit`（or `pnpm build` の型チェック）: 導出型で全体が型整合。RED/GREEN の穴確認もこれで行う。
+- `pnpm lint`: 定数移設後のスタイル整合。
+- E2E は不要（表示挙動・DTO 形状は不変。既存 `employees-list.e2e.ts` の緑は CI に委ねる）。
+
+## リスク / 非対象
+
+- **リスク（低）**: `GetPayload<{ select: typeof CONST }>` の導出型が現行手書き型と厳密一致するか。`satisfies` と `as const` の相性で `select` のネストが正しく型に反映されるかは実装時に `tsc` で即検証（不一致ならその場で判明）。
+- **非対象**: `findSuperiorRoleId` の独自 select、`EmployeeDTO`（application 層）、他 QueryService。本リファクタは `PrismaEmployeeQueryService` 内に閉じる。
+- **deviations**: 実装中に本計画と異なる対応をした場合、`docs/claude-plans/issue-578/deviations.md` に {元計画/実際/理由} を記録する（CLAUDE.md ルール）。

--- a/src/app/(features)/employees/_components/columns.tsx
+++ b/src/app/(features)/employees/_components/columns.tsx
@@ -27,6 +27,18 @@ export const columns: ColumnDef<EmployeeDTO, unknown>[] = [
     header: "部署",
   },
   {
+    accessorKey: "assignedRoleName",
+    header: "担当役割",
+    // 役割なし（課員）は null → "-" 表示
+    cell: ({ row }) => row.original.assignedRoleName ?? "-",
+  },
+  {
+    accessorKey: "superiorRoleName",
+    header: "上位役割",
+    // 上位役割なし（社長など階層最上位）は null → "-" 表示
+    cell: ({ row }) => row.original.superiorRoleName ?? "-",
+  },
+  {
     accessorKey: "email",
     header: "メールアドレス",
   },

--- a/src/app/(features)/employees/employees-list.e2e.ts
+++ b/src/app/(features)/employees/employees-list.e2e.ts
@@ -69,6 +69,35 @@ test.describe("従業員一覧（管理者）", () => {
     }
   });
 
+  test("担当役割・上位役割の列に役割名が表示される（役割保有従業員）", async ({ page }) => {
+    // EMP000004＝開発部長（ROLE004）。上位役割は役割階層の1段上＝営業本部長（ROLE002）。
+    await page.goto("/employees?employeeCd=EMP000004");
+    await waitForListReady(page);
+
+    // ヘッダー名からカラム位置を動的特定（カラム追加・並び替えに耐性を持たせる）
+    const headers = await page.locator("table thead th").allTextContents();
+    const assignedColIndex = headers.indexOf("担当役割") + 1;
+    const superiorColIndex = headers.indexOf("上位役割") + 1;
+
+    const row = page.locator("table tbody tr").first();
+    await expect(row.locator(`td:nth-child(${assignedColIndex})`)).toHaveText("開発部長");
+    await expect(row.locator(`td:nth-child(${superiorColIndex})`)).toHaveText("営業本部長");
+  });
+
+  test("担当役割なしの課員は担当役割が「-」・上位役割に明示上位役割名が出る", async ({ page }) => {
+    // EMP000006＝課員（担当役割なし）。明示上位役割＝営業課長（ROLE005）。
+    await page.goto("/employees?employeeCd=EMP000006");
+    await waitForListReady(page);
+
+    const headers = await page.locator("table thead th").allTextContents();
+    const assignedColIndex = headers.indexOf("担当役割") + 1;
+    const superiorColIndex = headers.indexOf("上位役割") + 1;
+
+    const row = page.locator("table tbody tr").first();
+    await expect(row.locator(`td:nth-child(${assignedColIndex})`)).toHaveText("-");
+    await expect(row.locator(`td:nth-child(${superiorColIndex})`)).toHaveText("営業課長");
+  });
+
   test("クリアボタンで検索条件がリセットされる", async ({ page }) => {
     await page.goto("/employees?email=employee1");
     await waitForListReady(page);

--- a/src/server/subdomains/employee/application/queries/dto/EmployeeDTO.ts
+++ b/src/server/subdomains/employee/application/queries/dto/EmployeeDTO.ts
@@ -19,15 +19,26 @@ export type EmployeeDTO = {
   role: UserRole | null;
   /**
    * 担当役割ID（EmployeeRole から導出、役割なし＝課員は null）。
-   * 編集画面の現在値復元に用いる。役割名はフォーム供給の一覧から解決するため持たない。
+   * 編集画面の現在値復元（セレクトの preselect）に用いる。
    */
   assignedRoleId: string | null;
+  /**
+   * 担当役割名（EmployeeRole → Role.name から解決、役割なし＝課員は null）。
+   * 一覧の担当役割列の表示に用いる（ADR-0013）。
+   */
+  assignedRoleName: string | null;
   /**
    * 明示上位役割ID（EmployeeSuperiorRole から導出）。課員（担当役割なし）のみ値を持ち、
    * 役割持ちは常に null（I1 により明示行を持たない）。登録・更新画面の現在値復元に用いる。
    * 承認起点の導出（findSuperiorRoleId）とは別読み。
    */
   explicitSuperiorRoleId: string | null;
+  /**
+   * 従業員の上位役割名（承認起点の役割名）。findSuperiorRoleId と同じ導出分岐を名前解決したもの。
+   * 担当役割あり→その役割の上位役割名／課員→明示上位役割名／どちらも無→null。
+   * 一覧の上位役割列の表示に用いる（ADR-0013）。承認起点の導出（findSuperiorRoleId）とは別読み。
+   */
+  superiorRoleName: string | null;
   /** 楽観ロックトークン（ADR-0039）。編集画面表示時の値をフォームで往復させる */
   version: number;
   createdAt: Date;

--- a/src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts
+++ b/src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts
@@ -9,6 +9,60 @@ import { Prisma } from "@generated/prisma/client";
 import type { UserRole } from "@server/shared/auth/types";
 
 /**
+ * 従業員 DTO の読み取り select 定義（単一真実源）。
+ * この定数から toDTO の行型（EmployeeRow）を GetPayload で機械導出するため、
+ * select を変えれば行型も1箇所で追従する（手書き行型との二重管理を排除・PR #594）。
+ * User.role、担当役割名（role.name）、上位役割名（role.superiorRole.name /
+ * superiorRole.role.name）も含めて取得する。
+ */
+const EMPLOYEE_SELECT = {
+  id: true,
+  employeeCd: true,
+  email: true,
+  name: true,
+  departmentId: true,
+  version: true,
+  createdAt: true,
+  updatedAt: true,
+  // Department.nameを取得
+  department: {
+    select: {
+      name: true,
+    },
+  },
+  // User.roleを取得
+  user: {
+    select: {
+      role: true,
+    },
+  },
+  // 担当役割（高々1件・ADR-20260706-c89）を取得。
+  // role.name＝担当役割名、role.superiorRole.name＝役割持ちの上位役割名（承認起点）。
+  employeeRoles: {
+    select: {
+      roleId: true,
+      role: {
+        select: {
+          name: true,
+          superiorRole: { select: { name: true } },
+        },
+      },
+    },
+  },
+  // 課員の明示上位役割（0/1 件・ADR-20260707-k4e）を取得。
+  // role.name＝課員の上位役割名（承認起点）。
+  superiorRole: {
+    select: {
+      roleId: true,
+      role: { select: { name: true } },
+    },
+  },
+} satisfies Prisma.EmployeeSelect;
+
+/** EMPLOYEE_SELECT が返す Employee 行の型（toDTO の入力・select と単一真実源）。 */
+type EmployeeRow = Prisma.EmployeeGetPayload<{ select: typeof EMPLOYEE_SELECT }>;
+
+/**
  * Prismaを使用した従業員クエリサービス実装
  *
  * データベースから直接DTOを取得し、軽量で高速な読み取りを実現
@@ -18,7 +72,7 @@ export class PrismaEmployeeQueryService implements EmployeeQueryService {
   async findById(id: string): Promise<EmployeeDTO | null> {
     const employee = await prisma.employee.findUnique({
       where: { id },
-      select: this.getSelectFields(),
+      select: EMPLOYEE_SELECT,
     });
 
     return employee ? this.toDTO(employee) : null;
@@ -27,7 +81,7 @@ export class PrismaEmployeeQueryService implements EmployeeQueryService {
   async findByEmployeeCd(employeeCd: string): Promise<EmployeeDTO | null> {
     const employee = await prisma.employee.findFirst({
       where: { employeeCd },
-      select: this.getSelectFields(),
+      select: EMPLOYEE_SELECT,
     });
 
     return employee ? this.toDTO(employee) : null;
@@ -39,7 +93,7 @@ export class PrismaEmployeeQueryService implements EmployeeQueryService {
 
     const employees = await prisma.employee.findMany({
       where,
-      select: this.getSelectFields(),
+      select: EMPLOYEE_SELECT,
       orderBy,
       take: options?.limit,
       skip: options?.offset,
@@ -138,75 +192,9 @@ export class PrismaEmployeeQueryService implements EmployeeQueryService {
   }
 
   /**
-   * DTOに必要なフィールドのみを取得するためのselect定義
-   * User.roleも含めて取得する
+   * PrismaモデルからDTOへ変換。入力型は EMPLOYEE_SELECT から導出（EmployeeRow）。
    */
-  private getSelectFields() {
-    return {
-      id: true,
-      employeeCd: true,
-      email: true,
-      name: true,
-      departmentId: true,
-      version: true,
-      createdAt: true,
-      updatedAt: true,
-      // Department.nameを取得
-      department: {
-        select: {
-          name: true,
-        },
-      },
-      // User.roleを取得
-      user: {
-        select: {
-          role: true,
-        },
-      },
-      // 担当役割（高々1件・ADR-20260706-c89）を取得。
-      // role.name＝担当役割名、role.superiorRole.name＝役割持ちの上位役割名（承認起点）。
-      employeeRoles: {
-        select: {
-          roleId: true,
-          role: {
-            select: {
-              name: true,
-              superiorRole: { select: { name: true } },
-            },
-          },
-        },
-      },
-      // 課員の明示上位役割（0/1 件・ADR-20260707-k4e）を取得。
-      // role.name＝課員の上位役割名（承認起点）。
-      superiorRole: {
-        select: {
-          roleId: true,
-          role: { select: { name: true } },
-        },
-      },
-    } as const;
-  }
-
-  /**
-   * PrismaモデルからDTOへ変換
-   */
-  private toDTO(employee: {
-    id: string;
-    employeeCd: string;
-    email: string;
-    name: string;
-    departmentId: string;
-    department: { name: string };
-    version: number;
-    createdAt: Date;
-    updatedAt: Date;
-    user: { role: string | null } | null;
-    employeeRoles: {
-      roleId: string;
-      role: { name: string; superiorRole: { name: string } | null };
-    }[];
-    superiorRole: { roleId: string; role: { name: string } } | null;
-  }): EmployeeDTO {
+  private toDTO(employee: EmployeeRow): EmployeeDTO {
     // 高々1件の担当役割（0件＝役割なし＝課員・ADR-20260706-c89）
     const assignedRole = employee.employeeRoles[0];
     return {

--- a/src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts
+++ b/src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts
@@ -163,16 +163,25 @@ export class PrismaEmployeeQueryService implements EmployeeQueryService {
           role: true,
         },
       },
-      // 担当役割（高々1件・ADR-20260706-c89）を取得
+      // 担当役割（高々1件・ADR-20260706-c89）を取得。
+      // role.name＝担当役割名、role.superiorRole.name＝役割持ちの上位役割名（承認起点）。
       employeeRoles: {
         select: {
           roleId: true,
+          role: {
+            select: {
+              name: true,
+              superiorRole: { select: { name: true } },
+            },
+          },
         },
       },
-      // 課員の明示上位役割（0/1 件・ADR-20260707-k4e）を取得
+      // 課員の明示上位役割（0/1 件・ADR-20260707-k4e）を取得。
+      // role.name＝課員の上位役割名（承認起点）。
       superiorRole: {
         select: {
           roleId: true,
+          role: { select: { name: true } },
         },
       },
     } as const;
@@ -192,9 +201,14 @@ export class PrismaEmployeeQueryService implements EmployeeQueryService {
     createdAt: Date;
     updatedAt: Date;
     user: { role: string | null } | null;
-    employeeRoles: { roleId: string }[];
-    superiorRole: { roleId: string } | null;
+    employeeRoles: {
+      roleId: string;
+      role: { name: string; superiorRole: { name: string } | null };
+    }[];
+    superiorRole: { roleId: string; role: { name: string } } | null;
   }): EmployeeDTO {
+    // 高々1件の担当役割（0件＝役割なし＝課員・ADR-20260706-c89）
+    const assignedRole = employee.employeeRoles[0];
     return {
       id: employee.id,
       employeeCd: employee.employeeCd,
@@ -204,10 +218,16 @@ export class PrismaEmployeeQueryService implements EmployeeQueryService {
       departmentName: employee.department.name,
       // User.roleを使用（"admin" | "user" | null）
       role: (employee.user?.role as UserRole) ?? null,
-      // 高々1件の担当役割を導出（0件＝役割なし＝課員）
-      assignedRoleId: employee.employeeRoles[0]?.roleId ?? null,
+      // 担当役割ID／名（0件＝役割なし＝課員 → null）
+      assignedRoleId: assignedRole?.roleId ?? null,
+      assignedRoleName: assignedRole?.role.name ?? null,
       // 課員の明示上位役割（役割持ちは明示行を持たない・I1 → null）
       explicitSuperiorRoleId: employee.superiorRole?.roleId ?? null,
+      // 従業員の上位役割名（承認起点の名前解決）。findSuperiorRoleId と同じ導出分岐：
+      //   担当役割あり → その役割の上位役割名／課員 → 明示上位役割名／どちらも無 → null
+      superiorRoleName: assignedRole
+        ? (assignedRole.role.superiorRole?.name ?? null)
+        : (employee.superiorRole?.role.name ?? null),
       version: employee.version,
       createdAt: employee.createdAt,
       updatedAt: employee.updatedAt,

--- a/src/server/subdomains/employee/infrastructure/queries/__tests__/PrismaEmployeeQueryService.roleNames.test.ts
+++ b/src/server/subdomains/employee/infrastructure/queries/__tests__/PrismaEmployeeQueryService.roleNames.test.ts
@@ -1,0 +1,173 @@
+import { ensureTestDepartment } from "@server/__tests__/helpers/ensureTestDepartment";
+import prisma from "@server/prisma";
+import { generateId } from "@server/shared/generateId";
+import { PrismaEmployeeQueryService } from "@subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * 読み取り DTO への役割名射影（assignedRoleName / superiorRoleName）の統合テスト（#578）。
+ * 一覧の担当役割列・上位役割列の表示に用いる（案B・ADR-0013）。
+ * 実 Prisma に対して検証する（モック禁止・ADR-0012）。
+ *
+ * superiorRoleName は findSuperiorRoleId と同じ導出分岐を名前解決したもの（承認起点とは別読み）：
+ *   担当役割あり → その担当役割の上位役割名
+ *   担当役割なし（課員）→ 明示上位役割名
+ *   どちらも無     → null
+ */
+describe("PrismaEmployeeQueryService 役割名(assignedRoleName / superiorRoleName)", () => {
+  // ファイル別プレフィックスで並列実行の P2002 を避ける（#327）。
+  const TEST_EMP_CDS = ["EMP990710", "EMP990711", "EMP990712", "EMP990713"];
+  const TEST_ROLE_CDS = ["ROLE971", "ROLE972", "ROLE973"];
+
+  let service: PrismaEmployeeQueryService;
+  let deptId: string;
+
+  let seniorRoleId: string; // 部長級。assignedRole の上位役割
+  let assignedRoleId: string; // 課長級。上位役割 = seniorRoleId を持つ
+  let leafRoleId: string; // 課長級。上位役割を持たない（担当役割にも明示上位役割にも使う）
+
+  async function cleanup() {
+    // 従業員削除で employeeRole / employeeSuperiorRole 子行は CASCADE される
+    await prisma.employee.deleteMany({ where: { employeeCd: { in: TEST_EMP_CDS } } });
+    await prisma.role.deleteMany({ where: { roleCd: { in: TEST_ROLE_CDS } } });
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+    deptId = await ensureTestDepartment();
+
+    const [kachou, buchou] = await Promise.all([
+      prisma.position.findUnique({ where: { positionCd: "POS001" } }),
+      prisma.position.findUnique({ where: { positionCd: "POS002" } }),
+    ]);
+
+    // 部長級（上位役割）→ 課長級（担当役割・上位あり）→ 課長級（上位なし）の順に用意する
+    seniorRoleId = generateId();
+    assignedRoleId = generateId();
+    leafRoleId = generateId();
+    await prisma.role.create({
+      data: {
+        id: seniorRoleId,
+        roleCd: TEST_ROLE_CDS[1],
+        name: "上位役割（部長級）",
+        positionId: buchou!.id,
+      },
+    });
+    await prisma.role.create({
+      data: {
+        id: assignedRoleId,
+        roleCd: TEST_ROLE_CDS[0],
+        name: "担当役割（課長級）",
+        positionId: kachou!.id,
+        superiorRoleId: seniorRoleId,
+      },
+    });
+    await prisma.role.create({
+      data: {
+        id: leafRoleId,
+        roleCd: TEST_ROLE_CDS[2],
+        name: "上位なし役割（課長級）",
+        positionId: kachou!.id,
+      },
+    });
+
+    service = new PrismaEmployeeQueryService();
+  });
+
+  afterEach(cleanup);
+
+  it("担当役割を持つ従業員は担当役割名と、その役割の上位役割名を返す", async () => {
+    const employeeId = generateId();
+    await prisma.employee.create({
+      data: {
+        id: employeeId,
+        employeeCd: TEST_EMP_CDS[0],
+        email: `${TEST_EMP_CDS[0]}@test.example.com`,
+        name: "担当役割あり従業員",
+        departmentId: deptId,
+        employeeRoles: { create: [{ roleId: assignedRoleId }] },
+      },
+    });
+
+    const dto = await service.findById(employeeId);
+
+    expect(dto?.assignedRoleName).toBe("担当役割（課長級）");
+    expect(dto?.superiorRoleName).toBe("上位役割（部長級）");
+  });
+
+  it("明示上位役割を持つ課員は担当役割名が null、上位役割名は明示役割名を返す", async () => {
+    const employeeId = generateId();
+    await prisma.employee.create({
+      data: {
+        id: employeeId,
+        employeeCd: TEST_EMP_CDS[1],
+        email: `${TEST_EMP_CDS[1]}@test.example.com`,
+        name: "明示上位役割あり課員",
+        departmentId: deptId,
+        superiorRole: { create: { roleId: leafRoleId } },
+      },
+    });
+
+    const dto = await service.findById(employeeId);
+
+    expect(dto?.assignedRoleName).toBeNull();
+    expect(dto?.superiorRoleName).toBe("上位なし役割（課長級）");
+  });
+
+  it("担当役割はあるが上位役割を持たない従業員は担当役割名を返し、上位役割名は null", async () => {
+    const employeeId = generateId();
+    await prisma.employee.create({
+      data: {
+        id: employeeId,
+        employeeCd: TEST_EMP_CDS[2],
+        email: `${TEST_EMP_CDS[2]}@test.example.com`,
+        name: "上位役割なし役割持ち従業員",
+        departmentId: deptId,
+        employeeRoles: { create: [{ roleId: leafRoleId }] },
+      },
+    });
+
+    const dto = await service.findById(employeeId);
+
+    expect(dto?.assignedRoleName).toBe("上位なし役割（課長級）");
+    expect(dto?.superiorRoleName).toBeNull();
+  });
+
+  it("担当役割も明示上位役割も持たない従業員は両方 null", async () => {
+    const employeeId = generateId();
+    await prisma.employee.create({
+      data: {
+        id: employeeId,
+        employeeCd: TEST_EMP_CDS[3],
+        email: `${TEST_EMP_CDS[3]}@test.example.com`,
+        name: "役割なし従業員",
+        departmentId: deptId,
+      },
+    });
+
+    const dto = await service.findById(employeeId);
+
+    expect(dto?.assignedRoleName).toBeNull();
+    expect(dto?.superiorRoleName).toBeNull();
+  });
+
+  it("search（一覧経路）でも役割名を返す", async () => {
+    const employeeId = generateId();
+    await prisma.employee.create({
+      data: {
+        id: employeeId,
+        employeeCd: TEST_EMP_CDS[0],
+        email: `${TEST_EMP_CDS[0]}-search@test.example.com`,
+        name: "一覧経路検証従業員",
+        departmentId: deptId,
+        employeeRoles: { create: [{ roleId: assignedRoleId }] },
+      },
+    });
+
+    const results = await service.search({ employeeCd: TEST_EMP_CDS[0] });
+    const dto = results.find((e) => e.employeeCd === TEST_EMP_CDS[0]);
+
+    expect(dto?.assignedRoleName).toBe("担当役割（課長級）");
+    expect(dto?.superiorRoleName).toBe("上位役割（部長級）");
+  });
+});


### PR DESCRIPTION
## Summary

- 従業員一覧に担当役割・上位役割の列を追加（FE）。
- 役割名の解決方式は案B（ADR-0013準拠）を採用し、`EmployeeDTO` に担当役割名・上位役割名を JOIN で搭載。
- `employees-list.e2e.ts` に役割列の表示アサーションを追加。

Closes #578

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### employee-list-role-columns.md

# Issue #578: 従業員一覧に担当役割（＋上位役割）の列を追加する — 実装計画

## Context

従業員一覧（`/employees`）には現在、担当役割・上位役割の列が無い。#565 は登録・更新フォーム文脈でのみ役割を扱い、一覧DTO（`EmployeeDTO`）には「役割名はフォーム供給の一覧から解決する」という理由で**役割名を意図的に載せなかった**。

#578 が初めて**一覧表示要件**を持ち込むため、役割名の解決方式を決める必要があった。ここに ADR-0013（一覧DTOにリレーション先の名前をJOINで載せる）と #565 の非搭載判断の緊張関係がある。

**ユーザー決定**:
- 役割名解決方式 = **案B（DTOにJOIN）**。ADR-0013 の標準パターンに統一（既存 `departmentName` と同方式）。#565 の非搭載判断は「表示要件が無かった時点の判断」として上書きする。
- 列スコープ = **担当役割列＋上位役割列の両方**。#567（`EmployeeSuperiorRole` 抽出・上位役割の読み取り時導出）は**CLOSED＝完了済み**で、導出ロジック（`findSuperiorRoleId`）・子表が確定しているため、上位役割列を本イシューで同時実装できる。

**目標**: 従業員一覧に「担当役割」「上位役割」列を追加し、案Bで名前を解決。E2Eで表示を検証する。

## 設計判断

### 役割名の解決方式（Issueの核心 decision）
- A. 一覧 `page.tsx` で全役割を取得し `Map<id,name>` を組んでFE側で解決（list DTO 不変）
- B. `EmployeeDTO` に `assignedRoleName` / `superiorRoleName` を JOIN して載せる
- **決定: B**（ユーザー選択）。ADR-0013 準拠、`departmentName` と一貫、変更がQueryServiceに局所化。#565 のDTOコメント（「役割名はフォーム供給の一覧から解決するため持たない」）は表示要件の発生に伴い更新する。

### 上位役割名の導出方式
- 表示する「上位役割」= 従業員の上位役割（承認起点＝`findSuperiorRoleId` と同じ導出分岐）。担当役割あり→その役割の上位役割名、課員→明示 `EmployeeSuperiorRole` の役割名、どちらも無→null。
- `findSuperiorRoleId`（ID専用・承認消費点）とは別に、`toDTO` 内で JOIN 済み行から**名前を導出**する。
  - A. `toDTO` にインライン導出（2分岐）
  - B. 共通ヘルパーへ抽出
  - **推奨: A（インライン）**。`findSuperiorRoleId` は別クエリ・ID返却でデータ形状が異なり、既存コードも `explicitSuperiorRoleId` に「承認起点の導出とは別読み」と明記済み。表示用と承認用の分離という既存方針に沿う。導出は2分岐と小さく、共通化の便益が薄い。

### 役割なし（null）の表示
- 担当役割なし（課員）／上位役割なし（社長）は列に `-` を表示。ADR-0013 が許容する departments の `-` 慣習に合わせる。`columns.tsx` の cell レンダラで `?? "-"`。

### #567 との整合
- 本イシューで案Bを採用。上位役割列も同じ案Bで実装するため、#567 と方式が揃う（列デザインの二度手間なし）。

## ステップ

### Step 1: BE — 一覧DTOに担当役割名・上位役割名を載せる（案B）
- 対象ファイル:
  - `src/server/subdomains/employee/application/queries/dto/EmployeeDTO.ts`
  - `src/server/subdomains/employee/infrastructure/queries/PrismaEmployeeQueryService.ts`
  - `src/server/subdomains/employee/infrastructure/queries/__tests__/PrismaEmployeeQueryService.assignedRoleId.test.ts`（等、既存テストパターンに倣い新規 or 追記）
- 作業内容:
  - `EmployeeDTO` に `assignedRoleName: string | null` と `superiorRoleName: string | null` を追加。`assignedRoleId` のコメントを「名前は一覧表示のため `assignedRoleName` に載せる／フォームの現在値復元はIDを使う」に更新。
  - `getSelectFields()` を拡張:
    - `employeeRoles.select` に `role: { select: { name: true, superiorRole: { select: { name: true } } } }`
    - `superiorRole.select`（EmployeeSuperiorRole）に `role: { select: { name: true } }`
  - `toDTO()` の引数型と本体を拡張:
    - `assignedRoleName = employee.employeeRoles[0]?.role.name ?? null`
    - `superiorRoleName`: 担当役割あり → `employeeRoles[0].role.superiorRole?.name ?? null`／課員 → `employee.superiorRole?.role?.name ?? null`（`findSuperiorRoleId` L74-81 と同分岐）
  - 単体テスト: 役割持ち（担当名＝役割名、上位名＝役割の上位役割名）・課員（担当 null、上位＝明示役割名）・社長（担当名あり、上位 null）の3系統を検証。既存 `*.assignedRoleId.test.ts` / `*.explicitSuperiorRoleId.test.ts` のパターン踏襲。
- コミットメッセージ: `feat: 従業員一覧DTOに担当役割名・上位役割名を載せる（案B/ADR-0013）`

### Step 2: FE — 一覧に担当役割・上位役割の列を追加
- 対象ファイル: `src/app/(features)/employees/_components/columns.tsx`
- 作業内容:
  - 「部署」列の後（または「権限」列の前）に列を2つ追加:
    - `{ accessorKey: "assignedRoleName", header: "担当役割", cell: ({ row }) => row.original.assignedRoleName ?? "-" }`
    - `{ accessorKey: "superiorRoleName", header: "上位役割", cell: ({ row }) => row.original.superiorRoleName ?? "-" }`
  - `page.tsx` は変更不要（DTOをそのまま流す＝ADR-0013 の狙い）。
- コミットメッセージ: `feat: 従業員一覧に担当役割・上位役割の列を追加（FE）`

### Step 3: E2E — 列表示アサーション追加
- 対象ファイル: `src/app/(features)/employees/employees-list.e2e.ts`
- 作業内容:
  - ヘッダー名からカラム位置を動的特定する既存パターン（「権限で検索できる」テスト L61-64 参照）に倣い、`EMP000004`（担当=開発部長／上位=営業本部長）で両列に役割名が出ることを検証するテストを追加。
  - 課員 `EMP000006`（担当=`-`／上位=営業課長）で null 表示と明示上位役割の表示も検証（余力あれば1テストに含める）。
  - 対象コードで検索して1行に絞り、`td:nth-child(担当役割列index)` / `td:nth-child(上位役割列index)` のテキストをアサート。
- コミットメッセージ: `test: 従業員一覧の担当役割・上位役割列のE2Eアサーションを追加`

## 検証

- `pnpm test`（単体）: Step 1 の QueryService 導出テストが通ること。事前に schema 変更は無いため `pnpm test:setup` 不要。
- `pnpm lint` / 型チェック: DTO 追加フィールドの型整合。
- `pnpm e2e -- employees-list`（該当specのみ。全体はCIに任せる）: 追加した列アサーションが通ること。事前に `pnpm e2e:seed` でシード最新化。
- 任意: `verify-frontend`（dev server + playwright MCP）で `/employees` を開き、担当役割・上位役割列と `-` 表示を目視確認。

## 補足
- E2Eフィクスチャ（`prisma/seed-e2e.ts`）の役割階層: ROLE004(開発部長)→上位 ROLE002(営業本部長)、ROLE005(営業課長)→上位 ROLE003(営業部長)、ROLE001(社長)→上位 null。課員 EMP000006(DEPT001)→明示上位 ROLE005(営業課長)。既存データで両列を検証可能、シード変更は不要。

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

---

Generated with [Claude Code](https://claude.ai/code)
