### PR TITLE
refactor: 記述子 optional プロパティの「省略＝クリア/未指定」を型で区別できず引き継ぎ生成で silent data loss を招く構造を塞ぐ

### DIFF
--- a/docs/adr/20260716-35a-type-enforce-no-fixed-discounts-on-repriced-generation.md
+++ b/docs/adr/20260716-35a-type-enforce-no-fixed-discounts-on-repriced-generation.md
@@ -62,3 +62,4 @@
 - `EstimateDuplicationService` の `copyItem` 戻り型・セット群マップが repriced 記述子型になる。
 - `Estimate.reviseForCustomer` は repriced 記述子を組み立て `buildRevisedVariation` へ委譲する形になり、自前のセット群 id 配線が共有 `buildSetGroups` に一本化される（#602 の再発防止）。挙動は不変。
 - 本 ADR は pv8（業務判断）の機構面を担う。将来「repriced 記述子の optional 全般（例: `setGroups?` 必須化）」に踏み込む場合は本 ADR とは別軸の判断として扱う（#603 スコープ外）。
+  - → ADR-20260716-w4k（#617）がこの別軸を担った。本 ADR の 3 決定は存続するが、`RepricedItemDescriptor` の定義のみ w4k が更新する（`Required` で包み `revisedDeliveryPrice` を `Omit` し、複製用／改訂用に割る）。

--- a/docs/adr/20260716-w4k-eradicate-optional-from-handoff-descriptors.md
+++ b/docs/adr/20260716-w4k-eradicate-optional-from-handoff-descriptors.md
@@ -1,0 +1,85 @@
+# ADR-20260716-w4k: 引き継ぎ生成の記述子から optional を根絶する（維持は Required で強制・クリアは Omit・経路は分割）
+
+| 項目 | 値 |
+|---|---|
+| ステータス | 採用 |
+| 起票日 | 2026-07-16 |
+| 最終更新日 | 2026-07-16 |
+
+## コンテキスト
+
+ADR-20260716-35a（#603 / #616）は「単価再解決を伴う生成（複製先・改訂先）では固定値引を持ち込まない」という不変則を、repriced 記述子の `Omit` で型強制した。だがそれは固定値引という**個別フィールドへの対処**であり、記述子の optional 全般が持つ「省略＝取りこぼしを黙認する」構造はそのまま残った（35a 自身が「repriced 記述子の optional 全般（例: `setGroups?` 必須化）は別軸の判断」として本 ADR を予告している）。
+
+記述子の `prop?: T` は「**省略＝クリアの意図**」と「**省略＝未指定（＝元の値を維持すべき）**」を型で区別できない。引き継ぎ生成では後者しか起こりえないにもかかわらず、populate を忘れても `undefined` が有効値として通り、型システムが取りこぼしを検出できない。
+
+実害は既に 2 度出ている。`setGroups?` の未引き継ぎが #602（複製）と #607（改訂）で噴出した。火元は共有ビルダーの
+
+```ts
+buildSetGroups(descriptor.setGroups ?? [])   // estimateChildBuilders.ts
+```
+
+で、「埋め忘れ」を「黙って空群」へ変換する実行点だった。同型の落とし穴は optional の数だけ残っており、次の引き継ぎ経路でまた静かに落ちうる。
+
+本 ADR は 35a の機構を**固定値引だけから optional 全般へ一般化する**決定を記録する。業務判断（なぜクリアするか・何を維持するか）は ADR-20260714-pv8 / ADR-20260714-k2m の管轄であり、本 ADR は機構（どう型で守るか）を扱う。
+
+## 検討した選択肢
+
+### 型表現の方針
+
+- **① 引き継ぎ経路では必須化（採用・「維持」フィールドの機構）**: 複製元・改訂元の getter は常に確定値を返す（`EstimateItem.discountRate(): DiscountRate` 等）ため、必須化しても供給元に困らない。
+- **② 「未指定」と「クリア」を別トークンで区別する型表現（`T | Clear`）（不採用）**: 引き継ぎ生成ではクリア／維持の選択が**フィールドごとに型レベルで固定**されており、実行時に分岐しない——固定値引は無条件にクリア（pv8）、率・メモ・セット群は無条件に維持。値レベルのトークンが要るのは同一フィールドが呼び出しごとにクリアか維持か変わる場合だけで、そのようなフィールドは引き継ぎ経路に存在しない。加えて `Omit` は「フィールド名すら書けない」ため、`itemDiscount: Clear` と書けてしまうトークンより**強い**。表現力を落として儀式を増やすことになる。
+- **③ `Omit` で経路ごとに型から消す（採用・「クリア」フィールドの機構。35a から継続）**: ①と併用し、全 optional を「必須化された維持」か「Omit されたクリア」のどちらかへ解消する。
+
+### 必須化の実現方法
+
+- **手で維持フィールドを列挙して必須化（不採用）**: 将来 `EstimateItemDescriptor` に optional が 1 本増えると、reprice 側へ optional のまま流れ込み穴が再び開く。しかもコンパイルは通るので誰も気づかない。「今日の穴は塞ぐが明日の穴には無力」であり、#603 が個別対処だったのと同じ轍を踏む。
+- **`Required<Omit<...>>` で機械導出（採用）**: 「optional を列挙して潰す」のではなく「optional という状態そのものを型構築子で禁止する」。将来 optional が増えても `Required<>` が自動的に reprice 側で必須にし、populate 箇所が即コンパイルエラーになって「維持かクリアか」の判断を書き手に強制する。放置＝黙って落とす、が構造的に不可能になる。副次的に `Omit` の引数が「クリアすると決めたフィールドの全量」として 1 行で読めるようになり、35a の `Omit` はそのまま本方針に吸収される（別機構の共存にならない）。
+
+### 経路で意味が変わるフィールド（`revisedDeliveryPrice`）
+
+`RepricedItemDescriptor` は複製・改訂で共有されていたが、`revisedDeliveryPrice` の実態は経路で正反対だった——複製は一切 populate せず（複製先に改訂明細詳細は存在しない）、改訂は必ず populate する（§8.4 の明細単位粗利の比較基準）。
+
+- **共有記述子に optional で残す（不採用）**: 改訂が書き忘れると `buildItem` の `!= null` 分岐で改訂明細詳細が黙って生成されず、§8.4 の比較基準が消える——**#602 と同型の未発火 silent data loss**。逆に複製がうっかり書けてしまい、複製先にあり得ない改訂明細詳細が生える穴も開く。
+- **複製用／改訂用に割る（採用）**: `CopiedItemDescriptor`（`Omit` で名前すら書けない）と `RevisedItemDescriptor`（`revisedDeliveryPrice: Money` 必須）に分ける。これは 35a が `revisedFrom` について採った論法——「optional な `revisedFrom` を共有ビルダーに持たせると、複製・新規作成が渡せてしまい『optional＝間違えられる余地』を別フィールドで再生産する。真に共通なのは子構築で、系譜を含む最終段は本質的差異として割る」——の**適用漏れを埋めるもの**。副次的に `undefined | null | Money` の 3 状態（前 2 者が同義）が `Money` へ潰れる。
+
+### `setGroups` の optional をどこで断つか
+
+- **reprice 側だけ必須化（不採用）**: 発生源（`EstimateVariationDescriptor.setGroups?`）が残るため、`?? []` が `estimateChildBuilders` / `assertSetComponentsValid` / `resolveLinePrices` の 3 読点に残存し、将来の経路がまた踏む。
+- **`EstimateVariationDescriptor` でも必須化し `??` をアプリ層マッパへ押し出す（採用）**: optional の発生源はドメインではなく**フォーム境界**（`setGroups?: EstimateSetGroupInput[]`）であり、それが `input.setGroups?.map(...)` でドメイン記述子へ素通しされていた。境界で `(input.setGroups ?? []).map(...)` と正規化すれば、ドメインは「ゼロ件＝`[]`」の単一表現になる。空配列はコレクションにとっての null object であり、`undefined` を併存させる理由がない。
+
+なお `discountRate?` / `customerMemo?` / `internalMemo?` / `overallDiscount?` を `EstimateItemDescriptor` 等で optional のまま据え置くのは、次の規則による。
+
+> **optional は「正規化する単一の所有者」が居るときだけ許す。居ないなら必須化して境界で正規化する。**
+
+これらは `EstimateItem.create` の `?? new DiscountRate(1.0)`、`EstimateSetGroup.create` の `?? Memo.empty()`、`EstimateVariation.create` の `?? Money.zero()` が **1 回だけ**既定化し、以後 getter は常に値を返す（＝所有者が居る）。対して `setGroups` は素の記述子上にあり正規化する所有者が居らず、読み手ごとに `??` が再適用されていた。所有者不在の optional は読み手の数だけ既定値解釈が増殖し、いずれ 1 つがズレる——それが #602 である。
+
+### 2 系統の型の書き方
+
+- **複製系・改訂系を別々に定義（不採用）**: `Required<Omit<...>>`（＝クリア判断の全量）が 2 箇所に重複し、将来クリア対象が増えたとき**片方だけ直る余地**が生まれる。これは #602（「片方の経路だけが持っていた配線」）と同型の再生産。
+- **明細型で径数化（採用）**: `RepricedVariationDescriptor<I extends RepricedItemDescriptor>` とし、複製系・改訂系はその実体化として得る。クリア判断が 1 箇所に集まる。35a の「同じ再解決生成の別実装を単一 locus へ集約する」と一貫。
+
+### 回帰防止
+
+- **フィールド個別の `@ts-expect-error` ガードのみ（不採用）**: 今日のフィールド名しか知らないため、将来 `RevisedItemDescriptor = RepricedItemDescriptor & { foo?: X }` のように `Required<>` の**外側**で optional を足す変更を検知できない。それでは #617 自身が「今日の optional だけ塞いだ個別対処」になり、本 ADR が否定した轍を踏む。
+- **個別ガード ＋ 構造ガード（採用）**: `OptionalKeys<T> extends never` で「引き継ぎ記述子に optional キーは 1 本も存在しない」を**最終合成型に対して**固定する。フィールド名を知らずに規則そのものを検査するため、未知のフィールドにも効く。
+
+## 決定
+
+引き継ぎ生成（複製先・改訂先）の記述子から optional を根絶する。すなわち **①「維持」フィールドは `Required<Omit<...>>` の機械導出で必須化し、②「クリア」フィールドは `Omit` で型から消し（35a を吸収）、③ 経路で意味が変わるフィールドは複製用／改訂用に型を割り、④ 2 系統は明細型で径数化して単一定義から得て、⑤「optional キーがゼロ本」を構造ガードで固定する**。`setGroups` は発生源（`EstimateVariationDescriptor`）でも必須化し、`??` による正規化はフォーム境界のアプリ層マッパ 1 箇所へ押し出す。
+
+## 根拠
+
+- **optional は「正規化する単一の所有者」が居るときだけ許す。** 所有者が居る optional（`discountRate?` 等、entity の `create` が既定化）は安全で、居ない optional（`setGroups?`）は読み手の数だけ既定値解釈が増殖して必ずズレる。この規則が「どの optional を潰し、どれを残すか」の判断基準であり、フィールドの数だけ場当たりに決めない。
+- **`Required<>` は変換であって不変則ではない。** `Required<Omit<...>>` が保証するのは「その式が評価された瞬間に optional が無い」ことだけで、`&` で後から optional を足す経路は塞がらない（`&` は本設計自身が `RevisedItemDescriptor` で使っている操作であり、型システムから見て正当な追加と区別できない）。構造ガードは**一度きりの変換を恒久的な検査済み不変則へ格上げする**役割を負う。
+- **型は書き忘れを閉じるが、誤った値は閉じない。** `Required<>` は「このフィールドについて判断せよ」と強制できるが、判断が正しいかは見ない——改訂経路が `setGroups: []` と明示的に書けば型は通り、セット群は黙って消える。ゆえに防御は二層とし、**型ガード＝書き忘れと禁止フィールド／振る舞いテスト＝運ばれた値の正しさ**で分担する。後者は既存の #602 回帰テスト群（`EstimateDuplicationService.test.ts` / `Estimate.test.ts`）が担い、本件は挙動不変ゆえ追加を要さない。
+- **業務判断と機構を責務で分ける（ADR-0011 / 35a と整合）。** pv8・k2m は「なぜクリアするか・何を維持するか」の業務判断であり、本 ADR は機構。粒度・寿命・想定読者が異なる。
+
+## 影響
+
+- **ADR-20260716-35a は有効なまま。** 35a の 3 決定（型で禁止する／子構築の共有ビルダー一本化／通常・改訂のバリエーション組み立て分割）はいずれも存続し、本 ADR はその機構を optional 全般へ一般化する。ただし 35a が定義した `RepricedItemDescriptor = Omit<EstimateItemDescriptor, "itemDiscount">` の定義のみ本 ADR が更新する（`Required` で包み、`revisedDeliveryPrice` を `Omit` し、複製用／改訂用に割る）。
+- **`EstimateItemDescriptor` は据え置く。** 新規作成経路の optional は「所有者が既定化する」規則を満たしており正当。とくに `revisedDeliveryPrice?: Money | null` の `undefined ≡ null` 冗長は wart だが、引き継ぎ側は `Omit` して自前で定義し直すため無関係であり、締めるとテスト約 100 箇所に `null` を書き足すだけの編集が発生して費用が便益を上回る。
+- **`setGroups` はドメインで必須になる。** `EstimateVariationDescriptor` / `VariationChildrenDescriptor` が必須化され、`estimateChildBuilders` / `assertSetComponentsValid` / `resolveLinePrices` の `??` は不要になる。アプリ層マッパ（`CreateEstimateCommand` / `variationContentInput`）が境界で正規化する。
+- **`EstimateItem.attachRevisedDetail` / `detachRevisedDetail` を削除する。** 本番コードからの呼び出しが存在せず（テストのみ）、非改訂明細へ事後に改訂詳細を付けられる唯一の経路だった。削除により `_revisedDetail` は `create` 時確定・以後不変になり、記述子の経路分割（生成時の防御）と併せて入口・事後の双方が塞がる。
+- **エンティティ分割には踏み込まない。** 「改訂先である」事実が `EstimateVariation.revisedFrom` と `EstimateItem.revisedDetail` の有無で二重に符号化され整合が守られていない構造は #620 に切り出した。`EstimateItem` を割っても二重符号化は解けず（`revisedFrom` があるバリの items は必ず改訂明細型、という不変則を型の外で守る羽目になる）、`EstimateItem`（18 ファイル）と `EstimateVariation`（29 読点）の同時分割は本 ADR とは別物の大手術になるため。
+- **ビルダーの引数型は変更不要。** `Required<Omit<T, K>>` は（K が T で optional である限り）`T` へ、`RevisedItemDescriptor` は `EstimateItemDescriptor` へ構造的に代入可能なため、共有ビルダーは両系統をそのまま受ける。
+- **型不変則の効力は `tsc --noEmit`（pre-push）が担保する。** 型を緩める変更が入ると `@ts-expect-error` が未使用になるか構造ガードが落ちて赤になる。

