### PR TITLE
ci: 両 ruleset の required status checks を strict 化する（#656 Step 7 / 8）

### DIFF
--- a/docs/adr/20260729-d8c-detect-and-prevent-stale-base-merges.md
+++ b/docs/adr/20260729-d8c-detect-and-prevent-stale-base-merges.md
@@ -161,13 +161,15 @@ no-op でなくなるのは、main に hotfix が直接入って develop → mai
 
 本 ADR は決定の全体を記述しているが、**起票時点で適用済みなのは A のみ**である。3 箇所のうち 2 箇所は未適用の状態でこの ADR がマージされる。
 
-| 箇所 | 起票時点 |
-|---|---|
-| `ci.yml` の `push` トリガー ＋ SHA 単位 concurrency | 適用済み（本 ADR と同じ PR） |
-| `renovate.json` の `rebaseWhen` | **未適用** |
-| 両 ruleset の `strict_required_status_checks_policy` | **未適用**（`false` のまま） |
+| 箇所 | 起票時点 | 2026-07-29 現在 |
+|---|---|---|
+| `ci.yml` の `push` トリガー ＋ SHA 単位 concurrency | 適用済み（本 ADR と同じ PR） | 適用済み |
+| `renovate.json` の `rebaseWhen` | **未適用** | 適用済み（#679） |
+| 両 ruleset の `strict_required_status_checks_policy` | **未適用**（`false` のまま） | 適用済み（`true`） |
 
 順序は「A →実物で検証→ `rebaseWhen` → strict 化」であり、間に検証を挟むため同一 PR にはならない。進捗は `docs/claude-plans/issue-656/` を参照。**ruleset の実際の値は `gh api repos/:owner/:repo/rulesets/12978563` で確認できる** — この ADR の記述ではなく、そちらが正本である。
+
+strict 化の適用直後、base が develop の open PR 4 件（Renovate）はいずれも `mergeable=MERGEABLE`（git 的な競合なし）のまま `mergeStateStatus=BEHIND`（マージ不可）へ変化した。この組み合わせが本 ADR の対象そのものであり、strict 化前は同じ 4 件が `CLEAN` としてマージ可能だった。
 
 ## 影響
 

--- a/docs/adr/20260729-d8c-detect-and-prevent-stale-base-merges.md
+++ b/docs/adr/20260729-d8c-detect-and-prevent-stale-base-merges.md
@@ -171,6 +171,8 @@ no-op でなくなるのは、main に hotfix が直接入って develop → mai
 
 strict 化の適用直後、base が develop の open PR 4 件（Renovate）はいずれも `mergeable=MERGEABLE`（git 的な競合なし）のまま `mergeStateStatus=BEHIND`（マージ不可）へ変化した。この組み合わせが本 ADR の対象そのものであり、strict 化前は同じ 4 件が `CLEAN` としてマージ可能だった。
 
+**A と B は同じ材料で前後を比較して検証してある**（#656 の Step 4 / Step 8）。同一の意味的衝突（export のリネームと旧名を import する新規テスト、同じ base から分岐した 2 PR）を strict 化の前後で流したところ、前は Y がマージできて develop が赤くなり（A が検知した）、後は Y のマージが `the head branch is not up to date with the base branch` で止まり、"Update branch" 後に PR 段階で `test` が赤くなった（B が防いだ）。**両方とも「Y の checks は緑のまま再実行されない」という同じ入力に対する結果である。**
+
 ## 影響
 
 - **develop が赤いことがあり得る状態になる。** これまで develop の CI 状態は「存在しない」だったが、以後は緑か赤のどちらかになる。デプロイ連携は無い（`deployments` / `environments` ともに 0 件）ため、赤が直ちに何かを止めることはない。

--- a/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
+++ b/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
@@ -227,16 +227,31 @@ concurrency:
 
 ### Step 8: 検証 B — 同じ操作が事前に阻止されることを確認する
 
-- [ ] **完了**
+- [x] **完了**
 - 対象ファイル: `src/server/__tests__/helpers/` 配下（使い捨て）
 - テスト戦略: テスト不要（CI 実地検証）
 - 作業内容:
   - Step 4 と同じ材料で PR X' / Y' を作り直す
   - 確認項目:
-    - [ ] X' をマージした後、Y' のマージが "This branch is out-of-date with the base branch" で**止まる**
-    - [ ] Y' で "Update branch" を実行すると CI が再実行され、今度は **PR 段階で赤くなる**（事後検知が事前防止に変わったことの確認）。赤くなるのは `test` ジョブである（`static` ではない。理由は `deviations.md` 逸脱 1）
+    - [x] X' をマージした後、Y' のマージが "This branch is out-of-date with the base branch" で**止まる**
+    - [x] Y' で "Update branch" を実行すると CI が再実行され、今度は **PR 段階で赤くなる**（事後検知が事前防止に変わったことの確認）。赤くなるのは `test` ジョブである（`static` ではない。理由は `deviations.md` 逸脱 1）
   - X' / Y' は close し、develop に何も残さない（X' をマージしていた場合は revert する）
 - コミットメッセージ: 使い捨て PR 側のため計画対象外
