### PR TITLE
docs: .env.production.example の *_IMAGE の説明を deploy.md の方針に揃える

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -22,8 +22,9 @@ BETTER_AUTH_SECRET=
 # 公開 URL（例: https://<ドメイン>。ドメイン取得前のローカル検証では http://localhost）
 BETTER_AUTH_URL=
 
-# --- イメージ参照の上書き（任意） ---
-# 省略時は GHCR の latest を使う。ロールバック時は SHA タグを指定する。
+# --- イメージ参照の上書き（ローカル検証専用） ---
+# EC2 では書かない。デプロイスクリプトが HEAD commit から sha タグを導出してシェル環境変数で
+# 渡す（docs/ops/deploy.md）。ロールバックも scripts/deploy.sh <commit> で行い、ここは触らない。
 # ローカル検証では必須。GHCR のイメージは arm64 単一アーキ（ADR-20260818-7pn）のため
 # x86_64 の開発機では動かない。docker build で作ったローカルタグ（ems-app:local /
 # ems-migrate:local）を指定する（docs/ops/prod-docker-local.md）

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -65,7 +65,7 @@ GitHub Actions でビルドして GHCR に置く（= EC2 でビルドさせな�
 ## 3. 前提条件
 
 - **対象 commit の Release Image ワークフローが完了している**（GitHub の Actions → Release Image が緑）。完了前にデプロイすると `pull` で止まる（8 章）
-- `.env.production` は**秘密だけ**を書く。`APP_IMAGE` / `MIGRATE_IMAGE` を書かない（書くとスクリプトが導出した値を上書きし、HEAD とイメージがずれる。compose の優先順位はシェル環境変数 > `--env-file` > 既定値だが、`.env.production` に書くこと自体を禁じる）
+- `.env.production` は**秘密だけ**を書く。`APP_IMAGE` / `MIGRATE_IMAGE` を書かない。compose の優先順位はシェル環境変数 > `--env-file` > 既定値なので、スクリプト経由なら書いても導出値が勝つが、`eval "$(scripts/deploy-env.sh)"` を通らない手動コマンドでは `.env.production` の固定タグが効いてしまい、HEAD とイメージがずれる。「ずれる経路を作らない」ために書くこと自体を禁じる
 - 実行ユーザーが `docker` グループに属し、`sudo` 無しで `docker compose` を実行できる（スクリプトは `sudo` を使わない）
 - クローンから `git fetch origin` が通る
 


### PR DESCRIPTION
## Summary

#786 で導入した手順書（`docs/ops/deploy.md`）と食い違っていた 2 か所を直す。

- `.env.production.example`: 「ロールバック時は SHA タグを指定する」は #784 以前の運用。現在はロールバックも `scripts/deploy.sh <commit>` で行い、`.env.production` に `APP_IMAGE` / `MIGRATE_IMAGE` を書かない（`deploy.md` 3 章）。コメントをその方針に揃え、この 2 変数がローカル検証専用であることを明記する
- `docs/ops/deploy.md` 3 章: 「書くとスクリプトの導出値を上書きする」は compose の優先順位（シェル環境変数 > `--env-file`）と矛盾していた。正しくは「スクリプト経由なら導出値が勝つが、`eval` を通らない手動コマンドでは固定タグが効いて HEAD とずれる」。理由付けを直す

リリース PR #787 に含めたいので、bump PR #788 と同じく #787 より先に develop へマージする。

Refs #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dt19Fndm9dXyFWPYNY5dQa
