### PR TITLE
agent: commit-types.md を作業タイプのマスターとして再定義し、実体との差異7件を解消する

### DIFF
--- a/.claude/references/commit-types.md
+++ b/.claude/references/commit-types.md
@@ -1,44 +1,63 @@
-# Commit Type リファレンス
+# 作業タイプ リファレンス
 
-commit type, GitHub label, branch prefix の対応関係を定義するマスターテーブル。
+Issue / ブランチ / PR / コミットの 4 文脈にまたがる**作業タイプのマスターテーブル**。
 各スキル（create-issue, auto-dev, finalize-work 等）はこのファイルを参照すること。
+
+> [!IMPORTANT]
+> **文脈ごとに使える値の集合が異なる。** 列を取り違えると、commitlint が拒否する type を
+> コミットに使ったり、存在しないラベルを付与しようとして `gh` が失敗したりする。
+> 用途に対応する列を見ること。
 
 ## マッピングテーブル
 
-| type | prefix | label | branch | keywords |
-|------|--------|-------|--------|----------|
-| feat | `feat:` | `Type: enhancement` | `feat/` | 機能追加, 実装, 新規, 追加 |
-| fix | `fix:` | `Type: bug` | `fix/` | バグ, エラー, 不具合, 修正 |
-| refactor | `refactor:` | `Type: refactor` | `refactor/` | リファクタ, 整理, 削除, cleanup, 統合, 分離 |
-| docs | `docs:` | `Type: documentation` | `docs/` | ドキュメント, 記録, README |
-| test | `test:` | `Type: test` | `test/` | テスト, カバレッジ, spec |
-| ci | `ci:` | `Type: ci` | `ci/` | CI, pipeline, deploy, lint |
-| agent | `agent:` | `Type: agent` | `agent/` | hook, skill, AI設定, CLAUDE.md, rules |
-| build | `build:` | `Type: build` | `build/` | ビルド, webpack, バンドル, 依存関係 |
-| chore | `chore:` | `Type: chore` | `chore/` | 雑務, メンテナンス |
-| perf | `perf:` | `Type: perf` | `perf/` | パフォーマンス, 高速化, 最適化 |
-| style | `style:` | `Type: style` | — | フォーマット, 整形, スタイル |
-| revert | `revert:` | — | — | 取り消し, 巻き戻し, revert |
-| question | `question:` | `Type: question` | — | 疑問, 検討, 方針, 議論, 質問, どうすべき |
-| architecture | `arch:` | `Type: architecture` | — | アーキテクチャ, 設計判断, 設計方針 |
+| type | Issue | branch | commit | label | keywords |
+|------|-------|--------|--------|-------|----------|
+| feat | `feat:` | `feat/` | `feat:` | `Type: enhancement` | 機能追加, 実装, 新規, 追加 |
+| fix | `fix:` | `fix/` | `fix:` | `Type: bug` | バグ, エラー, 不具合, 修正 |
+| refactor | `refactor:` | `refactor/` | `refactor:` | `Type: refactor` | リファクタ, 整理, 削除, cleanup, 統合, 分離 |
+| docs | `docs:` | `docs/` | `docs:` | `Type: documentation` | ドキュメント, 記録, README |
+| test | `test:` | `test/` | `test:` | `Type: test` | テスト, カバレッジ, spec |
+| ci | `ci:` | `ci/` | `ci:` | `Type: ci` | CI, pipeline, deploy, lint |
+| agent | `agent:` | `agent/` | `agent:` | `Type: agent` | hook, skill, AI設定, CLAUDE.md, rules |
+| build | `build:` | `build/` | `build:` | — | ビルド, webpack, バンドル, 依存関係 |
+| chore | `chore:` | `chore/` | `chore:` | — | 雑務, メンテナンス |
+| perf | `perf:` | `perf/` | `perf:` | — | パフォーマンス, 高速化, 最適化 |
+| style | `style:` | — | `style:` | — | フォーマット, 整形, スタイル |
+| revert | `revert:` | — | `revert:` | — | 取り消し, 巻き戻し, revert |
+| question | `question:` | — | ❌ `docs:` を使う | `Type: question` | 疑問, 検討, 方針, 議論, 質問, どうすべき |
+| architecture | `arch:` | — | ❌ `docs:` を使う | `Type: architecture` | アーキテクチャ, 設計判断, 設計方針 |
 
-## 補足
+## 各列の意味
 
