### PR TITLE
ci: rangeStrategy を bump から pin へ移行する（d3b D2 の改訂、config:js-app 採用）

### DIFF
--- a/docs/adr/20260726-d3b-adopt-renovate-with-approval-and-two-layer-cooldown.md
+++ b/docs/adr/20260726-d3b-adopt-renovate-with-approval-and-two-layer-cooldown.md
@@ -96,6 +96,9 @@ Renovate の運用負荷が見合わないと判断した場合には再検討�
 
 代償として、minor/patch 更新のたびに `package.json` に差分が出る。複数 PR が同時に開いているとリベース衝突が増えるため、`prConcurrentLimit: 3` とグルーピングで抑制する。
 
+> **改訂（2026-07-30 / #697 → ADR-20260730-aan）**
+> `bump` を `pin` へ移行した。`extends` の `config:recommended` を `config:js-app`（= `config:recommended` + `:pinAllExceptPeerDependencies`）に置き換え、トップレベルの `rangeStrategy` は削除した（pin はプリセットの packageRules 由来で、トップレベルに書いても効かない dead config になるため。D6 と同型の性質）。上記の「ESM はアプリでありレンジを開けておく動機がない」という前提から一歩進め、下限を追随させるのではなくレンジ宣言自体を廃止する。あわせて、`auto`（`update-lockfile`）を退けた理由——D4 の `lockFileMaintenance` との PR 重複——は pin では in-range 更新の概念ごと消えるため構造的に発生しない。むしろ `lockFileMaintenance` が動かせる対象が推移的依存のみに狭まり、D4 のリスク管理は強化される。
+
 ### D3. cooldown を二層で設定する
 
 `security:minimumReleaseAgeNpm`（Renovate 側・3 日）と `pnpm-workspace.yaml` の `minimumReleaseAge: 4320`（pnpm 側・3 日）を併用する。

