### PR TITLE
test: フィクスチャ商品の正準単価が固定されていることを検証する

### DIFF
--- a/src/server/__tests__/helpers/__tests__/ensureEstimateFixtures.test.ts
+++ b/src/server/__tests__/helpers/__tests__/ensureEstimateFixtures.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { FIXTURE_PRODUCT_UNIT_PRICE } from "../ensureEstimateFixtures";
+
+/**
+ * フィクスチャ商品の正準単価は全テストファイルで共有される定数であり、金額を検証する
+ * テストは「この値と異なる値」を意図的に作って観測可能性を確保している
+ * （例: DuplicateEstimateCommand.test.ts の複製時再解決）。
+ * 値が黙って変わると、それらのテストが「異なる値」を作れているつもりのまま同値になり、
+ * 検証が空振りする。定数そのものを固定して、変更を必ず此処で顕在化させる。
+ */
+describe("ensureEstimateFixtures の正準単価", () => {
+  it("フィクスチャ商品の共通販売単価は 1000 円に固定されている", () => {
+    expect(FIXTURE_PRODUCT_UNIT_PRICE).toBe(1000);
+  });
+});


### PR DESCRIPTION
## 概要

`FIXTURE_PRODUCT_UNIT_PRICE` が 1000 に固定されていることを検証するテストを追加した。

> [!WARNING]
> **#656 の Step 4（検証 A）のための使い捨て PR です。** マージすると develop が壊れます。これは意図された結果で、直後に PR X（#675）とあわせて revert します。

## 検証で果たす役割

本 PR は #675 と**同じ base（`297617fa`）から分岐**している。#675 は同じ定数をリネームするため、両者を順にマージすると develop で参照が解決しなくなる。

git はこれをテキスト衝突として検出しない（触っているファイルが違う）。そして本 PR の checks は #675 のマージ後も再実行されないため、**古い base に対する緑のまま**マージできてしまう。

確認したいのは以下:

- [ ] #675 マージ後も本 PR の checks が緑のままで、マージが許可される（＝ #656 が問題視した経路）
- [ ] マージ後、develop の `push` run が赤くなる
- [ ] commit 一覧に「緑 → 赤」の境界が現れ、本 PR が犯人として一意に読める
- [ ] `static` ジョブで落ちる（＝ `next build` が `*.test.ts` も型検査するという `ci.yml` の前提の実地確認）

Refs #656