### PR TITLE
test: フィクスチャ商品の正準単価が固定されていることを検証する（#656 検証 B / Y')

### DIFF
--- a/src/server/__tests__/helpers/__tests__/ensureEstimateFixtures.test.ts
+++ b/src/server/__tests__/helpers/__tests__/ensureEstimateFixtures.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { FIXTURE_PRODUCT_UNIT_PRICE } from "../ensureEstimateFixtures";
+
+describe("ensureEstimateFixtures の正準単価", () => {
+  it("フィクスチャ商品の共通販売単価は 1000 円に固定されている", () => {
+    expect(FIXTURE_PRODUCT_UNIT_PRICE).toBe(1000);
+  });
+});


### PR DESCRIPTION
#656 Step 8（検証 B）の使い捨て PR。**マージせず close する。**

Y' 側。X' と**同じ base（`54ace5f4`）から分岐**し、旧名 `FIXTURE_PRODUCT_UNIT_PRICE` を import する新しいテストを足した。単体では緑。

X' をマージした後、この PR が strict により "This branch is out-of-date with the base branch" で止まること、"Update branch" 後に PR 段階で赤くなることを確認する。