### PR TITLE
release: v0.1.2 証明書更新のコンテナ化と nginx 可用性の改善

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -134,9 +134,19 @@ services:
       - ./docker/nginx/conf.d:/etc/nginx/conf.d:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - /var/www/certbot:/var/www/certbot:ro
+    # app の healthy は待たない（service_started）。リバースプロキシの可用性は
+    # app の可用性の上位集合であるべきで、app が healthy にならない障害で
+    # nginx ごと起動不能になると、ACME チャレンジ（webroot）への応答と 80 番の
+    # 301 リダイレクトまで巻き添えで止まり、「nginx は生きているが app が死んでいる」
+    # という切り分け情報も失われる。
+    # app-ssl.conf は変数経由 proxy_pass + resolver 127.0.0.11 で upstream を
+    # リクエスト時に解決するため、nginx の起動に app の DNS 名解決は不要。
+    # 初回起動時に app ready まで 502 を返す窓が生じるが、接続拒否より望ましい
+    # （TLS 終端が生き、ACME に応答でき、アクセスログに証跡が残る）。
+    # depends_on 自体を消さないのは、起動ログが依存順に並ぶ実益を取るため
     depends_on:
       app:
-        condition: service_healthy
+        condition: service_started
 
 volumes:
   pgdata:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -126,6 +126,22 @@ services:
     # メジャー/マイナーをピン留めし、更新は Renovate で意図的に取り込む
     image: nginx:1.28.0-alpine
     restart: unless-stopped
+    # 証明書の更新を反映するため 6h ごとに reload する（ADR-20260827-ff0）。
+    # certbot サービスとは /etc/letsencrypt のファイル共有だけで繋がり、
+    # deploy-hook や docker socket で互いを参照しない（疎結合）。
+    # 周期 6h は原典 wmnnd/nginx-certbot どおり。reload は接続を切らないため
+    # 周期を伸ばして得るものが無く、独自値は説明責任を恒常的に生むだけになる。
+    #
+    # command を上書きすると公式イメージの /docker-entrypoint.sh は
+    # 「$1 = nginx」の条件を満たさず /docker-entrypoint.d/ を実行しない。
+    # 現構成ではそこにある 4 本（IPv6 listen 自動付与・resolver 環境変数・
+    # templates の envsubst・worker_processes autotune）はすべて no-op だが、
+    # これらを使うようになったら本方式（command 上書き）を見直すこと。
+    #
+    # 末尾の exec は PID 1 を nginx に固定するため。busybox ash は末尾コマンドを
+    # 暗黙に exec するが、実装依存に頼らず STOPSIGNAL SIGQUIT が nginx に
+    # 直接届くことを明示する
+    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & exec nginx -g \"daemon off;\"'"
     # 外部公開はここ（80/443）のみ
     ports:
       - "80:80"
@@ -148,5 +164,35 @@ services:
       app:
         condition: service_started
 
+  # 証明書の自動更新（ADR-20260827-ff0）。12h ごとに certbot renew を試み、
+  # 更新された証明書は nginx 側の 6h ごとの reload で取り込まれる。
+  # 反映まで最大 6h 遅れるが、certbot は失効 30 日前から更新するため問題にならない。
+  # 初回発行は手動（docs/ops/tls-certificates.md）。ここでは renew しかしない。
+  certbot:
+    # 無印タグは amd64 / arm64 / arm32v6 のマルチアーチマニフェストのため
+    # アーキ別タグは不要。更新は Renovate（docker-compose マネージャ）で取り込む
+    image: certbot/certbot:v5.7.0
+    # イメージの ENTRYPOINT が certbot そのものなので、ループを書くには
+    # command ではなく entrypoint を上書きする必要がある。
+    # trap exit TERM は docker stop で sleep を待たずに抜けるため
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    restart: unless-stopped
+    volumes:
+      # ホスト bind mount を維持（nginx 側と対称。既存の証明書資産をそのまま引き継ぐ）。
+      # renewal conf の webroot_path と一致させるため、webroot もホストと同じパスで
+      # マウントする
+      - /etc/letsencrypt:/etc/letsencrypt
+      - /var/www/certbot:/var/www/certbot
+      # イメージが VOLUME /var/lib/letsencrypt を宣言しているため、明示しないと
+      # コンテナ再作成のたびに匿名ボリュームが増える。中身はロック等の作業用で
+      # 引き継ぐ価値は無く、named volume にする目的は増殖防止のみ
+      - certbot-work:/var/lib/letsencrypt
+    # 初回 renew の webroot 応答を nginx が受けられるようにし、起動ログを依存順に
+    # 並べるため。renew が失敗しても 12h 後に再試行されるので healthy は待たない
+    depends_on:
+      nginx:
+        condition: service_started
+
 volumes:
   pgdata:
+  certbot-work:

--- a/docker/nginx/conf.d/app-ssl.conf
+++ b/docker/nginx/conf.d/app-ssl.conf
@@ -1,8 +1,10 @@
-# HTTPS（SSL 終端）設定（Issue #758, #772）
+# HTTPS（SSL 終端）設定（Issue #758, #772, #779）
 #