+- 実施結果（2026-07-29）:
+
+  | 項目 | 検証 A（strict 化前 / Step 4） | 検証 B（strict 化後 / Step 8） |
+  |---|---|---|
+  | 使い捨て PR | X=#675 / Y=#676 | X'=#680 / Y'=#681 |
+  | 両者の base | `297617fa`（共通） | `54ace5f4`（共通） |
+  | X マージ後の Y の checks | 再実行されず緑のまま | **同左**（run 30415795519 のまま） |
+  | X マージ後の Y の状態 | `MERGEABLE` / `CLEAN` | `MERGEABLE` / **`BEHIND`** |
+  | Y のマージ | **通った** → develop が赤化 | **拒否**（`the head branch is not up to date with the base branch`） |
+  | develop の verdict | `f500a1a2` = failure | **一度も赤くならず**（`742cc824` = success） |
+
+  - **確認項目 1**: Y'(#681) は checks が緑のまま `BEHIND` になり、`gh pr merge 681 --squash` が `the head branch is not up to date with the base branch` で拒否された（Web UI の "This branch is out-of-date with the base branch" と同じ判定）。**検証 A とまったく同じ入力に対して、結果だけが反転した**
+  - **確認項目 2**: "Update branch"（`PUT /repos/:owner/:repo/pulls/681/update-branch`）後に CI が新しい run（30415980679）で再実行され、`static` = pass / `test` = fail。失敗内容は `AssertionError: expected undefined to be 1000`（`ensureEstimateFixtures.test.ts:7`）。予測どおり `test` 側で捕まった
+  - 失敗が `undefined` として現れる点は題材の性質による。存在しない named export は TypeScript なら TS2724 だが、Vite/esbuild は型を捨てて実行するため実行時に `undefined` になる。**本番コードだけが壊れる意味的衝突は現状どのジョブも捕まえられない**ため、#678（独立した型検査の復活）の優先度を裏づける材料になる
+  - 後始末: Y'(#681) は close、X'(#680) は #682 で revert 済み。develop（`e8f4f737`）は検証前と同じ内容に戻っている
 
 ### Step 9: イシューをクローズし、派生 issue を起票する
 

--- a/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
+++ b/docs/claude-plans/issue-656/push-trigger-and-strict-required-status-checks.md
@@ -212,7 +212,7 @@ concurrency:
 
 ### Step 7: 両 ruleset の required status checks を strict 化する
 
-- [ ] **完了**
+- [x] **完了**
 - 対象ファイル: なし（GitHub API 操作、リポジトリ外）
 - テスト戦略: テスト不要（リポジトリ外の設定変更）
 - 作業内容:
@@ -220,6 +220,10 @@ concurrency:
   - `required_status_checks` の中身（`static` / `test`）と他のルール（`deletion` / `non_fast_forward` / `pull_request`）は変更しない
   - 適用後、両 ruleset を読み直して差分が意図どおりであることを確認する
 - コミットメッセージ: なし（リポジトリに変更が生じないため）
+- 実施結果（2026-07-29）:
+  - 適用前に現在の ruleset を `gh api` で取得し、`jq` で `strict_required_status_checks_policy` のみを書き換えて PUT した（手打ちの転記ミスを避けるため）。`name` / `target` / `enforcement` / `conditions` / `bypass_actors` も現在値を明示して送っている（PUT が省略フィールドをどう扱うかを保証に頼らないため）
+  - 適用後に再取得して差分を取り、**両 ruleset とも変更は当該 1 行のみ**であることを確認した
+  - 適用直後、base が develop の open PR 4 件（#670 / #671 / #672 / #673、いずれも Renovate）が `mergeable=MERGEABLE` のまま `mergeStateStatus=BEHIND` へ変化した。strict が実際に効いていることの直接の証拠であり、Step 8 の題材を作る前に確認できた
 
 ### Step 8: 検証 B — 同じ操作が事前に阻止されることを確認する
 


### PR DESCRIPTION
#656 の Step 7（strict 化の適用）と Step 8（検証 B）の記録。GitHub 側の設定変更のため、リポジトリの差分はドキュメントのみ。

## Step 7: strict 化の適用

| ruleset | id | 変更 |
|---|---|---|
| `protect-develop` | 12978563 | `strict_required_status_checks_policy: false → true` |
| `protect-main` | 12978605 | 同上 |

適用前後の JSON を diff で突き合わせ、**変更が当該 1 行のみ**であることを確認済み（`required_status_checks` の中身・`deletion` / `non_fast_forward` / `pull_request`・`conditions` / `bypass_actors` は不変）。

## Step 8: 検証 B

同じ材料を strict 化の前後で流し、結果が反転することを確認した。

| 項目 | 検証 A（strict 前） | 検証 B（strict 後） |
|---|---|---|
| X マージ後の Y の checks | 再実行されず緑のまま | 同左 |
| X マージ後の Y の状態 | `MERGEABLE` / `CLEAN` | `MERGEABLE` / **`BEHIND`** |
| Y のマージ | **通った** → develop 赤化 | **拒否** |
| develop の verdict | `f500a1a2` = failure | 一度も赤くならず |

"Update branch" 後は CI が再実行され `test` が `AssertionError: expected undefined to be 1000` で失敗（`static` は緑）。

使い捨て PR は #680（revert 済み: #682）/ #681（close 済み）。develop は検証前と同じ内容に戻っている。

残るは Step 9（#656 のクローズと派生 issue の起票）。