--- a/docs/adr/20260730-aan-migrate-range-strategy-to-pin-with-js-app.md
+++ b/docs/adr/20260730-aan-migrate-range-strategy-to-pin-with-js-app.md
@@ -1,0 +1,110 @@
+# ADR-20260730-aan: rangeStrategy を bump から pin へ移行し、config:js-app を採用する
+
+| 項目 | 値 |
+|------|-----|
+| ステータス | 採用 |
+| 起票日 | 2026-07-30 |
+| 最終更新日 | 2026-07-30 |
+
+## コンテキスト
+
+ADR-20260726-d3b の D2 は `rangeStrategy: "bump"` を選んだ。動機は「`^4` `^9` のようなメジャーのみのレンジ宣言からは実際に何が入っているか読み取れない」という乖離の解消であり、`bump` は in-range 更新のたびに `package.json` の下限を実バージョンへ引き上げることでこれに応えていた。
+
+しかしこの選択は、問題を「レンジの下限が古い」と定式化したうえでの対処である。ESM はライブラリではなくアプリであり、`package.json` のレンジを読む consumer は存在しない。**下限を正確に保つべきレンジ宣言そのものに読み手がいない**のなら、下限を追随させるのではなくレンジ自体を廃止する（= `pin`）方が問題の定式化として正しい。d3b D2 自身が「ESM はアプリであり consumer に対してレンジを広く開けておく動機がない」と書いており、その前提から `pin` は一歩先の結論として自然に導かれる。
+
+ADR-20260730-0b6 は `rangeStrategy` を明示的にスコープ外とし、pin への移行を #697 に委ねた。本 ADR がそれに応える。
+
+判断に先立ち、Renovate 本体のソース（`lib/config/presets/internal/config.preset.ts` / `default.preset.ts`）を実測した。
+
+1. **`config:js-app` = `config:recommended` + `:pinAllExceptPeerDependencies`** の完全上位互換である（`config:js-app` の定義は `extends: ['config:recommended', ':pinAllExceptPeerDependencies']` そのもの）
+2. **`:pinAllExceptPeerDependencies` は packageRules ベース**である。`matchPackageNames: ['*']` → `rangeStrategy: 'pin'` と、`matchDepTypes: ['engines', 'peerDependencies']` → `rangeStrategy: 'auto'` の 2 本で構成される
+3. したがって pin は**トップレベル `rangeStrategy` より常に優先される**。packageRules がトップレベル設定に勝つのは d3b D6 の `semanticCommitType` で既に踏んだ性質と同型である
+
+## 検討した選択肢
+
+### A. `config:recommended` を `config:js-app` に置き換える（採用）
+
+`extends` の先頭を差し替えるだけ。後続 3 エントリ（`security:minimumReleaseAgeNpm` / `:semanticCommitTypeAll(chore)` / `:maintainLockFilesMonthly`）は変更しない。
+
+### B. `config:recommended` を残し `:pinAllExceptPeerDependencies` を追加する（不採用）
+
+実測のとおり両案の実効設定は完全に同一であり、機能差はない。それでも A を採るのは次の理由による。
+
+- `config:js-app` という名前自体が「このリポジトリはアプリである」という意図の宣言であり、Issue の動機（consumer のいないレンジをやめる）をそのまま表現する。B は同じ設定を機構の羅列として書くだけで、なぜそうするのかが設定から読み取れない
+- 0b6 は `group:monorepos` の明記を「`config:recommended` に内蔵されているのに書いている二重 extend」として削除した。B は内蔵プリセットを外から足し直す形になり、この方針と逆行する
+- `config:js-app` は後続 3 プリセットとオプション単位で交差しない（`rangeStrategy` を触るのは js-app 側だけ）ため、新たな順序依存は生まれない
+
+### トップレベル `rangeStrategy: "bump"` の始末
+
+- **A. 単純削除し、機構を `description` に記録する（採用）**
+- B. `"pin"` に書き換えて明示する（不採用）
+
+B は一見「設定を読めば pin だと分かる」利点があるように見えるが、実際には**書いても効かない dead config** になる。pin はプリセットの packageRules 由来であり、トップレベル設定は packageRules に負けるためである。仮にプリセット側が pin をやめても、トップレベルの `"pin"` は勝てないので保険にもならない。さらに `matchPackageNames: ['*']` が全パッケージにマッチするため、「プリセットのルールにマッチせずトップレベルへフォールバックする依存」も存在しない。効かない値を書いて読み手を誤解させるより、削除して機構を `description` に記録する方が正確である（0b6 のプリセット委譲方針とも一貫する）。
+
+### 初回の一斉 Pin PR の取り込み方
+
+- **A. Renovate に Pin PR を生成させ、`dependencyDashboardApproval` をタイミング制御装置として使う（採用）**
+- B. config PR に手動 pin（`package.json` の exact 化）を同梱し、アトミックに済ませる（不採用）
+
+B は「config は pin だが宣言はまだレンジ」という中間状態を作らない点が魅力だが、直接依存 50 件超を手編集することになりミスの余地が大きく、Renovate が用意している機構と Dashboard での動作観察の機会を捨てることになる。そして中間状態のリスク自体が実は存在しない——全更新が承認制であるため、承認するまで副作用はゼロであり、実質的な窓が開かない。
+
+## 決定
+
+**A を採用する。** `extends` の `config:recommended` を `config:js-app` に置き換え、トップレベルの `"rangeStrategy": "bump"` を削除する。設定の全文は `renovate.json` を正とする。
+
+これにより ADR-20260726-d3b の **D2 を改訂する**（同 ADR の D2 セクションに追い注記済み）。D1・D3〜D7 は変更しない。
+
+### 初回 Pin PR の取り込み手順
+
+1. config PR マージ後、次回ジョブで Dashboard の Pending Approval に「Pin Dependencies」が現れる（updateType `pin` の既定 `groupName: 'Pin Dependencies'` により 1 本に束なる。`dependencyDashboardApproval` が効くため承認まで何も起きない）
+2. 承認して Pin PR を作らせ、**他のどの依存更新 PR よりも先に**マージする
+3. 検証: pin はロックファイルに既に入っているバージョンへの固定であり、実体は動かない。`pnpm-lock.yaml` の diff が specifier 行のみ（resolved バージョン不変）であること + CI 通過を確認する
+4. 以降の依存 PR は `rebaseWhen: behind-base-branch` により自動 rebase される（手当て不要）
+
+**適用タイミング条件**: config PR のマージは Dependency Dashboard 上にオープン中の Renovate PR がないタイミングで行う。pin 化で既存 PR ブランチが全面書き換えになるためで、#696（0b6）でグループ名変更に対して課したのと同じ運用注意である。
+
+## 根拠
+
+### 読み手のいないレンジ宣言を維持するより、廃止する
+
+d3b D2 の問題意識は「宣言が実態を記述していない」だった。`bump` はこれを「下限を実バージョンに追随させる」ことで解いたが、追随させた下限を読む主体がいない。ESM は npm に公開されるライブラリではなく、`package.json` のレンジが意味を持つのはインストール解決の入力としてだけである。そしてその解決結果は `pnpm-lock.yaml` に固定されている。
+
+`pin` はレンジという概念ごと消すため、`package.json` と `pnpm-lock.yaml` が同じことを言う状態になる。「どちらを見れば実態が分かるか」という問い自体が消滅し、これは `bump` が到達できない地点である（`bump` は `^4.3.3` を維持するので、`4.3.4` が入っている可能性を常に残す）。
+
+### lockFileMaintenance が直接依存を動かす経路を遮断する（D4 の強化）
+
+pin の最大の実益は宣言の正確さではなく、リスク管理側にある。
+
+`bump` の下では caret レンジが残るため、`lockFileMaintenance`（月次のロックファイル再生成）は**直接依存の in-range 更新も巻き込む**。d3b D4 が明記したとおり、この PR は差分が `pnpm-lock.yaml` のみで changelog もなく、**レビューが原理的に不可能**である。さらに d3b D3 のとおり `lockFileMaintenance` は `minimumReleaseAge` を検証できず、`security:minimumReleaseAgeNpm` は `minimumReleaseAge: null` を設定して警告文を出すだけである。
+
+つまり `bump` 下では「直接依存が、レビュー不能な PR 経由で、Renovate 側の cooldown を素通りして動く」経路が構造的に開いていた（実際に塞いでいるのは pnpm 側の `minimumReleaseAge` のみ）。pin にするとレンジが消えるため in-range 更新という概念自体が消滅し、`lockFileMaintenance` が動かせるのは推移的依存だけになる。レビュー不能 PR の守備範囲が狭まり、D4 のリスク管理は強化される。
+
+### 再現性
+
+pin 下では `package.json` 単体から解決されるバージョンが一意に定まる。ロックファイルを失った場合や、ロックファイルを使わない経路でインストールした場合でも、同じバージョンが入る。
+
+### D3 / D4 との相互作用（実測により事実決着・決定不要）
+
+d3b D2 は「`auto`（= `update-lockfile`）は D4 の `lockFileMaintenance` と PR が重複する既知の問題があり、`bump` は経路が分かれるためこれを回避する」と書いていた。pin では `update-lockfile` 経路そのものが消えるため、この重複は**構造的に起こり得ない**。`bump` が「経路を分けて回避」していた問題を、pin は「片方の経路を消して解消」する。D2 が `auto` を退けた理由は pin に対しては当たらない。
+
+### `engines` / `peerDependencies`（実測により事実決着・決定不要）
+
+pin してはならない depType の扱いは `:pinAllExceptPeerDependencies` の 2 本目のルール（`rangeStrategy: 'auto'`）が織り込み済みで、こちらで手当てする必要はない。加えて ESM には `engines`（ADR-20260728-44b で削除済み）も `peerDependencies`（`package.json` を grep して不在を確認）も存在せず、実影響はゼロである。プリセット名の "ExceptPeerDependencies" は本リポジトリでは空振りする条項にすぎない。
+
+## 影響
+
+- **`package.json` の全直接依存が exact バージョンになる**。初回は Dashboard の「Pin Dependencies」承認 → Pin PR マージで一括適用する（手順は §決定）
+- **適用は Dependency Dashboard 上にオープン中の Renovate PR がないタイミングで行うこと**。pin 化は既存 PR ブランチを全面書き換えする
+- **今後は patch 更新でも必ず `package.json` に差分が出る**。`bump` 下では in-range かつ下限を超えない更新はロックファイルのみだったが、pin ではすべての更新が宣言の変更を伴う。PR 件数は変わらないが、1 PR あたりの差分は `package.json` へ必ず及ぶ
+- **`lockFileMaintenance` PR の守備範囲が推移的依存のみに狭まる**（D4 の強化。レビュー不能 PR が直接依存を動かさなくなる）
+- **`rangeStrategy` の正は Renovate 本体のプリセット定義に依存する**（0b6 でグルーピングについて生じた依存が、レンジ戦略にも及ぶ）。`config:js-app` の定義が変わればこちらの実効設定も変わる
+- **検証は初回 Pin PR で行う**。`pnpm-lock.yaml` の diff が specifier 行のみで resolved バージョンが不変であること、CI が通ることを確認する
+
+## 関連
+
+- ADR-20260726-d3b（D2 を本 ADR が改訂。同 D2 に追い注記を追記済み。D3 / D4 との相互作用も本 ADR で事実決着）
+- ADR-20260730-0b6（`rangeStrategy` をスコープ外として #697 に委ねた。extends の二重 extend 排除方針・プリセット委譲方針を本 ADR が踏襲）
+- ADR-20260728-44b（`engines.node` の削除。pin の depType 例外が空振りする根拠）
+- Issue #697（本変更の経緯・グリルセッションの記録）
+- Issue #639（Dashboard による検証手順）
+- Renovate ソース: [config.preset.ts](https://github.com/renovatebot/renovate/blob/main/lib/config/presets/internal/config.preset.ts) / [default.preset.ts](https://github.com/renovatebot/renovate/blob/main/lib/config/presets/internal/default.preset.ts)

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -152,3 +152,4 @@
 | [20260728-9kq](20260728-9kq-monorepo-unit-grouping-replaces-non-major-base.md) | packageRules の non-major ベース層を廃止し、モノレポ単位 + 連動必須ファミリーのグルーピングに再設計する | 採用 | 2026-07-28 |
 | [20260729-d8c](20260729-d8c-detect-and-prevent-stale-base-merges.md) | マージ後の検査を push トリガーで観測し、strict required status checks で stale マージを防ぐ | 採用（ロールアウト途中） | 2026-07-29 |
 | [20260730-0b6](20260730-0b6-delegate-grouping-to-presets-and-drop-major-degrouping.md) | グルーピングを config:recommended 内蔵プリセットに全面委譲し、major グループ解除を廃止する | 採用 | 2026-07-30 |
+| [20260730-aan](20260730-aan-migrate-range-strategy-to-pin-with-js-app.md) | rangeStrategy を bump から pin へ移行し、config:js-app を採用する | 採用 | 2026-07-30 |

--- a/docs/claude-plans/issue-697/migrate-range-strategy-to-pin.md
+++ b/docs/claude-plans/issue-697/migrate-range-strategy-to-pin.md
@@ -65,7 +65,7 @@
 - コミットメッセージ: `ci: rangeStrategy を pin へ移行し config:js-app を採用する`
 
 ### Step 2: ADR を作成・改訂し INDEX を更新する
-- [ ] **完了**
+- [x] **完了**
 - 対象ファイル: `docs/adr/20260730-{sss}-migrate-range-strategy-to-pin-with-js-app.md`（新規。sss は ADR-0000 の採番規約に従い base36 3 桁で採番）、`docs/adr/20260726-d3b-adopt-renovate-with-approval-and-two-layer-cooldown.md`、`docs/adr/INDEX.md`
 - テスト戦略: テスト不要（ドキュメント）
 - 作業内容:

--- a/docs/claude-plans/issue-697/migrate-range-strategy-to-pin.md
+++ b/docs/claude-plans/issue-697/migrate-range-strategy-to-pin.md
@@ -1,0 +1,75 @@
+# Issue #697: rangeStrategy を bump から pin へ移行する（d3b D2 の改訂、config:js-app 採用） — 実装計画
+
+> **実行規約**: 各 step 完了時にこのファイルの該当チェックボックス（`- [ ]`）を
+> `- [x]` に更新し、その更新を step のコミットに含めること。
+> 再開時（compaction 後・新規セッション後を含む）は、まずこのファイルを読み、
+> 未チェックの最小 step 番号から続行すること。
+> **テスト戦略が `TDD` の step は red-green-refactor で進めること**（テストを先に書き、
+> RED を確認してから実装する）。`/tdd` スキルの規約に従う。
+
+## 概要
+
+`renovate.json` の `rangeStrategy` を `bump` から `pin` へ移行する。ADR-20260726-d3b の D2 を改訂し、`extends` の `config:recommended` を `config:js-app` に置き換える。判断の経緯はグリルセッション（2026-07-30）で決着済み。
+
+- Renovate 本体ソースの実測により、`config:js-app` = `config:recommended` + `:pinAllExceptPeerDependencies` の完全上位互換であることを確認済み（`config.preset.ts` / `default.preset.ts`）
+- `:pinAllExceptPeerDependencies` は packageRules ベース（`matchPackageNames: ['*']` → pin、`engines` / `peerDependencies` → auto）。**トップレベル `rangeStrategy` より常に優先される**（d3b D6 の `semanticCommitType` と同型）
+- pin の最大の実益は宣言の正確さではなく、**直接依存が lockFileMaintenance のレビュー不能 PR 経由で cooldown を素通りして動く経路の遮断**（D4 のリスク管理強化）
+- **適用タイミング条件**: config PR のマージは Dependency Dashboard 上にオープン中の Renovate PR がないタイミングで行う（pin 化で既存 PR ブランチが全面書き換えになるため。#696 と同じ運用注意）
+
+### 初回 Pin PR の取り込み手順（マージ後の運用）
+
+1. config PR マージ後、次回ジョブで Dashboard の Pending Approval に「Pin Dependencies」が現れる（updateType `pin` の既定値 `groupName: 'Pin Dependencies'` により 1 本に束なる。`dependencyDashboardApproval` が効くため承認まで何も起きない）
+2. 承認して Pin PR を作らせ、**他のどの依存更新 PR よりも先に**マージする
+3. 検証: pin はロックファイルに既に入っているバージョンへの固定であり実体は動かない。`pnpm-lock.yaml` の diff が specifier 行のみ（resolved バージョン不変）であること + CI 通過を確認する
+4. 以降の依存 PR は `rebaseWhen: behind-base-branch` により自動 rebase される（手当て不要）
+
+## 設計判断
+
+いずれもグリルセッション（2026-07-30）で決着済み。
+
+### extends の構成
+- A. `config:recommended` を `config:js-app` に置き換える（先頭配置のまま）
+- B. `config:recommended` を残し `:pinAllExceptPeerDependencies` を追加する
+- 採用: A（実測で両案の実効設定は完全同一。A は「ESM はアプリである」という意図の宣言であり Issue の動機そのものを表現する。0b6 が二重 extend を排除した前例とも一貫。後続 3 プリセットとはオプション単位で交差せず新たな順序依存は生まれない）
+
+### トップレベル `rangeStrategy: "bump"` の始末
+- A. 単純削除（トップレベルには何も書かない）+ `description` で機構を記録
+- B. `"pin"` に書き換えて明示する
+- 採用: A（pin はプリセットの packageRules 由来のためトップレベルに書いても効かない dead config になる。`'*'` が全パッケージにマッチするためフォールバック先が必要な依存も存在しない。0b6 のプリセット委譲方針と一貫）
+
+### 初回の一斉 Pin PR の取り込み方
+- A. Renovate に Pin PR を生成させ、承認制をタイミング制御装置として使う
+- B. config PR に手動 pin（package.json の exact 化）を同梱してアトミックに済ませる
+- 採用: A（直接依存 50 件超の手編集はミスの余地があり、Renovate の設計済み機構と Dashboard での動作観察の機会を捨てることになる。「config は pin だが宣言はまだレンジ」の中間状態は承認まで副作用ゼロで実質的な窓にならない）
+
+### ADR の改訂方法
+- A. 新規 ADR を起票し、d3b の D2 セクションに改訂注記を追記する
+- B. d3b を現地改訂する
+- 採用: A（0b6 で確立した「新 ADR + 旧 ADR への追い注記」パターンの踏襲。改訂対象は D1〜D7 のうち D2 のみで全体差替は過剰。bump を選んだ推論の連鎖は pin へ進む論理の出発点として歴史的価値がある。ADR-0000 は現地改訂を ADR-0000 自身にのみ許す）
+
+### 実測により事実決着した論点（決定不要・新 ADR に記録）
+- **D3/D4 との相互作用**: pin ではレンジが消えるため in-range 更新（`update-lockfile` 経路）が概念ごと消滅し、lockFileMaintenance との PR 重複は構造的に起きない。lockFileMaintenance が動かせるのは推移的依存のみになり、レビュー不能 PR の守備範囲が狭まって D4 は強化される
+- **engines / peerDependencies**: `:pinAllExceptPeerDependencies` の 2 本目のルールが `auto` に逃がす（pin してはいけない depType の織り込み済み設計）。ESM には `engines`（ADR-44b で削除済み）も `peerDependencies`（grep で不在確認済み）も存在せず実影響ゼロ
+
+## ステップ
+
+### Step 1: renovate.json を pin 移行版に改訂する
+- [ ] **完了**
+- 対象ファイル: `renovate.json`
+- テスト戦略: テスト不要（設定ファイル。検証はマージ後に Dependency Dashboard と初回 Pin PR で行う——概要の取り込み手順参照）
+- 作業内容:
+  - `extends` の `config:recommended` を `config:js-app` に置き換える（先頭のまま）。他の 3 エントリは変更しない
+  - トップレベル `"rangeStrategy": "bump"` を削除する
+  - `description` に rangeStrategy のエントリを 1 件追加する（pin は `config:js-app` 内蔵の `:pinAllExceptPeerDependencies` が packageRules として設定する・トップレベルに書いても packageRules に負けるため書かない・engines / peer は同プリセットが auto に逃がす）
+  - 既存 `description` の「group:monorepos（config:recommended 内蔵）」等の文言を `config:js-app` 前提に微修正する（js-app が recommended を包含するため内容は真のまま）
+- コミットメッセージ: `ci: rangeStrategy を pin へ移行し config:js-app を採用する`
+
+### Step 2: ADR を作成・改訂し INDEX を更新する
+- [ ] **完了**
+- 対象ファイル: `docs/adr/20260730-{sss}-migrate-range-strategy-to-pin-with-js-app.md`（新規。sss は ADR-0000 の採番規約に従い base36 3 桁で採番）、`docs/adr/20260726-d3b-adopt-renovate-with-approval-and-two-layer-cooldown.md`、`docs/adr/INDEX.md`
+- テスト戦略: テスト不要（ドキュメント）
+- 作業内容:
+  - 新規 ADR を作成する。記録する論点: pin 移行の根拠（読み手のいないレンジ宣言の廃止 / lockFileMaintenance 経路の遮断による D4 強化 / 再現性）、extends の js-app 置き換え（案 B 不採用理由）、トップレベル rangeStrategy 削除（dead config 回避）、初回 Pin PR の取り込み手順、事実決着 2 点（D3/D4 相互作用・engines/peer）
+  - d3b の D2 セクションに `> **改訂（2026-07-30 / #697 → 新 ADR）**` 形式の追い注記を加える（決定本文は書き換えない。D5 の注記チェーン形式に合わせる）
+  - `docs/adr/INDEX.md` に新規 ADR を追加する
+- コミットメッセージ: `docs: rangeStrategy の pin 移行と config:js-app 採用を ADR に記録する`

--- a/docs/claude-plans/issue-697/migrate-range-strategy-to-pin.md
+++ b/docs/claude-plans/issue-697/migrate-range-strategy-to-pin.md
@@ -54,7 +54,7 @@
 ## ステップ
 
 ### Step 1: renovate.json を pin 移行版に改訂する
-- [ ] **完了**
+- [x] **完了**
 - 対象ファイル: `renovate.json`
 - テスト戦略: テスト不要（設定ファイル。検証はマージ後に Dependency Dashboard と初回 Pin PR で行う——概要の取り込み手順参照）
 - 作業内容:

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:js-app",
     "security:minimumReleaseAgeNpm",
     ":semanticCommitTypeAll(chore)",
     ":maintainLockFilesMonthly"
@@ -11,13 +11,13 @@
     "既定の auto でも「ブランチが最新であることを要求するリポジトリ」を検出して behind-base-branch へ切り替わる建て付けだが、この検出は classic branch protection 前提で作られており Rulesets では既知の不具合報告がある（renovatebot/renovate discussion #38302）。本リポジトリは ruleset 運用のため明示する。",
     "検出に失敗したときの帰結が悪いことが明示の主因である。PR が stale のまま放置され、GitHub の Update branch を人間が押すとユーザー名義のコミットが PR ブランチに積まれ、Renovate はそのブランチの更新を一切やめる。PR は残りマージもできるが以降更新されず、close するまで同じ依存の新しい PR も作られない。気づく手段が実質ない。",
     "ruleset は GitHub 側にありリポジトリからは見えない。実際の値は gh api repos/:owner/:repo/rulesets/12978563 で確認すること。",
-    "グループ化は config:recommended 内蔵のプリセットに全面委譲する: group:monorepos（sourceUrl マッチ）に加え、group:recommended 経由の group:react が @types/react 系を名前ベースで react monorepo へ合流させる。手書きの packageRules グループは『プリセット定義に存在しない連動で、かつ片方だけ上げると壊れることが実測で確認されたもの』に限る（現状 node + @types/node のみ。→ 新 ADR）。無所属の @types/** を束ねたくなったら、手書きせず extends へ group:definitelyTyped → group:react の順で追加する（内蔵 group:react を打ち消す definitelyTyped を、明示の group:react が後勝ちで打ち消し返す。この順序でなければ @types/react 系が definitelyTyped に奪われる）。"
+    "グループ化は config:js-app 内蔵のプリセットに全面委譲する: group:monorepos（sourceUrl マッチ）に加え、group:recommended 経由の group:react が @types/react 系を名前ベースで react monorepo へ合流させる。手書きの packageRules グループは『プリセット定義に存在しない連動で、かつ片方だけ上げると壊れることが実測で確認されたもの』に限る（現状 node + @types/node のみ。→ ADR-20260730-0b6）。無所属の @types/** を束ねたくなったら、手書きせず extends へ group:definitelyTyped → group:react の順で追加する（内蔵 group:react を打ち消す definitelyTyped を、明示の group:react が後勝ちで打ち消し返す。この順序でなければ @types/react 系が definitelyTyped に奪われる）。",
+    "rangeStrategy は pin。config:js-app = config:recommended + :pinAllExceptPeerDependencies であり、pin は後者が packageRules（matchPackageNames: ['*'] → pin）として設定する。packageRules はトップレベル設定より優先されるため、トップレベルに rangeStrategy を書いても効かない dead config になる（D6 の semanticCommitType と同型）。ゆえにここには書かない。engines / peerDependencies は同プリセットの 2 本目のルールが rangeStrategy: auto へ逃がす（pin してはいけない depType の織り込み済み設計）。→ ADR-20260730-aan"
   ],
   "timezone": "Asia/Tokyo",
   "dependencyDashboardApproval": true,
   "prConcurrentLimit": 3,
   "rebaseWhen": "behind-base-branch",