--- a/docs/adr/20260716-w4k-eradicate-optional-from-handoff-descriptors.md
+++ b/docs/adr/20260716-w4k-eradicate-optional-from-handoff-descriptors.md
@@ -44,7 +44,7 @@ buildSetGroups(descriptor.setGroups ?? [])   // estimateChildBuilders.ts
 
 ### `setGroups` の optional をどこで断つか
 
-- **reprice 側だけ必須化（不採用）**: 発生源（`EstimateVariationDescriptor.setGroups?`）が残るため、`?? []` が `estimateChildBuilders` / `assertSetComponentsValid` / `resolveLinePrices` の 3 読点に残存し、将来の経路がまた踏む。
+- **reprice 側だけ必須化（不採用）**: 発生源（`EstimateVariationDescriptor.setGroups?`）が残るため、ドメイン側の `?? []`（`estimateChildBuilders` / `assertSetComponentsValid`）が残存し、将来の経路がまた踏む。
 - **`EstimateVariationDescriptor` でも必須化し `??` をアプリ層マッパへ押し出す（採用）**: optional の発生源はドメインではなく**フォーム境界**（`setGroups?: EstimateSetGroupInput[]`）であり、それが `input.setGroups?.map(...)` でドメイン記述子へ素通しされていた。境界で `(input.setGroups ?? []).map(...)` と正規化すれば、ドメインは「ゼロ件＝`[]`」の単一表現になる。空配列はコレクションにとっての null object であり、`undefined` を併存させる理由がない。
 
 なお `discountRate?` / `customerMemo?` / `internalMemo?` / `overallDiscount?` を `EstimateItemDescriptor` 等で optional のまま据え置くのは、次の規則による。
@@ -65,7 +65,9 @@ buildSetGroups(descriptor.setGroups ?? [])   // estimateChildBuilders.ts
 
 ## 決定
 
-引き継ぎ生成（複製先・改訂先）の記述子から optional を根絶する。すなわち **①「維持」フィールドは `Required<Omit<...>>` の機械導出で必須化し、②「クリア」フィールドは `Omit` で型から消し（35a を吸収）、③ 経路で意味が変わるフィールドは複製用／改訂用に型を割り、④ 2 系統は明細型で径数化して単一定義から得て、⑤「optional キーがゼロ本」を構造ガードで固定する**。`setGroups` は発生源（`EstimateVariationDescriptor`）でも必須化し、`??` による正規化はフォーム境界のアプリ層マッパ 1 箇所へ押し出す。
+引き継ぎ生成（複製先・改訂先）の記述子から optional を根絶する。すなわち **①「維持」フィールドは `Required<Omit<...>>` の機械導出で必須化し、②「クリア」フィールドは `Omit` で型から消し（35a を吸収）、③ 経路で意味が変わるフィールドは複製用／改訂用に型を割り、④ 2 系統は明細型で径数化して単一定義から得て、⑤「optional キーがゼロ本」を構造ガードで固定する**。`setGroups` は発生源（`EstimateVariationDescriptor`）でも必須化し、`??` による正規化は**フォーム入力をドメイン記述子へ写すアプリ層マッパ**（`CreateEstimateCommand` / `variationContentInput`）へ押し出す。
+
+境界の位置は次のとおり。マッパより**上流**（フォーム入力を直接扱う `resolveLinePrices` の `LinePriceTree`）は `setGroups?` のままとする——そこはキーが来ないことが実在する HTTP の世界であり、optional が事実を正しく表している。マッパより**下流**（記述子・エンティティ）には `undefined` を入れない。
 
 ## 根拠
 
@@ -78,7 +80,7 @@ buildSetGroups(descriptor.setGroups ?? [])   // estimateChildBuilders.ts
 
 - **ADR-20260716-35a は有効なまま。** 35a の 3 決定（型で禁止する／子構築の共有ビルダー一本化／通常・改訂のバリエーション組み立て分割）はいずれも存続し、本 ADR はその機構を optional 全般へ一般化する。ただし 35a が定義した `RepricedItemDescriptor = Omit<EstimateItemDescriptor, "itemDiscount">` の定義のみ本 ADR が更新する（`Required` で包み、`revisedDeliveryPrice` を `Omit` し、複製用／改訂用に割る）。
 - **`EstimateItemDescriptor` は据え置く。** 新規作成経路の optional は「所有者が既定化する」規則を満たしており正当。とくに `revisedDeliveryPrice?: Money | null` の `undefined ≡ null` 冗長は wart だが、引き継ぎ側は `Omit` して自前で定義し直すため無関係であり、締めるとテスト約 100 箇所に `null` を書き足すだけの編集が発生して費用が便益を上回る。
-- **`setGroups` はドメインで必須になる。** `EstimateVariationDescriptor` / `VariationChildrenDescriptor` が必須化され、`estimateChildBuilders` / `assertSetComponentsValid` / `resolveLinePrices` の `??` は不要になる。アプリ層マッパ（`CreateEstimateCommand` / `variationContentInput`）が境界で正規化する。
+- **`setGroups` はドメインで必須になる。** `EstimateVariationDescriptor` / `VariationChildrenDescriptor` が必須化され、`estimateChildBuilders` の `?? []` は不要になる。`assertSetComponentsValid` の `SetComponentValidationTarget.setGroups?` も必須化できる（呼び出し元は `estimate.variations` / `buildVariationContent` の戻り値＝**エンティティ**を渡しており、エンティティは常に `setGroups` 配列を持つため）。一方 `resolveLinePrices` の `LinePriceTree.setGroups?` は**据え置く**——同関数は記述子化より前のフォーム入力を扱う上流であり、そこでの optional は境界の事実を正しく表している。
 - **`EstimateItem.attachRevisedDetail` / `detachRevisedDetail` を削除する。** 本番コードからの呼び出しが存在せず（テストのみ）、非改訂明細へ事後に改訂詳細を付けられる唯一の経路だった。削除により `_revisedDetail` は `create` 時確定・以後不変になり、記述子の経路分割（生成時の防御）と併せて入口・事後の双方が塞がる。
 - **エンティティ分割には踏み込まない。** 「改訂先である」事実が `EstimateVariation.revisedFrom` と `EstimateItem.revisedDetail` の有無で二重に符号化され整合が守られていない構造は #620 に切り出した。`EstimateItem` を割っても二重符号化は解けず（`revisedFrom` があるバリの items は必ず改訂明細型、という不変則を型の外で守る羽目になる）、`EstimateItem`（18 ファイル）と `EstimateVariation`（29 読点）の同時分割は本 ADR とは別物の大手術になるため。
 - **ビルダーの引数型は変更不要。** `Required<Omit<T, K>>` は（K が T で optional である限り）`T` へ、`RevisedItemDescriptor` は `EstimateItemDescriptor` へ構造的に代入可能なため、共有ビルダーは両系統をそのまま受ける。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -106,6 +106,7 @@
 | [20260714-pv8](20260714-pv8-revised-variation-drops-fixed-discounts-on-unit-price-resolution.md) | 改訂先生成では固定値引を持ち込まない（単価再解決に伴う絶対額クリア・複製と対称化） | 採用 | 2026-07-14 |
 | [20260714-k2m](20260714-k2m-copy-and-revise-carry-set-groups-by-snapshot-not-master-reexpansion.md) | 複製・改訂はセット群を群ごとスナップショット複写する（マスタから再展開しない） | 採用 | 2026-07-14 |
 | [20260716-35a](20260716-35a-type-enforce-no-fixed-discounts-on-repriced-generation.md) | 単価再解決を伴う生成の固定値引不変則を型で強制する（repriced 記述子＋子構築の共有ビルダー一本化） | 採用 | 2026-07-16 |
+| [20260716-w4k](20260716-w4k-eradicate-optional-from-handoff-descriptors.md) | 引き継ぎ生成の記述子から optional を根絶する（維持は Required で強制・クリアは Omit・経路は分割） | 採用 | 2026-07-16 |
 
 ## アプリケーション（コマンド）
 

--- a/docs/claude-plans/issue-617/deviations.md
+++ b/docs/claude-plans/issue-617/deviations.md
@@ -1,0 +1,68 @@
+# Issue #617 実装計画からの逸脱記録
+
+## 1. `VariationContent.setGroups` も必須化した（Step 1）
+
+### 元の計画内容
+
+Step 1 の対象は記述子型（`EstimateVariationDescriptor` / `RepricedVariationDescriptor` /
+`VariationChildrenDescriptor`）と `SetComponentValidationTarget` の 4 つで、
+`EstimateVariation.VariationContent` は対象ファイルに挙がっていなかった。
+
+計画は `assertSetComponentsValid` の必須化根拠を「呼び出し元は `estimate.variations` /
+`buildVariationContent` の戻り値＝エンティティを渡しており常に配列を持つ」としていた。
+
+### 実際の実装内容
+
+`VariationContent.setGroups?: EstimateSetGroup[]` を必須化し、`replaceContent` の
+`input.setGroups ?? []` を削除した。
+
+### 逸脱の理由
+
+計画の根拠（「常に配列を持つ」）は**実行時の事実としては正しいが、型に書かれていなかった**。
+`VariationContent.setGroups` が optional のままだと `SetComponentValidationTarget` の必須化が
+型として通らず（`EstimateSetGroup[] | undefined` は必須の配列に代入できない）、Step 1 が
+成立しなかった。
+
+`VariationContent` の唯一の生産者は `EstimateFactory.buildVariationContent` であり、
+これは `buildVariationChildren` の戻り値（常に配列）を詰める。したがって optional は
+「起こり得ない undefined」を型に残すだけで、計画が掲げた
+**「optional は正規化する単一の所有者が居るときだけ許す」規則**にそのまま反していた。
+計画の意図の範囲内と判断し、新たな設計判断の追加ではなく計画の適用漏れの補完として実施した。
+
+---
+
+## 2. `Required<>` が `undefined` も除くため引き継ぎ側は具体値必須になった（Step 2）
+
+### 元の計画内容
+
+「維持すべきフィールドは `Required<Omit<...>>` の機械導出で必須化する」。計画は必須化＝
+「キーの省略を禁じる」意図で書かれており、値として `undefined` を渡せるかは明示していなかった。
+
+### 実際の実装内容
+
+型定義は計画どおり `Required<Omit<...>>`。ただし `Required<T>` は `?` を外すと同時に
+値域から `undefined` も除くため、`discountRate` / `customerMemo` / `internalMemo` は
+`undefined` を渡せず**具体値が必須**になった。
+
+これに伴い `EstimateFactory.test.ts` に引き継ぎ経路専用の `copiedItem()` ヘルパを追加し、
+`discountRate: new DiscountRate(1.0)` / `customerMemo: Memo.empty()` 等の具体値を置いた
+（計画に無い追加）。
+
+### 逸脱の理由
+
+本番の populate 2 経路（`Estimate.reviseForCustomer` / `EstimateDuplicationService.copyItem`）は
+複製元・改訂元**エンティティの getter** から値を引いており、これらの getter は
+`DiscountRate` / `Memo` を非 optional で返す（既定化は `EstimateItem.create` が 1 回だけ行う
+所有者であるため）。よって本番コードは無変更で通り、計画の意図（維持フィールドの取りこぼし防止）は
+そのまま達成される。
+
+テストヘルパのみ `EstimateItemDescriptor`（optional 持ち）と形状が合わなくなったため分離した。
+これは型が「引き継ぎ側では既定化済みの具体値しか流れない」という実際の不変則を正しく
+表現した結果であり、計画の意図に反しない。
+
+### 補足: 設計の実効性を確認済み
+
+`EstimateItemDescriptor` に optional フィールドを 1 本足す変異を試したところ、
+populate 2 経路（`Estimate.ts` / `EstimateDuplicationService.ts`）が両方ともコンパイル
+エラーになることを確認した。#617 の目的である「将来 optional が増えたら判断を書き手に強制する」が
+機能している。

--- a/docs/claude-plans/issue-617/eradicate-optional-from-handoff-descriptors.md
+++ b/docs/claude-plans/issue-617/eradicate-optional-from-handoff-descriptors.md
@@ -90,7 +90,7 @@
 - コミットメッセージ: `refactor: setGroups をドメインで必須化し undefined 正規化をアプリ境界へ押し出す (#617)`
 
 ### Step 2: 引き継ぎ記述子を Required 機械導出・経路分割・generics で再定義する
-- [ ] **完了**
+- [x] **完了**
 - 対象ファイル:
   - `src/server/subdomains/estimate/domain/entities/EstimateFactory.ts`（記述子ファミリ再定義）
   - `src/server/subdomains/estimate/domain/entities/index.ts`（バレルの公開型）

--- a/docs/claude-plans/issue-617/eradicate-optional-from-handoff-descriptors.md
+++ b/docs/claude-plans/issue-617/eradicate-optional-from-handoff-descriptors.md
@@ -133,7 +133,7 @@
 - コミットメッセージ: `refactor: 引き継ぎ記述子を Required 導出と経路分割で再定義し optional を根絶する (#617)`
 
 ### Step 3: 死んだ `attachRevisedDetail` / `detachRevisedDetail` を削除する
-- [ ] **完了**
+- [x] **完了**
 - 対象ファイル:
   - `src/server/subdomains/estimate/domain/entities/EstimateItem.ts`（193-200 行のメソッド削除・`_revisedDetail` を `readonly` 化）
   - `src/server/subdomains/estimate/domain/entities/__tests__/EstimateItem.test.ts`（162-172 行の専用テスト削除）