-- **prefix**: コミットメッセージ・PRタイトル・Issueタイトルの接頭辞
-- **label**: GitHub Issue に付与するラベル。`—` のものはラベル付与不要
-- **branch**: ブランチ名の接頭辞（`{branch}issue-{number}` 形式）。`—` のものはブランチ作成対象外
+- **Issue**: Issue タイトルの接頭辞
+- **branch**: ブランチ名の接頭辞（`{branch}issue-{number}` 形式）。`—` はブランチ作成対象外
+- **commit**: コミットメッセージの接頭辞。**`commitlint.config.mjs` の `type-enum` が正**であり、❌ の type は commit-msg フックが拒否する
+- **label**: GitHub Issue に付与するラベル。`—` は付与不要（対応するラベルが存在しない）
 - **keywords**: Issue 作成時のタイプ自動判定に使用するキーワード
-- commit type と GitHub label の名前が異なるもの（feat↔enhancement, fix↔bug）があるが、これはエコシステムの違いによる正常なずれ
 
-## commitlint との差異
+## 注意点
 
-**commit-msg フックが実際に許可する type は `commitlint.config.mjs` の `type-enum` が正**であり、上の表とは一致しない。
+### PR タイトルは commit 列に従う
 
-- 表にあるが commitlint が**拒否する**: `question`, `architecture`（`arch:`）
-  → 設計判断・方針の記録をコミットしたい場合は `docs:` を使う
-- commitlint にあるが表に無い: `deps`
+GitHub の squash merge は**コミットメッセージに PR タイトルをそのまま使う**ため、PR タイトルは事実上コミットメッセージになる。
+`question` / `architecture` の Issue から作った PR であっても、**PR タイトルには `docs:` を使う**こと。
 
-上の表は Issue のラベル付け・ブランチ命名を含む対応関係のマスターであり、コミット時は commitlint 側の制約が優先される。
+なお PR タイトルを検証する CI は無く、`commit-msg` フックも通らない。ここは規約でしか守れない。
+
+### label が `—` の type
+
+`build` / `chore` / `perf` に対応する GitHub ラベル（`Type: build` 等）は**存在しない**。
+`gh issue create --label` にこれらを渡すとコマンドが失敗するため、ラベルを指定せずに起票する。
+
+### 依存更新
+
+Renovate が `:semanticCommitTypeAll(chore)` で生成するため、**type は `chore`、`deps` は scope**（`chore(deps): ...`）。
+`deps` type は存在しない（`type-enum` から削除済み）。
+`dependencies` ラベルは Renovate が自動付与するので手動で付けない。
+
+### type と label の名前のずれ
+
+`feat` ↔ `Type: enhancement`、`fix` ↔ `Type: bug` のように名前が異なるものがあるが、これはエコシステムの違いによる正常なずれ。
 
 ## コミットメッセージの書き方
 

--- a/.claude/references/git-hooks.md
+++ b/.claude/references/git-hooks.md
@@ -23,7 +23,8 @@
 `pnpm commitlint --edit $1` で type を検証する。
 
 許可 type は `commitlint.config.mjs` の `type-enum` が正。
-対応表は [`commit-types.md`](commit-types.md) を参照（**表には commitlint が受け付けない type も含まれるため注意**）。
+作業タイプの対応表は [`commit-types.md`](commit-types.md) の **`commit` 列**を参照する。
+同じ表の `Issue` 列 / `branch` 列とは値の集合が異なり、`question` / `architecture` は commit-msg フックが拒否する。
 
 ## pre-push（`.husky/pre-push`）
 

--- a/.claude/skills/auto-dev/SKILL.md
+++ b/.claude/skills/auto-dev/SKILL.md
@@ -42,6 +42,7 @@ gh issue view {number} --json title,body,labels
 
 `.claude/references/commit-types.md` のマッピングテーブルを参照し、ラベル（`label` 列）からブランチタイプ（`branch` 列）を決定する。
 `branch` が `—` のタイプ、またはラベルなしの場合は `feat`（デフォルト）を使用する。
+`label` 列が `—` のタイプ（build / chore / perf）はラベルから逆引きできないため、ラベルなしと同じ扱いになる。
 
 ### 1.4 複雑度チェック
 

--- a/.claude/skills/auto-review-fix/SKILL.md
+++ b/.claude/skills/auto-review-fix/SKILL.md
@@ -250,7 +250,7 @@ EOF
 - ③cleanup は実装後に**挙動不変を再確認**する（`pnpm test` が緑のまま／public 抽出なら無状態・置き場所が計画どおりか）。挙動が変わった・基準を満たせなくなった場合は破棄し、④残課題に戻す。
 - 意味のあるまとまりごとにコミットする（一括コミットしない）。
   - ①correctness → `fix:` ／ ②方針違反 → 原則 `fix:`（DDD 配置換えなど構造変更主体なら `refactor:`）／ ③cleanup → `refactor:`（統合/共通化）でコミット。計画ファイル自体は `docs:`。