-  "rangeStrategy": "bump",
   "labels": ["dependencies"],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Renovate の `rangeStrategy` を `bump` から `pin` へ移行し、`extends` の `config:recommended` を `config:js-app`（= `config:recommended` + `:pinAllExceptPeerDependencies`）に置き換えた。pin はプリセットの `packageRules` 由来でトップレベル設定より優先されるため、トップレベルの `rangeStrategy` は dead config として削除した（engines / peerDependencies は同プリセットが `auto` へ逃がす）。
この方針転換を新 ADR（ADR-20260730-aan）に記録し、ADR-20260726-d3b の D2 に改訂注記を追加した。

Closes #697

## 実装計画

<details>
<summary>plan mode で作成した実装計画（クリックで展開）</summary>

### migrate-range-strategy-to-pin.md

# Issue #697: rangeStrategy を bump から pin へ移行する（d3b D2 の改訂、config:js-app 採用） — 実装計画

> **実行規約**: 各 step 完了時にこのファイルの該当チェックボックス（`- [ ]`）を
> `- [x]` に更新し、その更新を step のコミットに含めること。
> 再開時（compaction 後・新規セッション後を含む）は、まずこのファイルを読み、
> 未チェックの最小 step 番号から続行すること。
> **テスト戦略が `TDD` の step は red-green-refactor で進めること**（テストを先に書き、
> RED を確認してから実装する）。`/tdd` スキルの規約に従う。

