### PR TITLE
ci: マージ後の develop / main を検査する CI run が存在しない

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,31 @@ on:
     # paths フィルタは意図的に付けない。required status check は「起動しなかったジョブ」を
     # 待ち続けてマージ不能にするため相性が悪く、Renovate の PR（差分が lock ファイルだけの
     # ことがある）を確実に検査したい本ワークフローの目的とも衝突する。
+  # マージ後の develop / main を検査する（#656 / ADR-20260729-d8c）。
+  # pull_request の run が検査するのは refs/pull/N/merge（= その run の開始時点の base と
+  # head を合成した仮想コミット）であり、base が進んでも再実行されない。したがって PR の緑は
+  # 「古い base に対する緑」でしかなく、テキスト衝突しない意味的衝突（export のリネーム、
+  # VO のコンストラクタ引数追加など）はマージ後に初めて壊れる。それを観測する run がここ。
+  # paths フィルタは付けない。PR 側とは別の理由で、develop の HEAD が常に verdict を持つ
+  # 状態を作るのが目的のため（間引くと「最後に緑だったのは 3 コミット前」になり読めなくなる）。
+  # playwright.yml には push を付けない。E2E の既知の非決定要因（単一 shard の全面 404 ＝
+  # Next dev のスキャンレース）で develop が赤くなると、「develop が赤い ＝ 直近のマージが犯人」
+  # という本トリガーの中核価値が腐るため（→ ADR-20260729-d8c）。
+  push:
+    branches: [main, develop]
 
-# 同一 PR への連続 push で古い run をキャンセルする。playwright.yml と同じ 2 行を
-# 直書きして方針を揃える（github.workflow の前置で他ワークフローと殺し合わない）。
+# PR（refs/pull/N/merge）は従来どおり ref 単位。PR で問われるのは HEAD が緑かだけで、
+# 中間 commit の verdict に用は無いため、連続 push の古い run は畳むのが正しい。
+#
+# push だけはグループを commit（SHA）単位に分離する。ref 単位のままだと連続マージ
+#（Renovate の一斉マージなど）で最後の 1 commit 以外が cancelled になり、読み取れるのが
+# 「develop の HEAD が赤い」だけになって犯人を特定できない。cancel-in-progress: false でも
+# 解決しない（グループは実行中 1 本 + 待機中 1 本しか保持せず、3 本目の到着で待機中の
+# 2 本目が捨てられる）。そして取り逃した verdict は回復不能で、workflow_dispatch は
+# ref 指定でしか起動できないため任意の過去 SHA を後から検査する手段が無い。
+# 分離すれば全 commit に verdict が付き、commit 一覧の「緑 → 赤」の境界がそのまま犯人になる。
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
 
 # GITHUB_TOKEN は checkout に必要な読み取りのみに絞る。宣言が無いとリポジトリ設定の

