### PR TITLE
test: フィクスチャ単価定数に円単位であることを名前で示す

### DIFF
--- a/src/server/__tests__/helpers/ensureEstimateFixtures.ts
+++ b/src/server/__tests__/helpers/ensureEstimateFixtures.ts
@@ -10,7 +10,7 @@ import { ensureCommonSellingPrice } from "./sellingPriceScenario";
  * 入力ではなく販売単価マスタから解決されるため、種として作る見積の明細商品に単価が必要になる。
  * 全テストファイルで共有するため単一の値に固定する（金額を検証するテストは専用商品を用意すること）。
  */
-export const FIXTURE_PRODUCT_UNIT_PRICE = 1000;
+export const FIXTURE_PRODUCT_UNIT_PRICE_YEN = 1000;
 
 /**
  * 見積集約の永続化テストに必要な FK マスタ（部署・作成者従業員・得意先・納品先・商品）を
@@ -102,7 +102,7 @@ export async function ensureEstimateFixtures(): Promise<EstimateFixtureIds> {
 
   // 明細商品（productId）に正準の共通販売単価を用意する（#430。単価はマスタから解決される）。
   // セット商品（setProductId）は自前の売単価を持てず、構成明細は productId を使うためここで足りる。
-  await ensureCommonSellingPrice(product.id, { yen: FIXTURE_PRODUCT_UNIT_PRICE });
+  await ensureCommonSellingPrice(product.id, { yen: FIXTURE_PRODUCT_UNIT_PRICE_YEN });
 
   return {
     departmentId,

--- a/src/server/subdomains/estimate/application/commands/__tests__/DuplicateEstimateCommand.test.ts
+++ b/src/server/subdomains/estimate/application/commands/__tests__/DuplicateEstimateCommand.test.ts
@@ -1,6 +1,6 @@
 import {
   ensureEstimateFixtures,
-  FIXTURE_PRODUCT_UNIT_PRICE,
+  FIXTURE_PRODUCT_UNIT_PRICE_YEN,
   type EstimateFixtureIds,
 } from "@server/__tests__/helpers/ensureEstimateFixtures";
 import prisma from "@server/prisma";
@@ -104,7 +104,7 @@ describe("DuplicateEstimateCommand", () => {
       taxRoundingType: TaxRoundingType.ROUND_DOWN,
       createdBy: new EmployeeId(ids.employeeId),
       departmentId: new DepartmentId(ids.departmentId),
-      // 単価はマスタ（FIXTURE_PRODUCT_UNIT_PRICE=1000）と異なる値にし、複製先で再解決されることを観測可能にする
+      // 単価はマスタ（FIXTURE_PRODUCT_UNIT_PRICE_YEN=1000）と異なる値にし、複製先で再解決されることを観測可能にする
       variations: [variation(1, "商品A", 777), variation(2, "商品B", 555)],
     });
   }
@@ -140,11 +140,11 @@ describe("DuplicateEstimateCommand", () => {
     expect(result.estimateType.value).toBe("NEW");
 
     // 選択順を保持し連番に振り直し、単価は複製先条件で価格決定により再解決される（複製元の 555 を
-    // 引き継がず、マスタの FIXTURE_PRODUCT_UNIT_PRICE に解決される・#431）
+    // 引き継がず、マスタの FIXTURE_PRODUCT_UNIT_PRICE_YEN に解決される・#431）
     expect(result.variations).toHaveLength(2);
     expect(result.variations[0].variationNumber).toBe(1);
     expect(result.variations[0].items[0].itemName.value).toBe("商品B");
-    expect(result.variations[0].items[0].unitPrice.majorUnits).toBe(FIXTURE_PRODUCT_UNIT_PRICE);
+    expect(result.variations[0].items[0].unitPrice.majorUnits).toBe(FIXTURE_PRODUCT_UNIT_PRICE_YEN);
 
     // 系譜が選択順で保存される
     const copyRows = await prisma.estimateVariationCopy.findMany({


### PR DESCRIPTION
## 概要

`FIXTURE_PRODUCT_UNIT_PRICE` → `FIXTURE_PRODUCT_UNIT_PRICE_YEN` にリネームし、既存参照 2 ファイルをすべて追随させた。

> [!WARNING]
> **#656 の Step 4（検証 A）のための使い捨て PR です。** マージ後、PR Y（#656 の意味的衝突を再現する側）とあわせて revert します。単体では正当な変更ですが、恒久的に残す意図はありません。

## 検証で果たす役割

この PR は「意味的衝突」の**片側**にあたる。もう一方（旧名を import する新規テストを足す PR）は本 PR と**同じ base から分岐**しており、本 PR がマージされても checks が再実行されない。その結果、両方とも緑のままマージでき、develop で初めて壊れる。

これは #656 が問題視した経路そのものであり、`push` トリガーがそれを検知できることを実地で確認するための材料。

Refs #656