## 概要

`renovate.json` の `rangeStrategy` を `bump` から `pin` へ移行する。ADR-20260726-d3b の D2 を改訂し、`extends` の `config:recommended` を `config:js-app` に置き換える。判断の経緯はグリルセッション（2026-07-30）で決着済み。

- Renovate 本体ソースの実測により、`config:js-app` = `config:recommended` + `:pinAllExceptPeerDependencies` の完全上位互換であることを確認済み（`config.preset.ts` / `default.preset.ts`）
- `:pinAllExceptPeerDependencies` は packageRules ベース（`matchPackageNames: ['*']` → pin、`engines` / `peerDependencies` → auto）。**トップレベル `rangeStrategy` より常に優先される**（d3b D6 の `semanticCommitType` と同型）
- pin の最大の実益は宣言の正確さではなく、**直接依存が lockFileMaintenance のレビュー不能 PR 経由で cooldown を素通りして動く経路の遮断**（D4 のリスク管理強化）
- **適用タイミング条件**: config PR のマージは Dependency Dashboard 上にオープン中の Renovate PR がないタイミングで行う（pin 化で既存 PR ブランチが全面書き換えになるため。#696 と同じ運用注意）

### 初回 Pin PR の取り込み手順（マージ後の運用）

1. config PR マージ後、次回ジョブで Dashboard の Pending Approval に「Pin Dependencies」が現れる（updateType `pin` の既定値 `groupName: 'Pin Dependencies'` により 1 本に束なる。`dependencyDashboardApproval` が効くため承認まで何も起きない）
2. 承認して Pin PR を作らせ、**他のどの依存更新 PR よりも先に**マージする
3. 検証: pin はロックファイルに既に入っているバージョンへの固定であり実体は動かない。`pnpm-lock.yaml` の diff が specifier 行のみ（resolved バージョン不変）であること + CI 通過を確認する
4. 以降の依存 PR は `rebaseWhen: behind-base-branch` により自動 rebase される（手当て不要）

