### PR TITLE
ci: engines.node 削除後に残った参照を掃除する

### DIFF
--- a/docs/adr/20260726-d3b-adopt-renovate-with-approval-and-two-layer-cooldown.md
+++ b/docs/adr/20260726-d3b-adopt-renovate-with-approval-and-two-layer-cooldown.md
@@ -159,6 +159,9 @@ npm 依存に加え、以下も Renovate の管理下に入る。
 - 同ファイルの Docker タグ（CI の PostgreSQL サービスコンテナ）
 - `package.json` の `engines.node` と `packageManager`（pnpm バージョン）
 
+> **現在の管理対象（2026-07-28 追記 / #664, #667）**
+> `engines.node` は削除されたため管理対象外（→ ADR-20260728-44b）。Node 本体は `.nvmrc`（`nvm` manager）から検出する。ワークフローの `node-version` 直書きも #641 で消えているため、上記 1 点目の GitHub Actions に Node は含まれない。`packageManager` は現在も管理対象である。
+
 初回スキャンで npm 53 件 / github-actions 6 件が検出された。CI の構成要素も依存であり、同じ規律で更新されるべきという判断による。
 
 副作用として、`non-major` グループに GitHub Actions の更新が混ざる。分離するかは実 PR を見て判断する（§保留事項 4）。
@@ -191,6 +194,9 @@ npm 依存に加え、以下も Renovate の管理下に入る。
 **#641 で解決した。** Node は 22 系に統一し、値は `.nvmrc` だけに書く（CI の 4 ジョブは `node-version-file` で参照する）。あわせて `helpers:disableTypesNodeMajor` を除去し、`node` と `@types/node` を同一グループとして更新する。詳細と根拠は ADR-20260728-44b を参照。
 
 本 ADR に記した「`@types/node` は `^22` に固定されている」という状態は、上記の除去により解消している。型は本体（`.nvmrc` / `engines.node`）とグループで連動するようになった。
+
+> **2026-07-28 追記（#664, #667）**
+> その後 `engines.node` は削除され、Node 本体を宣言する箇所は `.nvmrc` だけになった。`node` グループは `.nvmrc` + `@types/node` の 2 者で構成される。撤回の根拠は ADR-20260728-44b §「なぜ `engines.node` を持たないか」を参照。
 
 ### 3. automerge への移行条件
 

--- a/renovate.json
+++ b/renovate.json
@@ -66,7 +66,7 @@
       "groupName": "commitlint"
     },
     {
-      "description": "Node 本体（.nvmrc / engines.node）と型定義は同時に上げる。helpers:disableTypesNodeMajor を外したのは、型が本体に先行するのを防ぐという同プリセットの目的は本グループが構造的に満たす一方、プリセットを残すとメジャー移行で @types/node だけが黙って据え置かれ「実行は 24・型は 22」という #641 の鏡像が生まれるため",
+      "description": "Node 本体（.nvmrc）と型定義は同時に上げる。node という depName は nvm manager が .nvmrc から検出するものであり、engines.node は #664 で削除済み（→ ADR-20260728-44b）。この matchPackageNames から node を外すと .nvmrc と @types/node が別 PR に割れる。helpers:disableTypesNodeMajor を外したのは、型が本体に先行するのを防ぐという同プリセットの目的は本グループが構造的に満たす一方、プリセットを残すとメジャー移行で @types/node だけが黙って据え置かれ「実行は 24・型は 22」という #641 の鏡像が生まれるため",
       "matchPackageNames": ["node", "@types/node"],
       "groupName": "node"
     }


### PR DESCRIPTION
## Summary

#665 で `engines.node` を削除したが、**それを指す記述が `renovate.json` と ADR-20260726-d3b に残っていた**（マージ後に発覚）。存在しないフィールドを指す説明は、次の Node メジャー移行時に「`engines.node` も直す必要がある」という誤読を招くため掃除する。

`origin/develop` の追跡ファイル全体を `engine` で検索し、修正対象は 3 箇所と判定した。実行系（`package.json` / CI ワークフロー）に残存はなく、**本 PR はドキュメントと設定コメントの整合のみで、挙動は変わらない**。

## 変更内容

| ファイル | 変更 |
|---|---|
| `renovate.json` | `node` グループの `description` から `engines.node` を除き、`matchPackageNames` の `"node"` を消してはならない理由を明記 |
| `docs/adr/20260726-d3b` | D7「管理対象の範囲」と §保留事項 2 に、`engines.node` 削除済みの注記を追記 |

## 設計判断

### `matchPackageNames: ["node", "@types/node"]` は変更していない

`node` という depName は Renovate の **nvm manager が `.nvmrc` から検出する**もので、`engines.node` の有無とは無関係に機能している。`engines.node` が消えた今「このマッチャも不要では」と読める状態にあるため、**消してはいけない理由を `description` 自身に持たせた**。

外した場合、`.nvmrc` と `@types/node` が別 PR に割れ、ADR-20260728-44b §副次効果が保証する「Node が動く PR は必ず `.nvmrc` の差分を伴う」（= `playwright.yml` の `paths` により E2E が確実に起動する）が崩れる。

### ADR-d3b は本文を書き換えず注記を添えた

D7 は「導入時点で何を Renovate の管理下に置いたか」の記録であり、本文を現状へ書き換えると当時の判断が読めなくなる。d3b は §保留事項 2 で既に同じ方式（「解決済み → ADR-20260728-44b」）を採っており、様式も揃う。

## 対象外（意図的に残したもの）

歴史的記録として正しいため遡って書き換えない。

- `d3b:21`（導入前は `engines.node` が存在しなかった）、`d3b:176`（導入に先立ち追加した作業記録）
- `44b:20`（コンテキストの当時の不一致表）、`44b` の選択肢 H〜K と撤回した根拠の引用（#664 で意図的に残した記録）
- `docs/claude-plans/issue-641/`、`docs/claude-plans/issue-643/`、`docs/nippo/`（計画・日報）

誤検出のため対象外: `Field Engineer`（業務定義）、`@prisma/engines`（`pnpm-workspace.yaml`）、`engineType`（`schema.prisma`）、`skills/engineering/*`（`skills-lock.json`）、`flows.html` の `.node` CSS クラス。

## 確認

- `renovate.json` の JSON パースと `matchPackageNames` の保持を確認済み
- `docs/claude-plans/issue-667/` は存在しないため、実装計画・逸脱セクションはなし

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDKuSM6UQfS2SBWSs2WUwb