--- a/docs/claude-plans/issue-617/eradicate-optional-from-handoff-descriptors.md
+++ b/docs/claude-plans/issue-617/eradicate-optional-from-handoff-descriptors.md
@@ -1,0 +1,146 @@
+# Issue #617: 記述子 optional プロパティの「省略＝クリア/未指定」を型で区別できず引き継ぎ生成で silent data loss を招く構造を塞ぐ — 実装計画
+
+> **実行規約**: 各 step 完了時にこのファイルの該当チェックボックス（`- [ ]`）を
+> `- [x]` に更新し、その更新を step のコミットに含めること。
+> 再開時（compaction 後・新規セッション後を含む）は、まずこのファイルを読み、
+> 未チェックの最小 step 番号から続行すること。
+> **テスト戦略が `TDD` の step は red-green-refactor で進めること**（テストを先に書き、
+> RED を確認してから実装する）。`/tdd` スキルの規約に従う。
+
+## 概要
+
+引き継ぎ生成（複製先・改訂先）の記述子から optional を根絶し、「省略＝黙って取りこぼす」構造を型で塞ぐ。
+
+- **維持すべきフィールドは `Required<Omit<...>>` の機械導出で必須化**する。将来 `EstimateItemDescriptor` に optional が増えても自動的に引き継ぎ側で必須になり、populate 箇所がコンパイルエラーになる（＝判断を書き手に強制する）。
+- **クリアすべきフィールドは `Omit` で型から消す**（ADR-20260716-35a の機構を吸収）。
+- **経路で意味が変わる `revisedDeliveryPrice` は複製用／改訂用に記述子を割る**。
+- **`setGroups` は発生源（`EstimateVariationDescriptor`）から必須化**し、`??` による正規化をフォーム入力→記述子のアプリ層マッパへ押し出す。
+- **「optional キーがゼロ本」を構造ガードで固定**する。`Required<>` は変換であって不変則ではないため、`&` で後から optional を足す経路を検査で塞ぐ。
+
+**挙動は不変**。既存の #602 回帰テスト群（`EstimateDuplicationService.test.ts` / `Estimate.test.ts`）がそれを担保する。
+
+設計判断の全量と根拠は **ADR-20260716-w4k**（`docs/adr/20260716-w4k-eradicate-optional-from-handoff-descriptors.md`、コミット済み）に記録済み。
+
+### スコープ外（別 issue）
+
+- **#620**: 「改訂先である」事実が `EstimateVariation.revisedFrom` と `EstimateItem.revisedDetail` の有無で二重に符号化され整合が守られていない構造の解消。`EstimateItem`（18 ファイル）と `EstimateVariation`（29 読点）の同時分割になり本 issue とは別物の大手術のため。
+- `EstimateItemDescriptor.revisedDeliveryPrice?: Money | null` の `undefined ≡ null` 冗長の解消。引き継ぎ側は `Omit` して自前定義するため無関係で、本 issue の目的に寄与しない。
+
+## 設計判断
+
+すべて対話で決着済み。詳細な選択肢と不採用理由は ADR-20260716-w4k を参照。
+
+### 型表現の方針
+- A. 引き継ぎ経路で必須化 / B. `T | Clear` トークンで未指定とクリアを区別 / C. `Omit` で経路ごとに型から消す
+- **決定: A（維持フィールド）＋ C（クリアフィールド）。B は不採用**
+- 理由: 引き継ぎ生成ではクリア／維持の選択がフィールドごとに型レベルで固定され実行時に分岐しない（固定値引は無条件クリア・率/メモ/セット群は無条件維持）ため、値レベルのトークンが必要な状況が存在しない。加えて `Omit` は「名前すら書けない」ぶんトークンより強い。
+
+### 必須化の実現方法
+- A. 維持フィールドを手で列挙して必須化 / B. `Required<Omit<...>>` で機械導出
+- **決定: B**
+- 理由: A は将来 `EstimateItemDescriptor` に optional が増えると引き継ぎ側へ optional のまま流れ込み、コンパイルが通るので誰も気づかない（#603 が個別対処だったのと同じ轍）。B は新フィールドを自動で必須化する。
+
+### 経路で意味が変わる `revisedDeliveryPrice`
+- A. 共有 `RepricedItemDescriptor` に optional で残す / B. 複製用（`Omit`）と改訂用（`Money` 必須）に割る
+- **決定: B**
+- 理由: A は改訂の書き忘れで改訂明細詳細が黙って生成されず §8.4 の比較基準が消える（#602 と同型の未発火 silent data loss）。逆に複製がうっかり書ける穴も開く。ADR-35a が `revisedFrom` に採った「本質的差異は最終段で割る」論法の適用漏れを埋める。
+
+### `setGroups` の optional をどこで断つか
+- A. 引き継ぎ側だけ必須化 / B. `EstimateVariationDescriptor` からも必須化しアプリ境界で正規化
+- **決定: B**
+- 理由: optional の発生源はフォーム境界であってドメインではない。A では `?? []` がドメインに残り将来の経路がまた踏む。**規則: optional は「正規化する単一の所有者」が居るときだけ許す**——`discountRate?` / メモは entity の `create` が 1 回だけ既定化するので据え置き、所有者不在の `setGroups?` のみ断つ。
+
+### 2 系統の型の書き方
+- A. 複製系・改訂系を別々に定義 / B. 明細型で径数化（generics）
+- **決定: B**
+- 理由: A は `Required<Omit<...>>`（＝クリア判断の全量）が 2 箇所に重複し、将来クリア対象が増えたとき片方だけ直る余地が生まれる（#602 と同型の再生産）。
+
+### 回帰防止
+- A. フィールド個別の `@ts-expect-error` ガードのみ / B. 個別ガード ＋ 構造ガード（`OptionalKeys<T> extends never`）
+- **決定: B**
+- 理由: `Required<>` は変換であって不変則ではなく、`&` で後から optional を足す経路（本設計自身が `RevisedItemDescriptor` で使う操作）を塞げない。A では #617 自身が「今日の optional だけ塞いだ個別対処」になる。
+
+## ステップ
+
+### Step 1: `setGroups` をドメインで必須化し正規化をアプリ境界へ押し出す
+- [ ] **完了**
+- 対象ファイル:
+  - `src/server/subdomains/estimate/domain/entities/EstimateFactory.ts`（`EstimateVariationDescriptor.setGroups` / `RepricedVariationDescriptor.setGroups`）
+  - `src/server/subdomains/estimate/domain/entities/estimateChildBuilders.ts`（`VariationChildrenDescriptor.setGroups` / `?? []` 削除）
+  - `src/server/subdomains/estimate/application/commands/CreateEstimateCommand.ts:224`（境界で正規化）
+  - `src/server/subdomains/estimate/application/shared/variationContentInput.ts:84`（境界で正規化）
+  - `src/server/subdomains/estimate/application/shared/assertSetComponentsValid.ts`（`SetComponentValidationTarget.setGroups` / `?? []` 削除）
+  - `src/server/subdomains/estimate/domain/entities/__tests__/repricedDescriptor.type.test.ts`（型ガード追加）
+  - seed 27 箇所・テスト 12 箇所（`setGroups: []` 追記。実測済みの内訳は下記）
+- テスト戦略: **TDD**（型ガードを先に書き `tsc --noEmit` の RED を確認してから型を締める。`@ts-expect-error` は「省略が許されている」間は未使用となり tsc が赤くなる＝意味のある RED）
+- 作業内容:
+  - 型ガード「`RepricedVariationDescriptor` は `setGroups` の省略を拒否する」を先に追加し RED を確認する
+    ```ts
+    const guard = (base: Omit<RepricedVariationDescriptor, "setGroups">): RepricedVariationDescriptor =>
+      // @ts-expect-error setGroups は省略できない（#602 の火元・#617）
+      ({ ...base });
+    ```
+  - `EstimateVariationDescriptor.setGroups` / `RepricedVariationDescriptor.setGroups` / `VariationChildrenDescriptor.setGroups` を必須化する
+  - `buildVariationChildren` の `descriptor.setGroups ?? []` を `descriptor.setGroups` にする
+  - マッパ 2 箇所を `(input.setGroups ?? []).map(...)` へ変更する（フォーム入力→記述子の境界で正規化）
+  - `assertSetComponentsValid` の `SetComponentValidationTarget.setGroups` を必須化し `?? []` を削除する（呼び出し元は `estimate.variations` / `buildVariationContent` の戻り値＝エンティティを渡しており常に配列を持つ）
+  - **`resolveLinePrices` の `LinePriceTree.setGroups?` は据え置く**（記述子化より前のフォーム入力を扱う上流であり、そこでの optional は境界の事実を正しく表している）
+  - 壊れる 39 箇所に `setGroups: []` を追記する（実測: seed 27 = `seed-estimates.ts` 16 / `seed-dev-data/estimates.ts` 8 / `seed-dev-data/applications.ts` 2 / `seed-estimate-applications.ts` 1、テスト 12 = `EstimateFactory.test.ts` 6 / `EstimateDuplicationService.test.ts` 3 / `DuplicateEstimateCommand.test.ts` 2 / `assertSetComponentsValid.test.ts` 1）
+  - `tsc --noEmit` と `pnpm test` が緑であることを確認する
+- コミットメッセージ: `refactor: setGroups をドメインで必須化し undefined 正規化をアプリ境界へ押し出す (#617)`
+
+### Step 2: 引き継ぎ記述子を Required 機械導出・経路分割・generics で再定義する
+- [ ] **完了**
+- 対象ファイル:
+  - `src/server/subdomains/estimate/domain/entities/EstimateFactory.ts`（記述子ファミリ再定義）
+  - `src/server/subdomains/estimate/domain/entities/index.ts`（バレルの公開型）
+  - `src/server/subdomains/estimate/domain/entities/Estimate.ts`（改訂経路 `reviseForCustomer`）
+  - `src/server/subdomains/estimate/domain/services/EstimateDuplicationService.ts`（複製経路 `copyItem` / `toCopiedDescriptor`）
+  - `src/server/subdomains/estimate/domain/entities/estimateChildBuilders.ts`（`buildRevisedVariation` の引数型）
+  - `src/server/subdomains/estimate/domain/entities/__tests__/repricedDescriptor.type.test.ts`（個別ガード＋構造ガード）
+- テスト戦略: **TDD**（型ガードを先に書き RED を確認してから型を再定義する。構造ガードは再定義前は `RepricedItemDescriptor` に optional が残るため `never` にならず RED になる＝意味のある RED）
+- 作業内容:
+  - 型ガードを先に追加し RED を確認する
+    - `CopiedItemDescriptor` は `revisedDeliveryPrice` を拒否する（複製先に改訂明細詳細は生えない）
+    - `RevisedItemDescriptor` は `revisedDeliveryPrice` の省略を拒否する（§8.4 の比較基準を落とさない）
+    - 構造ガード: 引き継ぎ記述子に optional キーが 1 本も存在しない
+      ```ts
+      type OptionalKeys<T> = { [K in keyof T]-?: object extends Pick<T, K> ? K : never }[keyof T];
+      type _NoOptional = [OptionalKeys<CopiedItemDescriptor>, OptionalKeys<RevisedItemDescriptor>] extends [never, never] ? true : never;
+      const _guard: _NoOptional = true;
+      ```
+  - 記述子ファミリを再定義する（`Omit` の 2 つの用途——削除＝クリア／置換＝入れ子の明細型差し替え——をコメントで書き分ける）
+    ```ts
+    type RepricedItemDescriptor = Required<Omit<EstimateItemDescriptor, "itemDiscount" | "revisedDeliveryPrice">>;
+    type CopiedItemDescriptor   = RepricedItemDescriptor;
+    type RevisedItemDescriptor  = RepricedItemDescriptor & { revisedDeliveryPrice: Money };
+
+    type RepricedSetGroupDescriptor<I extends RepricedItemDescriptor> =
+      Required<Omit<EstimateSetGroupDescriptor, "components">> & { components: I[] };
+
+    type RepricedVariationDescriptor<I extends RepricedItemDescriptor> =
+      Required<Omit<EstimateVariationDescriptor, "overallDiscount" | "items" | "setGroups">>
+      & { items: I[]; setGroups: RepricedSetGroupDescriptor<I>[] };
+
+    type CopiedVariationDescriptor  = RepricedVariationDescriptor<CopiedItemDescriptor> & { sourceVariationId: EstimateVariationId };
+    type RevisedVariationDescriptor = RepricedVariationDescriptor<RevisedItemDescriptor>;
+    ```
+  - populate 2 経路を新型へ移す（`Estimate.reviseForCustomer` の `toRepricedItem` → `RevisedItemDescriptor`、`EstimateDuplicationService.copyItem` → `CopiedItemDescriptor`）
+  - `buildRevisedVariation` の引数型を `RevisedVariationDescriptor` にする
+  - バレルの公開型を更新する（`CopiedItemDescriptor` / `RevisedItemDescriptor` / `RevisedVariationDescriptor` を追加）
+  - 既存の `itemDiscount` / `overallDiscount` ガードが引き続き機能することを確認する
+  - `tsc --noEmit` と `pnpm test` が緑であることを確認する
+- コミットメッセージ: `refactor: 引き継ぎ記述子を Required 導出と経路分割で再定義し optional を根絶する (#617)`
+
+### Step 3: 死んだ `attachRevisedDetail` / `detachRevisedDetail` を削除する
+- [ ] **完了**
+- 対象ファイル:
+  - `src/server/subdomains/estimate/domain/entities/EstimateItem.ts`（193-200 行のメソッド削除・`_revisedDetail` を `readonly` 化）
+  - `src/server/subdomains/estimate/domain/entities/__tests__/EstimateItem.test.ts`（162-172 行の専用テスト削除）
+- テスト戦略: **テスト不要**（本番からの呼び出しが存在しない死んだコードとその専用テストの削除であり、振る舞いの変更が無い。呼び出し元不在は pre-push の `tsc --noEmit` が担保する）
+- 作業内容:
+  - `attachRevisedDetail` / `detachRevisedDetail` を削除する（調査済み: 本番コードからの呼び出し元は存在せず、テストのみが呼んでいる）
+  - `private _revisedDetail` を `private readonly _revisedDetail` にする（`create` / `reconstruct` 時確定・以後不変を型で固定する）
+  - 対応するテスト 2 件を削除する
+  - `pnpm test` が緑であることを確認する
+- コミットメッセージ: `refactor: 死んだ attach/detachRevisedDetail を削除し改訂明細詳細を生成時確定にする (#617)`

--- a/docs/claude-plans/issue-617/eradicate-optional-from-handoff-descriptors.md
+++ b/docs/claude-plans/issue-617/eradicate-optional-from-handoff-descriptors.md
@@ -63,7 +63,7 @@
 ## ステップ
 
 ### Step 1: `setGroups` をドメインで必須化し正規化をアプリ境界へ押し出す