## 設計判断

いずれもグリルセッション（2026-07-30）で決着済み。

### extends の構成
- A. `config:recommended` を `config:js-app` に置き換える（先頭配置のまま）
- B. `config:recommended` を残し `:pinAllExceptPeerDependencies` を追加する
- 採用: A（実測で両案の実効設定は完全同一。A は「ESM はアプリである」という意図の宣言であり Issue の動機そのものを表現する。0b6 が二重 extend を排除した前例とも一貫。後続 3 プリセットとはオプション単位で交差せず新たな順序依存は生まれない）

### トップレベル `rangeStrategy: "bump"` の始末
- A. 単純削除（トップレベルには何も書かない）+ `description` で機構を記録
- B. `"pin"` に書き換えて明示する
- 採用: A（pin はプリセットの packageRules 由来のためトップレベルに書いても効かない dead config になる。`'*'` が全パッケージにマッチするためフォールバック先が必要な依存も存在しない。0b6 のプリセット委譲方針と一貫）

### 初回の一斉 Pin PR の取り込み方
- A. Renovate に Pin PR を生成させ、承認制をタイミング制御装置として使う
- B. config PR に手動 pin（package.json の exact 化）を同梱してアトミックに済ませる
- 採用: A（直接依存 50 件超の手編集はミスの余地があり、Renovate の設計済み機構と Dashboard での動作観察の機会を捨てることになる。「config は pin だが宣言はまだレンジ」の中間状態は承認まで副作用ゼロで実質的な窓にならない）

