### PR TITLE
ci: onlyBuiltDependencies を allowBuilds へ移行する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ concurrency:
 # GITHUB_TOKEN は checkout に必要な読み取りのみに絞る。宣言が無いとリポジトリ設定の
 # default_workflow_permissions（現在は read だが組織／リポジトリ側でいつでも write に
 # 変えられる値）に従うため、ワークフロー側で恒久的に閉じておく。
-# 本ワークフローは pnpm install で only-allow / onlyBuiltDependencies のビルドスクリプトを
+# 本ワークフローは pnpm install で only-allow / allowBuilds のビルドスクリプトを
 # 実行するため、書き込み権限付きトークンを同じ run に置かないことに意味がある。
 permissions:
   contents: read

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,9 @@
-onlyBuiltDependencies:
-  - "@prisma/engines"
-  - esbuild
-  - prisma
-  - sharp
-  - unrs-resolver
+allowBuilds:
+  "@prisma/engines": true
+  esbuild: true
+  prisma: true
+  sharp: true
+  unrs-resolver: true
 minimumReleaseAge: 4320 # 3 days (分単位)
 minimumReleaseAgeExclude:
   # Renovate security update: uuid@13.0.1


### PR DESCRIPTION
## Summary

pnpm 11.0.0 で削除された `onlyBuiltDependencies` を後継の `allowBuilds` へ移行する。#734（pnpm 11 へのメジャー更新）の CI が全 9 ジョブとも `pnpm install` 段階で落ちている原因の除去。

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:
  @prisma/engines@7.9.1, esbuild@0.27.7, esbuild@0.28.1,
  prisma@7.9.1, sharp@0.34.5, unrs-resolver@1.11.1
```

無視されたパッケージ一覧は `pnpm-workspace.yaml` の `onlyBuiltDependencies` と完全一致する。pnpm 11 で以下 2 つが同時に起きたため。

1. `onlyBuiltDependencies` の**削除**（`onlyBuiltDependenciesFile` / `neverBuiltDependencies` / `ignoredBuiltDependencies` / `ignoreDepScripts` も同時）。後継は `allowBuilds`
2. `strictDepBuilds` のデフォルトが `true` 化。未承認ビルドが残ると install が非ゼロ終了する

pnpm 11 は削除済みキーを**警告せず黙殺**するため、「設定は書いてあるのに効かない」という気づきにくい形で壊れていた。

## 変更内容

- `pnpm-workspace.yaml`: `onlyBuiltDependencies`（配列）→ `allowBuilds`（パッケージ名パターン → boolean のマップ）
- `.github/workflows/ci.yml`: `permissions` を絞る根拠として設定名を名指ししているコメントを追随

## #734 に直接当てず develop へ先行させた理由

- `allowBuilds` は **pnpm 10.26.0 で追加済み**であり、現行の pnpm 10.34.5 でも postinstall が実行されることを実測した。develop 先行でも現行環境は壊れない
- 逆に Renovate の PR ブランチへ直接コミットすると Renovate がそのブランチを modified と判定して以後 rebase しなくなる。`rebaseWhen: behind-base-branch` は ruleset の `strict_required_status_checks_policy: true` と対（→ ADR-20260729-d8c）であり、rebase が止まると develop 進行時に #734 がマージ不能になる

本 PR をマージした後、#734 を rebase させて CI 緑を確認する。

## 検証

worktree に PR #734 の HEAD（`d6cbc368`）を取り、本変更を当てた状態で pnpm 11.17.0 を実行。

| 項目 | 結果 |
| --- | --- |
| `pnpm install --frozen-lockfile` | ✅ exit 0 / lockfile 差分なし |
| ビルドスクリプト実行 | ✅ prisma schema-engine・esbuild バイナリの実体を確認 |
| `pnpm db:generate` | ✅ Prisma Client 7.9.1 生成成功 |
| `pnpm lint` | ✅ exit 0 |
| `pnpm build`（CI と同じ到達不能 DB env） | ✅ exit 0 |

後方互換（本 PR のブランチ = develop ベース、pnpm 10.34.5）。

| 項目 | 結果 |
| --- | --- |
| `pnpm install --frozen-lockfile` | ✅ exit 0、`Ignored builds` 警告なし |
| ビルドスクリプト実行 | ✅ prisma schema-engine・esbuild バイナリの実体を確認 |

## pnpm 11 のその他の破壊的変更（影響調査済み）

| 変更 | 影響 |
| --- | --- |
| Node.js 22+ 必須 | なし（`.nvmrc` = 24.18.1） |
| `minimumReleaseAge` デフォルト 1440 | なし（既に 4320 を明示指定） |
| `blockExoticSubdeps` デフォルト `true` | なし（lockfile に tarball/git 依存なし） |
| `.npmrc` は auth/registry のみ読む | なし（`.npmrc` は空） |
| `package.json` の `pnpm` フィールド無視 | なし（未使用） |
| `patchedDependencies` lockfile 形式変更 | なし（patch 未使用） |
| npm passthrough コマンド削除 | なし（`pnpm pkg` 等の使用なし） |
| `managePackageManagerVersions` 等削除 → `pmOnFail` | なし（未設定） |
| `npm_config_*` 環境変数を読まない | なし（使用箇所なし） |
| store v11（SQLite 化） | CI の pnpm store キャッシュが一度失効。初回のみ低速化 |
| CLI 出力形式変更（`$ cmd`、stderr へ） | なし（ログ文字列に依存する処理なし） |

## 申し送り

Renovate の PR 本文は文字数上限で切り詰められ、**v11.11.0 までしか載っていない**。メジャー更新なのに肝心の v11.0.0 Major Changes が PR 本文から欠落していた。今後の major 更新では PR 本文を信用せずリリースノート原典を当たること。

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UW8L1LqH5UsDFM6BEXWwkJ