-# 証明書はホスト側の certbot（webroot 方式）が /etc/letsencrypt に発行し、
-# compose.prod.yaml の nginx サービスが読み取り専用 bind mount で参照する。
-# 更新は certbot.timer が自動実行し、deploy-hook でコンテナ nginx を reload する。
+# 証明書は compose.prod.yaml の certbot サービスが /etc/letsencrypt に更新し、
+# nginx サービスは読み取り専用 bind mount で参照する。更新の反映は nginx 側の
+# 6h ごとの定期 reload で行い、certbot と nginx は互いを参照しない
+# （ADR-20260827-ff0）。初回発行・移行・失敗時の確認手順は
+# docs/ops/tls-certificates.md を参照。
 
 server {
     listen 443 ssl;

--- a/docs/adr/20260827-ff0-tls-renewal-decoupled-certbot-container-periodic-nginx-reload.md
+++ b/docs/adr/20260827-ff0-tls-renewal-decoupled-certbot-container-periodic-nginx-reload.md
@@ -1,0 +1,73 @@
+# ADR-20260827-ff0: 証明書更新は certbot コンテナと nginx の定期 reload による疎結合で行い、deploy-hook と docker socket を用いない
+
+| 項目 | 値 |
+|---|---|
+| ステータス | 採用 |
+| 起票日 | 2026-08-27 |
+| 最終更新日 | 2026-08-27 |
+
+## コンテキスト
+
+Issue #772 / PR #773 で nginx を HTTPS 構成へ切り替えた際、証明書の発行・更新は**ホスト側の certbot**（Ubuntu 24.04 の apt 版 2.9.0 + `certbot.timer`）に任せ、nginx コンテナは `/etc/letsencrypt` を読み取り専用 bind mount で参照する分離構成を取った。更新後の反映は renewal conf の `renew_hook` から `docker exec estimate-management-system-prod-nginx-1 nginx -s reload` を打つことで行っていた。
+
+動作は検証済みだが、Issue #779 で次の 3 点が課題として挙がった。
+
+- 証明書更新の仕組みがホスト依存で、`compose.prod.yaml` だけでは環境を再現できない
+- apt 版 certbot は Ubuntu 24.04 の feature freeze で 2.9.0 に固定され、Renovate の管理対象外
+- `renew_hook` が Compose の自動生成コンテナ名を直接参照しており、プロジェクト名やサービス名の変更で静かに失敗する
+
+ここで「証明書の更新と nginx への反映をどう結合するか」を決める必要がある。この判断はホスト側 certbot の撤去・renewal conf の書き換え・運用手順書（`docs/ops/tls-certificates.md`）に染み込むため、実装に先立って確定させる。
+
+前提となる事実（本 ADR 起票時に実測・確認したもの）:
+
+- Docker + nginx + certbot の組み合わせで最も引用されている雛形は [wmnnd/nginx-certbot](https://github.com/wmnnd/nginx-certbot)（Medium 記事 "nginx and Let's Encrypt with Docker in less than 5 minutes"、2018 年）で、certbot は `renew` を 12h ループ、nginx は `-s reload` を 6h ループで回し、両者は証明書ファイルの共有だけで繋がる。
+- `certbot/certbot:v5.7.0` の無印タグは amd64 / arm64 / arm32v6 のマルチアーキテクチャマニフェストであり、ADR-20260818-7pn の Graviton 前提でアーキテクチャ別タグは不要。`ENTRYPOINT` は `certbot` そのもので、`/etc/letsencrypt` と `/var/lib/letsencrypt` に `VOLUME` が宣言されている。
+- Renovate は `docker-compose` マネージャで `compose.prod.yaml` を既に検出しており（Dependency Dashboard #639 に `nginx 1.28.0-alpine` の更新が並んでいる）、certbot イメージを足せば追加設定なしで管理下に入る。
+- `nginx:1.28.0-alpine` の `/docker-entrypoint.sh` は `$1` が `nginx` のときだけ `/docker-entrypoint.d/` の初期化スクリプトを実行する。`command` を `/bin/sh -c ...` に差し替えるとこれらは走らないが、4 本（IPv6 listen 付与・local resolver 変数・templates の envsubst・worker autotune）はいずれも現構成では no-op であることを個別に確認した。
+- Let's Encrypt は 2025 年 6 月に期限切れ通知メールを廃止した。更新失敗に受動的に気づく手段はもう無い。
+- certbot は期限の 30 日前から更新を試みる。更新から反映までの遅延は、この 30 日のマージンに対して評価する。
+
+## 検討した選択肢
+
+### A. certbot コンテナ + nginx の定期 reload による疎結合（採用）
+
+wmnnd/nginx-certbot に準拠する。certbot コンテナは `entrypoint` を `certbot renew` → 12h sleep のループに差し替え、nginx コンテナは `command` に 6h ごとの `nginx -s reload` ループを足す。両者は `/etc/letsencrypt` のファイル共有だけで繋がり、互いのコンテナ名・存在を知らない。`renew_hook` / `--deploy-hook` は持たない。
+
+- 利点: compose ファイルだけで更新機構が完結する。certbot のバージョンが Renovate 管理下に入る。コンテナ名への依存が消える。certbot コンテナに与える権限は証明書ディレクトリの書き込みだけで済む。
+- 欠点: 更新から反映まで最大 6h の遅延がある。nginx の `command` 上書きで公式イメージの `/docker-entrypoint.d/` が走らなくなる。
+
+### B. certbot コンテナから docker socket 経由で nginx を reload（不採用）
+
+`--deploy-hook` を残し、certbot コンテナに `/var/run/docker.sock` をマウントして `docker exec <nginx> nginx -s reload` を打つ。
+
+- 利点: 更新が即時反映される。
+- 欠点: docker socket のマウントは実質的にホスト root 権限の付与であり、インターネットに向いた ACME クライアントに与える権限として釣り合わない。加えて「コンテナ名を直接参照する脆さ」という Issue #779 の問題意識をそのまま持ち込む（compose の `container_name` で固定しても、名前への依存自体は残る）。
+
+### C. certbot コンテナは one-shot、起動はホストの systemd timer / cron（不採用）
+
+`docker compose run --rm certbot renew` をホストが定期実行する。certbot のバージョン管理はコンテナ化で解決する。
+
+- 利点: certbot のバージョン管理は Renovate に乗る。常駐コンテナが増えない。
+- 欠点: 更新の起動がホストの timer に残り、「compose だけで再現できない」という第一の課題を解決しない。reload の経路も別途要る（B と同じ問題に戻る）。
+
+## 決定
+
+証明書更新は `compose.prod.yaml` 内の certbot コンテナ（`renew` 12h ループ）と nginx コンテナの定期 reload（6h ループ）による疎結合で行う（選択肢 A）。`renew_hook` / `--deploy-hook` と docker socket のマウントは用いない。ホスト側の certbot（apt 版 + `certbot.timer`）は撤去する。
+
+## 根拠
+
+- **課題の 3 点をすべて解決するのは A だけ。** C はホスト依存が残り、B はコンテナ名依存が残る。
+- **権限の釣り合い。** B が要求する docker socket は「証明書を更新する」という責務に対して過大で、ACME クライアントの脆弱性がそのままホスト掌握に繋がる経路を作る。A の certbot コンテナが持つのは `/etc/letsencrypt` と webroot の書き込み権限だけで、責務と権限が一致する。
+- **反映遅延は失効リスクに影響しない。** certbot は期限 30 日前から更新を始めるため、6h の反映遅延は 30 日のマージンに対して誤差であり、即時反映（B の唯一の利点）に実益が無い。
+- **周期は原典どおり 6h に揃える。** Issue 起票時は 36h が提案されたが、reload は設定再読込と worker の graceful 入替だけで接続を切らず、周期を伸ばして得るものが無い。独自値は「なぜその値か」の説明責任を恒常的に生むため、原典の値を採る。
+- **nginx の `command` 上書きは現構成で無害であることを確認したうえで受け入れる。** entrypoint の作法に乗せるために専用 Dockerfile を作る案（`/docker-entrypoint.d/` にループ起動スクリプトを置く）は、nginx 用イメージの build / GHCR push / `release-image.yml` の拡張を要し、起きていない問題に恒常コストを払うことになる。
+
+## 影響
+
+- **更新から反映まで最大 6h 遅れる。** 「certbot のログでは更新済みなのにブラウザが古い証明書を出す」は、6h 以内なら正常動作である。
+- **nginx の `command` 上書きにより `/docker-entrypoint.d/` は走らない。** templates（envsubst）・IPv6 listen の自動付与・worker autotune を使い始める場合は、この方式を見直す必要がある。`compose.prod.yaml` のコメントにこの制約を明記する。
+- **初回発行は手動手順とする。** `renew` ループは既存の証明書が無い環境では何もしない。`app-ssl.conf` が証明書パスを直書きしているため、証明書が無いと nginx が起動せず webroot チャレンジにも応答できない鶏卵問題があり、原典の `init-letsencrypt.sh` 相当は同梱しない（EC2 一台の公開デモ環境に対して過剰で、テストの無いシェルスクリプトを保守対象に加えることになる）。手順は `docs/ops/tls-certificates.md` に置く。
+- **更新失敗の検知は能動確認（`docker logs certbot`）のみになる。** 疎結合の代償として、certbot 側の失敗は nginx 側には失効の瞬間まで現れない。Let's Encrypt の通知メールも廃止済みのため、証明書期限の外形監視は別イシューで扱う。
+- **`/etc/letsencrypt` はホスト bind mount のまま**とし、既存の証明書・アカウント・renewal conf を移動せずに引き継ぐ。移行時は renewal conf から `renew_hook` 行を削除し、ホスト側 certbot はコンテナ起動より**先に**停止・撤去する（残したまま起動すると、コンテナ内に docker CLI が無いためフックだけが失敗する）。
+- **短命証明書（Let's Encrypt の 6 日有効期間プロファイル等）に切り替える場合は本 ADR の前提が崩れる。** 6h の反映遅延と 12h の更新周期は 90 日証明書の 30 日マージンを前提にしており、短命証明書では周期の再設計が要る。
+- `CONTEXT.md` には何も追加しない。certbot / reload はデプロイ環境の語彙であり、見積業務の用語集に属さない。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -156,3 +156,4 @@
 | [20260730-t6e](20260730-t6e-introduce-platform-automerge-with-approval-retained.md) | Renovate automerge は platformAutomerge + squash-only リポジトリ設定で導入し、Dashboard 承認は維持する | 採用（適用は #704 マージ後） | 2026-07-30 |
 | [20260818-7pn](20260818-7pn-production-images-arm64-single-arch-bind-ec2-to-graviton.md) | 本番イメージは arm64 単一アーキテクチャでビルドし、EC2 を Graviton に拘束する | 採用 | 2026-08-18 |
 | [20260821-4f1](20260821-4f1-deploy-target-is-public-demo-reuse-dev-seed.md) | デプロイ先を公開デモ環境と定義し、初期データ投入に開発 seed を流用する | 採用 | 2026-08-21 |
+| [20260827-ff0](20260827-ff0-tls-renewal-decoupled-certbot-container-periodic-nginx-reload.md) | 証明書更新は certbot コンテナと nginx の定期 reload による疎結合で行い、deploy-hook と docker socket を用いない | 採用 | 2026-08-27 |

--- a/docs/claude-plans/issue-776/relax-nginx-depends-on-to-service-started.md
+++ b/docs/claude-plans/issue-776/relax-nginx-depends-on-to-service-started.md
@@ -1,0 +1,64 @@
+# Issue #776: nginx の depends_on を service_healthy から service_started に緩和する — 実装計画
+
+> **実行規約**: 各 step 完了時にこのファイルの該当チェックボックス（`- [ ]`）を
+> `- [x]` に更新し、その更新を step のコミットに含めること。
+
+## 概要
+
+`compose.prod.yaml` の nginx サービスが `app: condition: service_healthy` に依存している。
+この依存を `service_started` に緩和し、app の障害が nginx（TLS 終端・ACME 応答・301 リダイレクト）に
+波及しないようにする。
+
+変更は `compose.prod.yaml` の 1 行（condition）と、判断理由を残すコメントのみ。
+アプリケーションコード・スキーマ・テストへの影響は無い。
+
+## 前提の裏取り
+
+計画時点で以下を実コードで確認した。
+
+- `docker/nginx/conf.d/app-ssl.conf` の `location /` は
+  `resolver 127.0.0.11 valid=10s` + `set $upstream_app app` + `proxy_pass http://$upstream_app:3000`
+  という**変数経由 proxy_pass**（Issue #772 で導入済み）。名前解決はリクエスト時に遅延されるため、
+  nginx の**起動**に app の存在も DNS 解決も不要
+- したがって現在の `service_healthy` が実際に担保しているのは
+  「初回 `up -d` 時、app が healthy になるまで 443 を開かない」ことだけである
+
+## 設計判断
+
+### 1. 依存を完全に外すか、`service_started` に緩めるか
+
+- A. `depends_on` ごと削除する
+- B. `condition: service_started` に緩める
+- **決定: B** — 技術的必然性という観点では A で足りる。ただし `depends_on` は compose の
+  起動ログ・`docker compose ps` の並び順を依存グラフ順に整える効果があり、
+  db → migrate → app → nginx という読み順が保たれる実益がある。
+  `service_started` はコンテナの起動のみを待ち healthcheck を見ないため、
+  「app が healthy にならない障害で nginx が起動不能になる」という本 Issue の問題は解消される
+
+### 2. 初回起動時に 502 を返す窓が生まれることの受容
+
+app のコンテナ起動直後〜アプリ ready までの短時間、クライアントは接続拒否ではなく 502 を受け取る。
+これを**望ましい退行**として受容する。理由:
+
+- TLS 終端が生きるため、証明書エラーではなく HTTP レベルのエラーとして観測できる
+- ACME チャレンジ（`/var/www/certbot` webroot）に応答できる。証明書更新が app の健全性に
+  巻き込まれない
+- アクセスログに証跡が残る。接続拒否は nginx 側に何も残さない
+
+## 実装ステップ
+
+- [x] **Step 1**: `compose.prod.yaml` の nginx `depends_on` を `service_started` に変更し、
+      なぜ healthy を待たないのかを説明するコメントを付す
+      - テスト戦略: **テスト不要** — compose の宣言的設定であり、単体テストの対象にならない
+- [x] **Step 2**: `docker compose -f compose.prod.yaml config` で構文と解決結果を検証する
+      - テスト戦略: **テスト不要**（検証のみ、コミット対象なし）
+
+## 影響範囲
+
+| 対象 | 影響 |
+|------|------|
+| `compose.prod.yaml` | nginx の `depends_on.app.condition` |
+| アプリケーションコード | なし |
+| Prisma スキーマ / マイグレーション | なし |
+| 単体テスト / E2E | なし |
+| CI ワークフロー | なし（`.github/workflows` は compose.prod.yaml の condition を参照していない） |

--- a/docs/claude-plans/issue-779/containerize-certbot-with-periodic-nginx-reload.md
+++ b/docs/claude-plans/issue-779/containerize-certbot-with-periodic-nginx-reload.md
@@ -1,0 +1,171 @@
+# Issue #779: certbot をコンテナ化し、証明書更新を Docker Compose に完結させる — 実装計画
+
+> **実行規約**: 各 step 完了時にこのファイルの該当チェックボックス（`- [ ]`）を
+> `- [x]` に更新し、その更新を step のコミットに含めること。
+> 再開時（compaction 後・新規セッション後を含む）は、まずこのファイルを読み、
+> 未チェックの最小 step 番号から続行すること。
+
+## 概要
+
+現在の本番（公開デモ）環境は、certbot がホスト側（apt 版 2.9.0 + `certbot.timer`）、nginx がコンテナ側という分離構成で、renewal conf の `renew_hook` が自動生成コンテナ名 `estimate-management-system-prod-nginx-1` を直接参照して reload している。
+
+これを `compose.prod.yaml` 内で完結する構成へ移行する。方式は [wmnnd/nginx-certbot](https://github.com/wmnnd/nginx-certbot) 準拠の疎結合（ADR-20260827-ff0）:
+
+- certbot コンテナ: `certbot renew` → 12h sleep のループ
+- nginx コンテナ: 6h ごとの `nginx -s reload` ループを `command` に追加
+- 両者は `/etc/letsencrypt` のファイル共有だけで繋がり、`renew_hook` / `--deploy-hook` / docker socket は用いない
+
+変更対象は `compose.prod.yaml`・`docker/nginx/conf.d/app-ssl.conf` のヘッダコメント・運用ドキュメント・ADR のみ。アプリケーションコード・スキーマ・テスト・CI ワークフローへの影響は無い。
+
+## 前提の裏取り
+
+計画時点で以下を実測・確認した（詳細は ADR-20260827-ff0「コンテキスト」節）。
+
+- `certbot/certbot:v5.7.0` の無印タグは amd64 / arm64 / arm32v6 のマルチアーチマニフェスト（Docker Hub API で確認）。ADR-20260818-7pn の Graviton 前提でもアーキ別タグは不要
+- 同イメージは `ENTRYPOINT ["certbot"]`、`VOLUME /etc/letsencrypt /var/lib/letsencrypt` を宣言（`docker image inspect` で確認）。ループを書くには `command` ではなく **`entrypoint` を上書き**する必要があり、`/var/lib/letsencrypt` を明示マウントしないと匿名ボリュームが増殖する
+- `nginx:1.28.0-alpine` の `/docker-entrypoint.sh` は `$1 = nginx` のときだけ `/docker-entrypoint.d/` を実行する。`command` を `/bin/sh -c` に差し替えると 4 本のスクリプトが走らなくなるが、現構成ではすべて no-op（`default.conf` 不在・templates 不使用・autotune 未設定・resolver 直書き）
+- 原典どおりの `command` でも busybox ash の末尾 exec 最適化により PID 1 は nginx になり、`docker stop` は約 0.4 秒で graceful 終了（実測）。実装では実装依存を消すため `exec` を明示する
+- Renovate は `docker-compose` マネージャで `compose.prod.yaml` を検出済み（Dashboard #639）。certbot イメージを足せば追加設定なしで管理下に入る
+- Let's Encrypt は 2025 年 6 月に期限切れ通知メールを廃止済み。更新失敗に受動的に気づく手段は無い
+
+## 設計判断
+
+いずれも `/grill-with-docs` セッションで合意済み。
+
+### 1. 更新→反映の結合方式
+- A. 定期 reload による疎結合（wmnnd/nginx-certbot 準拠）
+- B. certbot から docker socket 経由で nginx を reload（deploy-hook 維持）
+- C. certbot は one-shot、起動はホストの systemd timer
+- **決定: A** — B は socket マウントが実質 root 権限でありコンテナ名依存も残る。C はホスト依存が残る。反映遅延は certbot の 30 日マージンで吸収される。→ **ADR-20260827-ff0**
+
+### 2. nginx の reload 周期
+- Issue 提案の 36h / 原典の 6h
+- **決定: 6h** — reload は接続を切らず周期を伸ばして得るものが無い。独自値は説明責任を恒常的に生むため原典の値を採る
+
+### 3. nginx の `command` 上書き
+- A. `command` を上書きし entrypoint.d スキップをコメントで明記
+- B. 専用 Dockerfile で `/docker-entrypoint.d/` にループ起動スクリプトを置く
+- C. reload ループを別コンテナに出し `pid: "service:nginx"` で SIGHUP
+- **決定: A** — 4 本すべて現構成で no-op を確認済み。B は nginx 用イメージの build / GHCR push が新たに要り、起きていない問題に恒常コストを払う。末尾は `exec nginx -g "daemon off;"` と明示する
+
+### 4. 永続化先
+- `/etc/letsencrypt`: ホスト bind mount 維持（certbot 側 rw） / named volume へ移す
+- `/var/lib/letsencrypt`: named volume / 匿名ボリューム放置 / ホスト bind mount
+- **決定: `/etc/letsencrypt` は bind mount 維持、`/var/lib/letsencrypt` は named volume（`certbot-work`）** — 前者は既存資産を移動せず引き継げ nginx と対称。後者は匿名ボリューム増殖の防止のみが目的
+
+### 5. 初回発行（新規環境）の扱い
+- A. スコープ外 / B. 手動手順としてドキュメント化 / C. 原典の `init-letsencrypt.sh` 相当を同梱
+- **決定: B** — A では「compose 完結」の看板に対し既存 EC2 にしか適用できず復旧経路も無い。C はデモ環境一台に対し過剰で、テストの無いシェルスクリプトを保守対象に加える。`app-ssl.conf` 一時退避の手筋は `prod-docker-local.md` に既存
+
+### 6. 運用手順の置き場所
+- A. `docs/ops/tls-certificates.md` 新設 / B. README / C. `prod-docker-local.md` に追記
+- **決定: A** — README には本番運用の記述が無く、`docs/ops/` に前例（`demo-seed.md`）がある。CLAUDE.md のポインタ運用に沿う。README は触らない
+
+### 7. 更新失敗の検知
+- A. `docker logs certbot` の記載のみ / B. 外形監視をスコープに含める / C. certbot に healthcheck
+- **決定: A + 外形監視は別イシュー起票** — C は sleep ループの生死しか見えず偽装になる。B はコンテナ化と独立した設計（ツール選定・通知先・死活監視との統合）であり分割する
+
+### 8. ホスト側移行の順序
+- **決定: timer 停止 → `renew_hook` 削除 → `apt remove` → コンテナ起動** — 逆順だと `renew_hook` が残ったままコンテナの初回 `renew` が走り、コンテナ内に docker CLI が無いためフックだけが失敗する
+
+### 9. `depends_on` とローカル検証
+- **決定: `certbot` → `nginx` を `service_started` で宣言。ローカルでも certbot はそのまま起動（profiles に入れない）** — 前者は既存 `nginx` → `app` と同じ「起動ログが依存順に並ぶ」理由。後者は EC2 側の `up -d` に恒常的な `--profile` を増やさないため
+
+### 10. ADR / CONTEXT.md
+- **決定: ADR は判断 1 のみ起票（済）。`CONTEXT.md` は更新しない** — certbot / reload はデプロイ環境の語彙であり見積業務の用語集に属さない
+
+## ステップ
+
+### Step 1: ADR-20260827-ff0 をコミットする
+- [x] **完了**
+- 対象ファイル:
+  - `docs/adr/20260827-ff0-tls-renewal-decoupled-certbot-container-periodic-nginx-reload.md`（作成済み・未コミット）
+  - `docs/adr/INDEX.md`（「開発基盤（依存管理・CI）」表に 1 行追記済み・未コミット）
+- テスト戦略: テスト不要（ドキュメント）
+- 作業内容:
+  - grill セッションで作成済みのファイルをそのままコミットする。内容の再検討はしない
+- コミットメッセージ: `docs: ADR-20260827-ff0 証明書更新を certbot コンテナと定期 reload の疎結合で行う判断を記録する`
+
+### Step 2: `compose.prod.yaml` に certbot サービスを追加し、nginx を定期 reload に切り替える
+- [x] **完了**
+- 対象ファイル:
+  - `compose.prod.yaml`
+  - `docker/nginx/conf.d/app-ssl.conf`（ヘッダコメントのみ）
+- テスト戦略: テスト不要（compose の宣言的設定。`docker compose config` と起動実測で検証する）
+- 作業内容:
+  - `certbot` サービスを追加する:
+    - `image: certbot/certbot:v5.7.0`（Renovate の docker-compose マネージャが自動検出する。コメントに「無印タグはマルチアーチ、アーキ別タグ不要」を記す）
+    - `entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"`（`ENTRYPOINT` が `certbot` のため `command` ではなく `entrypoint` を上書きする旨をコメントに記す）
+    - `restart: unless-stopped`
+    - `volumes`: `/etc/letsencrypt:/etc/letsencrypt`（rw。renewal conf の `webroot_path` と一致させるため webroot も同パス）、`/var/www/certbot:/var/www/certbot`（rw）、`certbot-work:/var/lib/letsencrypt`（匿名ボリューム防止）
+    - `depends_on: nginx: condition: service_started`（理由コメント: 初回 `renew` の webroot 応答と起動ログの並び順のため。失敗しても 12h 後に再試行される）
+  - `nginx` サービスを変更する:
+    - `command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & exec nginx -g \"daemon off;\"'"`
+    - コメントに次を記す: 周期 6h は原典どおり／`command` 上書きにより `/docker-entrypoint.d/` は走らない（templates・IPv6 自動付与・worker autotune を使う場合は方式を見直す）／`exec` は PID 1 を nginx に固定し `STOPSIGNAL SIGQUIT` を直接届けるため
+    - `volumes` は現状維持（`/etc/letsencrypt` と `/var/www/certbot` は ro のまま）
+  - トップレベル `volumes:` に `certbot-work:` を追加する
+  - `app-ssl.conf` ヘッダの「証明書はホスト側の certbot が発行し…deploy-hook でコンテナ nginx を reload する」を、certbot コンテナと定期 reload の構成説明 + `docs/ops/tls-certificates.md` へのポインタに差し替える
+  - `docker compose -f compose.prod.yaml --env-file .env.production config` で構文と解決結果を確認する
+- コミットメッセージ: `ci: certbot をコンテナ化し nginx を 6h ごとの定期 reload に切り替える`（ボディに ADR-20260827-ff0 参照と、周期・exec・named volume の判断理由を記す）
+
+### Step 3: 運用手順を `docs/ops/tls-certificates.md` に集約し、既存ドキュメントをポインタ化する
+- [x] **完了**
+- 対象ファイル:
+  - `docs/ops/tls-certificates.md`（新規）
+  - `docs/ops/prod-docker-local.md`
+- テスト戦略: テスト不要（ドキュメント）
+- 作業内容:
+  - `tls-certificates.md` に次の節を置く:
+    1. **構成の概要** — certbot コンテナ（12h renew）と nginx（6h reload）の疎結合、反映まで最大 6h 遅れるのは正常動作である旨、ADR-20260827-ff0 へのリンク
+    2. **ホスト certbot からの移行（一回限り・証跡として残す）** — 判断 8 の順序で記す。`systemctl disable --now certbot.timer` → `/etc/letsencrypt/renewal/chapple-esm.duckdns.org.conf` から `renew_hook` 行を削除 → 同 conf の `authenticator = webroot` / `webroot_path = /var/www/certbot` を確認 → `apt remove certbot`（`purge` ではないので `/etc/letsencrypt` は残る） → `docker compose ... up -d` → `docker logs certbot` で初回 `renew` の結果を確認
+    3. **新規環境での初回発行（手動）** — `app-ssl.conf` を一時退避して nginx を 80 番のみで起動 → `docker compose -f compose.prod.yaml --env-file .env.production run --rm certbot certonly --webroot -w /var/www/certbot -d chapple-esm.duckdns.org --email <addr> --agree-tos --no-eff-email` → `app-ssl.conf` を戻して `docker compose ... exec nginx nginx -s reload`。スクリプト化しない理由（判断 5）を一文添える
+    4. **更新失敗の確認** — `docker logs certbot`（`renew` は 12h ごと。「No renewals were attempted」は正常）。Let's Encrypt の期限切れ通知メールは 2025 年 6 月に廃止済みで、能動確認が唯一の手段である旨。外形監視は別イシュー（Step 4 で起票した番号を記す）
+  - `prod-docker-local.md` を更新する:
+    - サービス構成表に `certbot` 行を追加（「ローカルでは `renew` が何もせず sleep に入るだけ」）
+    - 注意点の「証明書はホスト側 certbot（webroot 方式）が発行し…deploy-hook でコンテナ nginx を reload する」を削除し、`tls-certificates.md` へのポインタに差し替える
+    - 「そのままではローカルで起動しない」の項は維持（`app-ssl.conf` 退避の手筋は初回発行手順と共通なので、`tls-certificates.md` 側から逆参照する）
+- コミットメッセージ: `docs: TLS 証明書の運用手順を docs/ops/tls-certificates.md に集約する`
+
+### Step 4: 証明書期限の外形監視イシューを起票する
+- [x] **完了**
+- 対象ファイル: なし（GitHub Issue のみ）
+- テスト戦略: テスト不要（イシュー起票）
+- 作業内容:
+  - `/create-issue` で `ci:` タイプのイシューを起票する。要点: 疎結合化により certbot 側の失敗は失効まで nginx 側に現れない／Let's Encrypt の通知メールは廃止済み／証明書期限の外形監視（Uptime Kuma / UptimeRobot / healthchecks.io 等）を死活監視と合わせて設計する／#777（バックアップ）と同列の運用イシュー
+  - 起票した番号を Step 3 の `tls-certificates.md` に反映する（Step 3 のコミットに含めるため、実施順は Step 4 → Step 3 でもよい）
+- コミットメッセージ: なし（Step 3 に吸収）
+
+### Step 5: ローカルでの起動実測
+- [x] **完了**
+- 対象ファイル: なし
+- テスト戦略: テスト不要（検証のみ、コミット対象なし）
+- 作業内容:
+  - `prod-docker-local.md` の手順（`app-ssl.conf` 退避）で `up -d --wait` し、次を確認する:
+    - `docker compose ps` で certbot が running、`docker logs certbot` に `No renewals were attempted` 相当が出て sleep に入る
+    - `docker exec <nginx> cat /proc/1/comm` が `nginx`
+    - `docker compose stop nginx` が数秒以内に終わる（graceful）
+    - `docker volume ls` に `estimate-management-system-prod_certbot-work` があり、匿名ボリュームが増えていない
+  - `down -v` で片付ける
+- コミットメッセージ: なし
+
+## PR マージ後のユーザー作業（EC2 上）
+
+計画の対象外だが、Step 3 の手順書どおりに実施する。順序が結果に効く（判断 8）。
+
+- [ ] `systemctl disable --now certbot.timer`
+- [ ] renewal conf から `renew_hook` 行を削除、`webroot_path = /var/www/certbot` を確認
+- [ ] `apt remove certbot`
+- [ ] `docker compose -f compose.prod.yaml --env-file .env.production pull && up -d`
+- [ ] `docker compose -f compose.prod.yaml --env-file .env.production logs certbot` で初回 `renew` の結果を確認
+
+## 影響範囲
+
+| 対象 | 影響 |
+|------|------|
+| `compose.prod.yaml` | certbot サービス追加、nginx `command` 追加、named volume 追加 |
+| `docker/nginx/conf.d/app-ssl.conf` | ヘッダコメントのみ（設定本体は不変） |
+| `docs/ops/` | `tls-certificates.md` 新設、`prod-docker-local.md` 更新 |
+| `docs/adr/` | ADR-20260827-ff0 追加、INDEX 追記 |
+| Renovate | `certbot/certbot` が docker-compose マネージャの管理下に入る（設定変更なし。non-major は既存ルールで automerge） |
+| アプリケーションコード / Prisma / 単体テスト / E2E / CI ワークフロー | なし |
+| README / CONTEXT.md | なし |

--- a/docs/claude-plans/issue-779/deviations.md
+++ b/docs/claude-plans/issue-779/deviations.md
@@ -1,0 +1,45 @@
+# Issue #779: 計画からの逸脱記録
+
+## Step 5: ローカル起動実測の方法
+
+### 元の計画内容
+
+`prod-docker-local.md` の手順（`app-ssl.conf` を一時退避し `app.conf` を proxy_pass に戻す）で
+スタック全体を `up -d --wait` し、certbot / nginx の挙動を確認する。最後に `down -v` で片付ける。
+
+### 実際の実装内容
+
+- `up -d --no-deps nginx certbot` で **nginx と certbot の 2 サービスのみ**起動した
+- 証明書は自己署名（`openssl req -x509`）を scratchpad 配下の `live/chapple-esm.duckdns.org/` に生成し、
+  scratchpad に置いた compose override ファイルで `/etc/letsencrypt` と `/var/www/certbot` の bind mount 元を
+  scratchpad に差し替えた。リポジトリ内のファイル（`app-ssl.conf` / `app.conf`）には触れていない
+- 確認項目（certbot が `No renewals were attempted.` の後 sleep に入る／nginx の PID 1 が `nginx`／
+  `nginx -s reload` が master に届く／graceful stop が 1 秒未満／named volume `certbot-work` が作られ
+  匿名ボリュームが増えない／TLS 終端と 80→443 の 301）はすべて計画どおり実測した
+- `down -v` で片付けた（`pgdata` は本検証で作られたものであることを作成時刻で確認してから削除）
+
+### 逸脱の理由
+
+- 検証対象は nginx と certbot の起動挙動だけで、app / db / migrate は今回の変更に無関係
+- app イメージは arm64 単一アーキ（ADR-20260818-7pn）で、amd64 の開発機では GHCR のイメージがそのまま動かず、
+  ローカルビルドには Next.js のフルビルドが必要になる。検証の価値に対してコストが釣り合わない
+- 開発機にはホストの `/etc/letsencrypt` と `/var/www/certbot` が存在せず、compose をそのまま起動すると
+  docker が両ディレクトリを root 所有で作ってしまう。scratchpad への差し替えでこの副作用を避けた
+
+## Step 3: `tls-certificates.md` に計画外の節を追加
+
+### 元の計画内容
+
+「構成の概要」「ホスト certbot からの移行」「新規環境での初回発行」「更新失敗の確認」の 4 節。
+
+### 実際の実装内容
+
+上記 4 節に加え「5. 手動で即時更新したいとき」を追加した。また初回発行手順に
+`docker compose run --rm --entrypoint certbot certbot certonly ...` と **`--entrypoint certbot` が必須**である旨を明記した。
+
+### 逸脱の理由
+
+`compose.prod.yaml` で certbot サービスの `entrypoint` を renew ループに上書きしたため、
+`docker compose run certbot <サブコマンド>` は引数がループの `$0 $1 ...` に吸われて無視され、
+サブコマンドではなくループが始まる。この落とし穴は初回発行だけでなく手動 renew でも同じであり、
+手順書に正しい呼び出し方を一箇所にまとめておく必要があった。

--- a/docs/ops/prod-docker-local.md
+++ b/docs/ops/prod-docker-local.md
@@ -5,7 +5,7 @@
 構成ファイル:
 
 - `Dockerfile` — `runner`（Next.js standalone）/ `migrate`（Prisma マイグレーション）の 2 ステージ
-- `compose.prod.yaml` — db / migrate / seed / app / nginx
+- `compose.prod.yaml` — db / migrate / seed / app / nginx / certbot
 - `docker/nginx/` — リバースプロキシ設定
 
 デプロイ先は本番ではなく**公開デモ環境**と定義している（[ADR-20260821-4f1](../adr/20260821-4f1-deploy-target-is-public-demo-reuse-dev-seed.md)）。実業務データを扱わず、ダミーデータ込みで動きを見せる場所であるため、初期データ投入には開発 seed（`prisma/seed-dev.ts`）をそのまま流用する。
@@ -18,7 +18,8 @@
 | `migrate` | `prisma migrate deploy` | one-shot。db が healthy になってから走り、正常終了後に app が起動する |
 | `seed` | 初期データ投入 | **`up -d` では走らない**（`profiles: ["seed"]`）。[demo-seed.md](demo-seed.md) 参照 |
 | `app` | Next.js（standalone） | migrate が正常終了してから起動 |
-| `nginx` | リバースプロキシ | 公開ポートは 80 / 443 のみ |
+| `nginx` | リバースプロキシ | 公開ポートは 80 / 443 のみ。6h ごとに `nginx -s reload` して証明書の更新を取り込む |
+| `certbot` | 証明書の自動更新 | 常駐。12h ごとに `certbot renew`。**ローカルでは更新対象が無く、何もせず sleep に入るだけ**。[tls-certificates.md](tls-certificates.md) 参照 |
 
 `seed` は専用イメージを持たず `migrate` イメージに相乗りしている（`command` を `tsx prisma/seed-dev.ts` に上書き）。
 
@@ -71,6 +72,6 @@ docker compose -f compose.prod.yaml --env-file .env.production down -v
   の証明書を読むため、ホストに証明書がない環境では起動に失敗する。ローカルで検証する場合は
   `docker/nginx/conf.d/app-ssl.conf` を一時的に退避し、`app.conf` の `location /` を
   301 リダイレクトから `proxy_pass http://$upstream_app:3000;` に戻す（コミットはしない）
-- 証明書はホスト側 certbot（webroot 方式）が発行し、nginx は read-only bind mount で参照する。
-  更新は `certbot.timer` が自動実行し、deploy-hook でコンテナ nginx を reload する
+- 証明書の発行・更新・失敗時の確認は [tls-certificates.md](tls-certificates.md) にまとめている。
+  `app-ssl.conf` 退避の手筋は、そこに書いた新規環境での初回発行手順と共通
 - イメージは arm64 単一アーキテクチャでビルドする（[ADR-20260818-7pn](../adr/20260818-7pn-production-images-arm64-single-arch-bind-ec2-to-graviton.md)）

--- a/docs/ops/tls-certificates.md
+++ b/docs/ops/tls-certificates.md
@@ -1,0 +1,137 @@
+# TLS 証明書の運用
+
+公開デモ環境（`chapple-esm.duckdns.org`）の Let's Encrypt 証明書に関する運用手順（Issue #779）。
+構成の判断理由は [ADR-20260827-ff0](../adr/20260827-ff0-tls-renewal-decoupled-certbot-container-periodic-nginx-reload.md) を参照。
+
+以降のコマンドは、EC2 上のリポジトリ直下（`compose.prod.yaml` と `.env.production` がある場所）で実行する前提。
+
+## 1. 構成の概要
+
+証明書の更新と反映は `compose.prod.yaml` の 2 サービスで完結し、ホスト側に certbot は存在しない。
+
+| サービス | 役割 | 周期 |
+| --- | --- | --- |
+| `certbot` | `certbot renew` を実行し、更新された証明書を `/etc/letsencrypt` に書く | 12h |
+| `nginx` | `nginx -s reload` で `/etc/letsencrypt` の証明書を読み直す | 6h |
+
+両者は **`/etc/letsencrypt` のファイル共有だけで繋がる**。certbot は nginx を reload せず、nginx は certbot を待たない（`renew_hook` / `--deploy-hook` / docker socket は用いない）。
+
+この疎結合の帰結として、**更新された証明書が nginx に反映されるまで最大 6 時間の遅れがある**。certbot は失効の 30 日前から更新を始めるため、この遅れは問題にならない。`certbot` のログに更新成功が出た直後に `openssl s_client` 等で見ても古い証明書が返るのは正常動作であり、障害ではない。
+
+- 証明書の実体はホストの `/etc/letsencrypt`（bind mount）。`certbot` は読み書き、`nginx` は読み取り専用
+- ACME チャレンジ（HTTP-01）の webroot はホストの `/var/www/certbot`。`nginx` の `app.conf` が `/.well-known/acme-challenge/` をここから配信する
+- `/var/lib/letsencrypt`（certbot の作業領域）は named volume `certbot-work`。中身に引き継ぐ価値は無く、消しても支障はない
+
+## 2. ホスト certbot からの移行（一回限り）
+
+Issue #772 / #773 で構築したホスト側 certbot（apt 版 + `certbot.timer` + `renew_hook`）からの移行手順。
+一度きりの作業だが、何を行ったかの証跡として残す。
+
+> [!IMPORTANT]
+> **順序が結果に効く。** `renew_hook` を残したままコンテナを起動すると、コンテナの初回 `renew` がフックの
+> `docker exec ... nginx -s reload` を実行しようとし、コンテナ内に docker CLI が無いためフックだけが失敗する。
+> 証明書の更新自体は成功するがログに ERROR が残り、切り分けを混乱させる。
+
+```bash
+# 1. ホスト側の自動更新を止める（二重更新の防止）
+sudo systemctl disable --now certbot.timer
+systemctl is-enabled certbot.timer   # disabled と出ること
+
+# 2. renewal conf から renew_hook 行を削除する
+sudo sed -i '/^renew_hook/d' /etc/letsencrypt/renewal/chapple-esm.duckdns.org.conf
+
+# 3. webroot 方式のまま、パスがコンテナのマウント先と一致していることを確認する
+grep -E '^(authenticator|webroot_path)' /etc/letsencrypt/renewal/chapple-esm.duckdns.org.conf
+#   authenticator = webroot
+#   webroot_path = /var/www/certbot,
+
+# 4. ホスト側 certbot を削除する
+#    purge ではなく remove。/etc/letsencrypt（証明書・アカウント・renewal conf）は残す
+sudo apt remove certbot
+
+# 5. コンテナを起動する（certbot サービスが追加された compose.prod.yaml を pull 済みであること）
+docker compose -f compose.prod.yaml --env-file .env.production up -d
+
+# 6. 初回 renew の結果を確認する
+docker compose -f compose.prod.yaml --env-file .env.production logs certbot
+```
+
+手順 6 で期待するログは次のいずれか。
+
+- 期限まで 30 日以上ある場合: `Certificate not yet due for renewal` … `No renewals were attempted.`
+- 30 日を切っていた場合: `Congratulations, all renewals succeeded`
+
+`renew_hook` に関する ERROR が出た場合は手順 2 が漏れている。conf を修正すれば次回（12h 後）から正常化する。
+
+## 3. 新規環境での初回発行（手動）
+
+`certbot` サービスは `renew` しか行わないため、証明書が一枚も無い環境（EC2 の作り直し等）では**初回発行を手動で行う**。
+スクリプト化はしない。デモ環境一台に対し、テストの無いシェルスクリプトを保守対象に加える方が高くつくため。
+
+前提: DNS が EC2 に向いており、80 番ポートがインターネットから到達可能であること。
+
+```bash
+# 1. app-ssl.conf を一時退避する（証明書が無いと nginx が起動できないため）
+#    ※ 退避の手筋は prod-docker-local.md「注意点」と共通
+mv docker/nginx/conf.d/app-ssl.conf /tmp/app-ssl.conf.bak
+
+# 2. nginx を 80 番のみで起動する（app.conf の ACME location が応答する）
+docker compose -f compose.prod.yaml --env-file .env.production up -d nginx
+
+# 3. 証明書を発行する
+#    --entrypoint certbot が必須。compose.prod.yaml で entrypoint を renew ループに
+#    上書きしているため、これが無いと certonly 以下の引数が無視されてループが始まる
+docker compose -f compose.prod.yaml --env-file .env.production run --rm \
+  --entrypoint certbot certbot certonly \
+  --webroot -w /var/www/certbot \
+  -d chapple-esm.duckdns.org \
+  --email <メールアドレス> --agree-tos --no-eff-email
+
+# 4. app-ssl.conf を戻し、nginx に読み込ませる（6h の定期 reload を待たない）
+mv /tmp/app-ssl.conf.bak docker/nginx/conf.d/app-ssl.conf
+docker compose -f compose.prod.yaml --env-file .env.production exec nginx nginx -s reload
+
+# 5. 残りのサービスを起動する
+docker compose -f compose.prod.yaml --env-file .env.production up -d
+```
+
+発行後は `/etc/letsencrypt/renewal/chapple-esm.duckdns.org.conf` が自動生成され、以降の更新は `certbot` サービスが引き継ぐ。
+`--email` に指定したアドレスは Let's Encrypt のアカウント連絡先になるが、**期限切れ通知には使われない**（後述）。
+
+## 4. 更新失敗の確認
+
+> [!WARNING]
+> **Let's Encrypt は 2025 年 6 月に期限切れ通知メールを廃止した。** 更新が失敗し続けても、失効するまで
+> 外から何も知らせてくれない。現状、更新失敗に気づく手段はログの能動確認だけである。
+> 証明書期限の外形監視は [#780](https://github.com/chapplehub/estimate-management-system/issues/780) で別途設計する。
+
+```bash
+# certbot のログ（renew は 12h ごと。直近の実行結果を見る）
+docker compose -f compose.prod.yaml --env-file .env.production logs --since 24h certbot
+
+# 実際に配信されている証明書の期限（nginx の reload 済みかどうかはこちらで分かる）
+echo | openssl s_client -connect chapple-esm.duckdns.org:443 -servername chapple-esm.duckdns.org 2>/dev/null \
+  | openssl x509 -noout -dates
+```
+
+ログの読み方:
+
+| 出力 | 意味 |
+| --- | --- |
+| `No renewals were attempted.` | 期限まで 30 日以上あり、更新対象が無い。**正常** |
+| `Congratulations, all renewals succeeded` | 更新成功。最大 6h 後に nginx が反映する |
+| `Failed to renew certificate` / `All renewals failed` | 更新失敗。12h 後に再試行される。原因は直前の行（ACME への到達性、webroot の書き込み・配信、レート制限など）を見る |
+
+`docker compose ... logs` は `-f compose.prod.yaml` でプロジェクトを特定するため、コンテナ名（`estimate-management-system-prod-certbot-1`）に依存しない。
+`docker logs <コンテナ名>` でも同じものが読めるが、プロジェクト名の変更で壊れる書き方なので手順書には使わない。
+
+## 5. 手動で即時更新したいとき
+
+期限が迫っている、あるいは更新失敗の原因を直したあとすぐに再試行したい場合。`renew` の周期（12h）を待つ必要は無い。
+
+```bash
+docker compose -f compose.prod.yaml --env-file .env.production run --rm --entrypoint certbot certbot renew
+docker compose -f compose.prod.yaml --env-file .env.production exec nginx nginx -s reload
+```
+
+`--force-renewal` は付けない。Let's Encrypt のレート制限（同一証明書は週 5 回まで）を消費するため、期限内の証明書を無理に更新する理由が無い。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "packageManager": "pnpm@11.18.0",
   "scripts": {


### PR DESCRIPTION
## 概要

v0.1.1（#774）以降に develop へ蓄積した変更を main へ反映する。
アプリケーションコード（`src/`）・`Dockerfile` の変更は無く、**nginx の可用性改善と証明書更新のコンテナ化**（いずれも `compose.prod.yaml`）が内容。
マージにより `release-image.yml` が走り GHCR の `app` / `migrate` イメージが再ビルドされるが、中身に差分は無い。

## リリース内容

| PR | 内容 |
| --- | --- |
| #778 | nginx の `depends_on` を `service_healthy` から `service_started` に緩和（Closes #776） |
| #781 | certbot をコンテナ化し、証明書更新を Docker Compose に完結させる（Closes #779、ADR-20260827-ff0） |

### 運用に影響する変更

- **証明書更新がホスト certbot からコンテナへ移る**（#781）
  - `compose.prod.yaml` に `certbot` サービス（12h ごと `certbot renew`）を追加。nginx は `command` 上書きで 6h ごとに `nginx -s reload` する
  - 両者は `/etc/letsencrypt` の共有だけで繋がる。`renew_hook` / deploy-hook / docker socket は使わない。更新から反映まで最大 6h の遅れは正常動作
  - `/etc/letsencrypt` と `/var/www/certbot` はホスト bind mount のまま（既存の証明書を引き継ぐ。再発行不要）。`/var/lib/letsencrypt` は named volume `certbot-work`
  - **ホスト側 certbot は撤去が必須**（二重更新の防止。手順は下記）
  - 運用手順は `docs/ops/tls-certificates.md` に集約。Let's Encrypt の期限切れ通知メールは廃止済みのため、更新失敗の確認は `docker compose ... logs certbot` の能動確認のみ。外形監視は #780 で別途設計する
- **nginx が app の healthy を待たなくなる**（#778）
  - app 起動中の短時間、接続拒否ではなく 502 を返す窓が生じる。app 障害時も TLS 終端・ACME 応答・301 リダイレクトは生き続ける

## マージ前の前提条件

- [ ] バージョン bump PR（`package.json` を `0.1.2` へ）を develop にマージ済みであること

## マージ後の作業

順序が結果に効く（`docs/ops/tls-certificates.md` §2）。**`renew_hook` を残したままコンテナを起動すると、初回 `renew` でフックだけが失敗しログに ERROR が残る**。

- [ ] `release-image.yml` の run 完走を確認する
- [ ] `main` に annotated tag `v0.1.2` を打ち、GitHub Release を作成する
- [ ] EC2: `sudo systemctl disable --now certbot.timer`
- [ ] EC2: `/etc/letsencrypt/renewal/chapple-esm.duckdns.org.conf` から `renew_hook` 行を削除し、`authenticator = webroot` / `webroot_path = /var/www/certbot` を確認する
- [ ] EC2: `sudo apt remove certbot`（`purge` ではない。`/etc/letsencrypt` を残す）
- [ ] EC2: `docker compose -f compose.prod.yaml --env-file .env.production pull` → `up -d`
- [ ] EC2: `docker compose -f compose.prod.yaml --env-file .env.production logs certbot` で `No renewals were attempted.`（または更新成功）を確認し、`renew_hook` の ERROR が無いことを見る
- [ ] `docker volume ls` に `estimate-management-system-prod_certbot-work` があることを確認する

## バージョン

`src/` の変更が無く、アプリケーションの振る舞いは変わらないため patch とする（**v0.1.2**）。

## 注意

**squash / rebase ではなく merge commit でマージすること。**
squash すると main と develop の履歴が構造的に乖離し、
次回以降のリリース PR で全履歴が差分として現れる。
