### PR TITLE
chore: package.json のバージョンを 0.1.2 に上げる

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "packageManager": "pnpm@11.18.0",
   "scripts": {


### PR DESCRIPTION
## 概要

リリース PR #782（develop -> main）に合わせて `package.json` の `version` を `0.1.1` -> `0.1.2` に更新する。

## patch とした理由

#782 の差分に `src/` の変更が含まれず、アプリケーションの振る舞いが変わらないため。
内容は `compose.prod.yaml` の変更（nginx の `depends_on` 緩和 / certbot コンテナ化）と運用ドキュメントに限られる。

## 補足

- バージョンの参照箇所はリポジトリ内で `package.json` の 1 箇所のみ
- `private: true` のため npm 公開には使われず、`pnpm-lock.yaml` の再生成も不要

## マージ後

この PR を develop にマージした後、#782 を merge commit で main へマージする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoDt5bzSdxBCKJEpLXnRdm
