### PR TITLE
chore: 開発環境のDBをDocker化する（compose.yaml + initdbスクリプト、Phase 1: dbサービスのみ）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,20 @@
 3. Application layer uses repository **interfaces** from domain layer, NOT concrete implementations
 4. Infrastructure layer implements domain interfaces and handles Prisma <-> Domain mapping
 
+## Dev DB (Docker)
+
+開発・テスト用の PostgreSQL は Docker Compose で起動する（Issue #755）。Next.js アプリはホストで `pnpm dev` を実行する（コンテナ化しない）。
+
+```bash
+docker compose up -d --wait   # DB起動（dev / unit / e2e の3DBは初回起動時に自動作成）
+docker compose down           # DB停止（データは pgdata ボリュームに残る）
+docker compose down -v        # DB完全リセット（ボリューム削除。次回起動時にinitdb再実行）
+```
+
+- 接続先は従来どおり `localhost:5432`（`.env*` の `DATABASE_URL` は変更不要）
+- unit / e2e 用DBの作成は `docker/db/initdb/01-create-databases.sql`（データボリュームが空の初回のみ実行）
+- DB完全リセット後は `pnpm db:migrate && pnpm db:seed` / `pnpm test:setup` / `pnpm e2e:setup` で再構築する
+
 ## Unit Tests
 
 単体テスト（vitest）は開発DBと分離した専用DB（`.env.unit` の `DATABASE_URL`）を使う（Issue #584）。

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,11 @@ name: estimate-management-system
 
 services:
   db:
-    image: postgres:16.14 # 移行元のネイティブ PostgreSQL とバージョンを一致させる
+    # バージョンは移行元のネイティブ PostgreSQL と一致させる。
+    # OS サフィックス（-trixie）まで明示するのは、無印タグはベース Debian の
+    # 切替で glibc が黙って変わり、pgdata の照合順序依存インデックスを
+    # 壊しうるため。更新は Renovate の PR で意図的に取り込む
+    image: postgres:16.14-trixie
     ports:
       # 127.0.0.1 バインドで LAN に晒さない（ネイティブ版の listen_addresses と等価）。
       # ホストの prisma / createdb / psql はこれまで通り localhost:5432 で接続できる

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,29 @@
+# 開発環境用 Docker Compose（Phase 1: DB のみ）
+#
+# Next.js アプリはホストで `pnpm dev` を実行する（コンテナ化しない）。
+# 理由: husky フック・Playwright・単体テストがホストの Node 環境で動くため、
+# アプリをコンテナ化しても二重管理になるだけで利益がない。
+# 参考: https://nextjs.org/docs/app/guides/local-development#8-consider-local-development-over-docker
+services:
+  db:
+    image: postgres:16.14 # 移行元のネイティブ PostgreSQL とバージョンを一致させる
+    ports:
+      # 127.0.0.1 バインドで LAN に晒さない（ネイティブ版の listen_addresses と等価）。
+      # ホストの prisma / createdb / psql はこれまで通り localhost:5432 で接続できる
+      - "127.0.0.1:5432:5432"
+    environment:
+      POSTGRES_USER: dev_user
+      POSTGRES_PASSWORD: dev_password
+      POSTGRES_DB: estimate_management_dev
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      # unit / e2e 用 DB の作成スクリプト。データボリュームが空の初回起動時のみ実行される
+      - ./docker/db/initdb:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dev_user -d estimate_management_dev"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pgdata:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,15 @@
 # 開発環境用 Docker Compose（Phase 1: DB のみ）
 #
+# name: プロジェクト名を実行ディレクトリに依らず固定する。
+# これが無いと worktree 内で docker compose up した際にディレクトリ名由来の
+# 別プロジェクト扱いとなり、空ボリューム + 5432 ポート競合の事故になる。
+#
 # Next.js アプリはホストで `pnpm dev` を実行する（コンテナ化しない）。
 # 理由: husky フック・Playwright・単体テストがホストの Node 環境で動くため、
 # アプリをコンテナ化しても二重管理になるだけで利益がない。
 # 参考: https://nextjs.org/docs/app/guides/local-development#8-consider-local-development-over-docker
+name: estimate-management-system
+
 services:
   db:
     image: postgres:16.14 # 移行元のネイティブ PostgreSQL とバージョンを一致させる

--- a/docker/db/initdb/01-create-databases.sql
+++ b/docker/db/initdb/01-create-databases.sql
@@ -1,0 +1,5 @@
+-- 単体テスト（Issue #584）・E2E テスト用の DB を初回起動時に作成する。
+-- postgres イメージの POSTGRES_DB では 1 つの DB しか作れないため、残り 2 つをここで作る。
+-- scripts/unit-setup.ts / e2e-setup.ts の createdb は "already exists" 分岐に入るので無改修で共存できる。
+CREATE DATABASE estimate_management_unit OWNER dev_user;
+CREATE DATABASE estimate_management_e2e OWNER dev_user;


### PR DESCRIPTION
## Summary

開発用DBをDocker化するcompose.yaml（dbサービスのみ、Phase 1）とinitdbスクリプトを追加し、dev / unit / e2e の3DBを自動作成できるようにした。あわせてCLAUDE.mdにDocker Composeによる開発DB起動手順を追記。

Closes #755

---

Generated with [Claude Code](https://claude.ai/code)