-- コミットは `.claude/references/commit-types.md` の type に従う。
+- コミットは `.claude/references/commit-types.md` の **`commit` 列**に従う（`Issue` 列とは値の集合が異なる）。
 - **設計判断を含む場合はコミットボディに理由を記載**（CLAUDE.md のルール）。
 - 修正後、テストを実行して緑を確認する:
 

--- a/.claude/skills/auto-tdd/SKILL.md
+++ b/.claude/skills/auto-tdd/SKILL.md
@@ -86,7 +86,7 @@ git branch --show-current
 
 1. 計画ファイルの当該 step のチェックボックスを `- [ ]` → `- [x]` に更新する
 2. **step の変更と、そのチェックボックス更新を同一コミットに含める**（計画テンプレの実行規約）
-3. コミットメッセージは計画の `コミットメッセージ` 欄の案を使う（type は `.claude/references/commit-types.md` に従う）
+3. コミットメッセージは計画の `コミットメッセージ` 欄の案を使う（type は `.claude/references/commit-types.md` の **`commit` 列**に従う）
 4. **設計判断を含む step は、その判断理由をコミットボディに記載する**（CLAUDE.md のルール）
 
 ```bash

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -27,10 +27,12 @@ context: fork
 
 `.claude/references/commit-types.md` を読み、マッピングテーブルを取得する。
 `$ARGUMENTS` のキーワードとテーブルの `keywords` 列を照合して issue タイプを推定する。
-テーブルの `prefix` 列をタイトル接頭辞に、`label` 列を GitHub ラベルに使用する。
+テーブルの **`Issue` 列**をタイトル接頭辞に、`label` 列を GitHub ラベルに使用する。
 
 - 複数マッチした場合は最も適切なものを選択
 - どれにも該当しない場合は `feat`（`Type: enhancement`）をデフォルトとする
+- `label` 列が `—` のタイプ（build / chore / perf など）は、対応するラベルが存在しない。ラベルを指定せずに起票する
+- **`Issue` 列と `commit` 列は値が異なる**（`question` / `architecture` はコミットでは使えない）。ここで使うのは `Issue` 列
 
 ## ステップ 2: ラベル存在チェック
 

--- a/.claude/skills/finalize-work/SKILL.md
+++ b/.claude/skills/finalize-work/SKILL.md
@@ -70,9 +70,11 @@ git diff develop..HEAD --stat
 優先順位:
 
 1. `$ARGUMENTS` に明示的なタイトルがあればそれを使用
-2. `.claude/references/commit-types.md` のマッピングテーブルを参照し、ブランチ接頭辞（`branch` 列）からタイトル接頭辞（`prefix` 列）を決定する
+2. `.claude/references/commit-types.md` のマッピングテーブルを参照し、ブランチ接頭辞（`branch` 列）からタイトル接頭辞（**`commit` 列**）を決定する
 
 例: ブランチ `feat/issue-87` + issue タイトル「振り返りレポート付きPR作成スキル」→ `feat: 振り返りレポート付きPR作成スキル`
+
+`Issue` 列ではなく `commit` 列を使うこと。GitHub の squash merge は PR タイトルをそのままコミットメッセージにするため、PR タイトルは commitlint の `type-enum` に収まっている必要がある（`question:` / `arch:` は使えない）。
 
 ## ステップ 4: PR description 生成
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -19,8 +19,6 @@ const config = {
         "style",
         "test",
         // custom
-        // 依存更新は chore(deps) を使う（Renovate の :semanticCommitTypeAll(chore)）。
-        // deps type は追加しない
         "agent",
       ],
     ],

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -19,8 +19,9 @@ const config = {
         "style",
         "test",
         // custom
+        // 依存更新は chore(deps) を使う（Renovate の :semanticCommitTypeAll(chore)）。
+        // deps type は追加しない
         "agent",
-        "deps",
       ],
     ],
   },


### PR DESCRIPTION
## Summary

`.claude/references/commit-types.md` の記載と実体（commitlint の `type-enum` / GitHub のラベル）にあった **7 件の差異**を解消した。

差異の原因は表の構造にあった。表の `prefix` 列が Issue タイトル・PR タイトル・コミットメッセージという**許容値の異なる 3 つの文脈**を単一の集合で兼ねていたため、どこかで必ず嘘になる。`prefix` 列を `Issue` 列と `commit` 列へ分解し、表を「作業タイプのマスター」として再定義した。

Closes #770

## 解消した差異

| # | 項目 | 変更前の記載 | 実体 | 対応 |
|---|---|---|---|---|
| 1 | `question` | prefix `question:` | commitlint が拒否 | `commit` 列を ❌ にし代替 `docs:` を明示 |
| 2 | `architecture` | prefix `arch:` | commitlint が拒否 | 同上 |
| 3 | `deps` | 記載なし | `type-enum` にあるが使用実績 0 | `type-enum` から削除 |
| 4 | `Type: build` | ラベルとして記載 | GitHub に存在しない | `label` 列を `—` に |
| 5 | `Type: chore` | ラベルとして記載 | GitHub に存在しない | 同上 |
| 6 | `Type: perf` | ラベルとして記載 | GitHub に存在しない | 同上 |
| 7 | `dependencies` | 記載なし | 実在（Renovate が付与） | 「手動で付けない」旨を明記 |

## 新しい表の構成

```
| type | Issue | branch | commit | label | keywords |
|------|-------|--------|--------|-------|----------|
| feat | feat: | feat/  | feat:  | Type: enhancement | ... |
| chore| chore:| chore/ | chore: | —                 | ... |
| question     | question: | — | ❌ docs: を使う | Type: question     | ... |
| architecture | arch:     | — | ❌ docs: を使う | Type: architecture | ... |
```

`commit` 列が `commitlint.config.mjs` の `type-enum` と一致する。`question` / `architecture` は Issue 分類としては有効（ラベルが実在し機能している）なので表に残しつつ、コミットでの禁止と代替を明示した。

## 設計判断

### `deps` type は削除した

使用実績 0 の死んだ設定だった。Renovate は `:semanticCommitTypeAll(chore)` を使うため生成されるのは `chore(deps):` であり、**type は `chore`、`deps` は scope**。`deps` 単独のコミットは全履歴に 1 件も無い。再追加を防ぐため削除理由を config のコメントに残した。

### 実在しないラベルは作らず、表を `—` にした

`build` / `perf` はコミット実績 0、`chore` は 109 件あるがほぼ Renovate 由来で Issue 起票を伴わない。ラベルを新規作成しても使われないため、実態に合わせて「付与不要」とした。

### PR タイトルは `commit` 列に従う

`finalize-work` の PR タイトル生成を `prefix` 列 → `commit` 列に変更した。GitHub の squash merge は **PR タイトルをそのままコミットメッセージにする**ため、PR タイトルは `type-enum` に収まっている必要がある。

実際、commitlint 導入（2026-01-31）より後の 2026-06-13 に `question: 見積詳細画面 検討 ... (#336)` が履歴へ入っている。ローカルの `commit-msg` フックを通らない経路があり、これが差異の長期放置につながっていた。

## 変更ファイル

| ファイル | 内容 |
| --- | --- |
| `commitlint.config.mjs` | `type-enum` から `deps` を削除 |
| `.claude/references/commit-types.md` | 表を 6 列構成に再定義（84 行） |
| `.claude/references/git-hooks.md` | 参照先を `commit` 列に修正 |
| `.claude/skills/create-issue/SKILL.md` | `Issue` 列を使う旨、`label` が `—` の扱いを追記 |
| `.claude/skills/finalize-work/SKILL.md` | PR タイトルを `commit` 列に変更 |
| `.claude/skills/auto-dev/SKILL.md` | `label` が `—` のタイプの逆引き不可を追記 |
| `.claude/skills/auto-tdd/SKILL.md` | 参照先を `commit` 列に明示 |
| `.claude/skills/auto-review-fix/SKILL.md` | 同上 |

`create-pr` は「`commit-types.md` は読まない」仕様（接頭辞は恒等写像で解決）のため変更していない。

## 検証

スクリプトで表と実体を突き合わせ、以下を確認した。

- `commit` 列の 12 type すべてが `type-enum` に存在し、❌ の 2 type はどちらにも無い
- `label` 列の 9 件すべてが GitHub に実在し、`—` の 5 件は対応ラベルが無いことを確認
- `type-enum` の全 type が表に存在する（表にない type でコミットが通ることは無い）

pre-push のフルスイート（型チェック + 全テスト）通過。

## 計画からの逸脱

Issue #770 では差異 #4〜#6 の実害を「`gh issue create --label` が失敗する」と記載したが、**これは誤り**だった。`create-issue` には「ステップ 2: ラベル存在チェック」があり、`gh label list` で存在を確認してから付与するためコマンドは失敗しない。Issue 本文は訂正済み。

正確には、この 3 件は**表が信用できないことへの対症療法が既に入っていた**状態であり、本来不要な防御ステップが差異の表面化を遅らせていた。表が正しくなった今もこのステップは保険として有用なため、削除はしていない。

## スコープ外（別 Issue 候補）

PR タイトルを検証する CI が無い。`.github/workflows/` に commitlint / semantic-pr 系のチェックを追加すれば、squash merge 経由で規約外の type が履歴へ入る経路を塞げる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rwx4mC7Y37BbVVJnm5KShD