--- a/docs/adr/20260729-d8c-detect-and-prevent-stale-base-merges.md
+++ b/docs/adr/20260729-d8c-detect-and-prevent-stale-base-merges.md
@@ -1,0 +1,180 @@
+# ADR-20260729-d8c: マージ後の検査を push トリガーで観測し、strict required status checks で stale マージを防ぐ
+
+| 項目 | 値 |
+|---|---|
+| ステータス | 採用 |
+| 起票日 | 2026-07-29 |
+| 最終更新日 | 2026-07-29 |
+
+## コンテキスト
+
+`ci.yml` / `playwright.yml` のどちらにも `push` トリガーが無く、**マージ後の develop / main を検査する run が 1 つも存在しない**（#656）。CI が答えているのは「この PR は緑か」だけで、「develop はいま緑か」を誰も答えていない。
+
+これが実害になるのは、GitHub の `pull_request` イベントの意味論による。PR の run が検査するのは head そのものではなく `refs/pull/{N}/merge`、すなわち **run の開始時点の base と head を合成した仮想コミット**である。そして base が進んでも run は再実行されない。したがって PR に付いた緑は「あの時点の base に対する緑」でしかなく、時間の経過とともに黙って陳腐化する。
+
+git のマージはテキストの行単位でしか衝突を見ないため、次のような変更は 2 つの PR が別ファイルに触れている限り**衝突せずにマージされ、マージ後に初めて壊れる**。
+
+| PR A | PR B | マージ後 |
+|---|---|---|
+| `export` をリネームし、既存の参照を全て追随させた | 旧名を import する新しいファイルを足した | 参照先が存在せず型検査が落ちる |
+| Value Object のコンストラクタに引数を足した | 旧シグネチャで同じ VO を生成するコードを足した | 引数不足で型検査が落ちる |
+| Prisma に必須カラムを足し、既存ファクトリを追随させた | 追随前のファクトリを使うテストを足した | 実行時に必須カラム欠落で落ちる |
+
+以下これを **意味的衝突（semantic conflict）** と呼ぶ。B の PR は自分自身の CI が緑のままマージでき、develop が壊れても誰も通知を受けない。次に無関係の PR を出した人が赤い CI を見て自分の変更を疑うところから始まる — 誤診のコストは、壊した本人ではなく次の人が払う。
+
+#643 で両 ruleset に required status checks（`static` / `test`）を入れたが、`strict_required_status_checks_policy` は `false` のままにしてある。これは「checks が緑であること」だけを要求し、「その checks が最新の base に対する緑であること」は要求しない設定であり、上記の経路はこの穴をそのまま通る。
+
+## 検討した選択肢
+
+### A. `push` トリガーの追加（採用 / 事後検知）
+
+`ci.yml` に `push: branches: [main, develop]` を足し、マージ後の状態を検査する run を起動する。壊れることは防げないが、壊れたことが即座に分かる。
+
+### B. `strict_required_status_checks_policy: true`（採用 / 事前防止）
+
+両 ruleset の required status checks を strict 化し、base が進んだ PR のマージを止める。マージ前に base 最新で CI を回し直させるため、意味的衝突は PR 段階で赤くなる。
+
+### C. merge queue（不採用）
+
+マージ対象を GitHub 側のキューで直列化し、キュー内で「base + 先行するキュー要素 + 自分」を合成して検査してから入れる。B と違い、マージ待ちの PR が複数あっても人手の rebase 往復が発生しない。
+
+### D. `push` を `playwright.yml` にも付ける（不採用）
+
+E2E も含めてマージ後の develop を検査する。
+
+### E. push run の concurrency を現状の式のまま流用する（不採用）
+
+`group: ${{ github.workflow }}-${{ github.ref }}` を push にも適用する。
+
+### F. push のときだけ `cancel-in-progress: false` にする（不採用）
+
+古い run をキャンセルせず順に消化させる。
+
+### G. push のときだけグループを commit（SHA）単位に分離する（採用）
+
+### H. Renovate の `rebaseWhen` を既定の `"auto"` に任せる（不採用）
+
+### I. Renovate の `rebaseWhen` に `"behind-base-branch"` を明示する（採用）
+
+## 決定
+
+**A と B を併用する。** `ci.yml` にのみ `push: branches: [main, develop]` を足し、push run の concurrency グループは commit（SHA）単位に分離する。両 ruleset（`protect-develop` / `protect-main`）の `required_status_checks` を `strict_required_status_checks_policy: true` にし、それと対で `renovate.json` に `"rebaseWhen": "behind-base-branch"` を明示する。
+
+決定は 3 箇所に分かれて宿る。**ruleset はリポジトリの外にあり、コメントを書く場所が無い**ため、対応関係を記述できるのはこの ADR だけである。
+
+| 箇所 | 何が置かれるか | 役割 |
+|---|---|---|
+| `.github/workflows/ci.yml` | `push` トリガー ＋ SHA 単位の concurrency | A（事後検知） |
+| GitHub ruleset `protect-develop` (12978563) / `protect-main` (12978605) | `strict_required_status_checks_policy: true` | B（事前防止） |
+| `renovate.json` | `"rebaseWhen": "behind-base-branch"` | B の副作用を Renovate 自身に吸収させる |
+
+**後ろ 2 つは対であり、片方だけ変更してはならない。** strict 化は「base が古い PR はマージできない」を意味するため、Renovate の PR は誰かが rebase しない限り永久にマージできなくなる。その rebase を Renovate 自身にやらせるのが `rebaseWhen` である。
+
+## 根拠
+
+### なぜ A と B の併用か（A vs B）
+
+排他ではなく、守る対象が違う。
+
+B は「PR 経由の stale マージ」を止めるが、**develop がいま緑かという状態そのものを持たない**。B を入れても、CI 環境側の変化（レジストリ、Actions ランナーイメージ、外部サービス）で develop が壊れることは防げないし、そもそも「壊れていないこと」を確認した run が存在しない状態は変わらない。A はその状態を持つ唯一の手段で、事前防止では代替できない。
+
+逆に A だけでは、意味的衝突が「起きてから直す」運用になる。B は起きる前に止める。
+
+投入順序は **A →実物で検証→ B** とする。B を先に入れると、「B のせいでマージが止まったのか、CI が本当に壊れているのか」を切り分ける観測点が無いまま運用に入ることになる。
+
+### なぜ merge queue を採らないか（C）
+
+merge queue が解く問題は「**複数人がマージを競う**」ことである。キューは、同時にマージされようとしている PR 同士の組み合わせを直列に検査する機構であり、価値はマージの並行度に比例する。
+
+本リポジトリは単独開発者 + Renovate であり、直列化すべき競合が構造的に存在しない。Renovate の PR が同時に複数 open になることはあるが、マージは人間が 1 件ずつ押している。B が要求する「base 最新化の往復」も、キューが吸収するほどの頻度で発生しない。規模に対して過剰であり、キューの設定・失敗時の挙動・required checks との相互作用という新しい理解コストのほうが大きい。
+
+### なぜ `ci.yml` だけに push を付けるか（A vs D）
+
+3 つある。
+
+1. コンテキストに挙げた意味的衝突の例はいずれも `static`（型検査）と `test`（Vitest）の射程内にある。E2E を毎マージ回して追加で捕まえられるものが、費用に見合わない。
+2. **E2E の flaky が A の中核価値を壊す。** A の価値は「develop が赤い ＝ 直近のマージが犯人」という attribution にある。既知の非決定要因（単一 shard の全面 404 ＝ Next dev のスキャンレース / [next#96139](https://github.com/vercel/next.js/issues/96139)）で develop がランダムに赤くなり始めると、信号が腐って誰も見なくなる。**赤の意味が壊れることは、赤が出ないことより悪い。** `static` / `test` は決定的なのでこの汚染がない。
+3. `playwright` は required check ではない（#643 の判断）。PR 段階で保証していないものを push 側だけ厳格に見るのは非対称であり、それは「playwright を required に昇格させるか」という別の関心事に属する。
+
+develop の E2E 健全性を観測したくなった場合、適した器は push ではなく nightly の `schedule` である（flaky が attribution を壊さず、同時実行枠の競合も夜間に逃がせる）。別 issue として扱う。
+
+### なぜ push だけ concurrency を SHA 単位に分けるか（E / F vs G）
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+```
+
+concurrency の常識（同一グループの run を畳んで無駄を省く）と逆を向いて見えるので、理由を残す。
+
+E（ref 単位のまま）を採ると、連続マージ — Renovate の PR をまとめてマージするときに実際に起きる — で**最後の 1 commit 以外が `cancelled` になり、verdict を失う**。残るのは「develop の HEAD が赤い」という 1 ビットだけで、5 つマージしたうちどれが犯人かは分からない。これは #656 が問題視した誤診を、PR 単位からブランチ単位に移すだけである。
+
+F（`cancel-in-progress: false`）は解決にならない。concurrency グループが保持するのは**実行中 1 本 + 待機中 1 本**だけで、3 本目が到着した時点で待機中の 2 本目が捨てられる（GitHub Docs: "any existing `pending` job or workflow in the same concurrency group will be canceled"）。連続マージという、まさに問題が起きる場面で取りこぼす。
+
+そして **取り逃した verdict は回復不能**である。`workflow_dispatch` は ref（ブランチ / タグ）を指定してしか起動できず、任意の過去 SHA を後から検査する手段が無い。`git bisect` を手で回すしかなくなる。
+
+G ならば全 commit に verdict が付き、commit 一覧に「緑 → 赤」の境界が現れて、その 1 コミットがそのまま犯人になる。実質的に、**壊れる前に `git bisect` を全区間ぶん先に済ませている**状態を作っている。ランナー費用は public リポジトリのため発生せず、効くのは同時実行枠（20）だけである。
+
+PR 側（`refs/pull/{N}/merge`）を ref 単位のままにするのは、PR で問われるのが HEAD が緑かだけであり、中間 commit の verdict に用が無いためである。1 つの式に 2 つのポリシーが同居しているのはこの非対称性の帰結であって、書き分けそびれではない。
+
+### なぜ paths フィルタを付けないか
+
+`ci.yml` が `pull_request` で paths を付けていない理由（required status check は「起動しなかったジョブ」を待ち続けてマージ不能にする）は、push には**当てはまらない**。required checks は PR のマージ判定にしか使われないためである。
+
+それでも push に paths を付けないのは、別の理由による。A の目的は develop の HEAD が**常に** verdict を持つ状態を作ることであり、間引くと「最後に緑だったのは 3 コミット前」という読み取りにくい状態が生まれる。緑 → 赤の境界が犯人を指すという G の設計も、境界が連続していることに依存している。
+
+### なぜ main にも strict を入れるか
+
+本 ADR 起票時点で main は develop の**真の祖先**である（`develop..main` = 0 commits、`main..develop` = 492 commits）。develop → main のリリース PR は定義上つねに base を取り込み済みであり、strict は現状 **no-op として入る**。
+
+no-op でなくなるのは、main に hotfix が直接入って develop → main の PR が stale になる場面である。それはまさに機械に強制させたい場面であり、しかも最も慌てている時に起こる。main が休眠中の今が、最も安く入れられるタイミングである。
+
+加えて「develop は strict、main は非 strict」という非対称は、半年後に誰も理由を覚えていない。理由を思い出せない非対称は事故を生む。
+
+### なぜ `rebaseWhen` を明示するか（H vs I）
+
+`rebaseWhen` の既定値 `"auto"` は、「ブランチが最新であることを要求するリポジトリ」を検出したときに `behind-base-branch` へ切り替わる。つまり **strict 化に対して Renovate 側が自動で追随することを期待できる**設計になっている。それでも明示するのは、検出の信頼性と、検出に失敗したときの帰結の悪さによる。
+
+この検出は classic branch protection を前提に作られており、**Rulesets での検出には既知の不具合報告がある**（[renovatebot/renovate discussion #38302](https://github.com/renovatebot/renovate/discussions/38302)）。本リポジトリは ruleset 運用である。
+
+検出に失敗すると、Renovate の PR は stale のまま放置される。そこで人間がマージしようとして GitHub の **"Update branch" ボタンを押すと、それはユーザー名義のコミットを PR ブランチに足す操作**であるため、Renovate の規則「If you push a new commit to a Renovate branch ... then Renovate stops all updates of that branch」（[Updating and Rebasing branches](https://docs.renovatebot.com/updating-rebasing/)）が発動する。**その PR は Renovate の管理から静かに外れる** — PR は残りマージもできるが、以降 Renovate は更新せず、close するまで同じ依存の新しい PR も作らない。気づく手段が実質ない。
+
+明示すれば、ruleset の実装詳細と Renovate の検出ロジックから切り離せる。これは `.nvmrc` を単一ソースにする（ADR-20260728-44b）、`DATABASE_URL` をサービスコンテナ / ジョブ env / `.env.unit.example` の三者で一致させる、`db-unreachable.invalid` で「偶然の到達不能」ではなく「宣言された到達不能」にする（#643）と同じく、**推測される既定値ではなく宣言された値に依存する**という一貫した方針でもある。
+
+### なぜ `rebaseWhen` を strict 化より先に入れるか
+
+順序には片方向の危険がある。
+
+- **strict 化 → `rebaseWhen` 明示**: その間、Renovate の autodetect が ruleset を検出できるかに賭ける窓が開く。失敗すれば PR は stale のまま放置され、"Update branch" を押した瞬間にその PR が Renovate 管理から静かに外れる。
+- **`rebaseWhen` 明示 → strict 化**: 副作用は「strict でない期間に rebase の churn が先行する」だけで、壊れる方向の失敗が無い。
+
+**静かに壊れる側を後ろに置く。**
+
+### 検証の方法
+
+「意図的に壊した状態で想定どおり検知されること」は、使い捨ての 2 PR で本物の意味的衝突を再現して確認する。
+
+注意すべきは、**壊れた commit を develop に入れる経路が他に無い**ことである。自分自身が赤い PR は required checks に阻まれてマージできず、直 push も「その SHA に緑の checks が報告されていること」を要求されるが、そもそも develop 以外では run が起動しないため条件を満たせない（後述）。つまり **develop を壊す正当な経路は、#656 が問題視した「stale base の緑」しか残っていない** — 検証したいシナリオと、それを実施できる唯一の手段が一致している。
+
+## ロールアウト
+
+本 ADR は決定の全体を記述しているが、**起票時点で適用済みなのは A のみ**である。3 箇所のうち 2 箇所は未適用の状態でこの ADR がマージされる。
+
+| 箇所 | 起票時点 |
+|---|---|
+| `ci.yml` の `push` トリガー ＋ SHA 単位 concurrency | 適用済み（本 ADR と同じ PR） |
+| `renovate.json` の `rebaseWhen` | **未適用** |
+| 両 ruleset の `strict_required_status_checks_policy` | **未適用**（`false` のまま） |
+
+順序は「A →実物で検証→ `rebaseWhen` → strict 化」であり、間に検証を挟むため同一 PR にはならない。進捗は `docs/claude-plans/issue-656/` を参照。**ruleset の実際の値は `gh api repos/:owner/:repo/rulesets/12978563` で確認できる** — この ADR の記述ではなく、そちらが正本である。
+
+## 影響
+
+- **develop が赤いことがあり得る状態になる。** これまで develop の CI 状態は「存在しない」だったが、以後は緑か赤のどちらかになる。デプロイ連携は無い（`deployments` / `environments` ともに 0 件）ため、赤が直ちに何かを止めることはない。
+- **通知は GitHub Actions の既定のメール通知に頼る。** 失敗時に issue を自動起票する等の能動通知は、`issues: write` を要求し、`ci.yml` の `permissions: contents: read` を開くことになる。これは #643 が明示的な理由で閉じた設計（`pnpm install` が `only-allow` / `onlyBuiltDependencies` のビルドスクリプトを実行するため、書き込み権限付きトークンを同じ run に置かない）であり、Renovate PR を検査する CI で書き込みトークンと未検証の依存のビルドスクリプトを同居させることになる。**通知の便宜のために攻撃面を広げるのは割に合わない。** 既定通知は「自分が actor になった run の失敗」を通知し、PR をマージすると develop への push の actor はマージ実行者になるため、単独開発の本リポジトリでは通知先と当事者が常に一致する。
+- **strict 化により、base が進むたびに全 open PR の rebase が要る。** Renovate が自分で行うため人手はかからないが、develop へ 1 マージするごとに open PR 全部が rebase され、`4 PR × (ci 2 job + playwright 7 job) = 36 job` が一斉起動する。1 日 2 マージで約 72 job/日。public リポジトリのため課金は無く、効くのは同時実行枠（20）のみ。実測して痛ければ `prConcurrentLimit` や `schedule` で調整する（別 issue）。
+- **人間が "Update branch" を押してはならない。** 押すとその Renovate PR が Renovate の管理から静かに外れる。Renovate PR が stale なときは、Renovate の次回 run を待つか、Dependency Dashboard のチェックボックスで rebase を要求する。
+- **`playwright` は push で検査されない。** develop の E2E 健全性は誰も観測していない。この穴は意図的なもので、埋めるなら nightly `schedule` が適した器である。
+- **push トリガーが増えても develop への直 push は依然できない。** #643 の計画は直 push が不可能な理由を「CI に `push` トリガーが無いため checks が存在しない」と記録したが、本 ADR の A を入れてもこの結論は変わらない。本質はトリガーの有無ではなく**評価順序**であり、ruleset の required status checks は push を受け付ける**前**に評価される。よって push が拒否される → workflow が起動しない → checks が永久に付かない、というニワトリ卵になる。
+- **`ci.yml` の実行回数は概ね倍になる。** 1 PR につき PR run と push run が 1 本ずつ走る。push run は PR run とほぼ同じ内容を検査するが、**base が進んでいれば別のもの**を検査している。冗長に見えたときにこの ADR を読むこと。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -149,3 +149,4 @@
 | [20260727-2fb](20260727-2fb-explicit-dynamic-rendering-for-authenticated-routes.md) | 認証配下ルートの動的レンダリングを (features) レイアウトで既定宣言し、DB 非到達ビルドで担保する（CI の build に DB を与えないことが担保の本体） | 採用 | 2026-07-27 |
 | [20260727-55f](20260727-55f-e2e-ci-parallelization-by-shard.md) | E2E の CI 並列化は shard 分割で行い、shard 内は直列実行を維持する | 採用 | 2026-07-27 |
 | [20260728-44b](20260728-44b-node-version-unified-on-22-with-nvmrc-single-source.md) | Node のバージョンは 22 系に統一し、`.nvmrc` を唯一の宣言箇所とする | 採用 | 2026-07-28 |
+| [20260729-d8c](20260729-d8c-detect-and-prevent-stale-base-merges.md) | マージ後の検査を push トリガーで観測し、strict required status checks で stale マージを防ぐ | 採用（ロールアウト途中） | 2026-07-29 |

--- a/docs/claude-plans/issue-643/deviations.md
+++ b/docs/claude-plans/issue-643/deviations.md
@@ -50,3 +50,24 @@
 - **検討して採らなかった案**: `next.config.ts` に `typescript.ignoreBuildErrors: true` を置いて build 側の型検査を切り、`tsc` を型の唯一の権威にする案。フラグ名が「型検査を諦めた」と誤読される強さに加え、ローカルで `pnpm build` を直接叩いたときに型検査が効かなくなる。CI の 20 秒のためにローカルの安全性を削るのは向きが逆。
 
   レビューが提案した「build を独立ジョブにして lint / typecheck と並列化する」案も採らなかった。CI 実測でジョブ開始から検査開始までの setup が約 56 秒あり、約 20 秒の壁時計短縮のためにもう 1 ランナー分の setup を払うことになる。required check の名前が 3 つに増え、`static` / `test` の 2 つに絞った Step 5 の設計判断にも波及する。
+
+## 4. 【後日訂正 / #656】Step 5 が記録した「develop への直 push が不可能な理由」が誤っていた
+
+逸脱ではなく、**記録した理由づけの訂正**である（#656 の作業中に発見した）。
+
+- **計画に記録した内容**: Step 5 の「副作用として認識した点」に、`protect-develop` には `pull_request` ルールが無く develop への直接 push が可能だったが、required status checks の追加により事実上不可能になった、と書いた。その理由として「CI に `push` トリガーが無い（#656）ため、直接 push されたコミットには checks が存在せず条件を満たせないため」と記録した。
+- **実際**: **結論は正しいが、理由が誤っている。** 直 push は依然として不可能で、そこは変わらない。
+- **本質は評価順序である。** ruleset の required status checks は、push を**受け付ける前**に評価される。したがって因果は次のようになる。
+
+  ```
+  push を試みる
+    → ruleset が「この SHA に static / test の緑が報告されているか」を判定
+    → 報告が無いので push そのものが拒否される
+    → workflow が起動する機会がそもそも訪れない
+    → checks は永久に付かない
+  ```
+
+  「トリガーが無いから checks が存在しない」のではなく、「push が受理されないので workflow を起動できない」というニワトリ卵である。
+
+- **なぜ訂正が要るか**: #656 で `ci.yml` に `push: branches: [main, develop]` を追加したため、元の理由づけは「push トリガーが付いたのだから直 push は復活するのでは」という誤読を招く。復活しない。push トリガーが起動できるのは**マージによって develop が進んだとき**であって、直 push 経路は上記のとおり ruleset の段階で先に閉じている。
+- **参照**: ADR-20260729-d8c §影響、`docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md`

--- a/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
+++ b/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
@@ -132,7 +132,7 @@ concurrency:
 
 ### Step 1: ci.yml に push トリガーと commit 単位の concurrency を追加する
 
-- [ ] **完了**
+- [x] **完了**
 - 対象ファイル: `.github/workflows/ci.yml`
 - テスト戦略: テスト不要（設定ファイル）
 - 作業内容:

--- a/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
+++ b/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
@@ -161,7 +161,7 @@ concurrency:
 
 ### Step 3: #643 の「直 push 不可」の理由を訂正する
 
-- [ ] **完了**
+- [x] **完了**
 - 対象ファイル: `docs/claude-plans/issue-643/deviations.md`
 - テスト戦略: テスト不要（ドキュメント）
 - 作業内容:

--- a/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
+++ b/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
@@ -1,0 +1,247 @@
+# Issue #656: マージ後の develop / main を検査する CI run が存在しない — 実装計画
+
+> **実行規約**: 各 step 完了時にこのファイルの該当チェックボックス（`- [ ]`）を
+> `- [x]` に更新し、その更新を step のコミットに含めること。
+> 再開時（compaction 後・新規セッション後を含む）は、まずこのファイルを読み、
+> 未チェックの最小 step 番号から続行すること。
+> **テスト戦略が `TDD` の step は red-green-refactor で進めること**（テストを先に書き、
+> RED を確認してから実装する）。`/tdd` スキルの規約に従う。
+
+## 概要
+
+イシューの選択肢 **A（`push` トリガーによる事後検知）と B（required status checks の strict 化による事前防止）を併用**する。C（merge queue）は不採用。
+
+- **A**: `.github/workflows/ci.yml` に `push: branches: [main, develop]` を追加し、マージ後の develop / main を検査する run を起動する。あわせて push run の `concurrency` グループを commit（SHA）単位に分離し、連続マージでも 1 commit = 1 verdict を維持する。`playwright.yml` には push トリガーを付けない。
+- **B**: 両 ruleset（`protect-develop` / `protect-main`）の `required_status_checks` に `strict_required_status_checks_policy: true` を設定する。あわせて `renovate.json` に `"rebaseWhen": "behind-base-branch"` を明示し、strict 化に伴う rebase を Renovate 自身に行わせる。
+
+投入順序は **A → 実物で検証 → B**。検証は「意図的に壊した状態で想定どおり検知（または阻止）されることを確認する」というイシューの作業項目 3 に対応し、使い捨ての 2 PR で本物の意味的衝突を再現して行う。
+
+設計判断は `/grill-with-docs` で確定済み。ADR を 1 本起票する（`ADR-20260729-d8c`）。
+
+## 設計判断
+
+### 採用する方式（イシューの A / B / C）
+
+- A. `push` トリガーの追加（事後検知）
+- B. required status checks の strict 化（事前防止）
+- C. merge queue
+- **選択: A + B の併用**。守る対象が異なるため排他ではない。B は「PR 経由の stale マージ」を止めるが、develop がいま緑かという**状態そのもの**は持たない。A はその状態を持つ唯一の手段で、事前防止では代替できない。C は「複数人がマージを競う」ための機構であり、単独開発者 + Renovate という構成では直列化すべき競合が存在しないため規模に対して過剰。
+- **投入順序は A → 実物で検証 → B**。B を先に入れると「B のせいで止まったのか CI が本当に壊れているのか」を切り分ける観測点が無いまま運用に入る。
+
+### push トリガーの適用範囲
+
+- A. `ci.yml` のみ
+- B. `ci.yml` と `playwright.yml` の両方
+- **選択: A（`ci.yml` のみ）**。理由は 3 つ。
+  1. イシューが挙げる意味的衝突の例（export の削除・リネーム、Value Object のコンストラクタ引数追加、Prisma 必須カラム追加とファクトリ追随漏れ）はいずれも `static` / `test` の射程内で、E2E を毎マージ回す費用対効果が合わない。
+  2. **E2E の flaky が A の中核価値を壊す**。A の価値は「develop が赤い ＝ 直近のマージが犯人」という attribution にあり、既知の非決定要因（単一 shard の全面 404 ＝ Next dev のスキャンレース）で develop が赤くなり始めると信号が腐って誰も見なくなる。`static` / `test` は決定的なのでこの汚染がない。
+  3. `playwright` は required check ではない（#643 の判断）。PR 段階で保証していないものを push 側だけ厳格に見るのは非対称であり、これは「playwright を required に昇格させるか」という別の関心事に属する。
+- develop の E2E 健全性を観測したくなった場合は、push ではなく nightly の `schedule` トリガーが適した器（flaky が attribution を壊さず、同時実行枠の競合も夜間に逃がせる）。**別 issue に切り出す**。
+
+### push run の concurrency
+
+- A. 現状の式（`group: ${{ github.workflow }}-${{ github.ref }}`）をそのまま push にも適用する
+- B. `cancel-in-progress` を push のときだけ `false` にする
+- C. push のときだけグループを commit（SHA）単位に分離する
+- **選択: C**。
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+```
+
+- A を採ると、連続マージ（Renovate の一斉マージなど）で最後の 1 commit 以外が `cancelled` になり verdict を失う。読み取れるのは「develop の HEAD が赤い」だけで犯人を特定できず、イシューが問題視した誤診をブランチ単位に移すだけになる。
+- B は解決にならない。concurrency グループは「実行中 1 本 + 待機中 1 本」しか保持せず、3 本目が来た時点で待機中の 2 本目が捨てられる（GitHub ドキュメント: "any existing `pending` job or workflow in the same concurrency group will be canceled"）。
+- **取り逃した verdict は回復不能**。`workflow_dispatch` は ref 指定でしか起動できず、任意の過去 SHA を後から検査する手段がない。
+- C により全 commit に verdict が付き、commit 一覧で「緑 → 赤の境界」が犯人として一目で読める。実質的に `git bisect` を事前に全区間ぶん実行しているのと同じ。
+- PR 側（`refs/pull/N/merge`）は従来どおり ref 単位のまま。PR で問われるのは HEAD が緑かだけで中間 commit の verdict に用は無いため、畳むのが正しい。
+
+### push トリガーの branches と paths
+
+- **`branches: [main, develop]`**。develop → main のリリースマージ後の状態も同じ理由で観測対象。
+- **paths フィルタは付けない**。develop の HEAD が常に verdict を持つ状態を作るのが A の目的で、間引くと「最後に緑だったのは 3 コミット前」という読み取りにくい状態が生まれる。
+- なお `ci.yml` が PR で paths を付けていない理由（required check が「起動しなかったジョブ」を待ち続ける）は push には当てはまらない。required checks は PR のマージ判定にしか使われないため。**push に paths を付けない理由は上記の別論拠による**。
+
+### B の適用範囲
+
+- A. `protect-develop` のみ
+- B. `protect-develop` と `protect-main` の両方
+- **選択: B（両方）**。
+  - main は develop の**真の祖先**（`develop..main` = 0 commits、`main..develop` = 492 commits）であるため、develop → main の PR は定義上つねに最新を取り込み済みで、strict は現状 no-op として入る。
+  - no-op でなくなる場面（main に hotfix が直接入り develop が stale になる）こそ機械に強制させたい場面であり、main が休眠中の今が最も安く入れられるタイミング。
+  - 「develop は strict、main は非 strict」という非対称は半年後に誰も覚えておらず事故を生む。
+
+### Renovate の rebaseWhen
+
+- A. 既定の `"auto"` の自動検出に任せる
+- B. `"behind-base-branch"` を明示する
+- **選択: B（明示）**。
+  - `auto` は「ブランチが最新であることを要求するリポジトリ」を検出して `behind-base-branch` に切り替わるが、この検出は classic branch protection 前提で作られており、**Rulesets での検出には既知の不具合報告がある**（[renovatebot/renovate discussion #38302](https://github.com/renovatebot/renovate/discussions/38302)）。このリポジトリは ruleset 運用。
+  - 検出に失敗した場合の帰結が悪い。PR が stale のまま放置され、マージしようとして GitHub の "Update branch" を押すと、それは**ユーザー名義のコミットを PR ブランチに足す操作**であるため、Renovate の規則「If you push a new commit to a Renovate branch ... then Renovate stops all updates of that branch」（[Updating and Rebasing branches](https://docs.renovatebot.com/updating-rebasing/)）が発動し、**その PR は Renovate の管理から静かに外れる**。PR は残りマージもできるが以降更新されず、close するまで同じ依存の新しい PR も作られない。気づく手段が実質ない。
+  - 明示すれば ruleset の実装詳細から切り離せる。`.nvmrc` を単一ソースにする（ADR-20260728-44b）、`DATABASE_URL` を三者一致させる、`db-unreachable.invalid` で「宣言された到達不能」にする（#643）と同じく、**推測される既定値ではなく宣言された値に依存する**という一貫した方針。
+  - ruleset は GitHub 側にあってリポジトリからは見えないため、`renovate.json` のコメントで strict との対応関係を残す。
+- **受け入れるコスト**: develop へ 1 マージするたび、Renovate の次回 run で open PR 全部が rebase され、`4 PR × (ci 2 job + playwright 7 job) = 36 job` が一斉起動する。1 日 2 マージで約 72 job/日。public リポジトリのため課金は無く、効くのは同時実行枠（20）のみ。実測して痛ければ `prConcurrentLimit` や schedule で**別 issue として**調整する。
+
+### ロールアウト順序（rebaseWhen と strict 化）
+
+- A. ruleset を strict 化 → `renovate.json` に `rebaseWhen` を明示
+- B. `renovate.json` に `rebaseWhen` を明示 → ruleset を strict 化
+- **選択: B**。A の順序では、strict 化から `renovate.json` のマージまでの間、Renovate の autodetect が ruleset を検出できるかに賭ける窓が開く。検出に失敗すれば PR は stale のまま放置され、"Update branch" を押した瞬間にその PR が Renovate 管理から静かに外れる。B の副作用は「strict でない期間に rebase の churn が先行する」だけで、壊れる方向の失敗が無い。**失敗したときに静かに壊れる側を後ろに置く**。
+
+### 検証方法（イシューの作業項目 3）
+
+- A. 使い捨ての 2 PR で本物の意味的衝突を再現し、develop を実際に赤くする
+- B. 検証用ブランチを一時的に `push.branches` に足し、そこで壊す
+- **選択: A**。
+  - **そもそも「壊れた commit を develop に入れる」経路が他に無い**。自分自身が赤い PR は required checks（`static` / `test`）に阻まれてマージできず、直 push も「その SHA に緑の check が報告されていること」を要求されるが develop 以外では run が起動しないため条件を満たせない。**develop を壊す正当な経路は、イシューが問題視した「stale base の緑」しか残っていない** — 検証したいシナリオと実施できる唯一の手段が一致している。
+  - 検証対象は「push トリガーが起動すること」ではなく、「stale base の緑でマージできる → develop が壊れる → 検知される → 犯人が一意に特定できる」という因果の連鎖全体。B はその前半を飛ばすため作業項目 3 の要件を満たさない。
+  - 同じ材料を B の検証にそのまま再利用でき、「A で壊れる様子を見て、B で同じものが止まる様子を見る」という対になる。
+  - `ci.yml` のコメントが主張する「`next build` は `*.test.ts` も型検査する（独立した `tsc --noEmit` を置かない根拠）」という賭けの実地検証にもなる。
+- 材料は `src/server/__tests__/helpers/` 配下のテスト専用モジュール（本番コードに一切触れずに衝突を作れる）。
+- デプロイ連携が無い（`deployments` 0 件 / `environments` 0 件）ため、develop が一時的に赤くなる実害はほぼゼロ。
+- 後始末は revert PR で行う（`non_fast_forward` ルールにより force push で戻す経路は塞がれている）。
+
+### develop が壊れたことの検知手段
+
+- A. GitHub Actions の既定のメール通知に任せる
+- B. 失敗時に issue を自動起票する等の能動通知を足す
+- **選択: A**。
+  - B は `issues: write` を要求し、`ci.yml` の `permissions: contents: read` を開くことになる。これは #643 が明示的な理由で閉じた設計（「`pnpm install` で `onlyBuiltDependencies` のビルドスクリプトを実行するため、書き込み権限付きトークンを同じ run に置かないことに意味がある」）であり、Renovate PR を検査する CI で書き込みトークンと未検証の依存のビルドスクリプトを同居させることになる。通知の便宜のために攻撃面を広げるのは割に合わない。
+  - 既定通知は「自分が actor になったワークフローの失敗のみ」を通知する。PR をマージすると develop への push の actor はマージ実行者になるため、単独開発の本リポジトリでは通知先と当事者が常に一致する。
+  - ユーザー側のアカウント設定はリポジトリからは確認できないため、**Step 4 の検証で実際に届くかを確認する**。届かなければ本 issue のスコープを広げず別 issue に切り出す。
+
+### ADR の起票
+
+- **起票する**（`ADR-20260729-d8c`）。3 条件のうち特に「文脈なしでは驚く」と「本物のトレードオフの結果」に強く該当する。
+  - `group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}` は concurrency の常識（同一グループで畳む）と真逆に見える。
+  - **決定が GitHub 側の ruleset・`renovate.json`・`ci.yml` の 3 箇所にまたがる**。ruleset はリポジトリの外にありコメントを書けないため、「strict と `rebaseWhen: behind-base-branch` は対である」という対応関係を書ける場所が ADR しかない。
+  - CI に関する ADR の先例がある（ADR-20260727-55f / ADR-20260728-44b）。
+
+### CONTEXT.md の扱い
+
+- **更新しない**。`CONTEXT.md` は見積管理の業務ドメイン用語集（取引先・複製・改訂 等）であり、CI の語彙（意味的衝突、stale base）は住所が違う。用語集を「その他の決定事項置き場」にすると用語集として死ぬ。
+
+### #643 の記述訂正
+
+`docs/claude-plans/issue-643/add-pr-ci-workflow-with-db-unreachable-build.md` に、develop への直 push が不可能な理由として「CI に `push` トリガーが無い（#656）ため、直接 push されたコミットには checks が存在せず条件を満たせない」と記録されている。この理由づけは A を入れると陳腐化する（「push トリガーが付けば直 push が復活するのか」という誤読を招く）。
+
+**結論は変わらない**（直 push は依然不可能）。本質はトリガーの有無ではなく**評価順序**であり、ruleset の required status checks は push を受け付ける**前**に評価されるため、push が拒否される → workflow が起動しない → checks が永久に付かない、というニワトリ卵になる。この訂正を `docs/claude-plans/issue-643/deviations.md` に追記する。
+
+## ステップ
+
+### Step 1: ci.yml に push トリガーと commit 単位の concurrency を追加する
+
+- [ ] **完了**
+- 対象ファイル: `.github/workflows/ci.yml`
+- テスト戦略: テスト不要（設定ファイル）
+- 作業内容:
+  - `on:` に `push: branches: [main, develop]` を追加する（paths フィルタは付けない）
+  - `concurrency.group` を `${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}` に変更する
+  - 意図コメントを残す:
+    - push に paths を付けない理由（develop の HEAD が常に verdict を持つ状態を作る）
+    - push だけ SHA 単位にする理由（連続マージで verdict を失うと犯人特定ができない／`workflow_dispatch` は ref 指定のため過去 SHA を後から検査できない／グループは実行中 1 + 待機中 1 しか保持しない）
+    - PR 側を ref 単位のままにする理由
+    - `playwright.yml` に push を付けない理由（→ ADR-20260729-d8c）
+- コミットメッセージ: `ci: develop / main への push で CI を実行する`
+
+### Step 2: ADR を起票し INDEX に追記する
+
+- [ ] **完了**
+- 対象ファイル: `docs/adr/20260729-d8c-detect-and-prevent-stale-base-merges.md`（新規）、`docs/adr/INDEX.md`
+- テスト戦略: テスト不要（ドキュメント）
+- 作業内容:
+  - `docs/adr/TEMPLATE.md` に従って ADR を作成する。タイトルは「マージ後の検査を push トリガーで観測し、strict required status checks で stale マージを防ぐ」
+  - 検討した選択肢として A / B / C を記載し、C の不採用理由（規模に対して過剰）を残す
+  - 決定として、A + B の併用、`ci.yml` のみへの push、SHA 単位 concurrency、両 ruleset の strict 化、`rebaseWhen: behind-base-branch` の明示を記載する
+  - **ruleset・`renovate.json`・`ci.yml` の 3 箇所にまたがる対応関係**を明記する（ADR の主要な存在理由）
+  - ロールアウト節に、本 ADR 起票時点では Step 6 / Step 7 が未適用であることを記す
+  - `docs/adr/INDEX.md` の適切なカテゴリ見出しに 1 行追記する
+- コミットメッセージ: `docs: マージ後検査と stale マージ防止の ADR を追加する`
+
+### Step 3: #643 の「直 push 不可」の理由を訂正する
+
+- [ ] **完了**
+- 対象ファイル: `docs/claude-plans/issue-643/deviations.md`
+- テスト戦略: テスト不要（ドキュメント）
+- 作業内容:
+  - #643 の計画が記録した理由（push トリガーが無いため checks が存在しない）が本 issue の A によって陳腐化すること、および結論（直 push は不可）は変わらないことを追記する
+  - 本質が「required status checks は push 受理の**前**に評価される」という評価順序であることを記す
+- コミットメッセージ: `docs: issue-643 の「直 push 不可」の理由を訂正する`
+
+> ここまでを 1 本の PR としてマージし、develop の push run が緑で起動することを疎通確認する。
+
+### Step 4: 検証 A — 使い捨て 2 PR で意味的衝突を起こし、検知を確認する
+
+- [ ] **完了**
+- 対象ファイル: `src/server/__tests__/helpers/` 配下（使い捨て）
+- テスト戦略: テスト不要（CI 実地検証）
+- 作業内容:
+  - PR X: helper の export を 1 つリネームし、既存参照もすべて追随させる（X 単体の CI が緑になることを確認）
+  - PR X をマージし、develop の push run が緑になることを確認する
+  - PR Y: **X 以前の develop を base に**、旧名を import する `*.test.ts` を新規追加する（Y 単体の CI が緑になることを確認）
+  - PR Y をマージする（PR の check は古い base のまま緑なのでマージできる ＝ イシューが問題視した経路そのもの）
+  - 確認項目:
+    - [ ] develop の push run が赤くなる
+    - [ ] commit 一覧に「緑 → 赤」の境界が現れ、Y が犯人として一意に読める
+    - [ ] `static` ジョブで落ちる（＝ `next build` が `*.test.ts` も型検査しているという `ci.yml` の前提の実地確認）
+    - [ ] **失敗通知が実際にメールで届く**（届かない場合は本 issue のスコープを広げず別 issue に切り出す）
+- コミットメッセージ: 使い捨て PR 側のため計画対象外（`test:` 型で任意）
+
+### Step 5: 検証で壊した状態を revert する
+
+- [ ] **完了**
+- 対象ファイル: Step 4 で変更したファイル
+- テスト戦略: テスト不要（CI 実地検証）
+- 作業内容:
+  - Y と X をまとめて revert する PR を作成しマージする（`non_fast_forward` により force push で戻す経路は無い）
+  - develop の push run が緑に戻ることを確認する
+- コミットメッセージ: `revert: CI 検証用の変更を戻す`
+
+### Step 6: renovate.json に rebaseWhen を明示する
+
+- [ ] **完了**
+- 対象ファイル: `renovate.json`
+- テスト戦略: テスト不要（設定ファイル）
+- 作業内容:
+  - トップレベルに `"rebaseWhen": "behind-base-branch"` を追加する
+  - `description` ないしコメントで、両 ruleset の `strict_required_status_checks_policy: true` と対であること、`auto` の自動検出が Rulesets では信頼できないこと、"Update branch" を人間が押すと Renovate がそのブランチの管理を放棄することを記す
+- コミットメッセージ: `ci: renovate の rebaseWhen を behind-base-branch に明示する`
+
+> **Step 7 より必ず先にマージすること。** 逆順は「失敗したときに静かに壊れる」側を先に置くことになる。
+
+### Step 7: 両 ruleset の required status checks を strict 化する
+
+- [ ] **完了**
+- 対象ファイル: なし（GitHub API 操作、リポジトリ外）
+- テスト戦略: テスト不要（リポジトリ外の設定変更）
+- 作業内容:
+  - `gh api` で `protect-develop`（id: 12978563）と `protect-main`（id: 12978605）の `required_status_checks` に `strict_required_status_checks_policy: true` を設定する
+  - `required_status_checks` の中身（`static` / `test`）と他のルール（`deletion` / `non_fast_forward` / `pull_request`）は変更しない
+  - 適用後、両 ruleset を読み直して差分が意図どおりであることを確認する
+- コミットメッセージ: なし（リポジトリに変更が生じないため）
+
+### Step 8: 検証 B — 同じ操作が事前に阻止されることを確認する
+
+- [ ] **完了**
+- 対象ファイル: `src/server/__tests__/helpers/` 配下（使い捨て）
+- テスト戦略: テスト不要（CI 実地検証）
+- 作業内容:
+  - Step 4 と同じ材料で PR X' / Y' を作り直す
+  - 確認項目:
+    - [ ] X' をマージした後、Y' のマージが "This branch is out-of-date with the base branch" で**止まる**
+    - [ ] Y' で "Update branch" を実行すると CI が再実行され、今度は **PR 段階で赤くなる**（事後検知が事前防止に変わったことの確認）
+  - X' / Y' は close し、develop に何も残さない（X' をマージしていた場合は revert する）
+- コミットメッセージ: 使い捨て PR 側のため計画対象外
+
+### Step 9: イシューをクローズし、派生 issue を起票する
+
+- [ ] **完了**
+- 対象ファイル: なし
+- テスト戦略: テスト不要（ドキュメント作業）
+- 作業内容:
+  - #656 に検証結果（Step 4 / Step 8 の確認項目）を追記してクローズする
+  - 派生として別 issue に切り出す:
+    - rebase churn（1 日約 72 job）の実測と、痛い場合の `prConcurrentLimit` / schedule 調整
+    - develop の E2E 健全性を nightly `schedule` で観測するかの検討
+- コミットメッセージ: なし

--- a/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
+++ b/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
@@ -147,7 +147,7 @@ concurrency:
 
 ### Step 2: ADR を起票し INDEX に追記する
 
-- [ ] **完了**
+- [x] **完了**
 - 対象ファイル: `docs/adr/20260729-d8c-detect-and-prevent-stale-base-merges.md`（新規）、`docs/adr/INDEX.md`
 - テスト戦略: テスト不要（ドキュメント）
 - 作業内容:


### PR DESCRIPTION
## Summary

`ci.yml` に `push: branches: [main, develop]` を追加し、マージ後の develop / main を検査する run を起動する（計画の選択肢 A）。あわせて push run の concurrency グループを commit（SHA）単位に分離し、連続マージでも 1 commit = 1 verdict を保って「緑 → 赤の境界 = 犯人」が読める状態を維持する。`playwright.yml` には E2E の flaky が attribution を腐らせるため push を付けない。
判断の背景を ADR-20260729-d8c に起票し、#643 の deviations に記録されていた「develop への直 push が不可能な理由」（結論は正しいが理由づけが誤っていた）を訂正した。

本 PR は計画の **Step 1〜3**。残る Step 4 以降（実物での検知検証、`renovate.json` の `rebaseWhen`、ruleset の strict 化、事前防止の検証）は、push トリガーが develop に載っていないと実行できないため本 PR のマージ後に行う。

Refs #656

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### push-trigger-and-strict-required-status-checks.md

# Issue #656: マージ後の develop / main を検査する CI run が存在しない — 実装計画

> **実行規約**: 各 step 完了時にこのファイルの該当チェックボックス（`- [ ]`）を
> `- [x]` に更新し、その更新を step のコミットに含めること。
> 再開時（compaction 後・新規セッション後を含む）は、まずこのファイルを読み、
> 未チェックの最小 step 番号から続行すること。
> **テスト戦略が `TDD` の step は red-green-refactor で進めること**（テストを先に書き、
> RED を確認してから実装する）。`/tdd` スキルの規約に従う。

## 概要

イシューの選択肢 **A（`push` トリガーによる事後検知）と B（required status checks の strict 化による事前防止）を併用**する。C（merge queue）は不採用。

- **A**: `.github/workflows/ci.yml` に `push: branches: [main, develop]` を追加し、マージ後の develop / main を検査する run を起動する。あわせて push run の `concurrency` グループを commit（SHA）単位に分離し、連続マージでも 1 commit = 1 verdict を維持する。`playwright.yml` には push トリガーを付けない。
- **B**: 両 ruleset（`protect-develop` / `protect-main`）の `required_status_checks` に `strict_required_status_checks_policy: true` を設定する。あわせて `renovate.json` に `"rebaseWhen": "behind-base-branch"` を明示し、strict 化に伴う rebase を Renovate 自身に行わせる。

投入順序は **A → 実物で検証 → B**。検証は「意図的に壊した状態で想定どおり検知（または阻止）されることを確認する」というイシューの作業項目 3 に対応し、使い捨ての 2 PR で本物の意味的衝突を再現して行う。

設計判断は `/grill-with-docs` で確定済み。ADR を 1 本起票する（`ADR-20260729-d8c`）。

## 設計判断

### 採用する方式（イシューの A / B / C）

- A. `push` トリガーの追加（事後検知）
- B. required status checks の strict 化（事前防止）
- C. merge queue
- **選択: A + B の併用**。守る対象が異なるため排他ではない。B は「PR 経由の stale マージ」を止めるが、develop がいま緑かという**状態そのもの**は持たない。A はその状態を持つ唯一の手段で、事前防止では代替できない。C は「複数人がマージを競う」ための機構であり、単独開発者 + Renovate という構成では直列化すべき競合が存在しないため規模に対して過剰。
- **投入順序は A → 実物で検証 → B**。B を先に入れると「B のせいで止まったのか CI が本当に壊れているのか」を切り分ける観測点が無いまま運用に入る。

### push トリガーの適用範囲

- A. `ci.yml` のみ
- B. `ci.yml` と `playwright.yml` の両方
- **選択: A（`ci.yml` のみ）**。理由は 3 つ。
  1. イシューが挙げる意味的衝突の例（export の削除・リネーム、Value Object のコンストラクタ引数追加、Prisma 必須カラム追加とファクトリ追随漏れ）はいずれも `static` / `test` の射程内で、E2E を毎マージ回す費用対効果が合わない。
  2. **E2E の flaky が A の中核価値を壊す**。A の価値は「develop が赤い ＝ 直近のマージが犯人」という attribution にあり、既知の非決定要因（単一 shard の全面 404 ＝ Next dev のスキャンレース）で develop が赤くなり始めると信号が腐って誰も見なくなる。`static` / `test` は決定的なのでこの汚染がない。
  3. `playwright` は required check ではない（#643 の判断）。PR 段階で保証していないものを push 側だけ厳格に見るのは非対称であり、これは「playwright を required に昇格させるか」という別の関心事に属する。
- develop の E2E 健全性を観測したくなった場合は、push ではなく nightly の `schedule` トリガーが適した器（flaky が attribution を壊さず、同時実行枠の競合も夜間に逃がせる）。**別 issue に切り出す**。

### push run の concurrency

- A. 現状の式（`group: ${{ github.workflow }}-${{ github.ref }}`）をそのまま push にも適用する
- B. `cancel-in-progress` を push のときだけ `false` にする
- C. push のときだけグループを commit（SHA）単位に分離する
- **選択: C**。

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
  cancel-in-progress: true
```

- A を採ると、連続マージ（Renovate の一斉マージなど）で最後の 1 commit 以外が `cancelled` になり verdict を失う。読み取れるのは「develop の HEAD が赤い」だけで犯人を特定できず、イシューが問題視した誤診をブランチ単位に移すだけになる。
- B は解決にならない。concurrency グループは「実行中 1 本 + 待機中 1 本」しか保持せず、3 本目が来た時点で待機中の 2 本目が捨てられる（GitHub ドキュメント: "any existing `pending` job or workflow in the same concurrency group will be canceled"）。
- **取り逃した verdict は回復不能**。`workflow_dispatch` は ref 指定でしか起動できず、任意の過去 SHA を後から検査する手段がない。
- C により全 commit に verdict が付き、commit 一覧で「緑 → 赤の境界」が犯人として一目で読める。実質的に `git bisect` を事前に全区間ぶん実行しているのと同じ。
- PR 側（`refs/pull/N/merge`）は従来どおり ref 単位のまま。PR で問われるのは HEAD が緑かだけで中間 commit の verdict に用は無いため、畳むのが正しい。

### push トリガーの branches と paths

- **`branches: [main, develop]`**。develop → main のリリースマージ後の状態も同じ理由で観測対象。
- **paths フィルタは付けない**。develop の HEAD が常に verdict を持つ状態を作るのが A の目的で、間引くと「最後に緑だったのは 3 コミット前」という読み取りにくい状態が生まれる。
- なお `ci.yml` が PR で paths を付けていない理由（required check が「起動しなかったジョブ」を待ち続ける）は push には当てはまらない。required checks は PR のマージ判定にしか使われないため。**push に paths を付けない理由は上記の別論拠による**。

### B の適用範囲

- A. `protect-develop` のみ
- B. `protect-develop` と `protect-main` の両方
- **選択: B（両方）**。
  - main は develop の**真の祖先**（`develop..main` = 0 commits、`main..develop` = 492 commits）であるため、develop → main の PR は定義上つねに最新を取り込み済みで、strict は現状 no-op として入る。
  - no-op でなくなる場面（main に hotfix が直接入り develop が stale になる）こそ機械に強制させたい場面であり、main が休眠中の今が最も安く入れられるタイミング。
  - 「develop は strict、main は非 strict」という非対称は半年後に誰も覚えておらず事故を生む。

### Renovate の rebaseWhen

- A. 既定の `"auto"` の自動検出に任せる
- B. `"behind-base-branch"` を明示する
- **選択: B（明示）**。
  - `auto` は「ブランチが最新であることを要求するリポジトリ」を検出して `behind-base-branch` に切り替わるが、この検出は classic branch protection 前提で作られており、**Rulesets での検出には既知の不具合報告がある**（[renovatebot/renovate discussion #38302](https://github.com/renovatebot/renovate/discussions/38302)）。このリポジトリは ruleset 運用。
  - 検出に失敗した場合の帰結が悪い。PR が stale のまま放置され、マージしようとして GitHub の "Update branch" を押すと、それは**ユーザー名義のコミットを PR ブランチに足す操作**であるため、Renovate の規則「If you push a new commit to a Renovate branch ... then Renovate stops all updates of that branch」（[Updating and Rebasing branches](https://docs.renovatebot.com/updating-rebasing/)）が発動し、**その PR は Renovate の管理から静かに外れる**。PR は残りマージもできるが以降更新されず、close するまで同じ依存の新しい PR も作られない。気づく手段が実質ない。
  - 明示すれば ruleset の実装詳細から切り離せる。`.nvmrc` を単一ソースにする（ADR-20260728-44b）、`DATABASE_URL` を三者一致させる、`db-unreachable.invalid` で「宣言された到達不能」にする（#643）と同じく、**推測される既定値ではなく宣言された値に依存する**という一貫した方針。
  - ruleset は GitHub 側にあってリポジトリからは見えないため、`renovate.json` のコメントで strict との対応関係を残す。
- **受け入れるコスト**: develop へ 1 マージするたび、Renovate の次回 run で open PR 全部が rebase され、`4 PR × (ci 2 job + playwright 7 job) = 36 job` が一斉起動する。1 日 2 マージで約 72 job/日。public リポジトリのため課金は無く、効くのは同時実行枠（20）のみ。実測して痛ければ `prConcurrentLimit` や schedule で**別 issue として**調整する。

### ロールアウト順序（rebaseWhen と strict 化）

- A. ruleset を strict 化 → `renovate.json` に `rebaseWhen` を明示
- B. `renovate.json` に `rebaseWhen` を明示 → ruleset を strict 化
- **選択: B**。A の順序では、strict 化から `renovate.json` のマージまでの間、Renovate の autodetect が ruleset を検出できるかに賭ける窓が開く。検出に失敗すれば PR は stale のまま放置され、"Update branch" を押した瞬間にその PR が Renovate 管理から静かに外れる。B の副作用は「strict でない期間に rebase の churn が先行する」だけで、壊れる方向の失敗が無い。**失敗したときに静かに壊れる側を後ろに置く**。

### 検証方法（イシューの作業項目 3）

- A. 使い捨ての 2 PR で本物の意味的衝突を再現し、develop を実際に赤くする
- B. 検証用ブランチを一時的に `push.branches` に足し、そこで壊す
- **選択: A**。
  - **そもそも「壊れた commit を develop に入れる」経路が他に無い**。自分自身が赤い PR は required checks（`static` / `test`）に阻まれてマージできず、直 push も「その SHA に緑の check が報告されていること」を要求されるが develop 以外では run が起動しないため条件を満たせない。**develop を壊す正当な経路は、イシューが問題視した「stale base の緑」しか残っていない** — 検証したいシナリオと実施できる唯一の手段が一致している。
  - 検証対象は「push トリガーが起動すること」ではなく、「stale base の緑でマージできる → develop が壊れる → 検知される → 犯人が一意に特定できる」という因果の連鎖全体。B はその前半を飛ばすため作業項目 3 の要件を満たさない。
  - 同じ材料を B の検証にそのまま再利用でき、「A で壊れる様子を見て、B で同じものが止まる様子を見る」という対になる。
  - `ci.yml` のコメントが主張する「`next build` は `*.test.ts` も型検査する（独立した `tsc --noEmit` を置かない根拠）」という賭けの実地検証にもなる。
- 材料は `src/server/__tests__/helpers/` 配下のテスト専用モジュール（本番コードに一切触れずに衝突を作れる）。
- デプロイ連携が無い（`deployments` 0 件 / `environments` 0 件）ため、develop が一時的に赤くなる実害はほぼゼロ。
- 後始末は revert PR で行う（`non_fast_forward` ルールにより force push で戻す経路は塞がれている）。

### develop が壊れたことの検知手段

- A. GitHub Actions の既定のメール通知に任せる
- B. 失敗時に issue を自動起票する等の能動通知を足す
- **選択: A**。
  - B は `issues: write` を要求し、`ci.yml` の `permissions: contents: read` を開くことになる。これは #643 が明示的な理由で閉じた設計（「`pnpm install` で `onlyBuiltDependencies` のビルドスクリプトを実行するため、書き込み権限付きトークンを同じ run に置かないことに意味がある」）であり、Renovate PR を検査する CI で書き込みトークンと未検証の依存のビルドスクリプトを同居させることになる。通知の便宜のために攻撃面を広げるのは割に合わない。
  - 既定通知は「自分が actor になったワークフローの失敗のみ」を通知する。PR をマージすると develop への push の actor はマージ実行者になるため、単独開発の本リポジトリでは通知先と当事者が常に一致する。
  - ユーザー側のアカウント設定はリポジトリからは確認できないため、**Step 4 の検証で実際に届くかを確認する**。届かなければ本 issue のスコープを広げず別 issue に切り出す。

### ADR の起票

- **起票する**（`ADR-20260729-d8c`）。3 条件のうち特に「文脈なしでは驚く」と「本物のトレードオフの結果」に強く該当する。
  - `group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}` は concurrency の常識（同一グループで畳む）と真逆に見える。
  - **決定が GitHub 側の ruleset・`renovate.json`・`ci.yml` の 3 箇所にまたがる**。ruleset はリポジトリの外にありコメントを書けないため、「strict と `rebaseWhen: behind-base-branch` は対である」という対応関係を書ける場所が ADR しかない。
  - CI に関する ADR の先例がある（ADR-20260727-55f / ADR-20260728-44b）。

### CONTEXT.md の扱い

- **更新しない**。`CONTEXT.md` は見積管理の業務ドメイン用語集（取引先・複製・改訂 等）であり、CI の語彙（意味的衝突、stale base）は住所が違う。用語集を「その他の決定事項置き場」にすると用語集として死ぬ。

### #643 の記述訂正

`docs/claude-plans/issue-643/add-pr-ci-workflow-with-db-unreachable-build.md` に、develop への直 push が不可能な理由として「CI に `push` トリガーが無い（#656）ため、直接 push されたコミットには checks が存在せず条件を満たせない」と記録されている。この理由づけは A を入れると陳腐化する（「push トリガーが付けば直 push が復活するのか」という誤読を招く）。

**結論は変わらない**（直 push は依然不可能）。本質はトリガーの有無ではなく**評価順序**であり、ruleset の required status checks は push を受け付ける**前**に評価されるため、push が拒否される → workflow が起動しない → checks が永久に付かない、というニワトリ卵になる。この訂正を `docs/claude-plans/issue-643/deviations.md` に追記する。

## ステップ

### Step 1: ci.yml に push トリガーと commit 単位の concurrency を追加する

- [x] **完了**
- 対象ファイル: `.github/workflows/ci.yml`
- テスト戦略: テスト不要（設定ファイル）
- 作業内容:
  - `on:` に `push: branches: [main, develop]` を追加する（paths フィルタは付けない）
  - `concurrency.group` を `${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}` に変更する
  - 意図コメントを残す:
    - push に paths を付けない理由（develop の HEAD が常に verdict を持つ状態を作る）
    - push だけ SHA 単位にする理由（連続マージで verdict を失うと犯人特定ができない／`workflow_dispatch` は ref 指定のため過去 SHA を後から検査できない／グループは実行中 1 + 待機中 1 しか保持しない）
    - PR 側を ref 単位のままにする理由
    - `playwright.yml` に push を付けない理由（→ ADR-20260729-d8c）
- コミットメッセージ: `ci: develop / main への push で CI を実行する`

### Step 2: ADR を起票し INDEX に追記する

- [x] **完了**
- 対象ファイル: `docs/adr/20260729-d8c-detect-and-prevent-stale-base-merges.md`（新規）、`docs/adr/INDEX.md`
- テスト戦略: テスト不要（ドキュメント）
- 作業内容:
  - `docs/adr/TEMPLATE.md` に従って ADR を作成する。タイトルは「マージ後の検査を push トリガーで観測し、strict required status checks で stale マージを防ぐ」
  - 検討した選択肢として A / B / C を記載し、C の不採用理由（規模に対して過剰）を残す
  - 決定として、A + B の併用、`ci.yml` のみへの push、SHA 単位 concurrency、両 ruleset の strict 化、`rebaseWhen: behind-base-branch` の明示を記載する
  - **ruleset・`renovate.json`・`ci.yml` の 3 箇所にまたがる対応関係**を明記する（ADR の主要な存在理由）
  - ロールアウト節に、本 ADR 起票時点では Step 6 / Step 7 が未適用であることを記す
  - `docs/adr/INDEX.md` の適切なカテゴリ見出しに 1 行追記する
- コミットメッセージ: `docs: マージ後検査と stale マージ防止の ADR を追加する`

### Step 3: #643 の「直 push 不可」の理由を訂正する

- [x] **完了**
- 対象ファイル: `docs/claude-plans/issue-643/deviations.md`
- テスト戦略: テスト不要（ドキュメント）
- 作業内容:
  - #643 の計画が記録した理由（push トリガーが無いため checks が存在しない）が本 issue の A によって陳腐化すること、および結論（直 push は不可）は変わらないことを追記する
  - 本質が「required status checks は push 受理の**前**に評価される」という評価順序であることを記す
- コミットメッセージ: `docs: issue-643 の「直 push 不可」の理由を訂正する`

> ここまでを 1 本の PR としてマージし、develop の push run が緑で起動することを疎通確認する。

### Step 4: 検証 A — 使い捨て 2 PR で意味的衝突を起こし、検知を確認する

- [ ] **完了**
- 対象ファイル: `src/server/__tests__/helpers/` 配下（使い捨て）
- テスト戦略: テスト不要（CI 実地検証）
- 作業内容:
  - PR X: helper の export を 1 つリネームし、既存参照もすべて追随させる（X 単体の CI が緑になることを確認）
  - PR X をマージし、develop の push run が緑になることを確認する
  - PR Y: **X 以前の develop を base に**、旧名を import する `*.test.ts` を新規追加する（Y 単体の CI が緑になることを確認）
  - PR Y をマージする（PR の check は古い base のまま緑なのでマージできる ＝ イシューが問題視した経路そのもの）
  - 確認項目:
    - [ ] develop の push run が赤くなる
    - [ ] commit 一覧に「緑 → 赤」の境界が現れ、Y が犯人として一意に読める
    - [ ] `static` ジョブで落ちる（＝ `next build` が `*.test.ts` も型検査しているという `ci.yml` の前提の実地確認）
    - [ ] **失敗通知が実際にメールで届く**（届かない場合は本 issue のスコープを広げず別 issue に切り出す）
- コミットメッセージ: 使い捨て PR 側のため計画対象外（`test:` 型で任意）

### Step 5: 検証で壊した状態を revert する

- [ ] **完了**
- 対象ファイル: Step 4 で変更したファイル
- テスト戦略: テスト不要（CI 実地検証）
- 作業内容:
  - Y と X をまとめて revert する PR を作成しマージする（`non_fast_forward` により force push で戻す経路は無い）
  - develop の push run が緑に戻ることを確認する
- コミットメッセージ: `revert: CI 検証用の変更を戻す`

### Step 6: renovate.json に rebaseWhen を明示する

- [ ] **完了**
- 対象ファイル: `renovate.json`
- テスト戦略: テスト不要（設定ファイル）
- 作業内容:
  - トップレベルに `"rebaseWhen": "behind-base-branch"` を追加する
  - `description` ないしコメントで、両 ruleset の `strict_required_status_checks_policy: true` と対であること、`auto` の自動検出が Rulesets では信頼できないこと、"Update branch" を人間が押すと Renovate がそのブランチの管理を放棄することを記す
- コミットメッセージ: `ci: renovate の rebaseWhen を behind-base-branch に明示する`

> **Step 7 より必ず先にマージすること。** 逆順は「失敗したときに静かに壊れる」側を先に置くことになる。

### Step 7: 両 ruleset の required status checks を strict 化する

- [ ] **完了**
- 対象ファイル: なし（GitHub API 操作、リポジトリ外）
- テスト戦略: テスト不要（リポジトリ外の設定変更）
- 作業内容:
  - `gh api` で `protect-develop`（id: 12978563）と `protect-main`（id: 12978605）の `required_status_checks` に `strict_required_status_checks_policy: true` を設定する
  - `required_status_checks` の中身（`static` / `test`）と他のルール（`deletion` / `non_fast_forward` / `pull_request`）は変更しない
  - 適用後、両 ruleset を読み直して差分が意図どおりであることを確認する
- コミットメッセージ: なし（リポジトリに変更が生じないため）

### Step 8: 検証 B — 同じ操作が事前に阻止されることを確認する

- [ ] **完了**
- 対象ファイル: `src/server/__tests__/helpers/` 配下（使い捨て）
- テスト戦略: テスト不要（CI 実地検証）
- 作業内容:
  - Step 4 と同じ材料で PR X' / Y' を作り直す
  - 確認項目:
    - [ ] X' をマージした後、Y' のマージが "This branch is out-of-date with the base branch" で**止まる**
    - [ ] Y' で "Update branch" を実行すると CI が再実行され、今度は **PR 段階で赤くなる**（事後検知が事前防止に変わったことの確認）
  - X' / Y' は close し、develop に何も残さない（X' をマージしていた場合は revert する）
- コミットメッセージ: 使い捨て PR 側のため計画対象外

### Step 9: イシューをクローズし、派生 issue を起票する

- [ ] **完了**
- 対象ファイル: なし
- テスト戦略: テスト不要（ドキュメント作業）
- 作業内容:
  - #656 に検証結果（Step 4 / Step 8 の確認項目）を追記してクローズする
  - 派生として別 issue に切り出す:
    - rebase churn（1 日約 72 job）の実測と、痛い場合の `prConcurrentLimit` / schedule 調整
    - develop の E2E 健全性を nightly `schedule` で観測するかの検討
- コミットメッセージ: なし

</details>

## 計画からの逸脱

Step 1〜3 は計画どおりに実装した。特筆すべき逸脱はない（Step 4 以降は未着手のため、この PR の時点では逸脱記録も無い）。

---

Generated with [Claude Code](https://claude.ai/code)