-- [ ] **完了**
+- [x] **完了**
 - 対象ファイル:
   - `src/server/subdomains/estimate/domain/entities/EstimateFactory.ts`（`EstimateVariationDescriptor.setGroups` / `RepricedVariationDescriptor.setGroups`）
   - `src/server/subdomains/estimate/domain/entities/estimateChildBuilders.ts`（`VariationChildrenDescriptor.setGroups` / `?? []` 削除）

--- a/docs/claude-plans/issue-617/r1-fix-plan.md
+++ b/docs/claude-plans/issue-617/r1-fix-plan.md
@@ -1,0 +1,66 @@
+# Issue #617 ラウンド 1 修正計画（/auto-review-fix）
+
+`/code-review medium`（対象 `develop...HEAD`）の指摘 5 件を judge が評価した結果、
+**採用①② = 0 件（収束）／採用③ = 1 件／④ 残課題 = 4 件**。本ファイルは採用③の修正方針を定める。
+
+## 修正対象（採用 ③ cleanup）
+
+### R1-1 | ③ cleanup | severity(参考): Low | `src/server/subdomains/estimate/domain/services/EstimateDuplicationService.ts:166`
+
+**問題**
+
+複製経路のセット群記述子を組む箇所が、型引数なしの bare `RepricedSetGroupDescriptor` を使っている。
+
+```ts
+setGroups: structure.setGroups.map(
+  ({ group, components }): RepricedSetGroupDescriptor => ({   // ← 経路を名乗っていない
+```
+
+`RepricedSetGroupDescriptor<I extends RepricedItemDescriptor = RepricedItemDescriptor>` の
+既定型引数により `components: RepricedItemDescriptor[]` と解決される。これが今日通っているのは
+`CopiedItemDescriptor = RepricedItemDescriptor` という**別名関係にすぎない**。
+
+**修正方針**
+
+型引数を明示して経路を名乗らせる。
+
+```ts
+setGroups: structure.setGroups.map(
+  ({ group, components }): RepricedSetGroupDescriptor<CopiedItemDescriptor> => ({
+```
+
+`copyItem` は既に `CopiedItemDescriptor` を返しており（143 行）、囲む `toCopiedDescriptor` の
+戻り値型は `CopiedVariationDescriptor` ＝ `RepricedVariationDescriptor<CopiedItemDescriptor>`
+（＝ `setGroups: RepricedSetGroupDescriptor<CopiedItemDescriptor>[]` を要求）。
+よって書くべき型引数は `CopiedItemDescriptor` 一択で、設計判断の余地は無い。
+
+**影響範囲**
+
+`EstimateDuplicationService.ts` 1 ファイル・1 行の型注釈のみ。既定型引数は残すため
+他の呼び出し側（型ガードテストの bare 形 2 件）には波及しない。実行時コードは不変。
+
+**想定テスト**
+
+追加テスト不要（型注釈の精緻化であり挙動不変）。担保は次の 2 つ:
+
+- `tsc --noEmit` が緑（型注釈が実際の要求型と一致することの証明）
+- 既存の `EstimateDuplicationService.test.ts`（#602 セット群引き継ぎの回帰テストを含む）が緑のまま
+
+**③ 採用根拠**
+
+| 基準 | 充足 |
+|---|---|
+| 挙動不変 | ✅ 型注釈のみ。トランスパイル後に消える。既存テストは緑のまま通る |
+| 設計判断が不要 | ✅ 囲む戻り値型が `CopiedVariationDescriptor` に確定しており型引数は `CopiedItemDescriptor` 一択 |
+| 局所的 | ✅ 1 ファイル 1 行。レイヤ／集約をまたがず、公開シグネチャも変えない |
+
+## 修正しないもの（④ 残課題・報告のみ）
+
+- **R1-2**（`EstimateFactory.ts:176,187` 既定型引数が経路非依存な記述子を再導入）: ③基準 2・3 未達。
+  既定型引数を外すと型ガードテスト 2 件が壊れ、かつ「ガードを土台型で実体化するか経路型で検査し直すか」に
+  設計判断の余地がある（ADR-w4k「構造ガードは最終合成型に対して固定する」の解釈に踏み込む）。
+  現時点の実害は無い（`buildRevisedVariation` が `RevisedVariationDescriptor` を要求するため
+  bare 形は改訂ビルダーに届かない）。ADR-w4k 追記とセットで後続 Issue とすべき。
+- **R1-3**（`Estimate.ts:256` `toRepricedItem` の命名）: ④（命名の乱れ）。③の 4 カテゴリ非該当。
+- **R1-4**（`Estimate.ts:252` コメントが #617 に未言及）: ④（コメント）。③非該当。
+- **R1-5**（`repricedDescriptor.type.test.ts:15` docstring が #603 のまま）: ④（コメント）。③非該当。