### ADR の改訂方法
- A. 新規 ADR を起票し、d3b の D2 セクションに改訂注記を追記する
- B. d3b を現地改訂する
- 採用: A（0b6 で確立した「新 ADR + 旧 ADR への追い注記」パターンの踏襲。改訂対象は D1〜D7 のうち D2 のみで全体差替は過剰。bump を選んだ推論の連鎖は pin へ進む論理の出発点として歴史的価値がある。ADR-0000 は現地改訂を ADR-0000 自身にのみ許す）

### 実測により事実決着した論点（決定不要・新 ADR に記録）
- **D3/D4 との相互作用**: pin ではレンジが消えるため in-range 更新（`update-lockfile` 経路）が概念ごと消滅し、lockFileMaintenance との PR 重複は構造的に起きない。lockFileMaintenance が動かせるのは推移的依存のみになり、レビュー不能 PR の守備範囲が狭まって D4 は強化される
- **engines / peerDependencies**: `:pinAllExceptPeerDependencies` の 2 本目のルールが `auto` に逃がす（pin してはいけない depType の織り込み済み設計）。ESM には `engines`（ADR-44b で削除済み）も `peerDependencies`（grep で不在確認済み）も存在せず実影響ゼロ

## ステップ

### Step 1: renovate.json を pin 移行版に改訂する
- [x] **完了**
- 対象ファイル: `renovate.json`
- テスト戦略: テスト不要（設定ファイル。検証はマージ後に Dependency Dashboard と初回 Pin PR で行う——概要の取り込み手順参照）
- 作業内容:
  - `extends` の `config:recommended` を `config:js-app` に置き換える（先頭のまま）。他の 3 エントリは変更しない
  - トップレベル `"rangeStrategy": "bump"` を削除する
  - `description` に rangeStrategy のエントリを 1 件追加する（pin は `config:js-app` 内蔵の `:pinAllExceptPeerDependencies` が packageRules として設定する・トップレベルに書いても packageRules に負けるため書かない・engines / peer は同プリセットが auto に逃がす）
  - 既存 `description` の「group:monorepos（config:recommended 内蔵）」等の文言を `config:js-app` 前提に微修正する（js-app が recommended を包含するため内容は真のまま）