--- a/prisma/seed-dev-data/applications.ts
+++ b/prisma/seed-dev-data/applications.ts
@@ -651,6 +651,7 @@ export async function seedDevApplications(prisma: PrismaClient): Promise<number>
       estimateNumber: EstimateNumber.parse(opts.number),
       variations: [
         {
+          setGroups: [],
           variationNumber: 1,
           submissionType: SubmissionType.CUSTOMER,
           items: [
@@ -746,6 +747,7 @@ export async function seedDevApplications(prisma: PrismaClient): Promise<number>
         estimateNumber: EstimateNumber.parse(spec.number),
         variations: [
           {
+            setGroups: [],
             variationNumber: 1,
             submissionType: SubmissionType.CUSTOMER,
             items: [

--- a/prisma/seed-dev-data/estimates.ts
+++ b/prisma/seed-dev-data/estimates.ts
@@ -139,6 +139,7 @@ function buildSingleLine(
     estimateNumber: EstimateNumber.parse(estimateNumber),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(productId, 1, itemName, 1, amount)],
@@ -230,6 +231,7 @@ export async function seedDevEstimates(prisma: PrismaClient): Promise<number> {
     estimateNumber: EstimateNumber.parse(N.exemptConsumableOnly),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [
@@ -246,6 +248,7 @@ export async function seedDevEstimates(prisma: PrismaClient): Promise<number> {
     estimateNumber: EstimateNumber.parse(N.exemptAfterRepair),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(fk.repairTargetId, 1, "事後修理明細", 1, 300000)], // 税込330,000 でも事後→免除
@@ -263,6 +266,7 @@ export async function seedDevEstimates(prisma: PrismaClient): Promise<number> {
   // 構造: 全部入り（複数バリ・明細値引・全体値引・改訂価格・無効バリ）。
   const fullVariations: EstimateVariationDescriptor[] = [
     {
+      setGroups: [],
       variationNumber: 1,
       submissionType: SubmissionType.CUSTOMER,
       overallDiscount: Money.fromMajorUnits(5000),
@@ -273,11 +277,13 @@ export async function seedDevEstimates(prisma: PrismaClient): Promise<number> {
       ],
     },
     {
+      setGroups: [],
       variationNumber: 2,
       submissionType: SubmissionType.DELIVERY_LOCATION,
       items: [mkItem(fk.individualBId, 1, "納品先向け明細", 3, 20000)],
     },
     {
+      setGroups: [],
       variationNumber: 3,
       submissionType: SubmissionType.CUSTOMER,
       items: [mkItem(fk.individualAId, 1, "旧バリエーション（無効化予定）", 1, 10000)],
@@ -326,6 +332,7 @@ export async function seedDevEstimates(prisma: PrismaClient): Promise<number> {
     estimateNumber: EstimateNumber.parse(N.structRevised),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.DELIVERY_LOCATION,
         items: [mkItem(fk.individualAId, 1, "改訂元明細（納品先）", 1, 40000)],
@@ -352,6 +359,7 @@ export async function seedDevEstimates(prisma: PrismaClient): Promise<number> {
     estimateNumber: EstimateNumber.parse(N.structRepair),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(fk.repairTargetId, 1, "修理見積明細", 1, 80000)],

--- a/prisma/seed-estimate-applications.ts
+++ b/prisma/seed-estimate-applications.ts
@@ -119,6 +119,7 @@ function buildEstimate(fk: ApplicationSeedFk, estimateNumber: string, amount: nu
     estimateNumber: EstimateNumber.parse(estimateNumber),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [

--- a/prisma/seed-estimates.ts
+++ b/prisma/seed-estimates.ts
@@ -122,6 +122,7 @@ function header(fk: EstimateSeedFk) {
 function buildFullEstimate(fk: EstimateSeedFk) {
   const variations: EstimateVariationDescriptor[] = [
     {
+      setGroups: [],
       variationNumber: 1,
       submissionType: SubmissionType.CUSTOMER,
       overallDiscount: Money.fromMajorUnits(1000),
@@ -132,11 +133,13 @@ function buildFullEstimate(fk: EstimateSeedFk) {
       ],
     },
     {
+      setGroups: [],
       variationNumber: 2,
       submissionType: SubmissionType.DELIVERY_LOCATION,
       items: [mkItem(fk.productBId, 1, "納品先向け明細", 3, 3000)],
     },
     {
+      setGroups: [],
       variationNumber: 3,
       submissionType: SubmissionType.CUSTOMER,
       items: [mkItem(fk.productAId, 1, "旧バリエーション", 1, 1000)],
@@ -160,6 +163,7 @@ function buildEditableEstimate(fk: EstimateSeedFk) {
     estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.editable),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(fk.productAId, 1, "編集対象明細", 1, 1000)],
@@ -175,6 +179,7 @@ function buildRepairSeedEstimate(fk: EstimateSeedFk) {
     estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.repair),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(fk.productAId, 1, "修理見積明細", 1, 5000)],
@@ -198,6 +203,7 @@ function buildRevisedEstimate(fk: EstimateSeedFk) {
     estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.revised),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.DELIVERY_LOCATION,
         items: [mkItem(fk.productAId, 1, "改訂元明細", 1, 4000)],
@@ -226,11 +232,13 @@ function buildReviseSourceEstimate(fk: EstimateSeedFk) {
     estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.reviseSource),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.DELIVERY_LOCATION,
         items: [mkItem(fk.productAId, 1, "改訂元明細(納品先)", 1, 5000)],
       },
       {
+        setGroups: [],
         variationNumber: 2,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(fk.productBId, 1, "得意先明細", 1, 6000)],
@@ -246,11 +254,13 @@ function buildAllInactiveEstimate(fk: EstimateSeedFk) {
     estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.allInactive),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(fk.productAId, 1, "無効明細1", 1, 1000)],
       },
       {
+        setGroups: [],
         variationNumber: 2,
         submissionType: SubmissionType.DELIVERY_LOCATION,
         items: [mkItem(fk.productBId, 1, "無効明細2", 1, 2000)],
@@ -274,11 +284,13 @@ function buildS7ToggleEstimate(fk: EstimateSeedFk) {
     estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.s7Toggle),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(fk.productAId, 1, "S7トグル明細1", 1, 1000)],
       },
       {
+        setGroups: [],
         variationNumber: 2,
         submissionType: SubmissionType.DELIVERY_LOCATION,
         items: [mkItem(fk.productBId, 1, "S7トグル明細2", 1, 2000)],
@@ -297,6 +309,7 @@ function buildApplyExemptEstimate(fk: EstimateSeedFk) {
     estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.applyExempt),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(fk.productAId, 1, "免除対象明細", 1, 50000)],
@@ -316,6 +329,7 @@ function buildApplyRequiredEstimate(fk: EstimateSeedFk) {
     estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.applyRequired),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(fk.productAId, 1, "承認必要明細", 1, 300000)],
@@ -334,11 +348,13 @@ function buildApplyInactiveEstimate(fk: EstimateSeedFk) {
     estimateNumber: EstimateNumber.parse(SEED_ESTIMATE_NUMBERS.applyInactive),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [mkItem(fk.productAId, 1, "申請可明細", 1, 50000)],
       },
       {
+        setGroups: [],
         variationNumber: 2,
         submissionType: SubmissionType.DELIVERY_LOCATION,
         items: [mkItem(fk.productBId, 1, "無効バリ明細", 1, 60000)],

--- a/src/server/subdomains/estimate/application/commands/CreateEstimateCommand.ts
+++ b/src/server/subdomains/estimate/application/commands/CreateEstimateCommand.ts
@@ -221,7 +221,10 @@ export class CreateEstimateCommand {
       variationNumber: variation.variationNumber,
       submissionType: SubmissionType.from(variation.submissionType),
       items: variation.items.map((item) => this.toItemDescriptor(item, priceMap)),
-      setGroups: variation.setGroups?.map((group) => this.toSetGroupDescriptor(group, priceMap)),
+      // フォーム入力境界の undefined をここで空配列へ正規化する（記述子側は必須・#617）
+      setGroups: (variation.setGroups ?? []).map((group) =>
+        this.toSetGroupDescriptor(group, priceMap)
+      ),
       overallDiscount:
         variation.overallDiscount != null
           ? Money.fromMajorUnits(variation.overallDiscount)

--- a/src/server/subdomains/estimate/application/commands/__tests__/DuplicateEstimateCommand.test.ts
+++ b/src/server/subdomains/estimate/application/commands/__tests__/DuplicateEstimateCommand.test.ts
@@ -93,6 +93,7 @@ describe("DuplicateEstimateCommand", () => {
           unitPrice: Money.fromMajorUnits(unitPrice),
         },
       ],
+      setGroups: [],
     });
     return EstimateFactory.create({
       estimateNumber: EstimateNumber.parse("N9300001"),

--- a/src/server/subdomains/estimate/application/shared/__tests__/assertSetComponentsValid.test.ts
+++ b/src/server/subdomains/estimate/application/shared/__tests__/assertSetComponentsValid.test.ts
@@ -117,6 +117,7 @@ describe("assertSetComponentsValid", () => {
 
   it("セット群が無ければ商品クエリを呼ばずに空を返す", async () => {
     const content = EstimateFactory.buildVariationContent({
+      setGroups: [],
       items: [
         {
           productId: new ProductId(NORMAL_PID),

--- a/src/server/subdomains/estimate/application/shared/assertSetComponentsValid.ts
+++ b/src/server/subdomains/estimate/application/shared/assertSetComponentsValid.ts
@@ -18,7 +18,11 @@ export type SetComponentValidationTarget = {
     productId: { value: string };
     itemName: { value: string };
   }>;
-  setGroups?: ReadonlyArray<{ memberItemIds: ReadonlyArray<{ value: string }> }>;
+  /**
+   * セット群。呼び出し元は生成済み集約（`estimate.variations`）か `buildVariationContent` の
+   * 戻り値＝エンティティを渡しており、常に配列を持つため必須とする（#617）。
+   */
+  setGroups: ReadonlyArray<{ memberItemIds: ReadonlyArray<{ value: string }> }>;
 };
 
 /**
@@ -39,7 +43,7 @@ export async function assertSetComponentsValid(
   content: SetComponentValidationTarget,
   productQueryService: ProductQueryService
 ): Promise<SetComponentWarning[]> {
-  const setGroups = content.setGroups ?? [];
+  const setGroups = content.setGroups;
   if (setGroups.length === 0) {
     return [];
   }

--- a/src/server/subdomains/estimate/application/shared/variationContentInput.ts
+++ b/src/server/subdomains/estimate/application/shared/variationContentInput.ts
@@ -81,7 +81,10 @@ export function toVariationContentDescriptor(
 ): VariationContentDescriptor {
   return {
     items: input.items.map((item) => toEstimateItemDescriptor(item, priceMap)),
-    setGroups: input.setGroups?.map((group) => toEstimateSetGroupDescriptor(group, priceMap)),
+    // フォーム入力境界の undefined をここで空配列へ正規化する（記述子側は必須・#617）
+    setGroups: (input.setGroups ?? []).map((group) =>
+      toEstimateSetGroupDescriptor(group, priceMap)
+    ),
     overallDiscount:
       input.overallDiscount != null ? Money.fromMajorUnits(input.overallDiscount) : undefined,
     customerMemo: input.customerMemo != null ? Memo.create(input.customerMemo) : undefined,

--- a/src/server/subdomains/estimate/domain/entities/Estimate.ts
+++ b/src/server/subdomains/estimate/domain/entities/Estimate.ts
@@ -21,7 +21,7 @@ import { TaxRate } from "../values/TaxRate";
 import { TaxRoundingType } from "../values/TaxRoundingType";
 import type { AfterRepairEstimateDetail } from "./AfterRepairEstimateDetail";
 import { buildRevisedVariation } from "./estimateChildBuilders";
-import type { RepricedItemDescriptor, RepricedVariationDescriptor } from "./EstimateFactory";
+import type { RevisedItemDescriptor, RevisedVariationDescriptor } from "./EstimateFactory";
 import type { EstimateItem } from "./EstimateItem";
 import {
   EstimateVariation,
@@ -253,7 +253,7 @@ export class Estimate {
     // repriced 記述子型が Omit で禁止しており、書こうとするとコンパイルエラーになる（#603・
     // ADR-20260714-pv8 を型で強制）。子の構築（改訂明細詳細・セット群の id 配線）と系譜の付与は
     // 複製経路と共有の buildRevisedVariation / buildVariationChildren に委ねる（#602 の再発防止）。
-    const toRepricedItem = (item: Readonly<EstimateItem>): RepricedItemDescriptor => ({
+    const toRepricedItem = (item: Readonly<EstimateItem>): RevisedItemDescriptor => ({
       productId: item.productId,
       sortOrder: item.sortOrder,
       itemName: item.itemName,
@@ -268,7 +268,7 @@ export class Estimate {
       revisedDeliveryPrice: item.finalAmount,
     });
 
-    const descriptor: RepricedVariationDescriptor = {
+    const descriptor: RevisedVariationDescriptor = {
       variationNumber: this.nextVariationNumber(),
       submissionType: SubmissionType.CUSTOMER,
       items: structure.normalItems.map(toRepricedItem),

--- a/src/server/subdomains/estimate/domain/entities/EstimateFactory.ts
+++ b/src/server/subdomains/estimate/domain/entities/EstimateFactory.ts
@@ -80,8 +80,14 @@ export type EstimateVariationDescriptor = {
   submissionType: SubmissionType;
   /** 通常明細（非セット）の記述子。構成明細は setGroups の入れ子側に持つ。 */
   items: EstimateItemDescriptor[];
-  /** セット群（ADR-0047）。各群が構成明細を入れ子で持つ。省略時は空。 */
-  setGroups?: EstimateSetGroupDescriptor[];
+  /**
+   * セット群（ADR-0047）。各群が構成明細を入れ子で持つ。セット群が無い場合は空配列を明示する。
+   *
+   * **必須の理由（#617）**: optional は「正規化する単一の所有者」が居るときだけ許す。undefined の
+   * 発生源はフォーム入力境界であってドメインではないため、`?? []` による正規化はアプリ層の
+   * マッパ（フォーム入力 → 記述子）へ押し出し、ドメインには常に配列が届く状態を型で保つ。
+   */
+  setGroups: EstimateSetGroupDescriptor[];
   overallDiscount?: Money;
   customerMemo?: Memo;
   internalMemo?: Memo;
@@ -153,7 +159,7 @@ export type RepricedVariationDescriptor = Omit<
   "overallDiscount" | "items" | "setGroups"
 > & {
   items: RepricedItemDescriptor[];
-  setGroups?: RepricedSetGroupDescriptor[];
+  setGroups: RepricedSetGroupDescriptor[];
 };
 
 /**

--- a/src/server/subdomains/estimate/domain/entities/EstimateFactory.ts
+++ b/src/server/subdomains/estimate/domain/entities/EstimateFactory.ts
@@ -136,40 +136,71 @@ export type EstimateFactoryInput = {
 };
 
 /**
- * 単価再解決を伴う引き継ぎ生成（複製先・改訂先）専用の明細記述子。
+ * 単価再解決を伴う引き継ぎ生成（複製先・改訂先）専用の明細記述子の土台（#617・ADR-20260716-w4k）。
  *
- * 固定値引 `itemDiscount` を型から `Omit` で消す。これにより単価を宛先へ再解決した経路で
- * うっかり固定値引を持ち込む記述を書くと excess property でコンパイルエラーになる
- * （不変則 ADR-20260714-pv8・#598 を型で強制）。`itemDiscount` は optional のため、本型は
- * 元の {@link EstimateItemDescriptor} へ構造的に代入可能で、共有ビルダーの引数型は変更不要。
+ * **2 つの `Omit` の用途を区別すること**:
+ * - ここでの `Omit` は**クリア**（＝引き継ぎ先へ持ち込まない項目を「名前すら書けない」状態にする）。
+ *   `itemDiscount` は単価を宛先へ再解決した経路で持ち込むと不整合になるため型から消す
+ *   （不変則 ADR-20260714-pv8・#598）。`revisedDeliveryPrice` は経路で意味が変わるため土台からは
+ *   消し、改訂経路 {@link RevisedItemDescriptor} でのみ必須として足し直す。
+ * - 下位の {@link RepricedSetGroupDescriptor} 等での `Omit` は**置換**（入れ子の明細型差し替え）。
+ *
+ * **`Required<>` で機械導出する理由**: 維持フィールドを手で列挙すると、将来
+ * {@link EstimateItemDescriptor} に optional が増えたとき引き継ぎ側へ optional のまま流れ込み、
+ * コンパイルが通るので誰も気づかない（#602 / #603 と同型の silent data loss）。`Required<>` なら
+ * 新フィールドが自動で必須化され、populate 箇所がコンパイルエラーになる＝判断を書き手に強制できる。
  */
-export type RepricedItemDescriptor = Omit<EstimateItemDescriptor, "itemDiscount">;
-
-/** 単価再解決経路のセット群記述子。構成明細を repriced 明細記述子で持つ（構成明細も固定値引不可）。 */
-export type RepricedSetGroupDescriptor = Omit<EstimateSetGroupDescriptor, "components"> & {
-  components: RepricedItemDescriptor[];
-};
+export type RepricedItemDescriptor = Required<
+  Omit<EstimateItemDescriptor, "itemDiscount" | "revisedDeliveryPrice">
+>;
 
 /**
- * 単価再解決経路のバリエーション記述子。全体値引 `overallDiscount` を型から消し、
- * 通常明細・セット群を repriced 記述子に差し替える（固定値引を型で禁止）。
+ * 複製で生まれる明細の記述子。改訂明細詳細は複製先に生えないため `revisedDeliveryPrice` は
+ * 土台の `Omit` のまま（名前すら書けない）。
  */
-export type RepricedVariationDescriptor = Omit<
-  EstimateVariationDescriptor,
-  "overallDiscount" | "items" | "setGroups"
-> & {
-  items: RepricedItemDescriptor[];
-  setGroups: RepricedSetGroupDescriptor[];
-};
+export type CopiedItemDescriptor = RepricedItemDescriptor;
+
+/**
+ * 得意先改訂で生まれる明細の記述子。改訂元 `finalAmount` のスナップショットを**必須**で持つ。
+ *
+ * **必須の理由（#617）**: optional に残すと改訂経路の書き忘れで改訂明細詳細が黙って生成されず、
+ * §8.4 の比較基準が消える（#602 と同型の未発火 silent data loss）。逆に複製経路でうっかり
+ * 書ける穴も塞ぐため、複製用と改訂用で記述子を割る。
+ */
+export type RevisedItemDescriptor = RepricedItemDescriptor & { revisedDeliveryPrice: Money };
+
+/**
+ * 単価再解決経路のセット群記述子。構成明細を明細型 `I` で径数化する（構成明細も固定値引不可）。
+ * ここでの `Omit` は**置換**（入れ子の `components` を経路ごとの明細型へ差し替える）。
+ */
+export type RepricedSetGroupDescriptor<I extends RepricedItemDescriptor = RepricedItemDescriptor> =
+  Required<Omit<EstimateSetGroupDescriptor, "components">> & { components: I[] };
+
+/**
+ * 単価再解決経路のバリエーション記述子。全体値引 `overallDiscount` を型から消し（クリア）、
+ * 通常明細・セット群を経路ごとの明細型 `I` に差し替える（置換）。
+ *
+ * **generics で径数化する理由**: 複製系・改訂系を別々に定義すると `Required<Omit<...>>`
+ * （＝クリア判断の全量）が 2 箇所に重複し、将来クリア対象が増えたとき片方だけ直る余地が
+ * 生まれる（#602 と同型の再生産）。
+ */
+export type RepricedVariationDescriptor<I extends RepricedItemDescriptor = RepricedItemDescriptor> =
+  Required<Omit<EstimateVariationDescriptor, "overallDiscount" | "items" | "setGroups">> & {
+    items: I[];
+    setGroups: RepricedSetGroupDescriptor<I>[];
+  };
 
 /**
  * 複製で生まれるバリエーションの記述子。複製元バリエーション（出自）を id 参照として添える。
  * C6 DuplicateEstimate で「新バリエーションの生成 id ↔ 複製元 id」の系譜を作るために用いる。
  * 単価再解決経路のため repriced 記述子を土台にし、固定値引は型で禁止する（#603・ADR-20260714-pv8）。
  */
-export type CopiedVariationDescriptor = RepricedVariationDescriptor & {
+export type CopiedVariationDescriptor = RepricedVariationDescriptor<CopiedItemDescriptor> & {
   sourceVariationId: EstimateVariationId;
 };
+
+/** 得意先改訂で生まれるバリエーションの記述子。明細は改訂納品価格必須の記述子で持つ（#617）。 */
+export type RevisedVariationDescriptor = RepricedVariationDescriptor<RevisedItemDescriptor>;
 
 /** 見積複製の入力。variations 以外は新規生成と同じ記述子で、variations のみ系譜付き記述子。 */
 export type EstimateDuplicateInput = Omit<EstimateFactoryInput, "variations"> & {

--- a/src/server/subdomains/estimate/domain/entities/EstimateItem.ts
+++ b/src/server/subdomains/estimate/domain/entities/EstimateItem.ts
@@ -58,7 +58,8 @@ export class EstimateItem {
     private _itemDiscount: Money,
     private _customerMemo: Memo,
     private _internalMemo: Memo,
-    private _revisedDetail: RevisedEstimateItemDetail | null,
+    /** 改訂明細詳細は create / reconstruct 時に確定し以後不変（#617）。 */
+    private readonly _revisedDetail: RevisedEstimateItemDetail | null,
     private _baseAmount: Money,
     private _discountedAmount: Money,
     private _finalAmount: Money,
@@ -187,16 +188,6 @@ export class EstimateItem {
 
   changeInternalMemo(newMemo: Memo): void {
     this._internalMemo = newMemo;
-    this.touch();
-  }
-
-  attachRevisedDetail(detail: RevisedEstimateItemDetail): void {
-    this._revisedDetail = detail;
-    this.touch();
-  }
-
-  detachRevisedDetail(): void {
-    this._revisedDetail = null;
     this.touch();
   }
 

--- a/src/server/subdomains/estimate/domain/entities/EstimateVariation.ts
+++ b/src/server/subdomains/estimate/domain/entities/EstimateVariation.ts
@@ -52,11 +52,15 @@ export type ItemPriceAdjustment = {
 export type VariationContent = {
   items: EstimateItem[];
   /**
-   * セット群（ADR-0047 / Shape ③-a）。省略時は空（既存群をクリア）。構成明細は items に
-   * 含めたうえで所属を群が `EstimateItemId[]` で参照する。replaceContent 時に参照整合・
+   * セット群（ADR-0047 / Shape ③-a）。群が無い場合は空配列を明示する（既存群をクリア）。構成明細は
+   * items に含めたうえで所属を群が `EstimateItemId[]` で参照する。replaceContent 時に参照整合・
    * 排他所属を再検証する（create と同じ構造的不変条件）。
+   *
+   * **必須の理由（#617）**: 本型の唯一の生産者 `EstimateFactory.buildVariationContent` は常に
+   * 配列を詰める（正規化はアプリ層マッパが済ませている）ため、optional は「起こり得ない
+   * undefined」を型に残すだけで、クリアと未指定の区別を曖昧にする。
    */
-  setGroups?: EstimateSetGroup[];
+  setGroups: EstimateSetGroup[];
   overallDiscount?: Money;
   customerMemo?: Memo;
   internalMemo?: Memo;
@@ -346,7 +350,7 @@ export class EstimateVariation {
 
     // 構造的不変条件（参照整合・排他所属）を置換前に再検証する。create と同方針で、
     // 集約内で完結する不変条件のみを担保する（区分検証は集約越えのためアプリ層・ADR-0052）。
-    const setGroups = input.setGroups ?? [];
+    const setGroups = input.setGroups;
     EstimateVariation.assertSetGroupsConsistency(input.items, setGroups);
 
     // _items / _setGroups は readonly 参照だが配列中身は可変。同一参照を保ったまま全置換する。

--- a/src/server/subdomains/estimate/domain/entities/__tests__/Estimate.test.ts
+++ b/src/server/subdomains/estimate/domain/entities/__tests__/Estimate.test.ts
@@ -535,7 +535,10 @@ describe("Estimate", () => {
     it("max+1 で採番した新バリエーションを追加して返す", () => {
       const e = makeEstimate([makeVariation(1)]);
 
-      const added = e.appendVariation({ items: [makeItem(2000, 1)] }, SubmissionType.CUSTOMER);
+      const added = e.appendVariation(
+        { setGroups: [], items: [makeItem(2000, 1)] },
+        SubmissionType.CUSTOMER
+      );
 
       expect(added.variationNumber).toBe(2);
       expect(e.variations).toHaveLength(2);
@@ -545,7 +548,10 @@ describe("Estimate", () => {
     it("歯抜けがあっても max+1 で採番する（count+1 ではない）", () => {
       const e = makeEstimate([makeVariation(1), makeVariation(3)]);
 
-      const added = e.appendVariation({ items: [makeItem()] }, SubmissionType.CUSTOMER);
+      const added = e.appendVariation(
+        { setGroups: [], items: [makeItem()] },
+        SubmissionType.CUSTOMER
+      );
 
       // 既存 [1,3] → count+1=3 だと衝突。max+1=4 が正
       expect(added.variationNumber).toBe(4);
@@ -555,10 +561,7 @@ describe("Estimate", () => {
       const e = makeEstimate([makeVariation(1)]);
 
       const added = e.appendVariation(
-        {
-          items: [makeItem(10000, 1)],
-          overallDiscount: Money.fromMajorUnits(1000),
-        },
+        { setGroups: [], items: [makeItem(10000, 1)], overallDiscount: Money.fromMajorUnits(1000) },
         SubmissionType.CUSTOMER
       );
 
@@ -568,7 +571,10 @@ describe("Estimate", () => {
     it("指定した提出区分が新バリエーションに保持される（ADR-0045）", () => {
       const e = makeEstimate([makeVariation(1)]);
 
-      const added = e.appendVariation({ items: [makeItem()] }, SubmissionType.DELIVERY_LOCATION);
+      const added = e.appendVariation(
+        { setGroups: [], items: [makeItem()] },
+        SubmissionType.DELIVERY_LOCATION
+      );
 
       expect(added.submissionType.isDeliveryLocation()).toBe(true);
     });
@@ -587,7 +593,7 @@ describe("Estimate", () => {
       const target = makeVariation(1, [makeItem(1000, 1)]);
       const e = makeEstimate([target]);
 
-      e.updateVariation(target.id, { items: [makeItem(500, 2), makeItem(3000, 1)] });
+      e.updateVariation(target.id, { setGroups: [], items: [makeItem(500, 2), makeItem(3000, 1)] });
 
       const updated = e.variations.find((v) => v.id.equals(target.id))!;
       expect(updated.items).toHaveLength(2);
@@ -598,7 +604,7 @@ describe("Estimate", () => {
       const e = makeEstimate([makeVariation(1)]);
       const other = makeVariation(2);
 
-      expect(() => e.updateVariation(other.id, { items: [makeItem()] })).toThrow(
+      expect(() => e.updateVariation(other.id, { setGroups: [], items: [makeItem()] })).toThrow(
         "指定されたバリエーションは存在しません"
       );
     });
@@ -784,9 +790,9 @@ describe("Estimate", () => {
 
       estimate.reviseForCustomer(source.id, revisionPricesFor(source));
 
-      expect(() => estimate.updateVariation(source.id, { items: [makeItem()] })).toThrow(
-        BusinessRuleViolationError
-      );
+      expect(() =>
+        estimate.updateVariation(source.id, { setGroups: [], items: [makeItem()] })
+      ).toThrow(BusinessRuleViolationError);
     });
   });
 
@@ -1064,9 +1070,9 @@ describe("Estimate", () => {
     it("改訂元（凍結）は内容の一括差替え（C4）ができない", () => {
       const { estimate, source } = buildRevisedEstimate();
 
-      expect(() => estimate.updateVariation(source.id, { items: [makeItem()] })).toThrow(
-        BusinessRuleViolationError
-      );
+      expect(() =>
+        estimate.updateVariation(source.id, { setGroups: [], items: [makeItem()] })
+      ).toThrow(BusinessRuleViolationError);
     });
 
     it("改訂元（凍結）には明細操作（追加・掛率変更・全体値引変更）ができない", () => {

--- a/src/server/subdomains/estimate/domain/entities/__tests__/EstimateFactory.test.ts
+++ b/src/server/subdomains/estimate/domain/entities/__tests__/EstimateFactory.test.ts
@@ -51,7 +51,14 @@ function baseInput(overrides: Partial<EstimateFactoryInput> = {}): EstimateFacto
     taxRoundingType: TaxRoundingType.ROUND_DOWN,
     createdBy: new EmployeeId(UUID),
     departmentId: new DepartmentId(UUID),
-    variations: [{ variationNumber: 1, submissionType: SubmissionType.CUSTOMER, items: [item()] }],
+    variations: [
+      {
+        setGroups: [],
+        variationNumber: 1,
+        submissionType: SubmissionType.CUSTOMER,
+        items: [item()],
+      },
+    ],
     ...overrides,
   };
 }
@@ -62,6 +69,7 @@ describe("EstimateFactory", () => {
       baseInput({
         variations: [
           {
+            setGroups: [],
             variationNumber: 1,
             submissionType: SubmissionType.CUSTOMER,
             items: [
@@ -96,11 +104,13 @@ describe("EstimateFactory", () => {
       baseInput({
         variations: [
           {
+            setGroups: [],
             variationNumber: 1,
             submissionType: SubmissionType.DELIVERY_LOCATION,
             items: [item()],
           },
           {
+            setGroups: [],
             variationNumber: 2,
             submissionType: SubmissionType.CUSTOMER,
             items: [item()],
@@ -118,6 +128,7 @@ describe("EstimateFactory", () => {
       baseInput({
         variations: [
           {
+            setGroups: [],
             variationNumber: 1,
             submissionType: SubmissionType.CUSTOMER,
             items: [item({ revisedDeliveryPrice: Money.fromMajorUnits(800) })],
@@ -197,6 +208,7 @@ describe("EstimateFactory", () => {
         variationNumber: i + 1,
         submissionType: SubmissionType.CUSTOMER,
         items: [item({ unitPrice: Money.zero() })],
+        setGroups: [],
         sourceVariationId,
       }));
       return { ...baseInput(), variations, ...overrides };
@@ -248,6 +260,7 @@ describe("EstimateFactory", () => {
   describe("buildVariationContent - C3/C4 用の番号なし内容構築", () => {
     it("番号なし内容から構築済み明細を含む VariationContent を生成する", () => {
       const content = EstimateFactory.buildVariationContent({
+        setGroups: [],
         items: [item({ unitPrice: Money.fromMajorUnits(1000), quantity: new Quantity(2) })],
         overallDiscount: Money.fromMajorUnits(500),
       });

--- a/src/server/subdomains/estimate/domain/entities/__tests__/EstimateFactory.test.ts
+++ b/src/server/subdomains/estimate/domain/entities/__tests__/EstimateFactory.test.ts
@@ -6,10 +6,12 @@ import { ProductId } from "@subdomains/product/domain/values/ProductId";
 import { BusinessRuleViolationError } from "@server/shared/errors/DomainError";
 import { describe, expect, it } from "vitest";
 
+import { DiscountRate } from "../../values/DiscountRate";
 import { EmergencyReason } from "../../values/approval/EmergencyReason";
 import { EstimateNumber } from "../../values/EstimateNumber";
 import { FaultDescription } from "../../values/FaultDescription";
 import { ItemName } from "../../values/ItemName";
+import { Memo } from "../../values/Memo";
 import { Money } from "@server/shared/domain/values/Money";
 import { Quantity } from "../../values/Quantity";
 import { SubmissionType } from "../../values/SubmissionType";
@@ -19,6 +21,7 @@ import { Unit } from "../../values/Unit";
 import { EstimateVariationId } from "../../values/EstimateVariationId";
 import {
   EstimateFactory,
+  type CopiedItemDescriptor,
   type CopiedVariationDescriptor,
   type EstimateDuplicateInput,
   type EstimateFactoryInput,
@@ -36,6 +39,28 @@ function item(overrides: Partial<EstimateItemDescriptor> = {}): EstimateItemDesc
     quantity: new Quantity(2),
     unit: new Unit("個"),
     unitPrice: Money.fromMajorUnits(1000),
+    ...overrides,
+  };
+}
+
+/**
+ * 引き継ぎ（複製）経路の明細記述子。維持フィールドは `Required<>` で必須のため（#617）、
+ * optional を持つ {@link item} とは別に全フィールドを明示する。
+ *
+ * 実際の複製経路は「複製元エンティティの getter」から値を引くため常に具体値が揃う
+ * （既定化は `EstimateItem.create` が 1 回だけ行う所有者）。ここでもその既定値と同じ値を置く。
+ */
+function copiedItem(overrides: Partial<CopiedItemDescriptor> = {}): CopiedItemDescriptor {
+  return {
+    productId: new ProductId(UUID),
+    sortOrder: 1,
+    itemName: new ItemName("テスト商品"),
+    quantity: new Quantity(2),
+    unit: new Unit("個"),
+    unitPrice: Money.fromMajorUnits(1000),
+    discountRate: new DiscountRate(1.0),
+    customerMemo: Memo.empty(),
+    internalMemo: Memo.empty(),
     ...overrides,
   };
 }
@@ -207,8 +232,12 @@ describe("EstimateFactory", () => {
       const variations: CopiedVariationDescriptor[] = sources.map((sourceVariationId, i) => ({
         variationNumber: i + 1,
         submissionType: SubmissionType.CUSTOMER,
-        items: [item({ unitPrice: Money.zero() })],
+        items: [copiedItem({ unitPrice: Money.zero() })],
         setGroups: [],
+        // 引き継ぎ記述子は維持フィールドを機械導出で必須化しており（#617）、複写有無の判断を
+        // 省略で誤魔化せない。複製元バリエーションのメモを複写する経路に相当する値を明示する。
+        customerMemo: Memo.empty(),
+        internalMemo: Memo.empty(),
         sourceVariationId,
       }));
       return { ...baseInput(), variations, ...overrides };

--- a/src/server/subdomains/estimate/domain/entities/__tests__/EstimateItem.test.ts
+++ b/src/server/subdomains/estimate/domain/entities/__tests__/EstimateItem.test.ts
@@ -8,7 +8,6 @@ import { Money } from "@server/shared/domain/values/Money";
 import { Quantity } from "../../values/Quantity";
 import { Unit } from "../../values/Unit";
 import { EstimateItem, type EstimateItemCreateInput } from "../EstimateItem";
-import { RevisedEstimateItemDetail } from "../RevisedEstimateItemDetail";
 
 function buildInput(overrides: Partial<EstimateItemCreateInput> = {}): EstimateItemCreateInput {
   return {
@@ -155,22 +154,6 @@ describe("EstimateItem", () => {
       expect(item.customerMemo.value).toBe("初期メモ");
       item.changeCustomerMemo(Memo.empty());
       expect(item.customerMemo.isEmpty()).toBe(true);
-    });
-  });
-
-  describe("revisedDetail の attach/detach", () => {
-    it("attachRevisedDetail で改訂明細を付加できる", () => {
-      const item = EstimateItem.create(buildInput());
-      const detail = RevisedEstimateItemDetail.create(Money.fromMajorUnits(8000));
-      item.attachRevisedDetail(detail);
-      expect(item.revisedDetail).toBe(detail);
-    });
-
-    it("detachRevisedDetail で外せる", () => {
-      const item = EstimateItem.create(buildInput());
-      item.attachRevisedDetail(RevisedEstimateItemDetail.create(Money.fromMajorUnits(8000)));
-      item.detachRevisedDetail();
-      expect(item.revisedDetail).toBeNull();
     });
   });
 

--- a/src/server/subdomains/estimate/domain/entities/__tests__/EstimateVariation.test.ts
+++ b/src/server/subdomains/estimate/domain/entities/__tests__/EstimateVariation.test.ts
@@ -447,6 +447,7 @@ describe("EstimateVariation", () => {
 
       v.replaceContent(
         {
+          setGroups: [],
           items: [
             makeItem({ quantity: 2, unitPrice: 500 }),
             makeItem({ quantity: 1, unitPrice: 3000 }),
@@ -469,7 +470,7 @@ describe("EstimateVariation", () => {
       });
       v.deactivate();
 
-      expect(() => v.replaceContent({ items: [makeItem()] }, TAX)).toThrow(
+      expect(() => v.replaceContent({ setGroups: [], items: [makeItem()] }, TAX)).toThrow(
         BusinessRuleViolationError
       );
     });
@@ -483,6 +484,7 @@ describe("EstimateVariation", () => {
 
       v.replaceContent(
         {
+          setGroups: [],
           items: [makeItem({ quantity: 1, unitPrice: 10000 })],
           overallDiscount: Money.fromMajorUnits(1000),
           customerMemo: Memo.create("客先メモ"),
@@ -504,7 +506,7 @@ describe("EstimateVariation", () => {
         items: [makeItem({ unitPrice: 5000 })],
       });
 
-      v.replaceContent({ items: [] }, TAX);
+      v.replaceContent({ setGroups: [], items: [] }, TAX);
 
       expect(v.items).toHaveLength(0);
       expect(v.subtotal.isZero()).toBe(true);
@@ -567,7 +569,7 @@ describe("EstimateVariation", () => {
     it("改訂で生まれたバリエーションは内容の一括差替え（C4）ができない", () => {
       const v = makeRevisedVariation();
 
-      expect(() => v.replaceContent({ items: [makeItem()] }, TAX)).toThrow(
+      expect(() => v.replaceContent({ setGroups: [], items: [makeItem()] }, TAX)).toThrow(
         BusinessRuleViolationError
       );
     });
@@ -877,7 +879,7 @@ describe("EstimateVariation", () => {
       });
       expect(v.setGroups).toHaveLength(1);
 
-      v.replaceContent({ items: [makeItem({ unitPrice: 2000 })] }, TAX);
+      v.replaceContent({ setGroups: [], items: [makeItem({ unitPrice: 2000 })] }, TAX);
 
       expect(v.setGroups).toHaveLength(0);
     });

--- a/src/server/subdomains/estimate/domain/entities/__tests__/repricedDescriptor.type.test.ts
+++ b/src/server/subdomains/estimate/domain/entities/__tests__/repricedDescriptor.type.test.ts
@@ -3,9 +3,11 @@ import type { Money } from "@server/shared/domain/values/Money";
 import type { EstimateVariationId } from "../../values/EstimateVariationId";
 import { buildVariation } from "../estimateChildBuilders";
 import type {
+  CopiedItemDescriptor,
   EstimateVariationDescriptor,
   RepricedItemDescriptor,
   RepricedVariationDescriptor,
+  RevisedItemDescriptor,
 } from "../EstimateFactory";
 import type { TaxContext } from "../EstimateVariation";
 
@@ -19,7 +21,27 @@ import type { TaxContext } from "../EstimateVariation";
  * ガード本体は実行しない関数に閉じ込める（型検査のみが目的で、実行時に値は要らない）。テストは
  * その関数が存在することだけを確認し、実効性は tsc が保証する。
  */
+/**
+ * `T` の optional キーの合併（optional が 1 本も無ければ `never`）。
+ * `Pick<T, K>` が `object`（＝全キー省略可の型）を受け入れるなら K は optional、という判定。
+ */
+type OptionalKeys<T> = { [K in keyof T]-?: object extends Pick<T, K> ? K : never }[keyof T];
+
 describe("repriced 記述子・通常 buildVariation の型不変則", () => {
+  it("引き継ぎ記述子に optional キーが 1 本も存在しない", () => {
+    // 構造ガード（#617）: `Required<>` は変換であって不変則ではないため、`&` で後から optional を
+    // 足す経路（本設計自身が RevisedItemDescriptor で使う操作）をフィールド個別ガードでは塞げない。
+    // 「optional がゼロ本」を型で固定し、将来 optional が紛れ込んだら tsc を赤にする。
+    type _NoOptional = [
+      OptionalKeys<CopiedItemDescriptor>,
+      OptionalKeys<RevisedItemDescriptor>,
+    ] extends [never, never]
+      ? true
+      : never;
+    const guard: _NoOptional = true;
+    expect(guard).toBe(true);
+  });
+
   it("RepricedItemDescriptor は固定値引 itemDiscount を型で拒否する", () => {
     const guard = (base: RepricedItemDescriptor, itemDiscount: Money): RepricedItemDescriptor => ({
       ...base,
@@ -38,6 +60,27 @@ describe("repriced 記述子・通常 buildVariation の型不変則", () => {
       // @ts-expect-error overallDiscount は repriced 記述子で Omit 済み（#603・ADR-20260714-pv8）
       overallDiscount,
     });
+    expect(typeof guard).toBe("function");
+  });
+
+  it("CopiedItemDescriptor は改訂納品価格 revisedDeliveryPrice を型で拒否する", () => {
+    const guard = (
+      base: CopiedItemDescriptor,
+      revisedDeliveryPrice: Money
+    ): CopiedItemDescriptor => ({
+      ...base,
+      // @ts-expect-error 複製先に改訂明細詳細は生えない（revisedDeliveryPrice は Omit 済み・#617）
+      revisedDeliveryPrice,
+    });
+    expect(typeof guard).toBe("function");
+  });
+
+  it("RevisedItemDescriptor は改訂納品価格 revisedDeliveryPrice の省略を型で拒否する", () => {
+    const guard = (
+      base: Omit<RevisedItemDescriptor, "revisedDeliveryPrice">
+    ): RevisedItemDescriptor =>
+      // @ts-expect-error revisedDeliveryPrice は省略できない（§8.4 の比較基準を落とさない・#617）
+      ({ ...base });
     expect(typeof guard).toBe("function");
   });
 

--- a/src/server/subdomains/estimate/domain/entities/__tests__/repricedDescriptor.type.test.ts
+++ b/src/server/subdomains/estimate/domain/entities/__tests__/repricedDescriptor.type.test.ts
@@ -41,6 +41,15 @@ describe("repriced 記述子・通常 buildVariation の型不変則", () => {
     expect(typeof guard).toBe("function");
   });
 
+  it("RepricedVariationDescriptor はセット群 setGroups の省略を型で拒否する", () => {
+    const guard = (
+      base: Omit<RepricedVariationDescriptor, "setGroups">
+    ): RepricedVariationDescriptor =>
+      // @ts-expect-error setGroups は省略できない（#602 の火元・#617）
+      ({ ...base });
+    expect(typeof guard).toBe("function");
+  });
+
   it("通常 buildVariation は改訂系譜 revisedFrom を受け取らない", () => {
     const guard = (
       descriptor: EstimateVariationDescriptor,

--- a/src/server/subdomains/estimate/domain/entities/estimateChildBuilders.ts
+++ b/src/server/subdomains/estimate/domain/entities/estimateChildBuilders.ts
@@ -28,7 +28,7 @@ import type {
 /** 記述子の共通形状（通常明細＋セット群）。バリエーション記述子・内容記述子・repriced 記述子が構造的に満たす。 */
 type VariationChildrenDescriptor = {
   items: EstimateItemDescriptor[];
-  setGroups?: EstimateSetGroupDescriptor[];
+  setGroups: EstimateSetGroupDescriptor[];
 };
 
 /** 明細記述子（値オブジェクト止まり）から末端明細を構築する。改訂明細詳細は納品価格 VO から構築する。 */
@@ -91,7 +91,7 @@ export function buildVariationChildren(descriptor: VariationChildrenDescriptor):
   setGroups: EstimateSetGroup[];
 } {
   const normalItems = descriptor.items.map(buildItem);
-  const { groups, componentItems } = buildSetGroups(descriptor.setGroups ?? []);
+  const { groups, componentItems } = buildSetGroups(descriptor.setGroups);
   return { items: [...normalItems, ...componentItems], setGroups: groups };
 }
 

--- a/src/server/subdomains/estimate/domain/entities/estimateChildBuilders.ts
+++ b/src/server/subdomains/estimate/domain/entities/estimateChildBuilders.ts
@@ -8,7 +8,7 @@ import type {
   EstimateItemDescriptor,
   EstimateSetGroupDescriptor,
   EstimateVariationDescriptor,
-  RepricedVariationDescriptor,
+  RevisedVariationDescriptor,
 } from "./EstimateFactory";
 
 /**
@@ -129,7 +129,7 @@ export function buildVariation(
  * {@link buildVariationChildren}（＝複製経路と共有の土台）と repriced 記述子型が担保する。
  */
 export function buildRevisedVariation(
-  descriptor: RepricedVariationDescriptor,
+  descriptor: RevisedVariationDescriptor,
   ctx: { tax: TaxContext; revisedFrom: EstimateVariationId }
 ): EstimateVariation {
   const { items, setGroups } = buildVariationChildren(descriptor);

--- a/src/server/subdomains/estimate/domain/entities/index.ts
+++ b/src/server/subdomains/estimate/domain/entities/index.ts
@@ -42,7 +42,10 @@ export {
   type RepricedItemDescriptor,
   type RepricedSetGroupDescriptor,
   type RepricedVariationDescriptor,
+  type CopiedItemDescriptor,
   type CopiedVariationDescriptor,
+  type RevisedItemDescriptor,
+  type RevisedVariationDescriptor,
   type EstimateDuplicateInput,
 } from "./EstimateFactory";
 // VariationContent は appendVariation / updateVariation の引数型（集約ルートの公開 API）。

--- a/src/server/subdomains/estimate/domain/services/EstimateDuplicationService.ts
+++ b/src/server/subdomains/estimate/domain/services/EstimateDuplicationService.ts
@@ -6,7 +6,7 @@ import {
   EstimateFactory,
   type AfterRepairDetailDescriptor,
   type CopiedVariationDescriptor,
-  type RepricedItemDescriptor,
+  type CopiedItemDescriptor,
   type RepricedSetGroupDescriptor,
   type RepairDetailDescriptor,
 } from "../entities";
@@ -140,7 +140,7 @@ export class EstimateDuplicationService {
     // 平坦な items（通常明細＋構成明細の同居・ADR-0047）を群の所属で仕分けてから変換する。
     // 素通しすると構成明細がバラの通常明細として複写され、群が消える（#602）。
     const structure = source.lineStructure;
-    const copyItem = (item: SourceVariation["items"][number]): RepricedItemDescriptor => ({
+    const copyItem = (item: SourceVariation["items"][number]): CopiedItemDescriptor => ({
       productId: item.productId,
       sortOrder: item.sortOrder,
       itemName: item.itemName,

--- a/src/server/subdomains/estimate/domain/services/EstimateDuplicationService.ts
+++ b/src/server/subdomains/estimate/domain/services/EstimateDuplicationService.ts
@@ -163,7 +163,7 @@ export class EstimateDuplicationService {
       submissionType: source.submissionType,
       items: structure.normalItems.map(copyItem),
       setGroups: structure.setGroups.map(
-        ({ group, components }): RepricedSetGroupDescriptor => ({
+        ({ group, components }): RepricedSetGroupDescriptor<CopiedItemDescriptor> => ({
           productId: group.productId,
           itemName: group.itemName,
           unit: group.unit,

--- a/src/server/subdomains/estimate/domain/services/__tests__/EstimateDuplicationService.test.ts
+++ b/src/server/subdomains/estimate/domain/services/__tests__/EstimateDuplicationService.test.ts
@@ -62,6 +62,7 @@ function buildSourceNew(): Estimate {
     departmentId: new DepartmentId(UUID),
     variations: [
       {
+        setGroups: [],
         variationNumber: 1,
         submissionType: SubmissionType.DELIVERY_LOCATION,
         overallDiscount: Money.fromMajorUnits(300),
@@ -81,6 +82,7 @@ function buildSourceNew(): Estimate {
         ],
       },
       {
+        setGroups: [],
         variationNumber: 2,
         submissionType: SubmissionType.CUSTOMER,
         items: [
@@ -404,6 +406,7 @@ describe("EstimateDuplicationService", () => {
         departmentId: new DepartmentId(UUID),
         variations: [
           {
+            setGroups: [],
             variationNumber: 1,
             submissionType: SubmissionType.CUSTOMER,
             items: [

--- a/src/server/subdomains/estimate/infrastructure/prisma/__tests__/PrismaEstimateRepository.test.ts
+++ b/src/server/subdomains/estimate/infrastructure/prisma/__tests__/PrismaEstimateRepository.test.ts
@@ -448,9 +448,9 @@ describe("PrismaEstimateRepository", () => {
       expect(foundRevised?.items.every((i) => i.revisedDetail !== null)).toBe(true);
 
       // 再構築後の集約でも凍結（導出）が機能する
-      expect(() => found.updateVariation(source.id, { items: [makeItem(ids.productId)] })).toThrow(
-        BusinessRuleViolationError
-      );
+      expect(() =>
+        found.updateVariation(source.id, { setGroups: [], items: [makeItem(ids.productId)] })
+      ).toThrow(BusinessRuleViolationError);
     });
 
     it("改訂を含む見積を削除できる（系譜・改訂明細詳細ごと消える）", async () => {


### PR DESCRIPTION
## Summary

引き継ぎ生成（複製・改訂）の記述子から optional を根絶し、populate 漏れを型で検出できるようにした。`setGroups` をドメインで必須化して `undefined` 正規化をアプリ境界へ押し出し、引き継ぎ記述子を `Required` 導出＋経路分割で再定義。あわせて死んだ `attach/detachRevisedDetail` を削除し、改訂明細詳細を生成時確定に統一した。方針は ADR-w4k として起票済み。

Closes #617

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### eradicate-optional-from-handoff-descriptors.md

# Issue #617: 記述子 optional プロパティの「省略＝クリア/未指定」を型で区別できず引き継ぎ生成で silent data loss を招く構造を塞ぐ — 実装計画

> **実行規約**: 各 step 完了時にこのファイルの該当チェックボックス（`- [ ]`）を
> `- [x]` に更新し、その更新を step のコミットに含めること。
> 再開時（compaction 後・新規セッション後を含む）は、まずこのファイルを読み、
> 未チェックの最小 step 番号から続行すること。
> **テスト戦略が `TDD` の step は red-green-refactor で進めること**（テストを先に書き、
> RED を確認してから実装する）。`/tdd` スキルの規約に従う。

## 概要

引き継ぎ生成（複製先・改訂先）の記述子から optional を根絶し、「省略＝黙って取りこぼす」構造を型で塞ぐ。

- **維持すべきフィールドは `Required<Omit<...>>` の機械導出で必須化**する。将来 `EstimateItemDescriptor` に optional が増えても自動的に引き継ぎ側で必須になり、populate 箇所がコンパイルエラーになる（＝判断を書き手に強制する）。
- **クリアすべきフィールドは `Omit` で型から消す**（ADR-20260716-35a の機構を吸収）。
- **経路で意味が変わる `revisedDeliveryPrice` は複製用／改訂用に記述子を割る**。
- **`setGroups` は発生源（`EstimateVariationDescriptor`）から必須化**し、`??` による正規化をフォーム入力→記述子のアプリ層マッパへ押し出す。
- **「optional キーがゼロ本」を構造ガードで固定**する。`Required<>` は変換であって不変則ではないため、`&` で後から optional を足す経路を検査で塞ぐ。

**挙動は不変**。既存の #602 回帰テスト群（`EstimateDuplicationService.test.ts` / `Estimate.test.ts`）がそれを担保する。

設計判断の全量と根拠は **ADR-20260716-w4k**（`docs/adr/20260716-w4k-eradicate-optional-from-handoff-descriptors.md`、コミット済み）に記録済み。

### スコープ外（別 issue）

- **#620**: 「改訂先である」事実が `EstimateVariation.revisedFrom` と `EstimateItem.revisedDetail` の有無で二重に符号化され整合が守られていない構造の解消。`EstimateItem`（18 ファイル）と `EstimateVariation`（29 読点）の同時分割になり本 issue とは別物の大手術のため。
- `EstimateItemDescriptor.revisedDeliveryPrice?: Money | null` の `undefined ≡ null` 冗長の解消。引き継ぎ側は `Omit` して自前定義するため無関係で、本 issue の目的に寄与しない。

## 設計判断

すべて対話で決着済み。詳細な選択肢と不採用理由は ADR-20260716-w4k を参照。

### 型表現の方針
- A. 引き継ぎ経路で必須化 / B. `T | Clear` トークンで未指定とクリアを区別 / C. `Omit` で経路ごとに型から消す
- **決定: A（維持フィールド）＋ C（クリアフィールド）。B は不採用**
- 理由: 引き継ぎ生成ではクリア／維持の選択がフィールドごとに型レベルで固定され実行時に分岐しない（固定値引は無条件クリア・率/メモ/セット群は無条件維持）ため、値レベルのトークンが必要な状況が存在しない。加えて `Omit` は「名前すら書けない」ぶんトークンより強い。

### 必須化の実現方法
- A. 維持フィールドを手で列挙して必須化 / B. `Required<Omit<...>>` で機械導出
- **決定: B**
- 理由: A は将来 `EstimateItemDescriptor` に optional が増えると引き継ぎ側へ optional のまま流れ込み、コンパイルが通るので誰も気づかない（#603 が個別対処だったのと同じ轍）。B は新フィールドを自動で必須化する。

### 経路で意味が変わる `revisedDeliveryPrice`
- A. 共有 `RepricedItemDescriptor` に optional で残す / B. 複製用（`Omit`）と改訂用（`Money` 必須）に割る
- **決定: B**
- 理由: A は改訂の書き忘れで改訂明細詳細が黙って生成されず §8.4 の比較基準が消える（#602 と同型の未発火 silent data loss）。逆に複製がうっかり書ける穴も開く。ADR-35a が `revisedFrom` に採った「本質的差異は最終段で割る」論法の適用漏れを埋める。

### `setGroups` の optional をどこで断つか
- A. 引き継ぎ側だけ必須化 / B. `EstimateVariationDescriptor` からも必須化しアプリ境界で正規化
- **決定: B**
- 理由: optional の発生源はフォーム境界であってドメインではない。A では `?? []` がドメインに残り将来の経路がまた踏む。**規則: optional は「正規化する単一の所有者」が居るときだけ許す**——`discountRate?` / メモは entity の `create` が 1 回だけ既定化するので据え置き、所有者不在の `setGroups?` のみ断つ。

### 2 系統の型の書き方
- A. 複製系・改訂系を別々に定義 / B. 明細型で径数化（generics）
- **決定: B**
- 理由: A は `Required<Omit<...>>`（＝クリア判断の全量）が 2 箇所に重複し、将来クリア対象が増えたとき片方だけ直る余地が生まれる（#602 と同型の再生産）。

### 回帰防止
- A. フィールド個別の `@ts-expect-error` ガードのみ / B. 個別ガード ＋ 構造ガード（`OptionalKeys<T> extends never`）
- **決定: B**
- 理由: `Required<>` は変換であって不変則ではなく、`&` で後から optional を足す経路（本設計自身が `RevisedItemDescriptor` で使う操作）を塞げない。A では #617 自身が「今日の optional だけ塞いだ個別対処」になる。

## ステップ

### Step 1: `setGroups` をドメインで必須化し正規化をアプリ境界へ押し出す
- [x] **完了**
- 対象ファイル:
  - `src/server/subdomains/estimate/domain/entities/EstimateFactory.ts`（`EstimateVariationDescriptor.setGroups` / `RepricedVariationDescriptor.setGroups`）
  - `src/server/subdomains/estimate/domain/entities/estimateChildBuilders.ts`（`VariationChildrenDescriptor.setGroups` / `?? []` 削除）
  - `src/server/subdomains/estimate/application/commands/CreateEstimateCommand.ts:224`（境界で正規化）
  - `src/server/subdomains/estimate/application/shared/variationContentInput.ts:84`（境界で正規化）
  - `src/server/subdomains/estimate/application/shared/assertSetComponentsValid.ts`（`SetComponentValidationTarget.setGroups` / `?? []` 削除）
  - `src/server/subdomains/estimate/domain/entities/__tests__/repricedDescriptor.type.test.ts`（型ガード追加）
  - seed 27 箇所・テスト 12 箇所（`setGroups: []` 追記。実測済みの内訳は下記）
- テスト戦略: **TDD**（型ガードを先に書き `tsc --noEmit` の RED を確認してから型を締める。`@ts-expect-error` は「省略が許されている」間は未使用となり tsc が赤くなる＝意味のある RED）
- 作業内容:
  - 型ガード「`RepricedVariationDescriptor` は `setGroups` の省略を拒否する」を先に追加し RED を確認する
    ```ts
    const guard = (base: Omit<RepricedVariationDescriptor, "setGroups">): RepricedVariationDescriptor =>
      // @ts-expect-error setGroups は省略できない（#602 の火元・#617）
      ({ ...base });
    ```
  - `EstimateVariationDescriptor.setGroups` / `RepricedVariationDescriptor.setGroups` / `VariationChildrenDescriptor.setGroups` を必須化する
  - `buildVariationChildren` の `descriptor.setGroups ?? []` を `descriptor.setGroups` にする
  - マッパ 2 箇所を `(input.setGroups ?? []).map(...)` へ変更する（フォーム入力→記述子の境界で正規化）
  - `assertSetComponentsValid` の `SetComponentValidationTarget.setGroups` を必須化し `?? []` を削除する（呼び出し元は `estimate.variations` / `buildVariationContent` の戻り値＝エンティティを渡しており常に配列を持つ）
  - **`resolveLinePrices` の `LinePriceTree.setGroups?` は据え置く**（記述子化より前のフォーム入力を扱う上流であり、そこでの optional は境界の事実を正しく表している）
  - 壊れる 39 箇所に `setGroups: []` を追記する（実測: seed 27 = `seed-estimates.ts` 16 / `seed-dev-data/estimates.ts` 8 / `seed-dev-data/applications.ts` 2 / `seed-estimate-applications.ts` 1、テスト 12 = `EstimateFactory.test.ts` 6 / `EstimateDuplicationService.test.ts` 3 / `DuplicateEstimateCommand.test.ts` 2 / `assertSetComponentsValid.test.ts` 1）
  - `tsc --noEmit` と `pnpm test` が緑であることを確認する
- コミットメッセージ: `refactor: setGroups をドメインで必須化し undefined 正規化をアプリ境界へ押し出す (#617)`

### Step 2: 引き継ぎ記述子を Required 機械導出・経路分割・generics で再定義する
- [x] **完了**
- 対象ファイル:
  - `src/server/subdomains/estimate/domain/entities/EstimateFactory.ts`（記述子ファミリ再定義）
  - `src/server/subdomains/estimate/domain/entities/index.ts`（バレルの公開型）
  - `src/server/subdomains/estimate/domain/entities/Estimate.ts`（改訂経路 `reviseForCustomer`）
  - `src/server/subdomains/estimate/domain/services/EstimateDuplicationService.ts`（複製経路 `copyItem` / `toCopiedDescriptor`）
  - `src/server/subdomains/estimate/domain/entities/estimateChildBuilders.ts`（`buildRevisedVariation` の引数型）
  - `src/server/subdomains/estimate/domain/entities/__tests__/repricedDescriptor.type.test.ts`（個別ガード＋構造ガード）
- テスト戦略: **TDD**（型ガードを先に書き RED を確認してから型を再定義する。構造ガードは再定義前は `RepricedItemDescriptor` に optional が残るため `never` にならず RED になる＝意味のある RED）
- 作業内容:
  - 型ガードを先に追加し RED を確認する
    - `CopiedItemDescriptor` は `revisedDeliveryPrice` を拒否する（複製先に改訂明細詳細は生えない）
    - `RevisedItemDescriptor` は `revisedDeliveryPrice` の省略を拒否する（§8.4 の比較基準を落とさない）
    - 構造ガード: 引き継ぎ記述子に optional キーが 1 本も存在しない
      ```ts
      type OptionalKeys<T> = { [K in keyof T]-?: object extends Pick<T, K> ? K : never }[keyof T];
      type _NoOptional = [OptionalKeys<CopiedItemDescriptor>, OptionalKeys<RevisedItemDescriptor>] extends [never, never] ? true : never;
      const _guard: _NoOptional = true;
      ```
  - 記述子ファミリを再定義する（`Omit` の 2 つの用途——削除＝クリア／置換＝入れ子の明細型差し替え——をコメントで書き分ける）
    ```ts
    type RepricedItemDescriptor = Required<Omit<EstimateItemDescriptor, "itemDiscount" | "revisedDeliveryPrice">>;
    type CopiedItemDescriptor   = RepricedItemDescriptor;
    type RevisedItemDescriptor  = RepricedItemDescriptor & { revisedDeliveryPrice: Money };

    type RepricedSetGroupDescriptor<I extends RepricedItemDescriptor> =
      Required<Omit<EstimateSetGroupDescriptor, "components">> & { components: I[] };

    type RepricedVariationDescriptor<I extends RepricedItemDescriptor> =
      Required<Omit<EstimateVariationDescriptor, "overallDiscount" | "items" | "setGroups">>
      & { items: I[]; setGroups: RepricedSetGroupDescriptor<I>[] };

    type CopiedVariationDescriptor  = RepricedVariationDescriptor<CopiedItemDescriptor> & { sourceVariationId: EstimateVariationId };
    type RevisedVariationDescriptor = RepricedVariationDescriptor<RevisedItemDescriptor>;
    ```
  - populate 2 経路を新型へ移す（`Estimate.reviseForCustomer` の `toRepricedItem` → `RevisedItemDescriptor`、`EstimateDuplicationService.copyItem` → `CopiedItemDescriptor`）
  - `buildRevisedVariation` の引数型を `RevisedVariationDescriptor` にする
  - バレルの公開型を更新する（`CopiedItemDescriptor` / `RevisedItemDescriptor` / `RevisedVariationDescriptor` を追加）
  - 既存の `itemDiscount` / `overallDiscount` ガードが引き続き機能することを確認する
  - `tsc --noEmit` と `pnpm test` が緑であることを確認する
- コミットメッセージ: `refactor: 引き継ぎ記述子を Required 導出と経路分割で再定義し optional を根絶する (#617)`

### Step 3: 死んだ `attachRevisedDetail` / `detachRevisedDetail` を削除する
- [x] **完了**
- 対象ファイル:
  - `src/server/subdomains/estimate/domain/entities/EstimateItem.ts`（193-200 行のメソッド削除・`_revisedDetail` を `readonly` 化）
  - `src/server/subdomains/estimate/domain/entities/__tests__/EstimateItem.test.ts`（162-172 行の専用テスト削除）
- テスト戦略: **テスト不要**（本番からの呼び出しが存在しない死んだコードとその専用テストの削除であり、振る舞いの変更が無い。呼び出し元不在は pre-push の `tsc --noEmit` が担保する）
- 作業内容:
  - `attachRevisedDetail` / `detachRevisedDetail` を削除する（調査済み: 本番コードからの呼び出し元は存在せず、テストのみが呼んでいる）
  - `private _revisedDetail` を `private readonly _revisedDetail` にする（`create` / `reconstruct` 時確定・以後不変を型で固定する）
  - 対応するテスト 2 件を削除する
  - `pnpm test` が緑であることを確認する
- コミットメッセージ: `refactor: 死んだ attach/detachRevisedDetail を削除し改訂明細詳細を生成時確定にする (#617)`

</details>

## 計画からの逸脱

# Issue #617 実装計画からの逸脱記録

## 1. `VariationContent.setGroups` も必須化した（Step 1）

### 元の計画内容

Step 1 の対象は記述子型（`EstimateVariationDescriptor` / `RepricedVariationDescriptor` /
`VariationChildrenDescriptor`）と `SetComponentValidationTarget` の 4 つで、
`EstimateVariation.VariationContent` は対象ファイルに挙がっていなかった。

計画は `assertSetComponentsValid` の必須化根拠を「呼び出し元は `estimate.variations` /
`buildVariationContent` の戻り値＝エンティティを渡しており常に配列を持つ」としていた。

### 実際の実装内容

`VariationContent.setGroups?: EstimateSetGroup[]` を必須化し、`replaceContent` の
`input.setGroups ?? []` を削除した。

### 逸脱の理由

計画の根拠（「常に配列を持つ」）は**実行時の事実としては正しいが、型に書かれていなかった**。
`VariationContent.setGroups` が optional のままだと `SetComponentValidationTarget` の必須化が
型として通らず（`EstimateSetGroup[] | undefined` は必須の配列に代入できない）、Step 1 が
成立しなかった。

`VariationContent` の唯一の生産者は `EstimateFactory.buildVariationContent` であり、
これは `buildVariationChildren` の戻り値（常に配列）を詰める。したがって optional は
「起こり得ない undefined」を型に残すだけで、計画が掲げた
**「optional は正規化する単一の所有者が居るときだけ許す」規則**にそのまま反していた。
計画の意図の範囲内と判断し、新たな設計判断の追加ではなく計画の適用漏れの補完として実施した。

---

## 2. `Required<>` が `undefined` も除くため引き継ぎ側は具体値必須になった（Step 2）

### 元の計画内容

「維持すべきフィールドは `Required<Omit<...>>` の機械導出で必須化する」。計画は必須化＝
「キーの省略を禁じる」意図で書かれており、値として `undefined` を渡せるかは明示していなかった。

### 実際の実装内容

型定義は計画どおり `Required<Omit<...>>`。ただし `Required<T>` は `?` を外すと同時に
値域から `undefined` も除くため、`discountRate` / `customerMemo` / `internalMemo` は
`undefined` を渡せず**具体値が必須**になった。

これに伴い `EstimateFactory.test.ts` に引き継ぎ経路専用の `copiedItem()` ヘルパを追加し、
`discountRate: new DiscountRate(1.0)` / `customerMemo: Memo.empty()` 等の具体値を置いた
（計画に無い追加）。

### 逸脱の理由

本番の populate 2 経路（`Estimate.reviseForCustomer` / `EstimateDuplicationService.copyItem`）は
複製元・改訂元**エンティティの getter** から値を引いており、これらの getter は
`DiscountRate` / `Memo` を非 optional で返す（既定化は `EstimateItem.create` が 1 回だけ行う
所有者であるため）。よって本番コードは無変更で通り、計画の意図（維持フィールドの取りこぼし防止）は
そのまま達成される。

テストヘルパのみ `EstimateItemDescriptor`（optional 持ち）と形状が合わなくなったため分離した。
これは型が「引き継ぎ側では既定化済みの具体値しか流れない」という実際の不変則を正しく
表現した結果であり、計画の意図に反しない。

### 補足: 設計の実効性を確認済み

`EstimateItemDescriptor` に optional フィールドを 1 本足す変異を試したところ、
populate 2 経路（`Estimate.ts` / `EstimateDuplicationService.ts`）が両方ともコンパイル
エラーになることを確認した。#617 の目的である「将来 optional が増えたら判断を書き手に強制する」が
機能している。


---

Generated with [Claude Code](https://claude.ai/code)