- コミットメッセージ: `ci: rangeStrategy を pin へ移行し config:js-app を採用する`

### Step 2: ADR を作成・改訂し INDEX を更新する
- [x] **完了**
- 対象ファイル: `docs/adr/20260730-{sss}-migrate-range-strategy-to-pin-with-js-app.md`（新規。sss は ADR-0000 の採番規約に従い base36 3 桁で採番）、`docs/adr/20260726-d3b-adopt-renovate-with-approval-and-two-layer-cooldown.md`、`docs/adr/INDEX.md`
- テスト戦略: テスト不要（ドキュメント）
- 作業内容:
  - 新規 ADR を作成する。記録する論点: pin 移行の根拠（読み手のいないレンジ宣言の廃止 / lockFileMaintenance 経路の遮断による D4 強化 / 再現性）、extends の js-app 置き換え（案 B 不採用理由）、トップレベル rangeStrategy 削除（dead config 回避）、初回 Pin PR の取り込み手順、事実決着 2 点（D3/D4 相互作用・engines/peer）
  - d3b の D2 セクションに `> **改訂（2026-07-30 / #697 → 新 ADR）**` 形式の追い注記を加える（決定本文は書き換えない。D5 の注記チェーン形式に合わせる）
  - `docs/adr/INDEX.md` に新規 ADR を追加する
- コミットメッセージ: `docs: rangeStrategy の pin 移行と config:js-app 採用を ADR に記録する`

</details>

## 計画からの逸脱

計画通りに実装が完了しました。特筆すべき逸脱はありません。

---

Generated with [Claude Code](https://claude.ai/code)
